### PR TITLE
Proposing adding SEARCH method

### DIFF
--- a/versions/2.0.md
+++ b/versions/2.0.md
@@ -231,6 +231,7 @@ Field Name | Type | Description
 <a name="pathItemOptions"/>options | [Operation Object](#operationObject) | A definition of a OPTIONS operation on this path.
 <a name="pathItemHead"/>head | [Operation Object](#operationObject) | A definition of a HEAD operation on this path.
 <a name="pathItemPatch"/>patch | [Operation Object](#operationObject) | A definition of a PATCH operation on this path.
+<a name="pathItemSearch"/>search | [Operation Object](#operationObject) | A definition of a SEARCH operation on this path.
 <a name="pathItemParameters"/>parameters | [[Parameter Object](#parameterObject) <span>&#124;</span> [Reference Object](#referenceObject)] | A list of parameters that are applicable for all the operations described under this path. These parameters can be overridden at the operation level, but cannot be removed there. The list MUST NOT include duplicated parameters. A unique parameter is defined by a combination of a [name](#parameterName) and [location](#parameterIn). The list can use the [Reference Object](#referenceObject) to link to parameters that are defined at the [Swagger Object's parameters](#swaggerParameters).
 
 ##### Patterned Fields


### PR DESCRIPTION
We started using the SEARCH method when we found we couldn't gracefully accommodate our document store backed (reductive find) GET /users and our elastic-search backed (additive search) SEARCH /users.
It's a draft spec but seems pretty handy. We use it in anger at any rate.