### PR TITLE
Items Object should not be an array of object

### DIFF
--- a/examples/v2.0/json/uber.json
+++ b/examples/v2.0/json/uber.json
@@ -346,11 +346,9 @@
         },
         "history": {
           "type": "array",
-          "items": [
-            {
+          "items": {
               "$ref": "#/definitions/Activity"
-            }
-          ]
+           }
         }
       }
     },

--- a/examples/v2.0/yaml/uber.yaml
+++ b/examples/v2.0/yaml/uber.yaml
@@ -261,7 +261,7 @@ definitions:
       history:
         type: array
         items:
-          - $ref: '#/definitions/Activity'
+          $ref: '#/definitions/Activity'
   Error:
     properties:
       code:


### PR DESCRIPTION
As per the Swagger / OpenAPI specification, a property with an "array" type requires an items property as well that is an object (specifically a subset of a JSON Schema object). However in the Uber Examples, the items property is an array of objects. 