### PR TITLE
Typo fixes

### DIFF
--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -95,7 +95,7 @@ An additional primitive data type `"file"` is used by the [Parameter Object](#pa
 <a name="dataTypeFormat"></a>Primitives have an optional modifier property `format`.
 OAS uses several known formats to more finely define the data type being used.
 However, the `format` property is an open `string`-valued property, and can have any value to support documentation needs.
-Formats such as `"email"`, `"uuid"`, etc., can be used even though they are not defined by this specification
+Formats such as `"email"`, `"uuid"`, etc., can be used even though they are not defined by this specification.
 Types that are not accompanied by a `format` property follow their definition from the JSON Schema (except for `file` type which is defined above).
 The formats defined by the OAS are:
 
@@ -1525,7 +1525,7 @@ Using the `operationId` to reference an operation in the definition has many ben
 Many operations require parameters to be passed, and these may be dynamic depending on the response itself.
 
 To specify parameters required by the operation, we can use a **Link Parameters Object**.
-This object contains parameter names along with static or dynamic valus:
+This object contains parameter names along with static or dynamic values:
 
 ```yaml
 paths:
@@ -1638,7 +1638,7 @@ This does mean that `example`, structurally, can be either a string primitive or
 In locations where the field being provided an `example` is a scalar value _or_ has it's content-type definition determined by a higher-level construct (a response payload, for example, uses the `produces` attribute to select the correct message format), the plural `examples` shall be used, and the payload format be specified as a key to the example.
 
 In all cases, the payload is expected to be compatible with the type schema for the value that it is accompanying.
-Tooling Specifications may choose to valide compatibility automatically, and reject the example value(s) if they are not compatible.
+Tooling Specifications may choose to validate compatibility automatically, and reject the example value(s) if they are not compatible.
 
 ```yaml
 # in a model


### PR DESCRIPTION
s/this specification Types/this specification. Types/
s/valus/values/
s/valide/validate/