### PR TITLE
Fixed typos in Operation Object section

### DIFF
--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -465,7 +465,6 @@ Field Name | Type | Description
 <a name="operationRequestBody"></a>requestBody | [[Request Body Object](#requestBodyObject) <span>&#124;</span> [Reference Object](#referenceObject)] | The request body applicable for this operation. 
 <a name="operationResponses"></a>responses | [Responses Object](#responsesObject) | **Required.** The list of possible responses as they are returned from executing this operation.
 <a name="operationCallbacks"></a>callback responses | [Callback Responses Object](#callbackObject) | The list of possible callback responses as they are returned from executing this operation.
-<a name="operationSchemes"></a>schemes | [`string`] | The transfer protocol for the operation. Values MUST be from the list: `"http"`, `"https"`, `"ws"`, `"wss"`. The value overrides the OpenAPI Object [`schemes`](#oasSchemes) definition. 
 <a name="operationDeprecated"></a>deprecated | `boolean` | Declares this operation to be deprecated. Usage of the declared operation should be refrained. Default value is `false`.
 <a name="operationSecurity"></a>security | [[Security Requirement Object](#securityRequirementObject)] | A declaration of which security schemes are applied for this operation. The list of values describes alternative security schemes that can be used (that is, there is a logical OR between the security requirements). This definition overrides any declared top-level [`security`](#oasSecurity). To remove a top-level security declaration, an empty array can be used.
 <a name="operationHost"></a>host | `string` | The host (name or ip) serving the path. This optional value will override the top-level [host](#oasHost) or path item-level [host](#pathItemHost). if present. This MUST be the host only and does not include the scheme nor sub-paths. It MAY include a port. If the `host` is not included, the host serving the documentation is to be used (including the port). The `host` does not support [path templating](#pathTemplating).
@@ -494,19 +493,21 @@ This object can be extended with [Specification Extensions](#specificationExtens
     }
   ],
   "requestBody" : {
-    "content" : {
-      "application/x-www-form-urlencoded":{
-        "schema" : {
-          "type" : "object",
+    "content": {
+      "application/x-www-form-urlencoded": {
+        "schema": {
+          "type": "object",
            "properties": {
-              "name" 
-                "description" : "Updated name of the pet",
+              "name": { 
+                "description": "Updated name of the pet",
                 "type": "string"
-              "status":
-                "description" : "Updated status of the pet",
+              },
+              "status": {
+                "description": "Updated status of the pet",
                 "type": "string"
+             }
            },
-        "required" : ["status"] 
+        "required": ["status"] 
         }
       }
     }

--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -95,23 +95,33 @@ An additional primitive data type `"file"` is used by the [Parameter Object](#pa
 <a name="dataTypeFormat"></a>Primitives have an optional modifier property `format`.
 OAS uses several known formats to more finely define the data type being used.
 However, the `format` property is an open `string`-valued property, and can have any value to support documentation needs.
-Formats such as `"email"`, `"uuid"`, etc., can be used even though they are not defined by this specification.
+Formats such as `"email"`, `"T-shirt size"`, etc., can be used even though they are not defined by this specification.
 Types that are not accompanied by a `format` property follow their definition from the JSON Schema (except for `file` type which is defined above).
 The formats defined by the OAS are:
 
 
 Common Name | [`type`](#dataTypeType) | [`format`](#dataTypeFormat) | Comments
 ----------- | ------ | -------- | --------
+octet | `integer` | `uint8` | unsigned 8 bits
+signed byte| `integer` | `int8` | signed 8 bits
+short| `integer` | `int16` | signed 16 bits
 integer | `integer` | `int32` | signed 32 bits
 long | `integer` | `int64` | signed 64 bits
+big integer | `integer` | | | 
 float | `number` | `float` | |
 double | `number` | `double` | |
+decimal | `number` | `decimal` | decimal floating-point number, recipient-side internal representation as a binary floating-point number may lead to rounding errors
+big decimal  | `number` | | |
 string | `string` | | |
-byte | `string` | `byte` | base64 encoded characters
+encoded binary | `string` | `byte` | base64 encoded characters - [RFC4648](https://tools.ietf.org/html/rfc4648#section-4)
+url-safe encoded binary | `string` | `base64url` | base64url encoded characters - [RFC4648](https://tools.ietf.org/html/rfc4648#section-5)
 binary | `string` | `binary` | any sequence of octets
 boolean | `boolean` | | |
 date | `string` | `date` | As defined by `full-date` - [RFC3339](http://xml2rfc.ietf.org/public/rfc/html/rfc3339.html#anchor14)
 dateTime | `string` | `date-time` | As defined by `date-time` - [RFC3339](http://xml2rfc.ietf.org/public/rfc/html/rfc3339.html#anchor14)
+time (of day) | `string` | `time` |  As defined by `partial-time` - [RFC3339](http://xml2rfc.ietf.org/public/rfc/html/rfc3339.html#anchor14)
+duration| `string` | `duration` | As defined by `xs:dayTimeDuration` - [XML Schema 1.1](http://www.w3.org/TR/xmlschema11-2/#dayTimeDuration)
+uuid| `string` | `uuid` | Universally Unique Identifier (UUID) - [RFC4122](https://www.ietf.org/rfc/rfc4122.txt)
 password | `string` | `password` | Used to hint UIs the input needs to be obscured.
 
 ### Schema

--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -95,33 +95,23 @@ An additional primitive data type `"file"` is used by the [Parameter Object](#pa
 <a name="dataTypeFormat"></a>Primitives have an optional modifier property `format`.
 OAS uses several known formats to more finely define the data type being used.
 However, the `format` property is an open `string`-valued property, and can have any value to support documentation needs.
-Formats such as `"email"`, `"T-shirt size"`, etc., can be used even though they are not defined by this specification.
+Formats such as `"email"`, `"uuid"`, etc., can be used even though they are not defined by this specification.
 Types that are not accompanied by a `format` property follow their definition from the JSON Schema (except for `file` type which is defined above).
 The formats defined by the OAS are:
 
 
 Common Name | [`type`](#dataTypeType) | [`format`](#dataTypeFormat) | Comments
 ----------- | ------ | -------- | --------
-octet | `integer` | `uint8` | unsigned 8 bits
-signed byte| `integer` | `int8` | signed 8 bits
-short| `integer` | `int16` | signed 16 bits
 integer | `integer` | `int32` | signed 32 bits
 long | `integer` | `int64` | signed 64 bits
-big integer | `integer` | | | 
 float | `number` | `float` | |
 double | `number` | `double` | |
-decimal | `number` | `decimal` | decimal floating-point number, recipient-side internal representation as a binary floating-point number may lead to rounding errors
-big decimal  | `number` | | |
 string | `string` | | |
-encoded binary | `string` | `byte` | base64 encoded characters - [RFC4648](https://tools.ietf.org/html/rfc4648#section-4)
-url-safe encoded binary | `string` | `base64url` | base64url encoded characters - [RFC4648](https://tools.ietf.org/html/rfc4648#section-5)
+byte | `string` | `byte` | base64 encoded characters
 binary | `string` | `binary` | any sequence of octets
 boolean | `boolean` | | |
 date | `string` | `date` | As defined by `full-date` - [RFC3339](http://xml2rfc.ietf.org/public/rfc/html/rfc3339.html#anchor14)
 dateTime | `string` | `date-time` | As defined by `date-time` - [RFC3339](http://xml2rfc.ietf.org/public/rfc/html/rfc3339.html#anchor14)
-time (of day) | `string` | `time` |  As defined by `partial-time` - [RFC3339](http://xml2rfc.ietf.org/public/rfc/html/rfc3339.html#anchor14)
-duration| `string` | `duration` | As defined by `xs:dayTimeDuration` - [XML Schema 1.1](http://www.w3.org/TR/xmlschema11-2/#dayTimeDuration)
-uuid| `string` | `uuid` | Universally Unique Identifier (UUID) - [RFC4122](https://www.ietf.org/rfc/rfc4122.txt)
 password | `string` | `password` | Used to hint UIs the input needs to be obscured.
 
 ### Schema


### PR DESCRIPTION
"schemes" was listed twice in table, kept nicer line
JSON example lacked a few curly braces
