### PR TITLE
[Introduction] Clarify languages

### DIFF
--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -11,7 +11,7 @@ The OpenAPI Specification is licensed under [The Apache License, Version 2.0](ht
 The OpenAPI Specification is a project used to describe and document RESTful APIs.
 
 The OpenAPI Specification defines a set of files required to describe such an API.
-These files can then be used by the Swagger-UI project to display the API and Swagger-Codegen to generate clients in various languages.
+These files can then be used by the Swagger-UI project to display the API and Swagger-Codegen to generate clients in various programming languages.
 Additional utilities can also take advantage of the resulting files, such as testing tools.
 
 ## Table of Contents


### PR DESCRIPTION
Clarifies that languages are programming languages (ex: Java, Ruby, etc.) as opposed to spoken languages (English, Spanish, etc.)

Signed-off-by: Rob Dolin <robdolin@microsoft.com>