### PR TITLE
Minor corrections for OpenAPI 3.0 document

### DIFF
--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -466,9 +466,11 @@ This object can be extended with [Specification Extensions](#specificationExtens
       "in": "path",
       "description": "ID of pet to use",
       "required": true,
-      "type": "array",
-      "items": {
-        "type": "string"
+      "schema": {
+        "type": "array",
+        "items": {
+          "type": "string",
+        }
       },
       "collectionFormat": "csv"
     }
@@ -501,9 +503,10 @@ parameters:
   in: path
   description: ID of pet to use
   required: true
-  type: array
-  items:
-    type: string
+  schema:
+    type: array
+    items:
+      type: string
   collectionFormat: csv
 ```
 

--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -728,7 +728,7 @@ schema:
   items:
     type: integer
     format: int64
-  collectionFormat: csv
+collectionFormat: csv
 ```
 
 A path parameter of a string value:


### PR DESCRIPTION
Adds a few minor corrections for the 3.0 definition document (or I hope these are correct anyway):
- Moves a parameter object example over to use the new 3.0 `schema` type definition instead of using the 2.0 `type` and `items` fields.
- Moves a stray `collectionFormat` out of `schema` definition and back into the root of a parameter object.

Totally unrelated, but does anyone know if there's any thinking around a release date for OpenAPI 3.0? I've built out a 2.0 API definition, but unfortunately a number of quirks in that spec prevent me from accurately describing my API, and I'm stuck building in some very hacky workarounds until something changes. I'm very much looking forward to the 3.0 release :)
