### PR TITLE
fix broken linkObject links

### DIFF
--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -1853,7 +1853,7 @@ Field Pattern | Type | Description
 <a name="linkName"></a> {name} | [Link Object](#linkObject) <span>&#124;</span> [Reference Object](#referenceObject) | A short name for the link, following the naming constraints of the names for [Component Objects](#componentsObject).
 The link SHALL reference a single Link Object, or a JSON Reference to a single link object.
 
-#### <a name="#linkObject"></a>Link Object
+#### <a name="linkObject"></a>Link Object
 The `Link Object` is responsible for defining a possible operation based on a single response.
 
 Field Name  |  Type  | Description


### PR DESCRIPTION
The problem was a superfluous `#` in the anchor name.

This fixes #956.