### PR TITLE
Clenup JS test. Resolve external $ref during tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,5 @@ scala:
    - 2.10.4
 script:
   - npm install
-  - gulp lint
+  - npm test
   - sbt ++$TRAVIS_SCALA_VERSION test
-  - mocha
-env:
-  - VALIDATORS=tv4
-  - VALIDATORS=zschema
-matrix:
-  allow_failures:
-    - env: VALIDATORS=tv4

--- a/package.json
+++ b/package.json
@@ -1,32 +1,24 @@
 {
-  "name": "swagger-validator",
-  "version": "0.0.1",
-  "description": "validates a file",
-  "author": {
-    "name": "Tony Tam",
-    "email": "fehguy@gmail.com",
-    "url": "http://swagger.io"
+  "private": true,
+  "scripts": {
+    "test": "gulp lint && mocha"
   },
-  "license": "Apache",
-  "readmeFilename": "README.md",
-  "dependencies": {
-    "tv4": "~1.1.x",
-    "chai": "1.9.x"
-  },
+  "dependencies": {},
   "devDependencies": {
-    "glob": "^4.0.5",
+    "chai": "^3.5.0",
+    "glob": "^7.0.0",
     "gulp": "~3.8.x",
     "gulp-ext-replace": "^0.1.0",
     "gulp-jsonlint": "0.0.3",
     "gulp-util": "^3.0.0",
     "gulp-yaml": "0.0.3",
     "js-yaml": "^3.1.0",
+    "json-schema-ref-parser": "^2.2.0",
     "json2yaml": "^1.0.3",
     "jsonschema": "^1.0.0",
+    "lodash": "^4.5.1",
     "map-stream": "^0.1.0",
-    "mocha": "^1.21.3",
-    "q": "^1.0.1",
-    "request": "^2.39.0",
-    "z-schema": "^2.4.9"
+    "mocha": "^2.4.5",
+    "z-schema": "^3.16.1"
   }
 }

--- a/test/validate.js
+++ b/test/validate.js
@@ -1,139 +1,62 @@
-var Q = require('q');
-var glob = require('glob');
-var tv4 = require('tv4');
-var ZSchema = require('z-schema');
 var fs = require('fs');
-var assert = require('chai').assert;
+var path = require('path');
+
+var _ = require('lodash');
+var glob = require('glob');
 var yaml = require('js-yaml');
-var request = require("request")
+var ZSchema = require('z-schema');
+var expect = require('chai').expect;
+var RefParser = require('json-schema-ref-parser');
 
-var schema = JSON.parse(fs.readFileSync("./schemas/v2.0/schema.json", 'utf8'));
-var validators = (process.env.VALIDATORS || "tv4,zschema").split(",")
+var schema = require('../schemas/v2.0/schema.json');
 
-var validationMethods = {
-  tv4: {
-    setup: function() {
-      var deferred = Q.defer();
-      request({
-        url: "http://json-schema.org/draft-04/schema",
-        json: true
-      }, function (error, response, body) {
-        if (!error && response.statusCode === 200) {
-          tv4.addSchema("http://json-schema.org/draft-04/schema", body);
-          deferred.resolve();
-        } else {
-          deferred.reject(new Error("Request failed"));
+function validate(data) {
+  var validator = new ZSchema();
+  validator.validate(data, schema);
+  var error = validator.getLastError();
+  error = JSON.stringify(error, null, 2);
+  expect(error).to.deep.equal('null');
+}
+
+function readFile(file, isYaml) {
+  var ext = path.extname(file);
+  var data = fs.readFileSync(file, 'utf8');
+
+  expect(ext).to.be.oneOf(['.json', '.yaml']);
+  if (ext === '.yaml')
+    return yaml.safeLoad(data);
+  else if (ext === '.json')
+    return JSON.parse(data);
+}
+
+function validateFiles(pattern) {
+  files = glob.sync(pattern)
+  files.forEach(function(file) {
+    it("should validate " + file, function() {
+      var swagger = readFile(file);
+
+      expect(swagger).to.be.an('object');
+      if (_.isUndefined(swagger.swagger))
+        return;
+
+      validate(swagger);
+
+      return RefParser.dereference(file, {
+        $refs: {
+          internal: false // Don't dereference internal $refs, only external
         }
       })
-      return deferred.promise;
-    },
-    validate: function(schema, data) {
-      var result = tv4.validateMultiple(data, schema, true, true);
-      assert(result.missing.length == 0, "Missing schemas: " + result.missing)
-      if (result.errors.length > 0) {
-        for (i in result.errors) {
-          // Remove stack trace so results are readable
-          delete result.errors[i].stack;
-        }
-      }
-      assert(result.valid == true, "Validation failed: " + JSON.stringify(result, null, "\t"));
-    },
-  },
-  zschema: {
-    setup: function() {
-      var deferred = Q.defer()
-      request({
-        url: "http://json-schema.org/draft-04/schema"
-      }, function (error, response, body) {
-        if (!error && response.statusCode === 200) {
-          ZSchema.setRemoteReference("http://json-schema.org/draft-04/schema", body);
-          deferred.resolve();
-        } else {
-          deferred.reject(new Error("Request failed"));
-        }
-      })
-      return deferred.promise;
-    },
-    validate: function(schema, data) {
-      var validator = new ZSchema({ sync: true });
-      var valid = validator.validate(data, schema);
-      if (!valid) {
-          var error = validator.getLastError();
-          throw new Error("ZSchema failed: " + JSON.stringify(error, null, "\t"));
-      }
-      assert(valid == true)
-    }
-  }
-}
-
-var setupValidators = function(done) {
-  var setupPromises = []
-  validators.forEach(function(validator) {
-    setupPromises.push(validationMethods[validator].setup())
-  });
-  return Q.all(setupPromises).then(function() {
-    done();
-  })
-}
-
-var createYAMLTest = function(file, validator) {
-  if (validators.indexOf(validator) == -1)
-    return;
-
-  it("should validate " + file + " with " + validator, function() {
-    var data = yaml.safeLoad(fs.readFileSync(file, 'utf8'));
-    validationMethods[validator].validate(schema, data);
-  })
-}
-
-var createJSONTest = function(file, validator) {
-  if (validators.indexOf(validator) == -1)
-    return;
-
-  it("should validate " + file + " with " + validator, function() {
-    var data = JSON.parse(fs.readFileSync(file, 'utf8'));
-    validationMethods[validator].validate(schema, data);
+      .then(function(resolveSwagger) {
+        validate(resolveSwagger);
+      });
+    })
   })
 }
 
 describe('JSON Samples', function() {
-  before(function(done) {
-    setupValidators(done);
-  })
-  exclusions = ["./examples/v2.0/json/petstore-separate/common/Error.json",
-  "./examples/v2.0/json/petstore-separate/spec/NewPet.json",
-  "./examples/v2.0/json/petstore-separate/spec/Pet.json",
-  "./examples/v2.0/json/petstore-separate/spec/parameters.json"]
-
-  files = glob.sync("./examples/**/*.json")
-  validators.forEach(function(validator) {
-    files.forEach(function(file) {
-      if (exclusions.indexOf(file) == -1) {
-        createJSONTest(file, validator);
-      } else {
-        //TODO: validate separate schema files in exclusion list
-      }
-    })
-  })
+  validateFiles('./examples/**/*.json')
 })
 
 describe('YAML Samples', function() {
-  before(function(done) {
-    setupValidators(done);
-  })
-  exclusions = ["./examples/v2.0/yaml/petstore-separate/common/Error.yaml",
-  "./examples/v2.0/yaml/petstore-separate/spec/NewPet.yaml",
-  "./examples/v2.0/yaml/petstore-separate/spec/Pet.yaml",
-  "./examples/v2.0/yaml/petstore-separate/spec/parameters.yaml"]
-
-  files = glob.sync("./examples/**/*.yaml")
-  validators.forEach(function(validator) {
-    files.forEach(function(file) {
-      if (exclusions.indexOf(file) == -1) {
-        createYAMLTest(file, validator);
-      } else {
-        //TODO: validate separate schema files in exclusion list
-      }
-    })
-  })
+  validateFiles('./examples/**/*.yaml')
 })


### PR DESCRIPTION
Main improvements:
* cleanup `package.json`. Mark it as [private](https://docs.npmjs.com/files/package.json#private) package to forbid publishing. `swagger-validator` is totally [different] https://www.npmjs.com/package/swagger-validator) package on npm.
* Update all dependencies related to tests. Biggest update is `z-schema`.
* Remove `tv4` validation. It was failing for long period and was marked as expected. Another point is I'm working on switching unittests from Java to JS as disscussed [here](https://github.com/OAI/OpenAPI-Specification/pull/413#issuecomment-121944824), and it easy to do on `z-schema` but is very hard on `tv4`.

@webron Can you please review it?