### PR TITLE
schema 2.0: fix definitions of 'consumes'/'produces'

### DIFF
--- a/schemas/v2.0/schema.json
+++ b/schemas/v2.0/schema.json
@@ -39,12 +39,24 @@
       "$ref": "#/definitions/schemesList"
     },
     "consumes": {
-      "description": "A list of MIME types accepted by the API.",
-      "$ref": "#/definitions/mediaTypeList"
+      "allOf": [
+        {
+          "$ref": "#/definitions/mediaTypeList"
+        },
+        {
+          "description": "A list of MIME types accepted by the API."
+        }
+      ]
     },
     "produces": {
-      "description": "A list of MIME types the API can produce.",
-      "$ref": "#/definitions/mediaTypeList"
+      "allOf": [
+        {
+          "$ref": "#/definitions/mediaTypeList"
+        },
+        {
+          "description": "A list of MIME types the API can produce."
+        }
+      ]
     },
     "paths": {
       "$ref": "#/definitions/paths"
@@ -262,12 +274,24 @@
           "description": "A unique identifier of the operation."
         },
         "produces": {
-          "description": "A list of MIME types the API can produce.",
-          "$ref": "#/definitions/mediaTypeList"
+          "allOf": [
+            {
+              "$ref": "#/definitions/mediaTypeList"
+            },
+            {
+              "description": "A list of MIME types the API can produce."
+            }
+          ]
         },
         "consumes": {
-          "description": "A list of MIME types the API can consume.",
-          "$ref": "#/definitions/mediaTypeList"
+          "allOf": [
+            {
+              "$ref": "#/definitions/mediaTypeList"
+            },
+            {
+              "description": "A list of MIME types the API can consume."
+            }
+          ]
         },
         "parameters": {
           "$ref": "#/definitions/parametersList"


### PR DESCRIPTION
A JSON reference ($ref) is a JSON object containing ONLY the `$ref` property. The [specification (still a draft) for JSON references](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03#section-3) says explicitely that any other property must be ignored:

> Any members other than "$ref" in a JSON Reference object SHALL be ignored.

In the schema for Swagger 2.0 the properties `consumes` and `produces` were not respecting this contraint. This is fixed by using an `allOf` schema that combines the `{ "$ref": ...}` and an other object containing the other properties.
