### PR TITLE
Officially support HEAD in the spec and jsonschemas

### DIFF
--- a/schemas/v1.2/operationObject.json
+++ b/schemas/v1.2/operationObject.json
@@ -7,7 +7,7 @@
         {
             "required": [ "method", "nickname", "parameters" ],
             "properties": {
-                "method": { "enum": [ "GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS" ] },
+                "method": { "enum": [ "GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS" ] },
                 "summary": { "type": "string", "maxLength": 120 },
                 "notes": { "type": "string" },
                 "nickname": {

--- a/versions/1.2.md
+++ b/versions/1.2.md
@@ -786,7 +786,7 @@ This is the only object where the [`type`](#dataTypeType) MAY have the value of 
 
 Field Name | Type | Description 
 ---|:---:|---
-<a name="operationMethod"/>method | `string` | **Required.** The HTTP method required to invoke this operation. The value MUST be one of the following values: `"GET"`, `"POST"`, `"PUT"`, `"PATCH"`, `"DELETE"`, `"OPTIONS"`. Note that the values MUST be in uppercase. 
+<a name="operationMethod"/>method | `string` | **Required.** The HTTP method required to invoke this operation. The value MUST be one of the following values: `"GET"`, `"HEAD"`, `"POST"`, `"PUT"`, `"PATCH"`, `"DELETE"`, `"OPTIONS"`. Note that the values MUST be in uppercase. 
 <a name="operationSummary"/>summary | `string` | A short summary of what the operation does. For maximum readability in the swagger-ui, this field SHOULD be less than 120 characters.
 <a name="operationNotes"/>notes | `string` | A verbose explanation of the operation behavior.
 <a name="operationNickname"/>nickname |`string` | **Required.** A unique id for the operation that can be used by tools reading the output for further and easier manipulation. For example, Swagger-Codegen will use the nickname as the method name of the operation in the client it generates. The value MUST be alphanumeric and may include underscores. Whitespsace characters are not allowd.


### PR DESCRIPTION
As discussed in #swagger, all the tools (particularly Swagger-UI) seem to support HEAD but it goes unmentioned in both the Spec and throws validation errors in the jsonschemas.

This pull request adds it to both. I searched but couldn't find any other work that needed to be done. Happy to update the branch if I missed anything.
