### PR TITLE
Remove ambiguity about info.version

### DIFF
--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -221,7 +221,7 @@ Field Name | Type | Description
 <a name="infoTermsOfService"></a>termsOfService | `string` | A URL to the Terms of Service for the API.
 <a name="infoContact"></a>contact | [Contact Object](#contactObject) | The contact information for the exposed API.
 <a name="infoLicense"></a>license | [License Object](#licenseObject) | The license information for the exposed API.
-<a name="infoVersion"></a>version | `string` | **Required** The version of the API.  Is it suggested that the `info.version` value correspond to the version of the API definition (not to be confused with the [OpenAPI specification version](#oasVersion).) In practice, the version of the API _implementation_ (not specified here) may evolve at an entirely different rate.
+<a name="infoVersion"></a>version | `string` | **Required** The version of the API definition (which is distinct from the [OpenAPI specification version](#oasVersion) or the API implementation version which may evolve at different rates.)
 
 This object can be extended with [Specification Extensions](#specificationExtensions). 
 

--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -221,7 +221,7 @@ Field Name | Type | Description
 <a name="infoTermsOfService"></a>termsOfService | `string` | A URL to the Terms of Service for the API.
 <a name="infoContact"></a>contact | [Contact Object](#contactObject) | The contact information for the exposed API.
 <a name="infoLicense"></a>license | [License Object](#licenseObject) | The license information for the exposed API.
-<a name="infoVersion"></a>version | `string` | **Required** The version of the API definition (which is distinct from the [OpenAPI specification version](#oasVersion) or the API implementation version which may evolve at different rates.)
+<a name="infoVersion"></a>version | `string` | **Required** The version of the API definition (which is distinct from the OpenAPI specification version or the API implementation version.)
 
 This object can be extended with [Specification Extensions](#specificationExtensions). 
 

--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -221,7 +221,7 @@ Field Name | Type | Description
 <a name="infoTermsOfService"></a>termsOfService | `string` | A URL to the Terms of Service for the API.
 <a name="infoContact"></a>contact | [Contact Object](#contactObject) | The contact information for the exposed API.
 <a name="infoLicense"></a>license | [License Object](#licenseObject) | The license information for the exposed API.
-<a name="infoVersion"></a>version | `string` | **Required** Provides the version of the application API (not to be confused with the specification version).  While not required, is it suggested that the `info.version` value correspond to the version of the API definition.  In practice, the version of the API _implementation_ may evolve at an entirely different rate.
+<a name="infoVersion"></a>version | `string` | **Required** The version of the API (not to be confused with the OpenAPI specification version or the implementation version which may evolve at different rates).
 
 This object can be extended with [Specification Extensions](#specificationExtensions). 
 

--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -221,7 +221,7 @@ Field Name | Type | Description
 <a name="infoTermsOfService"></a>termsOfService | `string` | A URL to the Terms of Service for the API.
 <a name="infoContact"></a>contact | [Contact Object](#contactObject) | The contact information for the exposed API.
 <a name="infoLicense"></a>license | [License Object](#licenseObject) | The license information for the exposed API.
-<a name="infoVersion"></a>version | `string` | **Required** The version of the API (not to be confused with the OpenAPI specification version or the implementation version which may evolve at different rates).
+<a name="infoVersion"></a>version | `string` | **Required** The version of the API.  Is it suggested that the `info.version` value correspond to the version of the API definition (not to be confused with the [OpenAPI specification version](#oasVersion).) In practice, the version of the API _implementation_ (not specified here) may evolve at an entirely different rate.
 
 This object can be extended with [Specification Extensions](#specificationExtensions). 
 


### PR DESCRIPTION
In [OpenAPI.next versions/3.0.md](https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#infoObject) `info.version` is marked **Requried**, then the second sentence starts "While not required, ". Some may be confused and think this starts a contradiction. I suggest not adding this sentence at all, as it only raises additional questions (is "application API === "API definition"?) I propose more concise rephrasing.