### PR TITLE
Fix text/plain examples in Content Object

### DIFF
--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -1222,8 +1222,10 @@ Each key in the Content Object is the media type of the [Media Type Object](#med
     ]
   },
   "text/plain": {
-    "Bob,Diane,Mary,Bill",
-    ""
+    "examples": [
+      "Bob,Diane,Mary,Bill",
+      ""
+    ]
   }
 }
 ```
@@ -1250,6 +1252,7 @@ content:
   'text/plain':
     examples:
       - "Bob,Diane,Mary,Bill"
+      - ""
 ```
 
 #### <a name="mediaTypeObject"></a>Media Type Object


### PR DESCRIPTION
Missing `examples`  property in one case and missing empty example in the other.