### PR TITLE
Refined guidelines for external file reuse

### DIFF
--- a/guidelines/REUSE.md
+++ b/guidelines/REUSE.md
@@ -7,17 +7,54 @@ We encourage reuse and patterns through references.
 The following types are reusable, as defined by the spec:
 
 * Parameters
-* Models (or Schema Objects in general)
+* Models (_or Schema Objects in general_)
 * Responses
 * Operations (_Operations can only be remote references_)
 
 ## Reuse strategy
 
-When reusing components in an API design, a reference is created from the definition to target entity. The references are maintained in the structure, and can be updated by modifying the source definitions. This is different from a "copy on design" approach where references are injected into the design itself.
+When authoring API design documents, common object definitions can be utilized to avoid duplication. For example, imagine multiple path definitions that each share a common path parameter, or a common response structure. The OpenAPI specification allows reuse of common object definitions through the use of "references".
 
-The reuse technique is transparent between JSON or YAML and is lossless when converting between the two.
+A reference a construct in your API design document that indicates "the content for this portion of the document is defined elsewhere". To create a reference, at the location in your document where you want to reuse some other definition, create an object that has a `$ref` property whose value is a URI pointing to where the definition is (more on this in later sections). 
 
-YAML anchors are technically allowed but break the general reuse strategy in OpenAPI Specification, since anchors are "injected" into a single document.  They are not recommended.
+OpenAPI's provides reference capabilities using the [JSON Reference](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03) specification. 
+
+### JSON Example
+
+``` json
+{
+  // ... 
+  definitions: {
+    Person: {
+      type: 'object',
+      properties: {
+        friends: {
+          type: 'array',
+          items: {
+            $ref: '#/definitions/Person'
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### YAML Example
+
+``` yaml
+# ...
+definitions:
+  Person:
+    type: object
+    properties:
+      friends:
+        type: array
+        items:
+          $ref: '#/definitions/Person'
+```
+
+Note: YAML has a very similar feature, [YAML anchors](http://yaml.org/spec/1.2/spec.html#id2765878). Examples from this point will only be in JSON, using JSON References.
 
 ## Techniques
 
@@ -46,6 +83,7 @@ An example of a local definition reference:
 
 _Example from https://github.com/OAI/OpenAPI-Specification/blob/master/examples/v2.0/json/petstore.json_
 ``` json
+          // ... 
           "200": {
             "description": "pet response",
             "schema": {
@@ -65,6 +103,7 @@ Files can be referred to in relative paths to the current document.
 _Example from https://github.com/OAI/OpenAPI-Specification/tree/master/examples/v2.0/json/petstore-separate/spec/swagger.json_
 
 ``` json
+// ... 
 "responses": {
 	"default": {
 		"description": "unexpected error",
@@ -79,6 +118,7 @@ Remote references may also reference properties within the relative remote file.
 
 _Example from https://github.com/OAI/OpenAPI-Specification/tree/master/examples/v2.0/json/petstore-separate/spec/swagger.json_
 ``` json
+// ... 
 "parameters": [
 	{
 		"$ref": "parameters.json#/tagsParam"
@@ -233,7 +273,7 @@ To include these parameters, you would need to add them individually as such:
 
 ### Operations
 
-Again, Operations can be shared across files.  Although the reusability of operations will be less than with Parameters and models. For this example, we will share a common `health` resource so that all APIs can reference it:
+Again, Operations can be shared across files.  Although the reusability of operations will be less than with Parameters and Definitions. For this example, we will share a common `health` resource so that all APIs can reference it:
 
 Refer to [Guidelines for Referencing](#guidelines-for-referencing) for referencing strategies.
 

--- a/guidelines/REUSE.md
+++ b/guidelines/REUSE.md
@@ -391,6 +391,3 @@ You can refer to it from a response definition:
   }
 }
 ```
-
-### Constraints
-* Referenced objects must be to JSON structures.  YAML reuse structures may be supported in a future version.

--- a/guidelines/REUSE.md
+++ b/guidelines/REUSE.md
@@ -9,33 +9,40 @@ The following types are reusable, as defined by the spec:
 * Parameters
 * Models (or Schema Objects in general)
 * Responses
-* Operations (_Operations can only be referenced externally_)
+* Operations (_Operations can only be remote references_)
 
 ## Reuse strategy
 
-When reusing components in an API design, a pointer is created from the definition to target design.  The references are maintained in the structure, and can be updated by modifying the source definitions.  This is different from a "copy on design" approach where references are injected into the design itself.
+When reusing components in an API design, a reference is created from the definition to target entity. The references are maintained in the structure, and can be updated by modifying the source definitions. This is different from a "copy on design" approach where references are injected into the design itself.
 
 The reuse technique is transparent between JSON or YAML and is lossless when converting between the two.
 
 YAML anchors are technically allowed but break the general reuse strategy in OpenAPI Specification, since anchors are "injected" into a single document.  They are not recommended.
 
-Referenes can be made either internal to the OpenApi Specification file or to external files. 
-
 ## Techniques
 
 ### Guidelines for Referencing
 
-Whether you reference definitions internally or externally, you can never override or change their definitions from the referring location. The definitions can only be used as-is.
+All references should follow the [JSON Reference](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03) specification.
 
-#### Internal references
+JSON Reference provides guidance on the resolution of references, notably:
 
-When referencing internally, the target references have designated locations:
+> If the URI contained in the JSON Reference value is a relative URI,
+then the base URI resolution MUST be calculated according to
+[RFC3986], section 5.2. Resolution is performed relative to the
+referring document.
+
+Whether you reference definitions locally or remote, you can never override or change their definitions from the referring location. The definitions can only be used as-is.
+
+#### Local references
+
+When referencing locally (within the current document), the target references should follow the conventions, as defined by the spec:
 
 * Parameters -> `#/parameters`
 * Responses -> `#/responses`
-* Models (and general Schema Objects) -> `#/definitions`
+* Definitions (Models/Schema) -> `#/definitions`
 
-All references are canonical and must be a qualified [JSON Pointer, per RFC6901](http://tools.ietf.org/html/rfc6901). For example, simply referencing a model `Pet` is not allowed, even if there are no other definitions of it in the file.
+An example of a local definition reference:
 
 _Example from https://github.com/OAI/OpenAPI-Specification/blob/master/examples/v2.0/json/petstore.json_
 ``` json
@@ -49,77 +56,11 @@ _Example from https://github.com/OAI/OpenAPI-Specification/blob/master/examples/
             }
 ```
 
-#### External references
+#### Remote references
 
-If your referenced file contains only one root-level definition, you can refer to the file directly.
+##### Relative path
 
-To reference the example below: 
-
-`"$ref": "definitions/Model.json""`
-
-or
-
-`"$ref": "https://my.company.com/definitions/Model.json"`.
-
-_Assuming file https://my.company.com/definitions/Model.json_
-```json
-{
-  "description": "A simple model",
-  "type": "object",
-  "properties": {
-    "id": {
-      "type": "integer"
-    }
-  }
-}
-```
-
-To reference `Model` in the example below:
-
-_Note this approach potentially combines URL, JSON Reference, and JSON Pointer_
-
-`"$ref": "definitions/models.json#/models/Model"`
-
- or 
- 
-`"$ref": "https://my.company.com/definitions/models.json#/models/Model"`
-
-
-_Assuming file https://my.company.com/definitions/models.json_
-```json
-{
-  "models": {
-    "Model": {
-      "description": "A simple model",
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "integer"
-        }
-    },
-    "Tag": {
-      "description": "A tag entity in the system",
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string"
-        }
-      }
-    }
-  }
-}
-```
-
-#### External by relative reference
-
-All external relative references should follow the [JSON Reference](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03) specification.
-
-Per the JSON Reference spec:
-
-> If the URI contained in the JSON Reference value is a relative URI,
-then the base URI resolution MUST be calculated according to
-[RFC3986], section 5.2. Resolution is performed relative to the
-referring document.
+Files can be referred to in relative paths to the current document. 
 
 _Example from https://github.com/OAI/OpenAPI-Specification/tree/master/examples/v2.0/json/petstore-separate/spec/swagger.json_
 
@@ -134,7 +75,7 @@ _Example from https://github.com/OAI/OpenAPI-Specification/tree/master/examples/
 }
 ```
 
-External references may also utilize [JSON Pointer](http://tools.ietf.org/html/rfc6901) to reference properties within the relative external file.
+Remote references may also reference properties within the relative remote file.
 
 _Example from https://github.com/OAI/OpenAPI-Specification/tree/master/examples/v2.0/json/petstore-separate/spec/swagger.json_
 ``` json
@@ -149,13 +90,11 @@ _Example from https://github.com/OAI/OpenAPI-Specification/tree/master/examples/
 ```
 
 
-#### External by URL
+##### URL
 
-External files can be hosted on an HTTP server (rather than the local file system). 
+Remote files can be hosted on an HTTP server (rather than the local file system). 
 
 One risk of this approach is that environment specific issues could arise if DNS is not taken into account (as the reference can only contain one hostname).
-
-Resolution of URLs should follow [RFC3986](https://tools.ietf.org/html/rfc3986).
 
 _Assuming file https://my.company.com/definitions/Model.json_
 ```json
@@ -175,7 +114,7 @@ _Assuming file https://my.company.com/definitions/Model.json_
 }
 ```
 
-External references may also utilize a URL + JSON Pointer to reference properties within the external file.
+Remote references may also reference properties within the remote file.
 
 _Assuming file https://my.company.com/definitions/models.json_
 ```json
@@ -213,14 +152,14 @@ _Assuming file https://my.company.com/definitions/models.json_
 
 Reuse schema definitions by creating a repository of definitions.  This is done by simply hosting a file or set of files for commonly used definitions across a company or organization.
 
-Refer to [External references](#external-references) for referencing strategies.
+Refer to [Guidelines for Referencing](#guidelines-for-referencing) for referencing strategies.
 
 
 ### Parameters
 
 Similar to model schemas, you can create a repository of `parameters` to describe the common entities that appear throughout a set of systems.  
 
-Refer to [External references](#external-references) for referencing strategies.
+Refer to [Guidelines for Referencing](#guidelines-for-referencing) for referencing strategies.
 
 Using the same technique as above, you can host on either a single or multiple files.  For simplicity, the example below assumes a single file.
 
@@ -296,7 +235,7 @@ To include these parameters, you would need to add them individually as such:
 
 Again, Operations can be shared across files.  Although the reusability of operations will be less than with Parameters and models. For this example, we will share a common `health` resource so that all APIs can reference it:
 
-Refer to [External references](#external-references) for additional referencing strategies.
+Refer to [Guidelines for Referencing](#guidelines-for-referencing) for referencing strategies.
 
 ```json
 {
@@ -338,7 +277,7 @@ Remember, you cannot override the definitions, but in this case, you can add add
 
 ### Responses
 
-Refer to [External references](#external-references) for additional referencing strategies.
+Refer to [Guidelines for Referencing](#guidelines-for-referencing) for referencing strategies.
 
 Assume the file `responses.json`:
 

--- a/guidelines/REUSE.md
+++ b/guidelines/REUSE.md
@@ -15,13 +15,13 @@ The following types are reusable, as defined by the spec:
 
 When authoring API design documents, common object definitions can be utilized to avoid duplication. For example, imagine multiple path definitions that each share a common path parameter, or a common response structure. The OpenAPI specification allows reuse of common object definitions through the use of "references".
 
-A reference a construct in your API design document that indicates "the content for this portion of the document is defined elsewhere". To create a reference, at the location in your document where you want to reuse some other definition, create an object that has a `$ref` property whose value is a URI pointing to where the definition is (more on this in later sections). 
+A reference is a construct in your API design document that indicates "the content for this portion of the document is defined elsewhere". To create a reference, at the location in your document where you want to reuse some other definition, create an object that has a `$ref` property whose value is a URI pointing to where the definition is (more on this in later sections). 
 
 OpenAPI's provides reference capabilities using the [JSON Reference](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03) specification. 
 
 ### JSON Example
 
-``` json
+``` js
 {
   // ... 
   definitions: {


### PR DESCRIPTION
Fairly big refactor of this section, to address #388 
* Renamed mentions of `Swagger` to `OpenAPI Specification` (I presumed we're doing this on any updates to docs now)
* Added overall guidance for external files in dedicated section
  * Separated external files by URL from 'relative', i.e. local file references