### PR TITLE
Fix invalid JSON to use dpouble quotes; use "name": consistently in JSON

### DIFF
--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -938,7 +938,7 @@ A request body with a referenced model definition.
       "examples": [ "http://foo.bar/examples/user-example.txt" ]
     },
     "*": {
-      "schema": {
+      "example": {
         "$ref": "http://foo.bar/examples/user-example.whatever"
       }
     }
@@ -962,7 +962,7 @@ content:
     examples:
       - 'http://foo.bar/examples/user-example.txt'
   '*':
-    schema:
+    example:
       $ref: 'http://foo.bar/examples/user-example.whatever'
 ```
 

--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -937,7 +937,7 @@ A request body with a referenced model definition.
     "text/plain": {
       "examples": [ "http://foo.bar/examples/user-example.txt" ]
     },
-    "*": {
+    "*/*": {
       "example": {
         "$ref": "http://foo.bar/examples/user-example.whatever"
       }
@@ -961,7 +961,7 @@ content:
   'text/plain':
     examples:
       - 'http://foo.bar/examples/user-example.txt'
-  '*':
+  '*/*':
     example:
       $ref: 'http://foo.bar/examples/user-example.whatever'
 ```

--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -116,7 +116,7 @@ For example, if a field is said to have an array value, the JSON array represent
 
 ```json
 {
-   "field" : [...]
+   "field": [...]
 }
 ```
 
@@ -432,8 +432,8 @@ This object can be extended with [Specification Extensions](#specificationExtens
       "responses": {
         "200": {          
           "description": "A list of pets.",
-          "content" : {
-            "application/json" : {
+          "content": {
+            "application/json": {
               "schema": {
                 "type": "array",
                 "items": {
@@ -516,7 +516,7 @@ This object can be extended with [Specification Extensions](#specificationExtens
       "default": {
         "description": "error payload",
         "content": {
-          "text/html" : {
+          "text/html": {
             "schema": {
               "$ref": "#/definitions/ErrorModel"
             }
@@ -614,7 +614,7 @@ This object can be extended with [Specification Extensions](#specificationExtens
       "type": "string"
     }
   ],
-  "requestBody" : {
+  "requestBody": {
     "content": {
       "application/x-www-form-urlencoded": {
         "schema": {
@@ -637,16 +637,16 @@ This object can be extended with [Specification Extensions](#specificationExtens
   "responses": {
     "200": {
       "description": "Pet updated.",
-      "content" : {
-        "application/json" : {},
-        "application/xml" : {}
+      "content": {
+        "application/json": {},
+        "application/xml": {}
       }
     },
     "405": {
       "description": "Invalid input",
-      "content" : {
-        "application/json" : {},
-        "application/xml" : {}
+      "content": {
+        "application/json": {},
+        "application/xml": {}
       }
     }
   },
@@ -790,7 +790,7 @@ Assuming a parameter named `color` with one of the following values:
 ```
    string -> "blue"
    array -> ["blue","black","brown"]
-   object -> { "R" : 100, "G" :200, "B" : 150 }
+   object -> { "R": 100, "G": 200, "B": 150 }
 ```
 The following table shows examples of how those values would be rendered.
 
@@ -921,35 +921,29 @@ A request body with a referenced model definition.
 ```json
 {
   "description": "user to add to the system",
-  "content" : {
-    "application/json" : {
+  "content": {
+    "application/json": {
       "schema": {
-          "$ref": "#/definitions/User"
-        },
-      "examples": [
-        { "$ref": 'http://foo.bar#/examples/address-example.json'}
-      ]
-    },
-    "application/xml" : {
-       "schema": {
         "$ref": "#/definitions/User"
       },
-      "examples": [
-        { "$ref": 'http://foo.bar#/examples/address-example.xml'}
-      ]
+      "examples": [ "http://foo.bar/examples/user-example.json" ]
     },
-    "text/plain" : {
-      "examples": [
-        { "$ref": 'http://foo.bar#/examples/address-example.txt'}
-      ]
+    "application/xml": {
+      "schema": {
+        "$ref": "#/definitions/User"
+      },
+      "examples": [ "http://foo.bar/examples/user-example.xml" ]
+    },
+    "text/plain": {
+      "examples": [ "http://foo.bar/examples/user-example.txt" ]
     },
     "*": {
-      "example": {
-        $ref: "http://foo.bar#/examples/address-example.whatever"
+      "schema": {
+        "$ref": "http://foo.bar/examples/user-example.whatever"
       }
+    }
   }
-}
-```
+}```
 
 ```yaml
 description: user to add to the system
@@ -1010,7 +1004,7 @@ Each key in the content object is the media-type of the [Content Type Object](#c
 ##### Content Examples
 
 ```js
-"content" : {
+"content": {
   "application/json": {
     "schema": {
       "type": "array",
@@ -1023,13 +1017,13 @@ Each key in the content object is the media-type of the [Content Type Object](#c
       []
      ]
   },
-  "application/xml" : {
-    "examples" : [
+  "application/xml": {
+    "examples": [
       "<Users><User name='Bob'/><User name='Diane'/><User name='Mary'/><User name='Bill'/></Users>",
       "<Users/>"
     ]
   },
-  "text/plain" : {
+  "text/plain": {
     "Bob,Diane,Mary,Bill",
     ""
   }
@@ -1085,12 +1079,12 @@ A content type description.
          "$ref": "#/definitions/Pet"
     },
     "examples": [{
-                  "name" : "Fluffy",
-                  "petType" : "Cat"
+                  "name": "Fluffy",
+                  "petType": "Cat"
                  },
                  { 
-                   "name" : "Rover",
-                   "petType" : "Frog"
+                   "name": "Rover",
+                   "petType": "Frog"
                  }]
   }
 }
@@ -1319,8 +1313,8 @@ A 200 response for successful operation and a default response for others (imply
 {
   "200": {
     "description": "a pet to be returned",
-    "content" : {
-      "application/json" : {
+    "content": {
+      "application/json": {
         "schema": {
           "$ref": "#/definitions/Pet"
         }
@@ -1329,8 +1323,8 @@ A 200 response for successful operation and a default response for others (imply
   },
   "default": {
     "description": "Unexpected error",
-    "content" : {
-      "application/json" : {
+    "content": {
+      "application/json": {
         "schema": {
           "$ref": "#/definitions/ErrorModel"
         }
@@ -1386,8 +1380,8 @@ Response of an array of a complex type:
 ```json
 {
   "description": "A complex object array response",
-  "content" : {
-    "application/json" : {
+  "content": {
+    "application/json": {
       "schema": {
         "type": "array",
         "items": {
@@ -1414,8 +1408,8 @@ Response with a string type:
 ```json
 {
   "description": "A simple string response",
-  "content" : {
-    "text/plain" : {
+  "content": {
+    "text/plain": {
       "schema": {
         "type": "string"
       }
@@ -1438,7 +1432,7 @@ Plain text response with headers:
 ```json
 {
   "description": "A simple string response",
-  "content" : {
+  "content": {
     "text/plain": {
       "schema": {
         "type": "string"
@@ -3224,7 +3218,7 @@ This object can be extended with [Specification Extensions](#specificationExtens
 ```json
 {
   "type": "http",
-  "scheme" : "basic"
+  "scheme": "basic"
 }
 ```
 
@@ -3254,8 +3248,8 @@ in: header
 ```json
 {
   "type": "scheme",
-  "scheme" : "bearer",
-  "bearerFormat" : "JWT",
+  "scheme": "bearer",
+  "bearerFormat": "JWT",
 }
 ```
 


### PR DESCRIPTION
One JSON example was using single quotes around a string item ; changed to double quotes.

Also made spacing consistent in JSON examples to all use `"name": value` rather than a mix of no space or a space before the colon.