### PR TITLE
Callback feature

### DIFF
--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -453,6 +453,7 @@ Field Name | Type | Description
 <a name="operationParameters"></a>parameters | [[Parameter Object](#parameterObject) <span>&#124;</span> [Reference Object](#referenceObject)] | A list of parameters that are applicable for this operation. If a parameter is already defined at the [Path Item](#pathItemParameters), the new definition will override it, but can never remove it. The list MUST NOT include duplicated parameters. A unique parameter is defined by a combination of a [name](#parameterName) and [location](#parameterIn). The list can use the [Reference Object](#referenceObject) to link to parameters that are defined at the [OpenAPI Object's parameters](#oasParameters).
 <a name="operationRequestBody"></a>requestBody | [[Request Body Object](#requestBodyObject) <span>&#124;</span> [Reference Object](#referenceObject)] | The request body applicable for this operation. 
 <a name="operationResponses"></a>responses | [Responses Object](#responsesObject) | **Required.** The list of possible responses as they are returned from executing this operation.
+<a name="operationCallbacks"></a>callback responses | [Callback Responses Object](#callbackObject) | The list of possible callback responses as they are returned from executing this operation.
 <a name="operationSchemes"></a>schemes | [`string`] | The transfer protocol for the operation. Values MUST be from the list: `"http"`, `"https"`, `"ws"`, `"wss"`. The value overrides the OpenAPI Object [`schemes`](#oasSchemes) definition. 
 <a name="operationDeprecated"></a>deprecated | `boolean` | Declares this operation to be deprecated. Usage of the declared operation should be refrained. Default value is `false`.
 <a name="operationSecurity"></a>security | [[Security Requirement Object](#securityRequirementObject)] | A declaration of which security schemes are applied for this operation. The list of values describes alternative security schemes that can be used (that is, there is a logical OR between the security requirements). This definition overrides any declared top-level [`security`](#oasSecurity). To remove a top-level security declaration, an empty array can be used.
@@ -1049,6 +1050,36 @@ Response with no return value:
 ```yaml
 description: object created
 ```
+
+#### <a name="callbackObject"></a>Callback Object
+
+A container for possible out-of band callbacks from an operation. A callback may be returned from an operation, calling back to the path specified in the operation object.
+
+##### Patterned Fields
+Field Pattern | Type | Description
+---|:---:|---
+<a name="responseName"></a>Callback name | [Callback Operation Object](#operationObject) <span>&#124;</span> [Operation Object](#operationObject) | An operation object used to define a callback payload structure
+<a name="responsesExtensions"></a>^x- | Any | Allows extensions to the OpenAPI Schema. The field name MUST begin with `x-`, for example, `x-internal-id`. The value can be `null`, a primitive, an array or an object. See [Specification Extensions](#specificationExtensions) for further details.
+
+
+##### Callback Object Example
+
+A callback to the URL specified by the `url` parameter in the request
+
+
+```yaml
+myWebhook:
+  '$request.url':
+    post:
+      body:
+        name: postResponse
+        schema:
+          $ref: '#/definitions/SomePayload'
+      responses:
+        200:
+          description: webhook successfully processed an no retries will be performed
+```
+
 
 #### <a name="headersObject"></a>Headers Object
 Lists the headers that can be sent as part of a response.


### PR DESCRIPTION
Addresses #716, #735, #736, #737.

To support webhooks, a proposed `callback` mechanism is added.  Essentially, callbacks are out-of-band `operations` against some remote server.  The callback subscription mechanism is not prescribed, as it is actually implementation dependent.  The mechanism for responses, however, is created by added a `callbacks` section to any operation.

The `callbacks` section has named callbacks, which are essentially operations.  The operations can be applied to a URL as extracted from the `request` options using a syntax similar to with the `links` technique.

An example below describes the GitHub webhook mechanism, with comments, for discussion.

```
paths:
  /repos/{owner}/{repo}/hooks/{id}:
    post:
      body: |
        description: Repository service hooks (like email or Campfire) can have at most one configured at a time. Creating hooks for a service that already has one configured will update the existing hook.
        Repositories can have multiple webhooks installed. Each webhook should have a unique config. Multiple webhooks can share the same config as long as those webhooks do not have any events that overlap.
        schema:
          $ref: '#/components/definitions/WebhookRequest'
      responses:
        201:
          description: Webhook created
          schema:
            $ref: '#/components/definitions/WebhookResponse'
      callbacks:
        createWebhook:
          $ref: '#/components/callbacks/createWebhook'
components:
  callbacks:
    createWebhook:
      # extract the url parameter from the request
      '$request.body.url':
        post:
          parameters:
          - in: header
            name: X-GitHub-Event
            type: string
            description: Name of the [event](https://developer.github.com/webhooks/#events) that triggered this delivery.
            required: true
          - in: header
            name: X-Hub-Signature
            type: string
            description: HMAC hex digest of the payload, using the [the hook's `secret`](https://developer.github.com/v3/repos/hooks/#create-a-hook) as the key (if configured).
          - in: header
            name: X-GitHub-Delivery
            type: string
            description: Unique ID for this delivery.
          body:
            name: payload
            schema:
              $ref: '#/components/definitions/Event'
          responses:
            200:
              description: webhook successfully processed an no retries will be performed
  definitions:
    WebhookRequest:
      required:
      - name
      - config
      properties:
        name:
          type: string
          description: Use web for a webhook or use the name of a valid service. (See /hooks for the list of valid service names.)
        config:
          $ref: '#/components/definitions/WebhookConfig'
        events:
          type: array
          items:
            type: string
            enum:
            - push
          default: [push]
          description: Determines what events the hook is triggered for.
        active:
          type: boolean
          description: Determines whether the hook is actually triggered on pushes.
    WebhookResponse:
      properties:
        id:
          type: string
        url:
          type: string
          format: url
        test_url:
          type: string
          format: url
        ping_url:
          type: string
          format: url
        name:
          type: name
        events:
          type: array
          items:
            type: string
            enum:
            - push
            - pull_request
        active:
          type: boolean
        config:
          $ref: '#/components/definitions/WebhookConfig'
        updated_at:
          type: string
          format: date-time
        created_at:
          type: string
          format: date-time
    WebhookConfig:
      type: object
        properties:
          url:
            type: string
            format: url
          content_type:
            type: string
            enum:
            - json
        additionalProperties:
          type: string
          description: Key/value pairs to provide settings for this hook. These settings vary between hooks and some are defined in the [github-services](https://github.com/github/github-services) repository. Booleans are stored internally as "1" for true, and "0" for false. Any JSON true/false values will be converted automatically.
    Event:
      anyOf:
      - $ref: '#/components/definitions/commit_comment'
      - $ref: '#/components/definitions/create'
      - $ref: '#/components/definitions/delete'
      - $ref: '#/components/definitions/deployment'
      - $ref: '#/components/definitions/deployment_status'
      - $ref: '#/components/definitions/fork'
      - $ref: '#/components/definitions/gollum'
      - $ref: '#/components/definitions/issue_comment'
      - $ref: '#/components/definitions/issues'
      - $ref: '#/components/definitions/member'
      - $ref: '#/components/definitions/membership'
      - $ref: '#/components/definitions/page_build'
      - $ref: '#/components/definitions/public'
      - $ref: '#/components/definitions/pull_request_review_comment'
      - $ref: '#/components/definitions/pull_request'
      - $ref: '#/components/definitions/push'
      - $ref: '#/components/definitions/repository'
      - $ref: '#/components/definitions/release'
      - $ref: '#/components/definitions/status'
      - $ref: '#/components/definitions/team_add'
      - $ref: '#/components/definitions/watch'
```