### PR TITLE
[Grammar] Removes duplicate article `a`

### DIFF
--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -1731,7 +1731,7 @@ Field Name | Type | Description
 <a name="schemaReadOnly"></a>readOnly | `boolean` | Relevant only for Schema `"properties"` definitions. Declares the property as "read only". This means that it MAY be sent as part of a response but MUST NOT be sent as part of the request. Properties marked as `readOnly` being `true` SHOULD NOT be in the `required` list of the defined schema. Default value is `false`.
 <a name="schemaXml"></a>xml | [XML Object](#xmlObject) | This MAY be used only on properties schemas. It has no effect on root schemas. Adds Additional metadata to describe the XML representation format of this property.
 <a name="schemaExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation for this schema. 
-<a name="schemaExample"></a>example | Any | A free-form property to include a an example of an instance for this schema.
+<a name="schemaExample"></a>example | Any | A free-form property to include an example of an instance for this schema.
 <a name="schemaDeprecated"></a> deprecated | `boolean` | Specifies that a schema is deprecated and should be transitioned out of usage.
 
 ##### Patterned Objects 


### PR DESCRIPTION
Makes the same change as #740 as recommended by @ePaul