### PR TITLE
Wrap '$ref's to prevent 'definitions' override

### DIFF
--- a/schemas/v2.0/schema.json
+++ b/schemas/v2.0/schema.json
@@ -40,11 +40,19 @@
     },
     "consumes": {
       "description": "A list of MIME types accepted by the API.",
-      "$ref": "#/definitions/mediaTypeList"
+      "allOf": [
+        {
+          "$ref": "#/definitions/mediaTypeList"
+        }
+      ]
     },
     "produces": {
       "description": "A list of MIME types the API can produce.",
-      "$ref": "#/definitions/mediaTypeList"
+      "allOf": [
+        {
+          "$ref": "#/definitions/mediaTypeList"
+        }
+      ]
     },
     "paths": {
       "$ref": "#/definitions/paths"
@@ -263,11 +271,19 @@
         },
         "produces": {
           "description": "A list of MIME types the API can produce.",
-          "$ref": "#/definitions/mediaTypeList"
+          "allOf": [
+            {
+              "$ref": "#/definitions/mediaTypeList"
+            }
+          ]
         },
         "consumes": {
           "description": "A list of MIME types the API can consume.",
-          "$ref": "#/definitions/mediaTypeList"
+          "allOf": [
+            {
+              "$ref": "#/definitions/mediaTypeList"
+            }
+          ]
         },
         "parameters": {
           "$ref": "#/definitions/parametersList"


### PR DESCRIPTION
From [JSON Reference](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03):
> Any members other than "$ref" in a JSON Reference object SHALL be  ignored.

> Implementations MAY choose to replace the reference with the referenced value.