### PR TITLE
Incorrect definition name: pet

### DIFF
--- a/examples/v2.0/yaml/petstore-expanded.yaml
+++ b/examples/v2.0/yaml/petstore-expanded.yaml
@@ -58,7 +58,7 @@ paths:
       description: Creates a new pet in the store.  Duplicates are allowed
       operationId: addPet
       parameters:
-        - name: pet
+        - name: body
           in: body
           description: Pet to add to the store
           required: true


### PR DESCRIPTION
The definition for on the working example is "body" instead of "pet". Check out here http://petstore.swagger.io/v2/swagger.json.
