### PR TITLE
Fix invalid example

### DIFF
--- a/examples/v2.0/json/petstore-with-external-docs.json
+++ b/examples/v2.0/json/petstore-with-external-docs.json
@@ -211,7 +211,7 @@
         },
         {
           "required": [
-            "name"
+            "id"
           ],
           "properties": {
             "id": {


### PR DESCRIPTION
http://online.swagger.io/validator?url=https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/examples/v2.0/json/petstore-with-external-docs.json

>  Swagger Error
Missing required property definition: name
Jump to line 147
Details
 Object
code:  "OBJECT_MISSING_REQUIRED_PROPERTY_DEFINITION"
message:  "Missing required property definition: name"
 path: Array [4]
level: 900
type:  "Swagger Error"
description:  "Missing required property definition: name"
lineNumber: 147