### PR TITLE
Make clear that termsOfService should be an URL

### DIFF
--- a/versions/2.0.md
+++ b/versions/2.0.md
@@ -132,7 +132,7 @@ Field Name | Type | Description
 ---|:---:|---
 <a name="infoTitle"/>title | `string` | **Required.** The title of the application.
 <a name="infoDescription"/>description | `string` | A short description of the application. [GFM syntax](https://help.github.com/articles/github-flavored-markdown) can be used for rich text representation.
-<a name="infoTermsOfService"/>termsOfService | `string` | The Terms of Service for the API.
+<a name="infoTermsOfService"/>termsOfService | `string` | A URL to the Terms of Service for the API.
 <a name="infoContact"/>contact | [Contact Object](#contactObject) | The contact information for the exposed API.
 <a name="infoLicense"/>license | [License Object](#licenseObject) | The license information for the exposed API.
 <a name="infoVersion"/>version | `string` | **Required** Provides the version of the application API (not to be confused by the specification version).


### PR DESCRIPTION
There is an ambiguity in 2.0: `info.termsOfService` is said to be a `string`, but it does not say whether this string should be the full ToS, a title, or an URL linking to it.

The example gives an URL, and `swagger-ui` now [makes this assumption](https://github.com/swagger-api/swagger-ui/pull/812/files) too.

This changeset thus states that `termsOfService` is expected to contain an URL. It does not add a normative format, for retrocompatibilty.

---

In a next release, I think `termsOfService` should expose an object similar to a `License Object` to remove any ambiguity.