### PR TITLE
make path → URL resolution clearer.

### DIFF
--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -408,15 +408,15 @@ All the fixed fields declared above are objects that MUST use keys that match th
 
 #### <a name="pathsObject"></a>Paths Object
 
-Holds the relative paths to the individual endpoints.
-The path is appended to the [`Server Object`](#serverObject) in order to construct
+Holds the relative paths to the individual endpoints and their operations.
+The path is appended to the URL from the [`Server Object`](#serverObject) in order to construct
 the full URL.  The Paths MAY be empty, due to [ACL constraints](#securityFiltering).
 
 ##### Patterned Fields
 
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="pathsPath"></a>/{path} | [Path Item Object](#pathItemObject) | A relative path to an individual endpoint. The field name MUST begin with a slash. The path is appended to the [`Server Object`](#serverObject) in order to construct the full URL. [Path templating](#pathTemplating) is allowed.
+<a name="pathsPath"></a>/{path} | [Path Item Object](#pathItemObject) | A relative path to an individual endpoint. The field name MUST begin with a slash. The path is **appended** (no relative URL resolution) to the expanded URL from the [`Server Object`](#serverObject)'s `url` field in order to construct the full URL. [Path templating](#pathTemplating) is allowed.
 
 This object can be extended with [Specification Extensions](#specificationExtensions). 
 


### PR DESCRIPTION
You can't append a string to an object (at least not with a canonical result), so we should make clear that we want to append to the `url` field of the server object (possibly after filling in the templates there).

The highlighting of "appended" makes it clearer that there is no relative URL resolution as mentioned in https://github.com/OAI/OpenAPI-Specification/issues/843#issuecomment-261575257.

The task list in https://github.com/OAI/OpenAPI-Specification/issues/589#issuecomment-250816162 says the cleanup of the Paths object is already finished, so I felt free to add this edit now.