### PR TITLE
[Path Item Object Example] Match field order

### DIFF
--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -491,8 +491,8 @@ This object can be extended with [Specification Extensions](#specificationExtens
 ```json
 {
   "get": {
-    "description": "Returns pets based on ID",
     "summary": "Find pets by ID",
+    "description": "Returns pets based on ID",
     "operationId": "getPetsById",
     "responses": {
       "200": {
@@ -538,8 +538,8 @@ This object can be extended with [Specification Extensions](#specificationExtens
 
 ```yaml
 get:
-  description: Returns pets based on ID
   summary: Find pets by ID
+  description: Returns pets based on ID
   operationId: getPetsById
   responses:
     '200':


### PR DESCRIPTION
In the table describing the fields, the order is summary then description.  

This PR updates the examples to match that order.

Signed-off-by: Rob Dolin <robdolin@microsoft.com>