### PR TITLE
change some JSON snippets to used quoted names

### DIFF
--- a/versions/1.2.md
+++ b/versions/1.2.md
@@ -864,18 +864,18 @@ name: "limit"
 - If [`paramType`](#parameterParamType) is `"body"`:
 
     ```js
-name: "body"
+"name": "body"
     ```
 
 ##### 5.2.4.2 Object Example
 
 ```js
 {
-  name: "body",
-  description: "Pet object that needs to be updated in the store",
-  required: true,
-  type: "Pet",
-  paramType: "body"
+  "name": "body",
+  "description": "Pet object that needs to be updated in the store",
+  "required": true,
+  "type": "Pet",
+  "paramType": "body"
 }
 ```
 


### PR DESCRIPTION
Some examples in 1.2.md do not use quoted JSON member names.
This pull request adds the quotes.
