### PR TITLE
Update schema for apiDeclaration consumes/produces to require unique entries

### DIFF
--- a/schemas/v1.2/apiDeclaration.json
+++ b/schemas/v1.2/apiDeclaration.json
@@ -54,7 +54,8 @@
             "items": {
                 "type": "string",
                 "format": "mime-type"
-            }
+            },
+            "uniqueItems": true
         }
     }
 }

--- a/schemas/v1.2/operationObject.json
+++ b/schemas/v1.2/operationObject.json
@@ -58,7 +58,8 @@
             "items": {
                 "type": "string",
                 "format": "mime-type"
-            }
+            },
+            "uniqueItems": true
         }
     }
 }


### PR DESCRIPTION
I'm not sure if you are taking 1.2 enhancements but right now, an API Declaration will allow duplicate `consumes` and `produces` entries.  This was addressed in 2.0 but it would be nice to see 1.2 updated as well.
