### PR TITLE
Rename Content Type Object to Media Type Object

### DIFF
--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -1023,10 +1023,10 @@ content:
 
 #### <a name="contentObject"></a>Content Object
 
-Describes a set of supported media types. A content object can be used in [requestBody](#requestBody),
-[parameter objects](#parameterObject), [header objects](#headerObject), and [response objects](#responseObject).
+Describes a set of supported media types. A Content Object can be used in [Request Body Object](#requestBody),
+[Parameter Objects](#parameterObject), [Header Objects](#headerObject), and [Response Objects](#responseObject).
 
-Each key in the content object is the media-type of the [Media Type Object](#mediaTypeObject).
+Each key in the Content Object is the media type of the [Media Type Object](#mediaTypeObject).
 
 ##### Content Examples
 
@@ -1082,7 +1082,7 @@ content:
 ```
 
 #### <a name="mediaTypeObject"></a>Media Type Object
-Each media type object provides schema and examples for a the media type identified by its key.  Media Type objects can be used in a [content object](#contentObject).   
+Each Media Type Object provides schema and examples for a the media type identified by its key.  Media Type Objects can be used in a [Content Object](#contentObject).   
 
 ##### Fixed Fields
 Field Name | Type | Description
@@ -1090,7 +1090,7 @@ Field Name | Type | Description
 <a name="mediaTypeSchema"></a>schema | [Schema Object](#schemaObject) | The schema defining the type used for the request body.
 <a name="mediaTypeExamples"></a>examples | [Examples Array](#examplesArray) | Examples of the media type.  Each example in the Examples array SHOULD be in the correct format as specified in the _content_ type.  The `examples` object is mutually exclusive to the `example` object.  Furthermore, if referencing a `schema` which contains an example, the `examples` value SHALL _override_ the example provided by the schema.
 <a name="mediaTypeExample"></a>example | [Example Object](#exampleObject) | Example of the media type.  The example object SHOULD be in the correct format as specified in the _content_ type.  The `example` object is mutually exclusive to the `examples` object.  Furthermore, if referencing a `schema` which contains an example, the `example` value SHALL _override_ the the example provided by the schema.
-<a name="mediaTypeEncoding"></a>encoding | [Encoding Object](#encodingObject) | Encoding of the media type.  The encoding object SHOULD only apply to `requestBody` objects when the media type is `multipart`.
+<a name="mediaTypeEncoding"></a>encoding | [Encoding Object](#encodingObject) | Encoding of the media type.  The Encoding Object SHOULD only apply to `requestBody` objects when the media type is `multipart`.
 
 ##### Patterned Fields
 Field Pattern | Type | Description

--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -42,7 +42,7 @@ Additional utilities can also take advantage of the resulting files, such as tes
 		- [Parameter Object](#parameterObject)
 		- [Request Body Object](#requestBodyObject)
 		- [Content Object](#contentObject)
-		- [Content Type Object](#contentTypeObject)
+		- [Media Type Object](#mediaTypeObject)
 		- [Responses Object](#responsesObject)
 		- [Response Object](#responseObject)
 		- [Headers Object](#headersObject)
@@ -759,8 +759,8 @@ Field Name | Type | Description
 <a name="parameterExplode"></a>explode | `boolean` | When this is true, parameter values of type `array` or `object` generate separate parameters for each value of the array, or key-value-pair of the map.  For other types of parameters this property has no effect. When [`style`](#parameterStyle) is `form`, the default value is `true`. For all other styles, the default value is `false`.
 <a name="parameterAllowReserved"></a>allowReserved | `boolean` | Determines whether the parameter value SHOULD allow reserved characters, as defined by [RFC3986](https://tools.ietf.org/html/rfc3986#section-2.2) `:/?#[]@!$&'()*+,;=` to be included without percent-encoding. This property only applies to parameters with an `in` value of `query`. The default value is `false`.
 <a name="parameterSchema"></a>schema | [Schema Object](#schemaObject) | The schema defining the type used for the parameter.
-<a name="parameterExamples"></a>examples | [[Example Object](#exampleObject)] | Examples of the content type.  Each example in the Examples array SHOULD be in the correct format as specified parameter encoding.  The `examples` object is mutually exclusive to the `example` object.  Furthermore, if referencing a `schema` that contains an example, the `examples` value SHALL _override_ the example provided by the schema.
-<a name="parameterExample"></a>example | [Example Object](#exampleObject) | Example of the content type.  The example object SHOULD be in the correct format as specified in the parameter encoding.  The `example` object is mutually exclusive to the `examples` object.  Furthermore, if referencing a `schema` which contains an example, the `example` value SHALL _override_ the example provided by the the schema.
+<a name="parameterExamples"></a>examples | [[Example Object](#exampleObject)] | Examples of the media type.  Each example in the Examples array SHOULD be in the correct format as specified parameter encoding.  The `examples` object is mutually exclusive to the `example` object.  Furthermore, if referencing a `schema` that contains an example, the `examples` value SHALL _override_ the example provided by the schema.
+<a name="parameterExample"></a>example | [Example Object](#exampleObject) | Example of the media type.  The example object SHOULD be in the correct format as specified in the parameter encoding.  The `example` object is mutually exclusive to the `examples` object.  Furthermore, if referencing a `schema` which contains an example, the `example` value SHALL _override_ the example provided by the the schema.
 
 For more complex scenarios a `content` object can be used to define the media-type 
 and schema of the parameter.  This option is mutually exclusive with the simple scenario
@@ -1023,10 +1023,10 @@ content:
 
 #### <a name="contentObject"></a>Content Object
 
-Describes a set of supported content types. A content object can be used in [requestBody](#requestBody),
+Describes a set of supported media types. A content object can be used in [requestBody](#requestBody),
 [parameter objects](#parameterObject), [header objects](#headerObject), and [response objects](#responseObject).
 
-Each key in the content object is the media-type of the [Content Type Object](#contentTypeObject).
+Each key in the content object is the media-type of the [Media Type Object](#mediaTypeObject).
 
 ##### Content Examples
 
@@ -1081,25 +1081,24 @@ content:
       - "Bob,Diane,Mary,Bill"
 ```
 
-#### <a name="contentTypeObject"></a>Content Type Object
-Each content type object provides schema and examples for a the media type identified by its key.  Content Type objects can be used in a [content object](#contentObject).   
+#### <a name="mediaTypeObject"></a>Media Type Object
+Each media type object provides schema and examples for a the media type identified by its key.  Media Type objects can be used in a [content object](#contentObject).   
 
 ##### Fixed Fields
 Field Name | Type | Description
 ---|:---:|---
-<a name="contentTypeSchema"></a>schema | [Schema Object](#schemaObject) | The schema defining the type used for the request body.
-<a name="contentTypeExamples"></a>examples | [Examples Array](#examplesArray) | Examples of the content type.  Each example in the Examples array SHOULD be in the correct format as specified in the _content_ type.  The `examples` object is mutually exclusive to the `example` object.  Furthermore, if referencing a `schema` which contains an example, the `examples` value SHALL _override_ the example provided by the schema.
-<a name="contentTypeExample"></a>example | [Example Object](#exampleObject) | Example of the content type.  The example object SHOULD be in the correct format as specified in the _content_ type.  The `example` object is mutually exclusive to the `examples` object.  Furthermore, if referencing a `schema` which contains an example, the `example` value SHALL _override_ the the example provided by the schema.
-<a name="contentTypeEncoding"></a>encoding | [Encoding Object](#encodingObject) | Encoding of the content type.  The encoding object SHOULD only apply to `requestBody` objects when the content type is `multipart`.
+<a name="mediaTypeSchema"></a>schema | [Schema Object](#schemaObject) | The schema defining the type used for the request body.
+<a name="mediaTypeExamples"></a>examples | [Examples Array](#examplesArray) | Examples of the media type.  Each example in the Examples array SHOULD be in the correct format as specified in the _content_ type.  The `examples` object is mutually exclusive to the `example` object.  Furthermore, if referencing a `schema` which contains an example, the `examples` value SHALL _override_ the example provided by the schema.
+<a name="mediaTypeExample"></a>example | [Example Object](#exampleObject) | Example of the media type.  The example object SHOULD be in the correct format as specified in the _content_ type.  The `example` object is mutually exclusive to the `examples` object.  Furthermore, if referencing a `schema` which contains an example, the `example` value SHALL _override_ the the example provided by the schema.
+<a name="mediaTypeEncoding"></a>encoding | [Encoding Object](#encodingObject) | Encoding of the media type.  The encoding object SHOULD only apply to `requestBody` objects when the media type is `multipart`.
 
 ##### Patterned Fields
 Field Pattern | Type | Description
 ---|:---:|---
 <a name="parameterExtensions"></a>^x- | Any | Allows extensions to the OpenAPI Schema. The field name MUST begin with `x-`, for example, `x-internal-id`. The value can be `null`, a primitive, an array or an object. See [Specification Extensions](#specificationExtensions) for further details.
 
-##### Content Type Examples
+##### Media Type Examples
 
-A content type description.
 ```js
 {
   "application/json": {

--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -933,7 +933,7 @@ Field Name | Type | Description
 <a name="parameterExamples"></a>examples | [[Example Object](#exampleObject) <span>&#124;</span> [Reference Object](#referenceObject)] | Examples of the content type.  Each example in the Examples array SHOULD be in the correct format as specified parameter encoding.  The `examples` object is mutually exclusive to the `example` object.  Furthermore, if referencing a `schema` which contains an example, the `examples` value SHALL _override_ the example provided by the schema.
 <a name="parameterExample"></a>example | [Example Object](#exampleObject) <span>&#124;</span> [Reference Object](#referenceObject) | Example of the content type.  The example object SHOULD be in the correct format as specified in the parameter encoding.  The `example` object is mutually exclusive to the `examples` object.  Furthermore, if referencing a `schema` which contains an example, the `example` value SHALL _override_ the example provided by the the schema.
 
-For more complex scenarios a `content` object can be used to define the media-type 
+For more complex scenarios a [Content Object](#contentObject) can be used to define the media type 
 and schema of the parameter.  This option is mutually exclusive with the simple scenario
 above. When `example` or `examples` are provided in conjunction with the `schema` object, 
 the example must follow the prescribed serialization strategy for the parameter.
@@ -1453,7 +1453,7 @@ requestBody:
             format: binary
       encoding:
         historyMetadata:
-          # require XML content-type in utf-8 encoding
+          # require XML Content-Type in utf-8 encoding
           contentType: application/xml; charset=utf-8
         profileImage:
           # only accept png/jpeg
@@ -1467,9 +1467,9 @@ A single encoding definition applied to a single schema property.
 ##### Fixed Fields
 Field Name | Type | Description
 ---|:---:|---
-<a name="encodingContentType"></a>contentType | `string` | The content-type to use for encoding a specific property. Default value depends on the property type: for `string` with `format` being `binary` - `application/octet-stream`; for other primitive types - `plain/text`; for `object` - `application/json`; for `array` - the default is defined based on the inner type.
+<a name="encodingContentType"></a>contentType | `string` | The Content-Type to use for encoding a specific property. Default value depends on the property type: for `string` with `format` being `binary` - `application/octet-stream`; for other primitive types - `plain/text`; for `object` - `application/json`; for `array` - the default is defined based on the inner type.
 <a name="encodingHeaders"></a>Headers | `object` | A string map allowing additional information to be provided as headers, for example `Content-Disposition`.  Note `Content-Type` is described separately and will be ignored from this section.
-<a name="encodingStyle"></a>style | `string` | The content-type to use for encoding a specific property.  See (#parameterContent) for details on the [`style`](#parameterStyle) property. The behavior follows the same values allowed for `query` parameters, including default values.
+<a name="encodingStyle"></a>style | `string` | The Content-Type to use for encoding a specific property.  See (#parameterContent) for details on the [`style`](#parameterStyle) property. The behavior follows the same values allowed for `query` parameters, including default values.
 <a name="encodingExplode"></a>explode | `boolean` | When this is true, property values of type `array` or `object` generate separate parameters for each value of the array, or key-value-pair of the map.  For other types of properties this property has no effect. When [`style`](#encodingStyle) is `form`, the default value is `true`. For all other styles, the default value is `false`.
 
 This object can be extended with [Specification Extensions](#specificationExtensions). 
@@ -1890,7 +1890,7 @@ Because of the potential for name clashes, consider the `href` syntax as the pre
 
 #### <a name="responsePayload"></a>Response Payload Values
 
-Payload values are only available in parsable response payloads which match the advertised media-type and for media-types that can be referenced using a JSON Pointer fragment Id.
+Payload values are only available in parsable response payloads which match the advertised media type and for media types that can be referenced using a JSON Pointer fragment Id.
 In all cases, if a value does _not_ exist, the parameter will be considered a `null` value (as opposed to an empty value) and _not_ passed as a parameter to the linked resource.
 In cases where a value is required, and a parameter is not supplied, the client MAY choose to not follow the link definition. 
 
@@ -2255,7 +2255,7 @@ components:
 
 
 ### <a name="linkParametersObject"></a>Link Parameters Object
-Using the `operationId` to reference an operation in the definition has many benefits, including the ability to define media-type options, security requirements, response and error payloads.
+Using the `operationId` to reference an operation in the definition has many benefits, including the ability to define media type options, security requirements, response and error payloads.
 Many operations require parameters to be passed, and these MAY be dynamic depending on the response itself.
 
 To specify parameters required by the operation, we can use a **Link Parameters Object**.
@@ -2364,7 +2364,7 @@ definitions:
       example:
         $ref: http://foo.bar#/examples/name-example
 
-# in a request body, note the plural `examples` as the content-type is set to `*`:
+# in a request body, note the plural `examples` as the Content-Type is set to `*`:
 	requestBody:
     content:
       'application/json':


### PR DESCRIPTION
Now that Encoding has a Content-Type property there is some confusion when using the term `Content-Type` within the spec.  Using the term `Media Type Object` to describe the child objects of a `Content-Object` is consistent with the use of media type identifiers as the keys.