### PR TITLE
updated to support alternate link URLs

### DIFF
--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -1173,7 +1173,8 @@ The `Link Object` is responsible for defining a possible operation based on a si
 
 Field Name  |  Type  | Description
 ---|:---:|---
-href        | url    | a relative or absolute URL to a linked resource. This field is mutually exclusive with the `operationId` field.
+href        | url    | a relative or absolute URL to a linked resource definition. This field is mutually exclusive with the `operationId` field.
+url         | url    | a relative or absolute URL representing the target location for the link operation.  This is used to override the `{scheme}://{host}/{basePath}` defined at the global level for the linked operation.
 operationId | string | the name of an _existing_, resolvable OAS operation, as defined with a unique `operationId`.  This field is mutually exclusive with the `href` field.  Relative `href` values _may_ be used to locate an existing Operation Object in the OAS.
 parameters  | Link Parameters Object | an Object representing parameters to pass to an operation as specified with `operationId` or identified via `href`.
 headers     | Link Headers Object    | an Object representing headers to pass to the linked resource.
@@ -1183,6 +1184,23 @@ description | string | a description of the link, supports [CommonMark syntax](h
 Locating a linked resource may be performed by either a `href` or `operationId`.
 In the case of an `operationId`, it must be unique and resolved in the scope of the OAS document.
 Because of the potential for name clashes, consider the `href` syntax as the preferred method for specifications with external references.
+
+When the `url` attribute is provided, the target host may be overridden by the value provided.  For example:
+
+```
+components:
+  links:
+    UserRepositories:
+      operationId: getRepositoriesByOwner
+      url: $responseHeaders.link
+  definitions:
+    user:
+      type: object
+```
+
+will extract the URL from the response header named `link`.  If an absolute URL is provided, it will be used instead of the server / path provided in the target operation.  Parameters _may_ be provided as well.  If a `path` parameter is provided, it shall be ignored unless the `url` value contains a matching location for substitution.  If query parameters are provided in the `url` value, they will be interpreted per the operation definition, and the absence of a required query parameter will result in an invalid request.
+
+When a relative path is provided in the `url` attribute, the host defined in the specification will be used.
 
 #### <a name="responsePayload"></a>Response Payload Values
 


### PR DESCRIPTION
Fixes #783 

For links, I propose adding the `url` property to the `Link Object`. When supplied, the url will be applied to the operation, effectively overriding the `{scheme}://{host}/{basePath}` value.

If the target operation defines any parameters, the following rules will be applied:
- Path parameters _will_ be ignored unless a substitution is provided in the `url` value
- Query parameters _may_ be ignored if supplied in the `url` value.  Tooling will effectively extract these parameters to satisfy the requirements of parameter definitions
- Header parameters _must_ be extracted from the response and passed as named parameters

Example definition:

``` yaml
paths: 
  /2.0/users/{username}: 
    get: 
      operationId: getUserByName
      parameters: 
      - name: username
        type: string
        in: path
        required: true
      responses: 
        200: 
          description: The User
          headers:
            X-link:
                type: string
                format: uri
          schema: 
            $ref: '#/components/definitions/user'
          links:
            userRepositories:
              $ref: '#/components/links/UserRepositories'
  /2.0/repositories/{username}:
    get:
      operationId: getRepositoriesByOwner
      parameters:
        - name: username
          type: string
          in: path
          required: true
      responses:
        200:
          description: repositories owned by the supplied user
          schema:
            type: array
            items:
              $ref: '#/components/definitions/repository'
          links:
            userRepository:
              $ref: '#/components/links/UserRepository'
components:
  links:
    UserRepositories:
      operationId: getRepositoriesByOwner
      url: $responseHeaders.link
  definitions:
    user:
        type: object
```

Example request:

```
$ curl -I https://gigantic.server.com/2.0/users/fehguy
HTTP/1.1 200 OK
Date: Thu, 29 Sep 2016 04:20:52 GMT
Access-Control-Allow-Origin: *
Content-Length: 0
X-link: https://us-west.gigantic.server.com/alternate/path/0e6c11d79a/repositories
```

Following the response link would honor the definition provided in the `getRepositoriesByOwner` operationId.

Additional considerations:

When a `url` is provided, the single operation can target an alternate host and path combination.  Subsequent links from that targeted operation will be considered against the host as defined in the document, not the overridden host.  Thus if secondary links are required to reside on the alternate host, they must be supplied in the response from the alternate host.

The `url` field may be a relative url, allowing the existing scheme/host/basePath scheme to be used.
