### PR TITLE
Fixed invalid urls in v1.2 specifications

### DIFF
--- a/schemas/v1.2/apiDeclaration.json
+++ b/schemas/v1.2/apiDeclaration.json
@@ -1,5 +1,5 @@
 {
-    "id": "http://swagger-api.github.io/schemas/v1.2/apiDeclaration.json#",
+    "id": "https://raw.githubusercontent.com/swagger-api/swagger-spec/master/schemas/v1.2/apiDeclaration.json#",
     "$schema": "http://json-schema.org/draft-04/schema#",
     "type": "object",
     "required": [ "swaggerVersion", "basePath", "apis" ],

--- a/schemas/v1.2/authorizationObject.json
+++ b/schemas/v1.2/authorizationObject.json
@@ -1,5 +1,5 @@
 {
-    "id": "http://swagger-api.github.io/schemas/v1.2/authorizationObject.json#",
+    "id": "https://raw.githubusercontent.com/swagger-api/swagger-spec/master/schemas/v1.2/authorizationObject.json#",
     "$schema": "http://json-schema.org/draft-04/schema#",
     "type": "object",
     "additionalProperties": {

--- a/schemas/v1.2/dataType.json
+++ b/schemas/v1.2/dataType.json
@@ -1,5 +1,5 @@
 {
-    "id": "http://swagger-api.github.io/schemas/v1.2/dataType.json#",
+    "id": "https://raw.githubusercontent.com/swagger-api/swagger-spec/master/schemas/v1.2/dataType.json#",
     "$schema": "http://json-schema.org/draft-04/schema#",
     "description": "Data type as described by the specification (version 1.2)",
     "type": "object",

--- a/schemas/v1.2/dataTypeBase.json
+++ b/schemas/v1.2/dataTypeBase.json
@@ -1,5 +1,5 @@
 {
-    "id": "http://swagger-api.github.io/schemas/v1.2/dataTypeBase.json#",
+    "id": "https://raw.githubusercontent.com/swagger-api/swagger-spec/master/schemas/v1.2/dataTypeBase.json#",
     "$schema": "http://json-schema.org/draft-04/schema#",
     "description": "Data type fields (section 4.3.3)",
     "type": "object",

--- a/schemas/v1.2/infoObject.json
+++ b/schemas/v1.2/infoObject.json
@@ -1,5 +1,5 @@
 {
-    "id": "http://swagger-api.github.io/schemas/v1.2/infoObject.json#",
+    "id": "https://raw.githubusercontent.com/swagger-api/swagger-spec/master/schemas/v1.2/infoObject.json#",
     "$schema": "http://json-schema.org/draft-04/schema#",
     "description": "info object (section 5.1.3)",
     "type": "object",

--- a/schemas/v1.2/modelsObject.json
+++ b/schemas/v1.2/modelsObject.json
@@ -1,5 +1,5 @@
 {
-    "id": "http://swagger-api.github.io/schemas/v1.2/modelsObject.json#",
+    "id": "https://raw.githubusercontent.com/swagger-api/swagger-spec/master/schemas/v1.2/modelsObject.json#",
     "$schema": "http://json-schema.org/draft-04/schema#",
     "type": "object",
     "required": [ "id", "properties" ],

--- a/schemas/v1.2/oauth2GrantType.json
+++ b/schemas/v1.2/oauth2GrantType.json
@@ -1,5 +1,5 @@
 {
-    "id": "http://swagger-api.github.io/schemas/v1.2/oauth2GrantType.json#",
+    "id": "https://raw.githubusercontent.com/swagger-api/swagger-spec/master/schemas/v1.2/oauth2GrantType.json#",
     "$schema": "http://json-schema.org/draft-04/schema#",
     "type": "object",
     "minProperties": 1,

--- a/schemas/v1.2/operationObject.json
+++ b/schemas/v1.2/operationObject.json
@@ -1,5 +1,5 @@
 {
-    "id": "http://swagger-api.github.io/schemas/v1.2/operationObject.json#",
+    "id": "https://raw.githubusercontent.com/swagger-api/swagger-spec/master/schemas/v1.2/operationObject.json#",
     "$schema": "http://json-schema.org/draft-04/schema#",
     "type": "object",
     "allOf": [

--- a/schemas/v1.2/parameterObject.json
+++ b/schemas/v1.2/parameterObject.json
@@ -1,5 +1,5 @@
 {
-    "id": "http://swagger-api.github.io/schemas/v1.2/parameterObject.json#",
+    "id": "https://raw.githubusercontent.com/swagger-api/swagger-spec/master/schemas/v1.2/parameterObject.json#",
     "$schema": "http://json-schema.org/draft-04/schema#",
     "type": "object",
     "allOf": [

--- a/schemas/v1.2/resourceListing.json
+++ b/schemas/v1.2/resourceListing.json
@@ -1,5 +1,5 @@
 {
-    "id": "http://swagger-api.github.io/schemas/v1.2/resourceListing.json#",
+    "id": "https://raw.githubusercontent.com/swagger-api/swagger-spec/master/schemas/v1.2/resourceListing.json#",
     "$schema": "http://json-schema.org/draft-04/schema#",
     "type": "object",
     "required": [ "swaggerVersion", "apis" ],

--- a/schemas/v1.2/resourceObject.json
+++ b/schemas/v1.2/resourceObject.json
@@ -1,5 +1,5 @@
 {
-    "id": "http://swagger-api.github.io/schemas/v1.2/resourceObject.json#",
+    "id": "https://raw.githubusercontent.com/swagger-api/swagger-spec/master/schemas/v1.2/resourceObject.json#",
     "$schema": "http://json-schema.org/draft-04/schema#",
     "type": "object",
     "required": [ "path" ],


### PR DESCRIPTION
swagger-api.github.io isn't here any more