### PR TITLE
Make clear that info/termsOfService should be an URL.

### DIFF
--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -136,7 +136,7 @@ Field Name | Type | Description
 ---|:---:|---
 <a name="infoTitle"></a>title | `string` | **Required.** The title of the application.
 <a name="infoDescription"></a>description | `string` | A short description of the application. [GFM syntax](https://help.github.com/articles/github-flavored-markdown) can be used for rich text representation.
-<a name="infoTermsOfService"></a>termsOfService | `string` | The Terms of Service for the API.
+<a name="infoTermsOfService"></a>termsOfService | `string` | A URL to the Terms of Service for the API.
 <a name="infoContact"></a>contact | [Contact Object](#contactObject) | The contact information for the exposed API.
 <a name="infoLicense"></a>license | [License Object](#licenseObject) | The license information for the exposed API.
 <a name="infoVersion"></a>version | `string` | **Required** Provides the version of the application API (not to be confused with the specification version).


### PR DESCRIPTION
As discussed in previous pull request #255, current tooling already
interprets it like that. This pull request just redoes the same change
to the 3.0 version instead of the 2.0 one (where they were not applied).

Original change by Matti Schneider <hi@mattischneider.fr>,  2015-01-29 10:51:26.