### PR TITLE
Add URL format restriction on termsOfService

### DIFF
--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -211,7 +211,7 @@ Field Name | Type | Description
 ---|:---:|---
 <a name="infoTitle"></a>title | `string` | **Required.** The title of the application.
 <a name="infoDescription"></a>description | `string` | A short description of the application. [CommonMark syntax](http://spec.commonmark.org/) can be used for rich text representation.
-<a name="infoTermsOfService"></a>termsOfService | `string` | A URL to the Terms of Service for the API.
+<a name="infoTermsOfService"></a>termsOfService | `string` | A URL to the Terms of Service for the API. MUST be in the format of a URL.
 <a name="infoContact"></a>contact | [Contact Object](#contactObject) | The contact information for the exposed API.
 <a name="infoLicense"></a>license | [License Object](#licenseObject) | The license information for the exposed API.
 <a name="infoVersion"></a>version | `string` | **Required.** The version of the API definition (which is distinct from the OpenAPI specification version or the API implementation version).


### PR DESCRIPTION
If as per @earth2marsh's recent talk, this is a breaking change, we should draw attention to it as per the other URL-format properties.