### PR TITLE
Mention that Content objects can also be in parameters or response headers

### DIFF
--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -772,7 +772,7 @@ the example must follow the prescribed serialization strategy for the parameter.
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="parameterContent"></a>content | [Content Object](#contentObject) | The content of the request body.
+<a name="parameterContent"></a>content | [Content Object](#contentObject) | The content of the parameter.
 
 In order to support common ways of serializing simple parameters, a set of `style` values are defined.
 
@@ -1025,7 +1025,8 @@ content:
 
 #### <a name="contentObject"></a>Content Object
 
-Describes a set of supported content types. A content object can be used in [requestBody](#requestBody) and [response objects](#responseObject).
+Describes a set of supported content types. A content object can be used in [requestBody](#requestBody),
+[parameter objects](#parameterObject), [header objects](#headerObject), and [response objects](#responseObject).
 
 Each key in the content object is the media-type of the [Content Type Object](#contentTypeObject).
 


### PR DESCRIPTION
Previously only request and response body were mentioned.

I'm not sure whether singular or plural is appropriate here, it was not consistent before.