### PR TITLE
Grammar and phrasing fixes

### DIFF
--- a/versions/1.2.md
+++ b/versions/1.2.md
@@ -10,7 +10,7 @@ The Swagger specification is licensed under [The Apache License, Version 2.0](ht
 
 Swagger™  is a project used to describe and document RESTful APIs.
 
-The Swagger specification defines a set of files required to describe such an API. These files can then be used by the Swagger-UI project to display the API and Swagger-Codegen to generate clients in various languages. Additional utilities can also take advantage of the resulted files, for example, testing tools.
+The Swagger specification defines a set of files required to describe such an API. These files can then be used by the Swagger-UI project to display the API and Swagger-Codegen to generate clients in various languages. Additional utilities can also take advantage of the resulting files, such as testing tools.
 
 ## 2. Revision History
 
@@ -22,7 +22,7 @@ Version | Date | Notes
 
 ## 3. Definitions
 
-- <a name="definitionResource"/>Resource: A `resource` in Swagger is a an entity that has a set of exposed operations. The entity can represent an actual object (pets, users..) or a set of logical operations collated together. It is up to the specification user to decide whether sub-resources should be referred to as part of their main resource or as a resource of their own.
+- <a name="definitionResource"/>Resource: A `resource` in Swagger is an entity that has a set of exposed operations. The entity can represent an actual object (pets, users..) or a set of logical operations collated together. It is up to the specification user to decide whether sub-resources should be referred to as part of their main resource or as a resource of their own.
 For example, assume the following URL set:
     ```
   - /users      - GET
@@ -49,7 +49,7 @@ For example, if a field is said to have an array value, the JSON array represent
 }
 ```
 
-Please note that while the API is described using JSON, it does not mean that the input nor output can’t be in XML, YAML, plain text, or whichever format you chose to use with your API.
+Please note that while the API is described using JSON, the input and/or output can be in XML, YAML, plain text, or whichever format you chose to use with your API.
 
 Unless noted otherwise, all field names in the specification are **case sensitive**.
 
@@ -66,7 +66,7 @@ The Swagger representation of the API is comprised of two file types:
 
 In the Swagger specification, the data types are used in several locations - [Operations](#523-operation-object), [Operation Parameters](#524-parameter-object), [Models](#527-model-object), and within the data types themselves (arrays).
 
-The fields used to describe a given data type are added flatly to the relevant object. For example, if we have the object Foo with the field `name`, and we say it can also represent a data type, we MUST add the field `type` (or its variance, as explained ahead), and as such Foo would look like:
+The fields used to describe a given data type are added flatly to the relevant object. For example, if an object Foo has the field `name`, and is also a data type, then it MUST also include the field `type` (or its variance, as explained ahead). In this example, Foo would look like:
 ```js
 "Foo" : {
    "name" : "sample",
@@ -77,7 +77,7 @@ The fields used to describe a given data type are added flatly to the relevant o
 
 This section describes the general fields that are available to describe such data types. Some data types allow additional fields to extend further limitations on the data type *value* (see [4.3.3 Data Type Fields](#433-data-type-fields) for further details).
 
-Special care should be used when referencing a model (or a complex type). There are currently two variations, and the proper variation would be documented everywhere it may be used. This behavior will be unified in future versions of the spec.
+Special care should be taken when referencing a model (or a complex type). There are currently two variations, and the proper variation should be documented everywhere the model may be used. This behavior will be unified in future versions of the spec.
 
 The Swagger specification supports five data types:
 
@@ -105,15 +105,15 @@ dateTime | `string` | `date-time` |
 
 #### 4.3.2 `void`
 
-This value type is used to indicate that an [operation](#523-operation-object) returns no value. As such it MAY be used only for operations return type.
+This value type is used to indicate that an [operation](#523-operation-object) returns no value. As such it MAY be used only for the return type of operations.
 
 #### 4.3.3 Data Type Fields
 
-As explained above, when an object is said to include a data type, there are a set of fields may be added to it (in fact, some are required, and some are optional).
+As explained above, when an object is said to include a data type, there are a set of fields it may include (some are required and some are optional).
 
-Special care should be used when referencing a model (or a complex type). There currently two variations, and the proper variation would be documented everywhere it may be used. This behavior will be unified in future versions of the spec.
+Special care should be taken when referencing a model (or a complex type). There currently two variations, and the proper variation should be documented everywhere it may be used. This behavior will be unified in future versions of the spec.
 
-The table below shows the available fields to describe a data type. Note the `Validity` column may impose additional restrictions as to which data type is required in order to include this field. For example, [`enum`](#dataTypeEnum) may only be included of the [`type`](#dataTypeType) field is set to `string`.
+The table below shows the available fields to describe a data type. The `Validity` column may impose additional restrictions as to which data type is required in order to include this field. For example, [`enum`](#dataTypeEnum) may only be included if the [`type`](#dataTypeType) field is set to `string`.
 
 Field Name | Type | Validity |Description
 ---|:---:|---|---
@@ -129,9 +129,9 @@ Field Name | Type | Validity |Description
 
 #### 4.3.4 Items Object
 
-This object is used to describe the value types used inside an array. Out of the [Data Type Fields](#433-data-type-fields) it can include either the [`type`](#dataTypeType) + [`format`](#dataTypeFormat) fields *OR* the [`$ref`](#dataTypeRef) field (when referencing a model). The rest of the listed fields are not applicable.
+This object is used to describe the value types used inside an array. Of the [Data Type Fields](#433-data-type-fields), it can include either the [`type`](#dataTypeType) and [`format`](#dataTypeFormat) fields *OR* the [`$ref`](#dataTypeRef) field (when referencing a model). The rest of the listed Data Type fields are not applicable.
 
-In this case, [`type`](#dataTypeType) MUST NOT be `array`. Currently, there's no support for containers within containers.
+If the [`type`](#dataTypeType) field is included it MUST NOT have the value `array`. There's currently no support for containers within containers.
 
 ##### 4.3.4.1 Object Examples
 
@@ -166,11 +166,11 @@ By default, this document SHOULD be served at the `/api-docs` path.
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="rlSwaggerVersion"/>swaggerVersion | `string` | **Required.** Specifies the Swagger Specification version being used. It can be used by the Swagger UI and other clients to interpret the API listing. The value MUST be an existing Swagger specification version. <br>Currently, `"1.0"`, `"1.1"`, `"1.2"` are valid values. The field is of `string` value for possible non-numeric versions in the future (for example, "1.2a").
+<a name="rlSwaggerVersion"/>swaggerVersion | `string` | **Required.** Specifies the Swagger Specification version being used. It can be used by the Swagger UI and other clients to interpret the API listing. The value MUST be an existing Swagger specification version. <br>Currently, `"1.0"`, `"1.1"`, `"1.2"` are valid values. The field is a `string` type for possible non-numeric versions in the future (for example, "1.2a").
 <a name="rlApis"/>apis | [ [Resource Object](#512-resource-object) ] | **Required.** Lists the resources to be described by this specification implementation. The array can have 0 or more elements.
 <a name="rlApiVersion"/>apiVersion| `string` | Provides the version of the application API (not to be confused by the [specification version](#rlSwaggerVersion)).
 <a name="rlInfo"/>info | [Info Object](#513-info-object) | Provides metadata about the API. The metadata can be used by the clients if needed, and can be presented in the Swagger-UI for convenience.
-<a name="rlAuthorizations"/>authorizations | [Authorizations Object](#514-authorizations-object) | Provides information about the authorization schemes allowed on his API.
+<a name="rlAuthorizations"/>authorizations | [Authorizations Object](#514-authorizations-object) | Provides information about the authorization schemes allowed on this API.
 
 #### 5.1.1 Object Example
 
@@ -350,7 +350,7 @@ Field Name | Type | Validity | Description
 <a name="authorizationPassAs"/>passAs | `string` | `apiKey` | **Required.** Denotes how the API key must be passed. Valid values are `"header"` or `"query"`.
 <a name="authorizationKeyname"/>keyname | `string` | `apiKey` | **Required.** The name of the `header` or `query` parameter to be used when passing the API key.
 <a name="authorizationScopes"/>scopes | [[Scope Object](#516-scope-object)] | `oauth2` | A list of supported OAuth2 scopes.
-<a name="authorizationGrantTypes"/>grantTypes | [Grant Types Object](#517-grant-types-object) | `oauth2` | **Required.** Detailed information about the grant types supported by the oauth2 authorization scheme.
+<a name="authorizationGrantTypes"/>grantTypes | [Grant Types Object](#517-grant-types-object) | `oauth2` | **Required.** Detailed information about the grant types supported by the OAuth2 authorization scheme.
 
 ##### 5.1.5.1 Object Example:
 ```js
@@ -499,7 +499,7 @@ Field Name | Type | Description
 ---|:---:|---
 <a name="treUrl"/>url | `string` | **Required.** The URL of the authorization endpoint for the authentication code grant flow. The value SHOULD be in a URL format.
 <a name="treCliendIdName"/>clientIdName | `string` | An optional alternative name to standard "client_id" OAuth2 parameter.
-<a name="treCliendSecretName"/>clientSecretName | `string` | An optional alternative name to standard "client_secret" OAuth2 parameter.
+<a name="treCliendSecretName"/>clientSecretName | `string` | An optional alternative name to the standard "client_secret" OAuth2 parameter.
 
 ##### 5.1.11.1 Object Example:
 ```js
@@ -534,7 +534,7 @@ Field Name | Type | Description
 ---|:---:|---
 <a name="adSwaggerVersion"/>swaggerVersion | `string` | **Required.** Specifies the Swagger Specification version being used. It can be used by the Swagger UI and other clients to interpret the API listing. The value MUST be an existing Swagger specification version. <br>Currently, `"1.0"`, `"1.1"`, `"1.2"` are valid values.
 <a name="adApiVersion"/>apiVersion | `string` | Provides the version of the application API (not to be confused by the [specification version](#adSwaggerVersion)).
-<a name="adBasePath"/>basePath | `string` | **Required.** The root URL serving the API. This field is important as while it is common to have the Resource Listing and API Declarations on the server providing the APIs themselves, it is not a requirement. The API specifications can be served using static files and not generated by the API server itself, so the URL for serving the API cannot always be derived from the URL serving the API specification. The value SHOULD be in the format of a URL.
+<a name="adBasePath"/>basePath | `string` | **Required.** The root URL serving the API. This field is important because while it is common to have the Resource Listing and API Declarations on the server providing the APIs themselves, it is not a requirement. The API specifications can be served using static files and not generated by the API server itself, so the URL for serving the API cannot always be derived from the URL serving the API specification. The value SHOULD be in the format of a URL.
 <a name="adResourcePath"/>resourcePath | `string` | The *relative* path to the resource, from the [`basePath`](#adBasePath), which this API Specification describes. The value MUST precede with a forward slash (`"/"`).
 <a name="adApis"/>apis | [[API Object](#522-api-object)] | **Required.** A list of the APIs exposed on this resource. There MUST NOT be more than one API Object per [`path`](#apiPath) in the array.
 <a name="adModels"/>models | [Models Object](#526-models-object) | A list of the models available to this resource. Note that these need to be exposed separately for each API Declaration.
@@ -786,7 +786,7 @@ This is the only object where the [`type`](#dataTypeType) MAY have the value of 
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="operationMethod"/>method | `string` | **Required.** The HTTP method required to invoke this operation. The value MUST be one of the following values: `"GET"`, `"HEAD"`, `"POST"`, `"PUT"`, `"PATCH"`, `"DELETE"`, `"OPTIONS"`. Note that the values MUST be in uppercase.
+<a name="operationMethod"/>method | `string` | **Required.** The HTTP method required to invoke this operation. The value MUST be one of the following values: `"GET"`, `"HEAD"`, `"POST"`, `"PUT"`, `"PATCH"`, `"DELETE"`, `"OPTIONS"`. The values MUST be in uppercase.
 <a name="operationSummary"/>summary | `string` | A short summary of what the operation does. For maximum readability in the swagger-ui, this field SHOULD be less than 120 characters.
 <a name="operationNotes"/>notes | `string` | A verbose explanation of the operation behavior.
 <a name="operationNickname"/>nickname |`string` | **Required.** A unique id for the operation that can be used by tools reading the output for further and easier manipulation. For example, Swagger-Codegen will use the nickname as the method name of the operation in the client it generates. The value MUST be alphanumeric and may include underscores. Whitespace characters are not allowed.
@@ -845,7 +845,7 @@ Field Name | Type | Description
 <a name="parameterParamType"/>paramType | `string` | **Required.** The type of the parameter (that is, the location of the parameter in the request). The value MUST be one of these values: `"path"`, `"query"`, `"body"`, `"header"`, `"form"`. Note that the values MUST be lower case.
 <a name="parameterName"/>name | `string` | **Required.** The unique name for the parameter. Each `name` MUST be unique, even if they are associated with different `paramType` values. Parameter names are *case sensitive*. <ul><li>If [`paramType`](#parameterParamType) is `"path"`, the `name` field MUST correspond to the associated path segment from the [`path`](#apiPath) field in the [API Object](#522-api-object). <li>If [`paramType`](#parameterParamType) is `"query"`, the `name` field corresponds to the query parameter name. <li>If [`paramType`](#parameterParamType) is `"body"`, the name is used only for Swagger-UI and Swagger-Codegen. In this case, the `name` MUST be `"body"`. <li>If [`paramType`](#parameterParamType) is `"form"`, the `name` field corresponds to the form parameter key. <li>If [`paramType`](#parameterParamType) is `"header"`, the `name` field corresponds to the header parameter key. </ul> See [here](#5241-name-examples) for some examples.
 <a name="parameterDescription"/>description | `string` | *Recommended.* A brief description of this parameter.
-<a name="parameterRequired"/>required | `boolean` | A flag to note whether this parameter is required. If this field is not included, it is equivalent to adding this field with the value `false`. The field MUST be included if [`paramType`](#parameterParamType) is `"path"` and MUST have the value `true`.
+<a name="parameterRequired"/>required | `boolean` | A flag to note whether this parameter is required. If this field is not included, it is equivalent to adding this field with the value `false`. If [`paramType`](#parameterParamType) is `"path"` then this field MUST be included and have the value `true`.
 <a name="parameterAllowMultiple"/>allowMultiple | `boolean` | Another way to allow multiple values for a "query" parameter. If used, the query parameter may accept comma-separated values. The field may be used only if [`paramType`](#parameterParamType) is `"query"`, `"header"` or `"path"`.
 
 ##### 5.2.4.1 Name Examples
@@ -855,7 +855,7 @@ Field Name | Type | Description
 "name": "id"
     ```
 
-- If [`paramType`](#parameterParamType) is `"query"`, and assuming the URL call is `"http://host/resource?limit=100"` (that is, there's a query parameter called `"limit"`:
+- If [`paramType`](#parameterParamType) is `"query"`, and assuming the URL call is `"http://host/resource?limit=100"` (that is, there's a query parameter called `"limit"`):
 
     ```js
 "name": "limit"
@@ -949,7 +949,7 @@ Field Name | Type | Description
 <a name="modelRequired"/>required | [`string`] | A definition of which properties MUST exist when a model instance is produced. The values MUST be the [`{Property Name}`](#propertiesPropertyName) of one of the [`properties`](#528-properties-object).
 <a name="modelProperties"/>properties | [Properties Object](#528-properties-object) | **Required.** A list of properties (fields) that are part of the model
 <a name="modelSubTypes"/>subTypes | [`string`] | List of the [model `id`s](#modelId) that inherit from this model. Sub models inherit all the properties of the parent model. Since inheritance is transitive, if the parent of a model inherits from another model, its sub-model will include all properties. As such, if you have `Foo->Bar->Baz`, then Baz will inherit the properties of Bar and Foo. There MUST NOT be a cyclic definition of inheritance. For example, if `Foo -> ... -> Bar`, having `Bar -> ... -> Foo` is not allowed. There also MUST NOT be a case of multiple inheritance. For example, `Foo -> Baz <- Bar` is not allowed. A sub-model definition MUST NOT override the [`properties`](#modelProperties) of any of its ancestors. All sub-models MUST be defined in the same [API Declaration](#52-api-declaration).
-<a name="modelDiscriminator"/>discriminator | `string` | MUST be included only if [`subTypes`](#modelSubTypes) is included. This field allows for polymorphism within the described inherited models. This field MAY be included at any base model but MUST NOT be included in a sub-model. The value of this field MUST be a name of one of the [`properties`](#modelProperties) in this model, and that field MUST be in the [`required`](#modelRequired) list. When used, the value of the *discriminator property* MUST be the name of parent or any of its sub-models (to any depth of inheritance).
+<a name="modelDiscriminator"/>discriminator | `string` | MUST be included only if [`subTypes`](#modelSubTypes) is included. This field allows for polymorphism within the described inherited models. This field MAY be included at any base model but MUST NOT be included in a sub-model. The value of this field MUST be a name of one of the [`properties`](#modelProperties) in this model, and that field MUST be in the [`required`](#modelRequired) list. When used, the value of the *discriminator property* MUST be the name of the parent model or any of its sub-models (to any depth of inheritance).
 
 ##### 5.2.7.1 Object Example
 
@@ -1058,7 +1058,7 @@ Field Name | Type | Description
 
 A Property Object holds the definition of a new property for a model.
 
-This object includes the [Data Type Fields](#433-data-type-fields) in order to describe the type of this property. The [`$ref`](#dataTypeRef) field MUST be used to link to other models.
+This object includes the [Data Type Fields](#433-data-type-fields) in order to describe the type of this property. The [`$ref`](#dataTypeRef) field MUST be used when linking to other models.
 
 Properties MUST NOT contain other properties. If there's a need for an internal object hierarchy, additional models MUST be created and linked to a flat structure.
 
@@ -1100,7 +1100,7 @@ A "tags" field of type array containing Tag models.
 ```
 
 #### 5.2.10 Authorizations Object
-The object provides information about the authorization schemes enforced on this API. If used in the API Declaration's [authorizations](#adAuthorizations), it applies to all operations listed. If used in the Operation's [authorizations](#operationAuthorizations), it applies to the operation itself and may override the API Declaration's authorizations.
+The Authorizations Object provides information about the authorization schemes enforced on this API. If used in the API Declaration's [authorizations](#adAuthorizations), it applies to all operations listed. If used in the Operation's [authorizations](#operationAuthorizations), it applies to the operation itself and may override the API Declaration's authorizations.
 If multiple authorization schemes are described, they are **all** required to perform the operations listed.
 
 Please note that the Authorizations Object is an object containing arrays of object definitions and as such is structured as follows:


### PR DESCRIPTION
Fixes various grammar and phrasing issues in the spec. Also fixes a seeming typo in the restriction of discriminator property value of models to be the names of the parent model or any of its sub-models. The intent seems to restrict the discriminator property value of models to NOT be the name of the parent model or any of its sub-models. (Let me know if that wasn't the intent and I can revert that change).
