### PR TITLE
[Spec] Suggestions from Liz Lynch

### DIFF
--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -4,22 +4,19 @@
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](http://www.ietf.org/rfc/rfc2119.txt).
 
-The OpenAPI Specification is licensed under [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.html).
+This document is licensed under [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.html).
 
 ## Introduction
 
-The OpenAPI Specification is a project used to describe and document RESTful APIs.
+The OpenAPI Specification (OAS) is a project used to describe and document RESTful APIs.
 
-The OpenAPI Specification defines a set of files required to describe such an API.
+The OAS defines a set of files required to describe such an API.
 These files can then be used by the Swagger-UI project to display the API and Swagger-Codegen to generate clients in various languages.
 Additional utilities can also take advantage of the resulting files, such as testing tools.
 
 ## Table of Contents
 <!-- TOC depthFrom:1 depthTo:3 withLinks:1 updateOnSave:1 orderedList:0 -->
 
-- [OpenAPI Specification](#openapi-specification)
-- [Introduction](#introduction)
-- [Table of Contents](#table-of-contents)
 - [Revision History](#revision-history)
 - [Definitions](#definitions)
 - [Specification](#specification)


### PR DESCRIPTION
Incorporates some suggestions from Liz Lynch:
* OpenAPI Specification (OAS) early and then OAS further on
* "a OAS" to "an OAS"
* Remove first three bullets from ToC

Signed-off-by: Rob Dolin <robdolin@microsoft.com>