### PR TITLE
Hyphenate adjective?

### DIFF
--- a/guidelines/EXTENSIONS.md
+++ b/guidelines/EXTENSIONS.md
@@ -89,4 +89,4 @@ An API consumer reading these parameter definitions could interpret this as havi
 
 ## Annotations
 
-The Swagger specific annotations currently available for jax-rs APIs do not support the addition of extension data.
+The Swagger-specific annotations currently available for jax-rs APIs do not support the addition of extension data.


### PR DESCRIPTION
Sorry, total nit, if "Swagger-specific" is a term describing "annotations", maybe it's easier to read with a hyphen? 

I don't think what's there is wrong, I was just scanning this document and got tripped up over "The Swagger specific annotations...", so if I tripped, maybe others will too. 

Just a thought. Overall, love the project!