### PR TITLE
add missing ":" and quotes in callback object example

### DIFF
--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -1761,7 +1761,7 @@ myWebhook:
       requestBody:
         description: Callback payload
         content: 
-          'application/json'
+          'application/json':
             schema:
               $ref: '#/components/schemas/SomePayload'
       responses:

--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -1765,7 +1765,7 @@ myWebhook:
             schema:
               $ref: '#/components/schemas/SomePayload'
       responses:
-        200:
+        '200':
           description: webhook successfully processed an no retries will be performed
 ```
 

--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -1766,7 +1766,7 @@ myWebhook:
               $ref: '#/components/schemas/SomePayload'
       responses:
         '200':
-          description: webhook successfully processed an no retries will be performed
+          description: webhook successfully processed and no retries will be performed
 ```
 
 


### PR DESCRIPTION
Noted this while copying (and recoloring) this example for a presentation.