### PR TITLE
Add missing quotes to YAML keys.

### DIFF
--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -1765,7 +1765,7 @@ myWebhook:
             schema:
               $ref: '#/components/schemas/SomePayload'
       responses:
-        200:
+        '200':
           description: webhook successfully processed an no retries will be performed
 ```
 
@@ -1974,7 +1974,7 @@ paths:
       schema:
         type: string
     responses:
-      200:
+      '200':
         description: the user being returned
         content:
           application/json:
@@ -2048,7 +2048,7 @@ paths:
         schema:
           type: string
       responses: 
-        200: 
+        '200':
           description: The User
           content:
             application/json:
@@ -2067,7 +2067,7 @@ paths:
           schema:
             type: string
       responses:
-        200:
+        '200':
           description: repositories owned by the supplied user
           content: 
             application/json:
@@ -2094,7 +2094,7 @@ paths:
           schema:
             type: string
       responses: 
-        200:
+        '200':
           description: The repository
             content:
               application/json: 
@@ -2126,7 +2126,7 @@ paths:
             - merged
             - declined
       responses: 
-        200: 
+        '200':
           description: an array of pull request objects
           content:
             application/json: 
@@ -2154,7 +2154,7 @@ paths:
         schema:
           type: string
       responses: 
-        200: 
+        '200':
           description: a pull request object
           content:
             application/json: 
@@ -2182,7 +2182,7 @@ paths:
         schema:
           type: string
       responses: 
-        204:
+        '204':
           description: the PR was successfully merged
 components:
   links:
@@ -2402,7 +2402,7 @@ schemas:
           $ref: 'http://foo.bar#/examples/zip-example'
 # in a response, note the plural `examples`:
   responses:
-    200:
+    '200':
       description: your car appointment has been booked
       content: 
         application/json:


### PR DESCRIPTION
By the "Format" section, keys in YAML need to be strings, and unquoted numbers are not strings in YAML. This adds missing quotes to all the response codes serving as keys.