### PR TITLE
[Info Object Example] Update description

### DIFF
--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -227,7 +227,7 @@ This object can be extended with [Specification Extensions](#specificationExtens
 ```json
 {
   "title": "Swagger Sample App",
-  "description": "This is a sample server Petstore server.",
+  "description": "This is a sample server for a pet store.",
   "termsOfService": "http://swagger.io/terms/",
   "contact": {
     "name": "API Support",
@@ -244,7 +244,7 @@ This object can be extended with [Specification Extensions](#specificationExtens
 
 ```yaml
 title: Swagger Sample App
-description: This is a sample server Petstore server.
+description: This is a sample server for a pet store.
 termsOfService: http://swagger.io/terms/
 contact:
   name: API Support


### PR DESCRIPTION
Removes duplicative use of word "server" 

Changes "Petstore" to "pet store" since "Petstore" is not a proper noun

Signed-off-by: Rob Dolin <robdolin@microsoft.com>