### PR TITLE
Small grammar nits

### DIFF
--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -933,7 +933,7 @@ Field Name | Type | Description
 <a name="parameterAllowReserved"></a>allowReserved | `boolean` | Determines whether the parameter value SHOULD allow reserved characters, as defined by [RFC3986](https://tools.ietf.org/html/rfc3986#section-2.2) `:/?#[]@!$&'()*+,;=` to be included without percent-encoding. This property only applies to parameters with an `in` value of `query`. The default value is `false`.
 <a name="parameterSchema"></a>schema | [Schema Object](#schemaObject) <span>&#124;</span> [Reference Object](#referenceObject)] | The schema defining the type used for the parameter.
 <a name="parameterExamples"></a>examples | [[Example Object](#exampleObject) <span>&#124;</span> [Reference Object](#referenceObject)] | Examples of the content type.  Each example in the Examples array SHOULD be in the correct format as specified parameter encoding.  The `examples` object is mutually exclusive to the `example` object.  Furthermore, if referencing a `schema` which contains an example, the `examples` value SHALL _override_ the example provided by the schema.
-<a name="parameterExample"></a>example | [Example Object](#exampleObject) <span>&#124;</span> [Reference Object](#referenceObject) | Example of the content type.  The example object SHOULD be in the correct format as specified in the parameter encoding.  The `example` object is mutually exclusive to the `examples` object.  Furthermore, if referencing a `schema` which contains an example, the `example` value SHALL _override_ the example provided by the the schema.
+<a name="parameterExample"></a>example | [Example Object](#exampleObject) <span>&#124;</span> [Reference Object](#referenceObject) | Example of the content type.  The example object SHOULD be in the correct format as specified in the parameter encoding.  The `example` object is mutually exclusive to the `examples` object.  Furthermore, if referencing a `schema` which contains an example, the `example` value SHALL _override_ the example provided by the schema.
 
 For more complex scenarios a [Content Object](#contentObject) can be used to define the media type 
 and schema of the parameter.  This option is mutually exclusive with the simple scenario
@@ -1260,7 +1260,7 @@ Field Name | Type | Description
 ---|:---:|---
 <a name="mediaTypeSchema"></a>schema | [Schema Object](#schemaObject) <span>&#124;</span> [Reference Object](#referenceObject)] | The schema defining the type used for the request body.
 <a name="mediaTypeExamples"></a>examples | [[Example Object](#exampleObject) <span>&#124;</span> [Reference Object](#referenceObject)] | Examples of the media type.  Each example in the Examples array SHOULD be in the correct format as specified in the media type.  The `examples` object is mutually exclusive to the `example` object.  Furthermore, if referencing a `schema` which contains an example, the `examples` value SHALL _override_ the example provided by the schema.
-<a name="mediaTypeExample"></a>example | [Example Object](#exampleObject) <span>&#124;</span> [Reference Object](#referenceObject) | Example of the media type.  The example object SHOULD be in the correct format as specified in the media type.  The `example` object is mutually exclusive to the `examples` object.  Furthermore, if referencing a `schema` which contains an example, the `example` value SHALL _override_ the the example provided by the schema.
+<a name="mediaTypeExample"></a>example | [Example Object](#exampleObject) <span>&#124;</span> [Reference Object](#referenceObject) | Example of the media type.  The example object SHOULD be in the correct format as specified in the media type.  The `example` object is mutually exclusive to the `examples` object.  Furthermore, if referencing a `schema` which contains an example, the `example` value SHALL _override_ the example provided by the schema.
 <a name="mediaTypeEncoding"></a>encoding | [Encoding Object](#encodingObject) | Encoding of the media type.  The encoding object SHOULD only apply to `requestBody` objects when the content type is `multipart`.
 
 This object can be extended with [Specification Extensions](#specificationExtensions). 
@@ -1952,7 +1952,7 @@ The `name` identifier is case-sensitive, whereas `token` is not.
 
 
 ##### Request Parameter Example
-Computing a link from a request operation like such:
+Computing a link from a request operation like this:
 
 ```yaml
 paths:
@@ -2020,7 +2020,7 @@ href: 'http://colors.my-server.com/colors/green'
 href: 'http://colors.my-server.com/colors/blue'
 ```
 
-As with all links, it at the the clients' discretion to follow them, and permissions and the ability to make a successful call to that link is not guaranteed solely by the existence of a relationship.
+As with all links, it is at the clients' discretion to follow them, neither permissions nor the ability to make a successful call to that link is guaranteed solely by the existence of a relationship.
 
 
 ##### Example


### PR DESCRIPTION
'Like such' reads badly, and add missing 'is' to 'it at the'. Fixed 3 double 'the the's (thanks @willdady) and reword a clunky negative clause.