### PR TITLE
[Operation Update Example] Remove empty field

### DIFF
--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -601,7 +601,6 @@ This object can be extended with [Specification Extensions](#specificationExtens
     "pet"
   ],
   "summary": "Updates a pet in the store with form data",
-  "description": "",
   "operationId": "updatePetWithForm",
   "parameters": [
     {
@@ -663,7 +662,6 @@ This object can be extended with [Specification Extensions](#specificationExtens
 tags:
 - pet
 summary: Updates a pet in the store with form data
-description: ''
 operationId: updatePetWithForm
 parameters:
 - name: petId


### PR DESCRIPTION
The `description` in the example is empty.

Since it is not a required field, this PR removes it.

Signed-off-by: Rob Dolin <robdolin@microsoft.com>