### PR TITLE
Fix a few missing entries and a broken link in the Table of Contents.

### DIFF
--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -34,8 +34,8 @@ Additional utilities can also take advantage of the resulting files, such as tes
 		- [Contact Object](#contactObject)
 		- [License Object](#licenseObject)
 		- [Server Object](#serverObject)
-        - [Server Variables Object](#serverVariablesObject)
-        - [Server Variable Object](#serverVariableObject)
+		- [Server Variables Object](#serverVariablesObject)
+		- [Server Variable Object](#serverVariableObject)
 		- [Components Object](#componentsObject)
 		- [Paths Object](#pathsObject)
 		- [Path Item Object](#pathItemObject)
@@ -45,8 +45,12 @@ Additional utilities can also take advantage of the resulting files, such as tes
 		- [Request Body Object](#requestBodyObject)
 		- [Content Object](#contentObject)
 		- [Media Type Object](#mediaTypeObject)
+		- [Encoding Object](#encodingObject)
+		- [Encoding Property Object](#encodingPropertyObject)
 		- [Responses Object](#responsesObject)
 		- [Response Object](#responseObject)
+		- [Callbacks Object](#callbacksObject)
+		- [Callback Object](#callbackObject)
 		- [Headers Object](#headersObject)
 		- [Example Object](#exampleObject)
 		- [Links Object](#linksObject)
@@ -59,6 +63,8 @@ Additional utilities can also take advantage of the resulting files, such as tes
 		- [Schema Object](#schemaObject)
 		- [XML Object](#xmlObject)
 		- [Security Scheme Object](#securitySchemeObject)
+		- [OAuth Flows Object](#oauthFlowsObject)
+		- [OAuth Flow Object](#oauthFlowObject)
 		- [Scopes Object](#scopesObject)
 		- [Security Requirement Object](#securityRequirementObject)
 	- [Specification Extensions](#specificationExtensions)
@@ -1853,7 +1859,7 @@ Field Pattern | Type | Description
 <a name="linkName"></a> {name} | [Link Object](#linkObject) <span>&#124;</span> [Reference Object](#referenceObject) | A short name for the link, following the naming constraints of the names for [Component Objects](#componentsObject).
 The link SHALL reference a single Link Object, or a JSON Reference to a single link object.
 
-#### <a name="#linkObject"></a>Link Object
+#### <a name="linkObject"></a>Link Object
 The `Link Object` is responsible for defining a possible operation based on a single response.
 
 Field Name  |  Type  | Description


### PR DESCRIPTION
I noticed a few entries were missing in the TOC, so I did a quick scan to pull out the link targets: 

```grep "#### <a name" 3.0.md | grep -v "#####" | sed -e "s/^.*\"\(.*\)\".*$/\1/"``` 

That gave me a list of objects which I used to update the TOC. I also noticed that the linkObject anchor was "#linkObject", which seemed to break the TOC link in the current doc.

