### PR TITLE
Fix error in json example

### DIFF
--- a/versions/2.0.md
+++ b/versions/2.0.md
@@ -1686,13 +1686,13 @@ In this example, a full model definition is shown.
         "format": "int32",
         "xml": {
           "attribute": true
-        },
-        "name": {
-          "type": "string",
-          "xml": {
-            "namespace": "http://swagger.io/schema/sample",
-            "prefix": "sample"
-          }
+        }
+      },
+      "name": {
+        "type": "string",
+        "xml": {
+          "namespace": "http://swagger.io/schema/sample",
+          "prefix": "sample"
         }
       }
     }


### PR DESCRIPTION
The XML property example in JSON nested the name property inside the id property which is wrong I guess and the two properties should be next to each other.