### PR TITLE
Fix multipart encoding example

### DIFF
--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -1088,6 +1088,7 @@ Field Name | Type | Description
 <a name="contentTypeSchema"></a>schema | [Schema Object](#schemaObject) | The schema defining the type used for the request body.
 <a name="contentTypeExamples"></a>examples | [Examples Array](#examplesArray) | Examples of the content type.  Each example in the Examples array SHOULD be in the correct format as specified in the _content_ type.  The `examples` object is mutually exclusive to the `example` object.  Furthermore, if referencing a `schema` which contains an example, the `examples` value SHALL _override_ the example provided by the schema.
 <a name="contentTypeExample"></a>example | [Example Object](#exampleObject) | Example of the content type.  The example object SHOULD be in the correct format as specified in the _content_ type.  The `example` object is mutually exclusive to the `examples` object.  Furthermore, if referencing a `schema` which contains an example, the `example` value SHALL _override_ the the example provided by the schema.
+<a name="contentTypeEncoding"></a>encoding | [Encoding Object](#encodingObject) | Encoding of the content type.  The encoding object SHOULD only apply to `requestBody` objects when the content type is `multipart`.
 
 ##### Patterned Fields
 Field Pattern | Type | Description
@@ -1291,13 +1292,13 @@ requestBody:
             # default is application/octet-stream, need to declare an image type only!
             type: string
             format: binary
-encoding:
-  historyMetadata:
-    # require XML content-type in utf-8 encoding
-    contentType: application/xml; charset=utf-8
-  profileImage:
-    # only accept png/jpeg
-    contentType: image/png, image/jpeg
+      encoding:
+        historyMetadata:
+          # require XML content-type in utf-8 encoding
+          contentType: application/xml; charset=utf-8
+        profileImage:
+        # only accept png/jpeg
+        contentType: image/png, image/jpeg
 ```
 
 #### <a name="responsesObject"></a>Responses Object


### PR DESCRIPTION
This PR fixes the multipart encoding example based on https://gist.github.com/fehguy/fc04aa2420a89b5c9f625c55181f87f1#file-requestbody-yaml-L106. The encoding object is also listed as an optional child element for `contentTypeObject`.