### PR TITLE
Fix ambiguous regexes

### DIFF
--- a/schemas/v2.0/schema.json
+++ b/schemas/v2.0/schema.json
@@ -171,13 +171,13 @@
     "example": {
       "type": "object",
       "patternProperties": {
-        "^[a-z0-9-]+/[a-z0-9-+]+$": {}
+        "^[a-z0-9-]+/[a-z0-9\\-+]+$": {}
       },
       "additionalProperties": false
     },
     "mimeType": {
       "type": "string",
-      "pattern": "^[\\sa-z0-9-+;\\.=\\/]+$",
+      "pattern": "^[\\sa-z0-9\\-+;\\.=\\/]+$",
       "description": "The MIME type of the HTTP message."
     },
     "operation": {
@@ -488,7 +488,7 @@
         "enum": { "$ref": "http://json-schema.org/draft-04/schema#/properties/enum" },
         "type": { "$ref": "http://json-schema.org/draft-04/schema#/properties/type" },
         "example": {
-          
+
         },
         "allOf": {
           "type": "array",


### PR DESCRIPTION
The schema contains some ambiguous regexes. This causes Ruby to display warnings like this:

```
warning: character class has '-' without escape: /^[\sa-z0-9-+;\.=\/]+$/
warning: character class has '-' without escape: /^[a-z0-9-]+\/[a-z0-9-+]+$/
```

That's because `-` is a special character within a character group definition (i.e. between []'s). In order to make it clear if the regex intended to use it as a range delimiter or a literal `-`, you are supposed to either escape it or put it as the first or last character in the group. I'm not sure if the first/last trick is universally supported (and it is not mentioned in the limited regex constructs that [json-schema recommends](http://json-schema.org/latest/json-schema-validation.html#anchor6) for broad support) so escaped it.

NB: ResourcesTest.scala:161 is already failing. That is a pre-existing problem. All other tests pass.
