### PR TITLE
Docs/examples cleanup for Request/Response/Content/Types

### DIFF
--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -85,10 +85,10 @@ Version | Date | Notes
 Path templating refers to the usage of curly braces ({}) to mark a section of a URL path as replaceable using path parameters.
 
 ##### <a name="mediaTypes"></a>Media Types
-Media type definitions are spread across several resources.
-The media type definitions should be in compliance with [RFC 6838](http://tools.ietf.org/html/rfc6838).
+Media-type definitions are spread across several resources.
+The media-type definitions should be in compliance with [RFC 6838](http://tools.ietf.org/html/rfc6838).
 
-Some examples of possible media type definitions:
+Some examples of possible media-type definitions:
 ```
   text/plain; charset=utf-8
   application/json
@@ -869,7 +869,8 @@ Field Name | Type | Description
 Field Pattern | Type | Description
 ---|:---:|---
 <a name="requestBodyRepresentation"></a>`*` | [Schema Object](#schemaObject) | The schema defining the request body.
-<a name="parameterExtensions"></a>^x- | Any | Allows extensions to the OpenAPI Schema. The field name MUST begin with `x-`, for example, `x-internal-id`. The value can be `null`, a primitive, an array or an object. See [Vendor Extensions](#vendorExtensions) for further details.
+
+This object can be extended with [Specification Extensions](#specificationExtensions). 
 
 
 ##### Request Body Examples
@@ -884,7 +885,7 @@ A request body with a referenced model definition.
           "$ref": "#/definitions/User"
         },
       "examples": [
-        { "$ref": 'http://foo.bar#/examples/address-example.json'}
+        { "$ref": "http://foo.bar#/examples/address-example.json"}
       ]
     },
     "application/xml" : {
@@ -892,41 +893,42 @@ A request body with a referenced model definition.
         "$ref": "#/definitions/User"
       },
       "examples": [
-        { "$ref": 'http://foo.bar#/examples/address-example.xml'}
+        { "$ref": "http://foo.bar#/examples/address-example.xml"}
       ]
     },
     "text/plain" : {
       "examples": [
-        { "$ref": 'http://foo.bar#/examples/address-example.txt'}
+        { "$ref": "http://foo.bar#/examples/address-example.txt"}
       ]
     },
     "*": {
       "example": {
-        $ref: "http://foo.bar#/examples/address-example.whatever"
+        "$ref": "http://foo.bar#/examples/address-example.whatever"
       }
+    }
   }
 }
 ```
 
 ```yaml
 description: user to add to the system
-content: 
-  'application/json':
+content:
+  application/json:
     schema:
-      $ref: '#/definitions/User'
+      "$ref": "#/definitions/User"
     examples:
-      - 'http://foo.bar/examples/user-example.json'
-  'application/xml':
+    - "$ref": http://foo.bar#/examples/address-example.json
+  application/xml:
     schema:
-      $ref: '#/definitions/User'
+      "$ref": "#/definitions/User"
     examples:
-      - 'http://foo.bar/examples/user-example.xml'
-  'text/plain':
+    - "$ref": http://foo.bar#/examples/address-example.xml
+  text/plain:
     examples:
-      - 'http://foo.bar/examples/user-example.txt'
-  '*':
-    schema:
-      $ref: 'http://foo.bar/examples/user-example.whatever'
+    - "$ref": http://foo.bar#/examples/address-example.txt
+  "*":
+    example:
+      "$ref": http://foo.bar#/examples/address-example.whatever
 ```
 
 A body parameter that is an array of string values:
@@ -964,61 +966,71 @@ Describes a set of supported content types. A content object can be used in [req
 
 Each key in the content object is the media-type of the [Content Type Object](#contentTypeObject).
 
+The media-type may take the form of a wildcard (`*`) to designate any `Content-Type`, or a regular expression for matching a specific type
+
 ##### Content Examples
 
 ```js
-"content" : {
-  "application/json": {
-    "schema": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
+{
+  "content": {
+    "application/json": {
+      "schema": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "examples": [
+        [
+          "Bob",
+          "Diane",
+          "Mary",
+          "Bill"
+        ],
+        []
+      ]
     },
-    "examples": [
-      ["Bob","Diane","Mary","Bill"],
-      []
-     ]
-  },
-  "application/xml" : {
-    "examples" : [
-      "<Users><User name='Bob'/><User name='Diane'/><User name='Mary'/><User name='Bill'/></Users>",
-      "<Users/>"
-    ]
-  },
-  "text/plain" : {
-    "Bob,Diane,Mary,Bill",
-    ""
+    "application/xml": {
+      "examples": [
+        "<Users><User name='Bob'/><User name='Diane'/><User name='Mary'/><User name='Bill'/></Users>",
+        "<Users/>"
+      ]
+    },
+    "text/plain": {
+      "examples": [
+        "Bob,Diane,Mary,Bill",
+        ""
+      ]
+    }
   }
 }
 ```
 
 ```yaml
 content:
-  'application/json': 
+  application/json:
     schema:
       type: array
       items:
         type: string
     examples:
-      - 
-        - Bob
-        - Diane
-        - Mary
-        - Bill
-      - {}
-
-  'application/xml': 
+    - - Bob
+      - Diane
+      - Mary
+      - Bill
+    - []
+  application/xml:
     examples:
-      - "<Users><User name='Bob'/><User name='Diane'/><User name='Mary'/><User name='Bill'/></Users>"
-      - "<Users/>"
-  'text/plain':
+    - "<Users><User name='Bob'/><User name='Diane'/><User name='Mary'/><User name='Bill'/></Users>"
+    - "<Users/>"
+  text/plain:
     examples:
-      - "Bob,Diane,Mary,Bill"
+    - Bob,Diane,Mary,Bill
+    - ''
 ```
 
 #### <a name="contentTypeObject"></a>Content Type Object
-Each content type object provides schema and examples for a the media type identified by its key.  Content Type objects can be used in a [content object](#contentObject).   
+Each content type object provides schema and examples for a the media-type identified by its key.  Content Type objects can be used in a [content object](#contentObject).
 
 ##### Fixed Fields
 Field Name | Type | Description
@@ -1028,9 +1040,8 @@ Field Name | Type | Description
 <a name="contentTypeExample"></a>example | [Example Object](#exampleObject) | Example of the content type.
 
 ##### Patterned Fields
-Field Pattern | Type | Description
----|:---:|---
-<a name="parameterExtensions"></a>^x- | Any | Allows extensions to the OpenAPI Schema. The field name MUST begin with `x-`, for example, `x-internal-id`. The value can be `null`, a primitive, an array or an object. See [Vendor Extensions](#vendorExtensions) for further details.
+
+This object can be extended with [Specification Extensions](#specificationExtensions).
 
 ##### Content Type Examples
 
@@ -1039,29 +1050,31 @@ A content type description.
 {
   "application/json": {
     "schema": {
-         "$ref": "#/definitions/Pet"
+      "$ref": "#/definitions/Pet"
     },
-    "examples": [{
-                  "name" : "Fluffy",
-                  "petType" : "Cat"
-                 },
-                 { 
-                   "name" : "Rover",
-                   "petType" : "Frog"
-                 }]
+    "examples": [
+      {
+        "name": "Fluffy",
+        "petType": "Cat"
+      },
+      {
+        "name": "Rover",
+        "petType": "Frog"
+      }
+    ]
   }
 }
 ```
 
 ```yaml
-application/json: 
+application/json:
   schema:
-    $ref: "#/definitions/Pet"
+    "$ref": "#/definitions/Pet"
   examples:
-    - name: Fluffy
-      petType: Cat
-    - name: Rover
-      petType: Frog
+  - name: Fluffy
+    petType: Cat
+  - name: Rover
+    petType: Frog
 
 ```
 
@@ -1154,7 +1167,6 @@ Field Pattern | Type | Description
 ---|:---:|---
 <a name="responsesCode"></a>[HTTP Status Code](#httpCodes) | [Response Object](#responseObject) <span>&#124;</span> [Reference Object](#referenceObject) | Any [HTTP status code](#httpCodes) can be used as the property name (one property per HTTP status code). Describes the expected response for that HTTP status code.  [Reference Object](#referenceObject) can be used to link to a response that is defined at the [OpenAPI Object's responses](#oasResponses) section. This field must quoted for compatibility between JSON and YAML (i.e. "200"), and may contain the uppercase character, `X` to designate a wildcard, such as `2XX` to represent all response codes between `[200-299]`.
 
-
 This object can be extended with [Specification Extensions](#specificationExtensions). 
 
 ##### Responses Object Example
@@ -1219,8 +1231,6 @@ Field Pattern | Type | Description
 ---|:---:|---
 <a name="representations"></a>`*` | [Schema Object](#schemaObject)<span>&#124;</span> [Reference Object](#referenceObject) | A schema describing the response value for a specific `Content-Type`
 
-Representations may take the form of a wildcard (`*`) to designate any `Content-Type`, or a regular expression for matching a specific type
-
 This object can be extended with [Specification Extensions](#specificationExtensions). 
 
 ##### Response Object Examples
@@ -1271,7 +1281,7 @@ Response with a string type:
 
 ```yaml
 description: A simple string response
-representations:
+content:
   text/plain:
     schema:
       type: string
@@ -1416,11 +1426,11 @@ Allows sharing examples for operation requests and responses.
 ##### Patterned Fields
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="exampleMediaType"></a>{[media type](#mediaTypes)} | Any | The name of the property MUST be one of the Operation `produces` values (either implicit or inherited). The value SHOULD be an example of what such a response would look like. 
+<a name="exampleMediaType"></a>{[media-type](#mediaTypes)} | Any | The name of the property MUST be one of the Operation `produces` values (either implicit or inherited). The value SHOULD be an example of what such a response would look like. 
 
 ##### Examples Array Example
 
-Example representation for application/json media type of a Pet data type:
+Example representation for application/json media-type of a Pet data type:
 
 ```json
 [


### PR DESCRIPTION
* "media type" vs "media-type" consistency
* Broken or inconsistent formatting in samples
* A few tweaks here and there