### PR TITLE
Fix example in json example in 3.0

### DIFF
--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -2183,13 +2183,13 @@ In this example, a full model definition is shown.
         "format": "int32",
         "xml": {
           "attribute": true
-        },
-        "name": {
-          "type": "string",
-          "xml": {
-            "namespace": "http://swagger.io/schema/sample",
-            "prefix": "sample"
-          }
+        }
+      },
+      "name": {
+        "type": "string",
+        "xml": {
+          "namespace": "http://swagger.io/schema/sample",
+          "prefix": "sample"
         }
       }
     }


### PR DESCRIPTION
As asked for in the conversation in #749 this PR applies the same change to the 3.0 spec.