### PR TITLE
Remove trailing spaces

### DIFF
--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -97,7 +97,7 @@ Some examples of possible media type definitions:
   application/vnd.github.v3.patch
 ```
 ##### <a name="httpCodes"></a>HTTP Status Codes
-The HTTP Status Codes are used to indicate the status of the executed operation. 
+The HTTP Status Codes are used to indicate the status of the executed operation.
 The available status codes are defined by [RFC 7231](http://tools.ietf.org/html/rfc7231#section-6) and registered status codes are listed in the [IANA Status Code Registry](http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml).
 
 ## Specification
@@ -105,7 +105,7 @@ The available status codes are defined by [RFC 7231](http://tools.ietf.org/html/
 ### Format
 
 The files describing the RESTful API in accordance with this specification are represented as JSON objects and conform to the JSON standards.
-YAML, being a superset of JSON, can be used as well to represent an OAS file. 
+YAML, being a superset of JSON, can be used as well to represent an OAS file.
 
 For example, if a field has an array value, the JSON array representation will be used:
 
@@ -121,7 +121,7 @@ All field names in the specification are **case sensitive**.
 
 The schema exposes two types of fields.
 Fixed fields, which have a declared name, and Patterned fields, which declare a regular expression pattern for the field name.
-Patterned fields can have multiple occurrences as long as each has a unique name. 
+Patterned fields can have multiple occurrences as long as each has a unique name.
 
 In order to preserve the ability to round-trip between YAML and JSON formats, YAML version [1.2](http://www.yaml.org/spec/1.2/spec.html) is recommended along with some additional constraints:
 
@@ -138,8 +138,8 @@ By convention, it is RECOMMENDED that the OpenAPI Specification (OAS) file be na
 
 ### <a name="dataTypes"></a>Data Types
 
-Primitive data types in the OAS are based on the types supported by the [JSON Schema Specification Wright Draft 00](https://tools.ietf.org/html/draft-wright-json-schema-00#section-4.2). 
-Note that `integer` as a type is also supported and is defined as a JSON number without a fraction or exponent part. 
+Primitive data types in the OAS are based on the types supported by the [JSON Schema Specification Wright Draft 00](https://tools.ietf.org/html/draft-wright-json-schema-00#section-4.2).
+Note that `integer` as a type is also supported and is defined as a JSON number without a fraction or exponent part.
 `null` is not supported as a value.
 Models are described using the [Schema Object](#schemaObject) which is an extended subset of JSON Schema Specification Wright Draft 00.
 
@@ -175,7 +175,7 @@ Relative references used in `$ref` are processed as per [JSON Reference](https:/
 
 ### Schema
 
-In the following description, if a field is not explicitly **Required** or described with a MUST or SHALL, it can be considered OPTIONAL. 
+In the following description, if a field is not explicitly **Required** or described with a MUST or SHALL, it can be considered OPTIONAL.
 
 #### <a name="oasObject"></a>OpenAPI Object
 
@@ -195,7 +195,7 @@ Field Name | Type | Description
 <a name="oasTags"></a>tags | [[Tag Object](#tagObject)] | A list of tags used by the specification with additional metadata. The order of the tags can be used to reflect on their order by the parsing tools. Not all tags that are used by the [Operation Object](#operationObject) must be declared. The tags that are not declared MAY be organized randomly or based on the tools' logic. Each tag name in the list MUST be unique.
 <a name="oasExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation.
 
-This object can be extended with [Specification Extensions](#specificationExtensions). 
+This object can be extended with [Specification Extensions](#specificationExtensions).
 
 #### <a name="oasVersionString"></a>OpenAPI Version String
 
@@ -223,7 +223,7 @@ Field Name | Type | Description
 <a name="infoVersion"></a>version | `string` | **Required.** The version of the API definition (which is distinct from the OpenAPI specification version or the API implementation version).
 
 
-This object can be extended with [Specification Extensions](#specificationExtensions). 
+This object can be extended with [Specification Extensions](#specificationExtensions).
 
 ##### Info Object Example:
 
@@ -271,7 +271,7 @@ Field Name | Type | Description
 <a name="contactUrl"></a>url | `string` | The URL pointing to the contact information. MUST be in the format of a URL.
 <a name="contactEmail"></a>email | `string` | The email address of the contact person/organization. MUST be in the format of an email address.
 
-This object can be extended with [Specification Extensions](#specificationExtensions). 
+This object can be extended with [Specification Extensions](#specificationExtensions).
 
 ##### Contact Object Example:
 
@@ -300,7 +300,7 @@ Field Name | Type | Description
 <a name="licenseName"></a>name | `string` | **Required.** The license name used for the API.
 <a name="licenseUrl"></a>url | `string` | A URL to the license used for the API. MUST be in the format of a URL.
 
-This object can be extended with [Specification Extensions](#specificationExtensions). 
+This object can be extended with [Specification Extensions](#specificationExtensions).
 
 ##### License Object Example:
 
@@ -328,7 +328,7 @@ Field Name | Type | Description
 <a name="serverDescription"></a>description | `string` | An optional string describing the host designated by the URL.
 <a name="serverVariables"></a>variables | [Server Variables Object](#serverVariablesObject) | An object holding variables for substitution in the URL template.
 
-This object can be extended with [Specification Extensions](#specificationExtensions). 
+This object can be extended with [Specification Extensions](#specificationExtensions).
 
 ##### Server Object Example
 
@@ -380,7 +380,7 @@ Field Pattern | Type | Description
 ---|:---:|---
 <a name="serverVariablesName"></a> {name} | [Server Variable Object](#serverVariableObject) | A variable to be used for substitution in a Server's URL template.
 
-This object can be extended with [Specification Extensions](#specificationExtensions). 
+This object can be extended with [Specification Extensions](#specificationExtensions).
 
 
 #### <a name="serverVariableObject"></a>Server Variable Object
@@ -393,7 +393,7 @@ Field Name | Type | Description
 <a name="serverVariableDefault"></a>default | `primitive` |  **Required.** The default value to use for substitution if an alternate value is not specified, and will be sent if an alternative value is _not_ supplied. Unlike the [Schema Object's](#schemaObject) `default`, this value MUST be provided by the consumer.
 <a name="serverVariableDescription"></a>description | `string` | An optional description for the server variable.
 
-This object can be extended with [Specification Extensions](#specificationExtensions). 
+This object can be extended with [Specification Extensions](#specificationExtensions).
 
 #### <a name="componentsObject"></a>Components Object
 
@@ -415,7 +415,7 @@ Field Name | Type | Description
 <a name="componentsLinks"></a> links | Map[`string`, [Link Object](#linkObject)] | An object to hold reusable [Link Objects](#linkObject).
 <a name="componentsCallbacks"></a> callbacks | Map[`string`, [Callback Object](#callbackObject)] | An object to hold reusable [Callback Objects](#callbackObject).
 
-This object can be extended with [Specification Extensions](#specificationExtensions). 
+This object can be extended with [Specification Extensions](#specificationExtensions).
 
 All the fixed fields declared above are objects that MUST use keys that match the regular expression: `^[a-zA-Z0-9\.\-_]+$`.
 
@@ -577,7 +577,7 @@ components:
       in: header
     petstore_auth:
       type: oauth2
-      flow: 
+      flow:
         implicit:
           authorizationUrl: http://example.org/api/oauth/dialog
           scopes:
@@ -597,7 +597,7 @@ Field Pattern | Type | Description
 ---|:---:|---
 <a name="pathsPath"></a>/{path} | [Path Item Object](#pathItemObject) | A relative path to an individual endpoint. The field name MUST begin with a slash. The path is **appended** (no relative URL resolution) to the expanded URL from the [`Server Object`](#serverObject)'s `url` field in order to construct the full URL. [Path templating](#pathTemplating) is allowed.
 
-This object can be extended with [Specification Extensions](#specificationExtensions). 
+This object can be extended with [Specification Extensions](#specificationExtensions).
 
 ##### Paths Object Example
 
@@ -607,7 +607,7 @@ This object can be extended with [Specification Extensions](#specificationExtens
     "get": {
       "description": "Returns all pets from the system that the user has access to",
       "responses": {
-        "200": {          
+        "200": {
           "description": "A list of pets.",
           "content": {
             "application/json": {
@@ -662,11 +662,11 @@ Field Name | Type | Description
 <a name="pathItemHead"></a>head | [Operation Object](#operationObject) | A definition of a HEAD operation on this path.
 <a name="pathItemPatch"></a>patch | [Operation Object](#operationObject) | A definition of a PATCH operation on this path.
 <a name="pathItemTrace"></a>trace | [Operation Object](#operationObject) | A definition of a TRACE operation on this path.
-<a name="pathItemServers"></a>servers | [Server Object](#serverObject) | An alternative `server` array to service all operations in this path.  
+<a name="pathItemServers"></a>servers | [Server Object](#serverObject) | An alternative `server` array to service all operations in this path.
 <a name="pathItemParameters"></a>parameters | [[Parameter Object](#parameterObject) \| [Reference Object](#referenceObject)] | A list of parameters that are applicable for all the operations described under this path. These parameters can be overridden at the operation level, but cannot be removed there. The list MUST NOT include duplicated parameters. A unique parameter is defined by a combination of a [name](#parameterName) and [location](#parameterIn). The list can use the [Reference Object](#referenceObject) to link to parameters that are defined at the [OpenAPI Object's parameters](#oasParameters).
 
 
-This object can be extended with [Specification Extensions](#specificationExtensions). 
+This object can be extended with [Specification Extensions](#specificationExtensions).
 
 ##### Path Item Object Example
 
@@ -746,7 +746,7 @@ parameters:
   type: array
   format: form
   items:
-    type: string  
+    type: string
 ```
 
 #### <a name="operationObject"></a>Operation Object
@@ -770,7 +770,7 @@ Field Name | Type | Description
 <a name="operationSecurity"></a>security | [[Security Requirement Object](#securityRequirementObject)] | A declaration of which security mechanisms can be used for this operation. The list of values includes alternative security requirement objects that can be used. Only one of the security requirement objects need to be satisfied to authorize a request. This definition overrides any declared top-level [`security`](#oasSecurity). To remove a top-level security declaration, an empty array can be used.
 <a name="operationServers"></a>servers | [Server Object](#serverObject) | An alternative `server` array to service this operation. If an alternative `server` object is specified at the Path Item Object or Root level, it will be overridden by this value.
 
-This object can be extended with [Specification Extensions](#specificationExtensions). 
+This object can be extended with [Specification Extensions](#specificationExtensions).
 
 ##### Operation Object Example
 
@@ -796,7 +796,7 @@ This object can be extended with [Specification Extensions](#specificationExtens
         "schema": {
           "type": "object",
            "properties": {
-              "name": { 
+              "name": {
                 "description": "Updated name of the pet",
                 "type": "string"
               },
@@ -805,7 +805,7 @@ This object can be extended with [Specification Extensions](#specificationExtens
                 "type": "string"
              }
            },
-        "required": ["status"] 
+        "required": ["status"]
         }
       }
     }
@@ -853,23 +853,23 @@ requestBody:
     'application/x-www-form-urlencoded':
       schema:
        properties:
-          name: 
+          name:
             description: Updated name of the pet
             type: string
           status:
             description: Updated status of the pet
             type: string
-        required: 
+        required:
           - status
 responses:
   '200':
     description: Pet updated.
-    content: 
+    content:
       'application/json': {}
       'application/xml': {}
   '405':
     description: Invalid input
-    content: 
+    content:
       'application/json': {}
       'application/xml': {}
 security:
@@ -890,7 +890,7 @@ Field Name | Type | Description
 <a name="externalDocDescription"></a>description | `string` | A short description of the target documentation. [CommonMark syntax](http://spec.commonmark.org/) can be used for rich text representation.
 <a name="externalDocUrl"></a>url | `string` | **Required.** The URL for the target documentation. Value MUST be in the format of a URL.
 
-This object can be extended with [Specification Extensions](#specificationExtensions). 
+This object can be extended with [Specification Extensions](#specificationExtensions).
 
 ##### External Documentation Object Example
 
@@ -925,7 +925,7 @@ Field Name | Type | Description
 <a name="parameterName"></a>name | `string` | **Required.** The name of the parameter. Parameter names are *case sensitive*. <ul><li>If [`in`](#parameterIn) is `"path"`, the `name` field MUST correspond to the associated path segment from the [path](#pathsPath) field in the [Paths Object](#pathsObject). See [Path Templating](#pathTemplating) for further information.<li>For all other cases, the `name` corresponds to the parameter name used based on the [`in`](#parameterIn) property.</ul>
 <a name="parameterIn"></a>in | `string` | **Required.** The location of the parameter. Possible values are "query", "header", "path" or "cookie".
 <a name="parameterDescription"></a>description | `string` | A brief description of the parameter. This could contain examples of use.  [CommonMark syntax](http://spec.commonmark.org/) can be used for rich text representation.
-<a name="parameterRequired"></a>required | `boolean` | Determines whether this parameter is mandatory. If the [parameter location](#parameterIn) is "path", this property is **required** and its value MUST be `true`. Otherwise, the property MAY be included and its default value is `false`. 
+<a name="parameterRequired"></a>required | `boolean` | Determines whether this parameter is mandatory. If the [parameter location](#parameterIn) is "path", this property is **required** and its value MUST be `true`. Otherwise, the property MAY be included and its default value is `false`.
 <a name="parameterDeprecated"></a> deprecated | `boolean` | Specifies that a parameter is deprecated and SHOULD be transitioned out of usage.
 <a name="parameterAllowEmptyValue"/>allowEmptyValue | `boolean` | Sets the ability to pass empty-valued parameters. This is valid only for `query` parameters and allows sending a parameter with an empty value. Default value is `false`. If [`style`](#parameterStyle) is used, if behavior is `n/a`, the value of `allowEmptyValue` SHALL be ignored.
 
@@ -941,9 +941,9 @@ Field Name | Type | Description
 <a name="parameterExamples"></a>examples | [[Example Object](#exampleObject) \| [Reference Object](#referenceObject)] | Examples of the content type.  Each example in the Examples array SHOULD be in the correct format as specified parameter encoding.  The `examples` object is mutually exclusive to the `example` object.  Furthermore, if referencing a `schema` which contains an example, the `examples` value SHALL _override_ the example provided by the schema.
 <a name="parameterExample"></a>example | [Example Object](#exampleObject) \| [Reference Object](#referenceObject) | Example of the content type.  The example object SHOULD be in the correct format as specified in the parameter encoding.  The `example` object is mutually exclusive to the `examples` object.  Furthermore, if referencing a `schema` which contains an example, the `example` value SHALL _override_ the example provided by the schema.
 
-For more complex scenarios a [Content Object](#contentObject) can be used to define the media type 
+For more complex scenarios a [Content Object](#contentObject) can be used to define the media type
 and schema of the parameter.  This option is mutually exclusive with the simple scenario
-above. When `example` or `examples` are provided in conjunction with the `schema` object, 
+above. When `example` or `examples` are provided in conjunction with the `schema` object,
 the example MUST follow the prescribed serialization strategy for the parameter.
 
 
@@ -955,11 +955,11 @@ In order to support common ways of serializing simple parameters, a set of `styl
 
 `style` | [`type`](#dataTypeType) |  `in` | Comments
 ----------- | ------ | -------- | --------
-matrix |  `primitive`, `array`, `object` |  `path` | Path-style parameters defined by [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.7) 
+matrix |  `primitive`, `array`, `object` |  `path` | Path-style parameters defined by [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.7)
 label | `primitive`, `array`, `object` |  `path` | Label style parameters defined by [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.5)
-form |  `primitive`, `array`, `object` |  `query`, `cookie` | Form style parameters defined by [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.8). This option replaces `collectionFormat` with a `csv` value. 
+form |  `primitive`, `array`, `object` |  `query`, `cookie` | Form style parameters defined by [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.8). This option replaces `collectionFormat` with a `csv` value.
 simple | `array` | `path`, `header` | Simple style parameters defined by [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.2).
-spaceDelimited | `array` | `query` | Space separated array values. This option replaces `collectionFormat` equal to `ssv`. 
+spaceDelimited | `array` | `query` | Space separated array values. This option replaces `collectionFormat` equal to `ssv`.
 pipeDelimited | `array` | `query` | Pipe separated array values. This option replaces `collectionFormat` equal to `pipes`.
 deepObject | `object` | `query` | Provides a simple way of rendering nested objects using form parameters.
 
@@ -989,7 +989,7 @@ spaceDelimited | false | n/a | n/a | blue%20black%20brown | R%20100%20G%20200%20
 pipeDelimited | false | n/a | n/a | blue\|black\|brown | R\|100\|G\|200|G\|150
 deepObject | true | n/a | n/a | n/a | color[R]=100&color[G]=200&color[B]=150
 
-This object can be extended with [Specification Extensions](#specificationExtensions). 
+This object can be extended with [Specification Extensions](#specificationExtensions).
 
 ##### Parameter Object Examples
 
@@ -1115,7 +1115,7 @@ Field Name | Type | Description
 <a name="requestBodyRequired"></a>required | `boolean` | Determines if the request body is required in the request. Defaults to `true`.
 
 
-This object can be extended with [Specification Extensions](#specificationExtensions). 
+This object can be extended with [Specification Extensions](#specificationExtensions).
 
 ##### Request Body Examples
 
@@ -1150,7 +1150,7 @@ A request body with a referenced model definition.
 
 ```yaml
 description: user to add to the system
-content: 
+content:
   'application/json':
     schema:
       $ref: '#/components/schemas/User'
@@ -1238,20 +1238,20 @@ Each key in the Content Object is the media type of the [Media Type Object](#med
 
 ```yaml
 content:
-  'application/json': 
+  'application/json':
     schema:
       type: array
       items:
         type: string
     examples:
-      - 
+      -
         - Bob
         - Diane
         - Mary
         - Bill
       - {}
 
-  'application/xml': 
+  'application/xml':
     examples:
       - "<Users><User name='Bob'/><User name='Diane'/><User name='Mary'/><User name='Bill'/></Users>"
       - "<Users/>"
@@ -1262,7 +1262,7 @@ content:
 ```
 
 #### <a name="mediaTypeObject"></a>Media Type Object
-Each Media Type Object provides schema and examples for a the media type identified by its key.  Media Type Objects can be used in a [Content Object](#contentObject).   
+Each Media Type Object provides schema and examples for a the media type identified by its key.  Media Type Objects can be used in a [Content Object](#contentObject).
 
 ##### Fixed Fields
 Field Name | Type | Description
@@ -1272,7 +1272,7 @@ Field Name | Type | Description
 <a name="mediaTypeExample"></a>example | [Example Object](#exampleObject) \| [Reference Object](#referenceObject) | Example of the media type.  The example object SHOULD be in the correct format as specified in the media type.  The `example` object is mutually exclusive to the `examples` object.  Furthermore, if referencing a `schema` which contains an example, the `example` value SHALL _override_ the example provided by the schema.
 <a name="mediaTypeEncoding"></a>encoding | [Encoding Object](#encodingObject) | Encoding of the media type.  The encoding object SHOULD only apply to `requestBody` objects when the content type is `multipart`.
 
-This object can be extended with [Specification Extensions](#specificationExtensions). 
+This object can be extended with [Specification Extensions](#specificationExtensions).
 
 ##### Media Type Examples
 
@@ -1286,7 +1286,7 @@ This object can be extended with [Specification Extensions](#specificationExtens
                   "name": "Fluffy",
                   "petType": "Cat"
                  },
-                 { 
+                 {
                    "name": "Rover",
                    "petType": "Frog"
                  }]
@@ -1295,7 +1295,7 @@ This object can be extended with [Specification Extensions](#specificationExtens
 ```
 
 ```yaml
-application/json: 
+application/json:
   schema:
     $ref: "#/components/schemas/Pet"
   examples:
@@ -1308,7 +1308,7 @@ application/json:
 
 ##### Considerations for file uploads
 
-In contrast with the 2.0 specification, describing `file` input/output content in OpenAPI is 
+In contrast with the 2.0 specification, describing `file` input/output content in OpenAPI is
 described with the same semantics as any other schema type. Specifically:
 
 ```yaml
@@ -1477,20 +1477,20 @@ Field Name | Type | Description
 <a name="encodingStyle"></a>style | `string` | The Content-Type to use for encoding a specific property.  See [Parameter Object](#parameterObject) for details on the [`style`](#parameterStyle) property. The behavior follows the same values allowed for `query` parameters, including default values.
 <a name="encodingExplode"></a>explode | `boolean` | When this is true, property values of type `array` or `object` generate separate parameters for each value of the array, or key-value-pair of the map.  For other types of properties this property has no effect. When [`style`](#encodingStyle) is `form`, the default value is `true`. For all other styles, the default value is `false`.
 
-This object can be extended with [Specification Extensions](#specificationExtensions). 
+This object can be extended with [Specification Extensions](#specificationExtensions).
 
 #### <a name="responsesObject"></a>Responses Object
 
 A container for the expected responses of an operation.
 The container maps a HTTP response code to the expected response.
-It is not expected from the documentation to necessarily cover all possible HTTP response codes, since they may not be known in advance. However, it is expected 
-from the documentation to cover a successful operation response and any 
+It is not expected from the documentation to necessarily cover all possible HTTP response codes, since they may not be known in advance. However, it is expected
+from the documentation to cover a successful operation response and any
 known errors.
 
-The `default` MAY be used as a default response object for all HTTP codes 
+The `default` MAY be used as a default response object for all HTTP codes
 that are not covered individually by the specification.
 
-The `Responses Object` MUST contain at least one response code, and it 
+The `Responses Object` MUST contain at least one response code, and it
 SHOULD be the response for a successful operation call.
 
 ##### Fixed Fields
@@ -1506,7 +1506,7 @@ Field Pattern | Type | Description
 <a name="responsesCode"></a>[HTTP Status Code](#httpCodes) | [Response Object](#responseObject) \| [Reference Object](#referenceObject) | Any [HTTP status code](#httpCodes) can be used as the property name (one property per HTTP status code). Describes the expected response for that HTTP status code.  [Reference Object](#referenceObject) can be used to link to a response that is defined at the [OpenAPI Object's responses](#oasResponses) section. This field MUST be quoted for compatibility between JSON and YAML (i.e. "200"), and MAY contain the uppercase character, `X` to designate a wildcard, such as `2XX` to represent all response codes between `[200-299]`.
 
 
-This object can be extended with [Specification Extensions](#specificationExtensions). 
+This object can be extended with [Specification Extensions](#specificationExtensions).
 
 ##### Responses Object Example
 
@@ -1540,7 +1540,7 @@ A 200 response for successful operation and a default response for others (imply
 ```yaml
 '200':
   description: a pet to be returned
-  content: 
+  content:
     application/json:
       schema:
         $ref: '#/components/schemas/Pet'
@@ -1553,7 +1553,7 @@ default:
 ```
 
 #### <a name="responseObject"></a>Response Object
-Describes a single response from an API Operation, including design-time, static 
+Describes a single response from an API Operation, including design-time, static
 `links` to operations based on the response.
 
 ##### Fixed Fields
@@ -1564,7 +1564,7 @@ Field Name | Type | Description
 <a name="responseContentObject"></a>content | [Content Object](#contentObject) | An object containing descriptions of potential response payloads.
 <a name="responseLinks"></a>links | [Links Object](#linksObject) | An object representing operations related to the response payload.
 
-This object can be extended with [Specification Extensions](#specificationExtensions). 
+This object can be extended with [Specification Extensions](#specificationExtensions).
 
 ##### Response Object Examples
 
@@ -1588,9 +1588,9 @@ Response of an array of a complex type:
 
 ```yaml
 description: A complex object array response
-content: 
+content:
   application/json:
-    schema: 
+    schema:
       type: array
       items:
         $ref: '#/components/schemas/VeryComplexType'
@@ -1691,7 +1691,7 @@ Field Pattern | Type | Description
 ---|:---:|---
 <a name="callbackName"></a>{name} | [Callback Object](#callbackObject) \| [Reference Object](#ReferenceObject) | A Callback Object used to define a callback request and expected responses
 
-This object can be extended with [Specification Extensions](#specificationExtensions). 
+This object can be extended with [Specification Extensions](#specificationExtensions).
 
 #### <a name="callbackObject"></a>Callback Object
 
@@ -1704,14 +1704,14 @@ Field Pattern | Type | Description
 ---|:---:|---
 <a name="callbackExpression"></a>{expression} | [Path Item Object](#pathItemObject) | A Path Item Object used to define a callback request and expected responses
 
-This object can be extended with [Specification Extensions](#specificationExtensions). 
+This object can be extended with [Specification Extensions](#specificationExtensions).
 
 ##### Key Expression
 
 The key used to identify the [Path Item Object](#pathItemObject) is a variable expression that can be evaluated in the context of a runtime HTTP request/response to identify the URL to be used for the callback request.
 A simple example might be `$request.body#/url`.
 However, using [variable substitution](#variableSubstitution) syntax the complete HTTP message can be accessed.
-This includes accessing any part of a body that can be accessed using a JSON Pointer [RFC6901](https://tools.ietf.org/html/rfc6901). 
+This includes accessing any part of a body that can be accessed using a JSON Pointer [RFC6901](https://tools.ietf.org/html/rfc6901).
 
 For example, given the following HTTP request:
 
@@ -1727,7 +1727,7 @@ Content-Length: 123
     "http://clientdomain.com/fast",
     "http://clientdomain.com/medium",
     "http://clientdomain.com/slow"
-  ] 
+  ]
 }
 
 201 Created
@@ -1737,7 +1737,7 @@ Location: http://example.org/subscription/1
 
 Here are the examples of how the various expressions evaluate, assuming a the callback operation has a path parameter named `eventType` and a query parameter named `queryUrl`.
 
-Expression | Value 
+Expression | Value
 ---|:---
 $url | http://example.org/subscribe/myevent?queryUrl=http://clientdomain.com/stillrunning
 $method | POST
@@ -1760,7 +1760,7 @@ myWebhook:
     post:
       requestBody:
         description: Callback payload
-        content: 
+        content:
           'application/json'
             schema:
               $ref: '#/components/schemas/SomePayload'
@@ -1822,7 +1822,7 @@ X-Rate-Limit-Reset:
 
 #### <a name="exampleObject"></a>Example Object
 
-Allows sharing examples for operation requests and responses. This object can either be a freeform object, array or primitive value.  To represent examples of media types that cannot naturally represented in the OpenAPI definition, a string value can be used to contain the example with escaping where necessary. 
+Allows sharing examples for operation requests and responses. This object can either be a freeform object, array or primitive value.  To represent examples of media types that cannot naturally represented in the OpenAPI definition, a string value can be used to contain the example with escaping where necessary.
 
 ##### Example Example
 
@@ -1873,7 +1873,7 @@ parameters  | [Link Parameters Object](#linkParametersObject) | an object repres
 headers     | [Headers Object](#headersObject)    | an object representing headers to pass to the linked resource. Where conflicts occur between these headers, and those defined in the related operation, these headers override.
 description | `string` | a description of the link, supports [CommonMark syntax](http://spec.commonmark.org/).
 
-This object can be extended with [Specification Extensions](#specificationExtensions). 
+This object can be extended with [Specification Extensions](#specificationExtensions).
 
 Locating a linked resource MAY be performed by either a `href` or `operationId`.
 In the case of an `operationId`, it MUST be unique and resolved in the scope of the OAS document.
@@ -1883,7 +1883,7 @@ Because of the potential for name clashes, consider the `href` syntax as the pre
 
 Payload values are only available in parsable response payloads which match the advertised media type and for media types that can be referenced using a JSON Pointer fragment Id.
 In all cases, if a value does _not_ exist, the parameter will be considered a `null` value (as opposed to an empty value) and _not_ passed as a parameter to the linked resource.
-In cases where a value is required, and a parameter is not supplied, the client MAY choose to not follow the link definition. 
+In cases where a value is required, and a parameter is not supplied, the client MAY choose to not follow the link definition.
 
 ##### Example
 
@@ -1930,34 +1930,34 @@ The table below provides examples of variable expressions and examples of their 
 
 Source Location | variable expression | example reference | notes
 ---|:---|:---|:---
-HTTP Method            | `$method`         | `/users/{$method}`                | The allowable values for the `$method` will be those for the HTTP operation 
-Requested content type | `$request.header.accept`        | `/users/3?format={$request.header.accept}`      |  
-Request parameter      | `$request.path.id`        | `/users/{$request.path.id}`            | Request parameters MUST be declared in the `parameters` section for the operation or they cannot be used in substitution.  This includes request headers
+HTTP Method            | `$method`         | `/users/{$method}`                | The allowable values for the `$method` will be those for the HTTP operation
+Requested content type | `$request.header.accept`        | `/users/3?format={$request.header.accept}`      |
+Request parameter      | `$request.path.id`        | `/users/{$request.path.id}`            | Request parameters MUST be declared in the `parameters` section for the operation or they cannot be used in substitution.  This includes request headers.
 Request body           | `$request.body`    | `/users/{$request.body#/user/uuid}` | For operations which accept payloads, references may be made to portions of the `requestBody` or the entire body itself
-Request URL            | `$url`            | `/track?url={$url}`               | 
-Response value         | `$response.body`       | `{$response.body#/uuid}`                | Only the payload in the response can be accessed with the `$response` syntax.  
+Request URL            | `$url`            | `/track?url={$url}`               |
+Response value         | `$response.body`       | `{$response.body#/uuid}`                | Only the payload in the response can be accessed with the `$response` syntax.
 Response header        | `$response.header` | `{$response.header.Server}`        | Single header values only are available
 
 From the request, the `parameter`s used in calling the operation are made available through the `$request` syntax.
 For responses, the response payload may be used with the `$response` syntax.
-For both requests and responses, values will be substituted in the link in sections designated with a variable expression, surrounded by curly brackets `{}`. 
+For both requests and responses, values will be substituted in the link in sections designated with a variable expression, surrounded by curly brackets `{}`.
 
 The variable expression is defined by the following [ABNF](https://tools.ietf.org/html/rfc5234) syntax
 
 ```
       expression = ( "$url" | "$method" | "$request." [ source ] | "$response." [ source ])
-      source = ( header-reference | query-reference | path-reference | body-reference )  
+      source = ( header-reference | query-reference | path-reference | body-reference )
       header-reference = "header." token
-      query-reference = "query." name  
+      query-reference = "query." name
       path-reference = "path." name
       body-reference = "body#" fragment
-      fragment = a JSON Pointer [RFC 6901](https://tools.ietf.org/html/rfc6901)  
+      fragment = a JSON Pointer [RFC 6901](https://tools.ietf.org/html/rfc6901)
       name = *( char )
       char = as per RFC [7159](https://tools.ietf.org/html/rfc7159#section-7)
       token = as per RFC [7230](https://tools.ietf.org/html/rfc7230#section-3.2.6)
 ```
 
-The `name` identifier is case-sensitive, whereas `token` is not. 
+The `name` identifier is case-sensitive, whereas `token` is not.
 
 
 ##### Request Parameter Example
@@ -2037,22 +2037,22 @@ As with all links, it is at the clients' discretion to follow them, neither perm
 The example below shows how relationships in the BitBucket API can be represented with the link schema. This example uses `operationId` values to link responses to possible operations.
 
 ```yaml
-paths: 
-  /2.0/users/{username}: 
-    get: 
+paths:
+  /2.0/users/{username}:
+    get:
       operationId: getUserByName
-      parameters: 
+      parameters:
       - name: username
         in: path
         required: true
         schema:
           type: string
-      responses: 
+      responses:
         '200':
           description: The User
           content:
             application/json:
-              schema: 
+              schema:
                 $ref: '#/components/schemas/user'
           links:
             userRepositories:
@@ -2069,7 +2069,7 @@ paths:
       responses:
         '200':
           description: repositories owned by the supplied user
-          content: 
+          content:
             application/json:
               schema:
                 type: array
@@ -2078,10 +2078,10 @@ paths:
           links:
             userRepository:
               $ref: '#/components/links/UserRepository'
-  /2.0/repositories/{username}/{slug}: 
-    get: 
+  /2.0/repositories/{username}/{slug}:
+    get:
       operationId: getRepository
-      parameters: 
+      parameters:
         - name: username
           type: string
           in: path
@@ -2093,20 +2093,20 @@ paths:
           required: true
           schema:
             type: string
-      responses: 
+      responses:
         '200':
           description: The repository
             content:
-              application/json: 
-                schema: 
+              application/json:
+                schema:
                   $ref: '#/components/schemas/repository'
           links:
             repositoryPullRequests:
               $ref: '#/components/links/RepositoryPullRequests'
-  /2.0/repositories/{username}/{slug}/pullrequests: 
-    get: 
+  /2.0/repositories/{username}/{slug}/pullrequests:
+    get:
       operationId: getPullRequestsByRepository
-      parameters: 
+      parameters:
       - name: username
         in: path
         required: true
@@ -2121,23 +2121,23 @@ paths:
         in: query
         schema:
           type: string
-          enum: 
+          enum:
             - open
             - merged
             - declined
-      responses: 
+      responses:
         '200':
           description: an array of pull request objects
           content:
-            application/json: 
-              schema: 
+            application/json:
+              schema:
                 type: array
-                items: 
+                items:
                   $ref: '#/components/schemas/pullrequest'
-  /2.0/repositories/{username}/{slug}/pullrequests/{pid}: 
-    get: 
+  /2.0/repositories/{username}/{slug}/pullrequests/{pid}:
+    get:
       operationId: getPullRequestsById
-      parameters: 
+      parameters:
       - name: username
         in: path
         required: true
@@ -2153,19 +2153,19 @@ paths:
         required: true
         schema:
           type: string
-      responses: 
+      responses:
         '200':
           description: a pull request object
           content:
-            application/json: 
-              schema: 
+            application/json:
+              schema:
                 $ref: '#/components/schemas/pullrequest'
           links:
             $ref: '#/components/links/PullRequestMerge'
-  /2.0/repositories/{username}/{slug}/pullrequests/{pid}/merge: 
-    post: 
+  /2.0/repositories/{username}/{slug}/pullrequests/{pid}/merge:
+    post:
       operationId: mergePullRequest
-      parameters: 
+      parameters:
       - name: username
         in: path
         required: true
@@ -2181,7 +2181,7 @@ paths:
         required: true
         schema:
           type: string
-      responses: 
+      responses:
         '204':
           description: the PR was successfully merged
 components:
@@ -2200,7 +2200,7 @@ components:
     RepositoryPullRequests:
       # returns '#/components/schemas/pullrequest'
       operationId: getPullRequestsByRepository
-        parameters: 
+        parameters:
           username: $response.body#/owner/username
           slug: $response.body#/slug
     PullRequestMerge:
@@ -2210,31 +2210,31 @@ components:
         username: $response.body#/user/username # Should be $response.author.username?
         slug: $response.body#/repository/slug
         pid: $response.body#/id
-  schemas: 
-    user: 
+  schemas:
+    user:
       type: object
-      properties: 
-        username: 
+      properties:
+        username:
           type: string
-        uuid: 
+        uuid:
           type: string
-    repository: 
+    repository:
       type: object
-      properties: 
-        slug: 
+      properties:
+        slug:
           type: string
-        owner: 
+        owner:
           $ref: '#/components/schemas/user'
-    pullrequest: 
+    pullrequest:
       type: object
-      properties: 
-        id: 
+      properties:
+        id:
           type: integer
-        title: 
+        title:
           type: string
-        repository: 
+        repository:
           $ref: '#/components/schemas/repository'
-        author: 
+        author:
           $ref: '#/components/schemas/user'
 ```
 
@@ -2337,7 +2337,7 @@ Field Name | Type | Description
 <a name="tagDescription"></a>description | `string` | A short description for the tag. [CommonMark syntax](http://spec.commonmark.org/) can be used for rich text representation.
 <a name="tagExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation for this tag.
 
-This object can be extended with [Specification Extensions](#specificationExtensions). 
+This object can be extended with [Specification Extensions](#specificationExtensions).
 
 ##### Tag Object Example
 
@@ -2355,14 +2355,14 @@ description: Pets operations
 
 #### <a name="examplesObject"></a>Examples Object
 
-Anywhere an `example` may be given, a JSON Reference MAY be used, with the 
-explicit restriction that examples having a JSON format with object named 
-`$ref` are not allowed. This does mean that `example`, structurally, can be 
+Anywhere an `example` may be given, a JSON Reference MAY be used, with the
+explicit restriction that examples having a JSON format with object named
+`$ref` are not allowed. This does mean that `example`, structurally, can be
 either a string primitive or an object, similar to `additionalProperties`.
 
-In all cases, the payload is expected to be compatible with the type schema 
-for the value that it is accompanying.  Tooling implementations MAY choose to 
-validate compatibility automatically, and reject the example value(s) if they 
+In all cases, the payload is expected to be compatible with the type schema
+for the value that it is accompanying.  Tooling implementations MAY choose to
+validate compatibility automatically, and reject the example value(s) if they
 are not compatible.
 
 ```yaml
@@ -2380,16 +2380,16 @@ schemas:
       'application/json':
         schema:
           $ref: '#/components/schemas/Address'
-        examples: 
+        examples:
           - {"foo": "bar"}
           - {"bar": "baz"}
       'application/xml':
-        examples: 
-          - $ref: 'http://foo.bar#/examples/address-example.xml' 
+        examples:
+          - $ref: 'http://foo.bar#/examples/address-example.xml'
       'text/plain':
-        examples: 
-          - $ref: 'http://foo.bar#/examples/address-example.txt' 
-        
+        examples:
+          - $ref: 'http://foo.bar#/examples/address-example.txt'
+
 # in a parameter
 
   parameters:
@@ -2398,13 +2398,13 @@ schemas:
       schema:
         type: 'string'
         format: 'zip-code'
-        example: 
+        example:
           $ref: 'http://foo.bar#/examples/zip-example'
 # in a response, note the plural `examples`:
   responses:
     '200':
       description: your car appointment has been booked
-      content: 
+      content:
         application/json:
           schema:
             $ref: '#/components/schemas/SuccessResponse'
@@ -2416,14 +2416,14 @@ schemas:
 
 A simple object to allow referencing other components in the specification, internally and externally.
 
-The Reference Object is defined by [JSON Reference](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03) and follows the same structure, behavior and rules. 
+The Reference Object is defined by [JSON Reference](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03) and follows the same structure, behavior and rules.
 
 For this specification, reference resolution is done as defined by the JSON Reference specification and not by the JSON Schema specification.
 
 ##### Fixed Fields
 Field Name | Type | Description
 ---|:---:|---
-<a name="referenceRef"></a>$ref | `string` | **Required.** The reference string. 
+<a name="referenceRef"></a>$ref | `string` | **Required.** The reference string.
 
 This object cannot be extended with additional properties and any properties added SHALL be ignored.
 
@@ -2489,7 +2489,7 @@ The following properties are taken directly from the JSON Schema definition and 
 - required
 - enum
 
-The following properties are taken from the JSON Schema definition but their definitions were adjusted to the OpenAPI Specification. 
+The following properties are taken from the JSON Schema definition but their definitions were adjusted to the OpenAPI Specification.
 - type - Value MUST be a string. Multiple types via an array are not supported.
 - allOf - Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard JSON Schema.
 - oneOf - Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard JSON Schema.
@@ -2516,17 +2516,17 @@ Field Name | Type | Description
 <a name="schemaReadOnly"></a>readOnly | `boolean` | Relevant only for Schema `"properties"` definitions. Declares the property as "read only". This means that it MAY be sent as part of a response but SHOULD NOT be sent as part of the request. If property is marked as `readOnly` being `true` and is in the `required` list, the `required` will take effect on the response only. A property MUST NOT be marked as both `readOnly` and `writeOnly` being `true`. Default value is `false`.
 <a name="schemaWriteOnly"></a>writeOnly | `boolean` | Relevant only for Schema `"properties"` definitions. Declares the property as "write only". This means that it MAY be sent as part of a request but SHOULD NOT be sent as part of the response. If property is marked as `writeOnly` being `true` and is in the `required` list, the `required` will take effect on the request only. A property MUST NOT be marked as both `readOnly` and `writeOnly` being `true`. Default value is `false`.
 <a name="schemaXml"></a>xml | [XML Object](#xmlObject) | This MAY be used only on properties schemas. It has no effect on root schemas. Adds Additional metadata to describe the XML representation format of this property.
-<a name="schemaExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation for this schema. 
+<a name="schemaExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation for this schema.
 <a name="schemaExample"></a>example | Any | A free-form property to include an example of an instance for this schema.
 <a name="schemaExamples"></a>examples | Any | An array of free-formed properties to include examples for this schema.
 <a name="schemaDeprecated"></a> deprecated | `boolean` | Specifies that a schema is deprecated and SHOULD be transitioned out of usage.
 
-This object can be extended with [Specification Extensions](#specificationExtensions). 
+This object can be extended with [Specification Extensions](#specificationExtensions).
 
 ###### <a name="schemaComposition"></a>Composition and Inheritance (Polymorphism)
 
 The OpenAPI Specification allows combining and extending model definitions using the `allOf` property of JSON Schema, in effect offering model composition.
-`allOf` takes in an array of object definitions that are validated *independently* but together compose a single object. 
+`allOf` takes in an array of object definitions that are validated *independently* but together compose a single object.
 
 While composition offers model extensibility, it does not imply a hierarchy between the models.
 To support polymorphism, OpenAPI Specification adds the support of the `discriminator` field.
@@ -2923,7 +2923,7 @@ Field Name | Type | Description
 <a name="xmlAttribute"></a>attribute | `boolean` | Declares whether the property definition translates to an attribute instead of an element. Default value is `false`.
 <a name="xmlWrapped"></a>wrapped | `boolean` | MAY be used only for an array definition. Signifies whether the array is wrapped (for example, `<books><book/><book/></books>`) or unwrapped (`<book/><book/>`). Default value is `false`. The definition takes effect only when defined alongside `type` being `array` (outside the `items`).
 
-This object can be extended with [Specification Extensions](#specificationExtensions). 
+This object can be extended with [Specification Extensions](#specificationExtensions).
 
 ##### XML Object Examples
 
@@ -3274,10 +3274,10 @@ Field Name | Type | Validity | Description
 <a name="securitySchemeIn"></a>in | `string` | `apiKey` | **Required.** The location of the API key. Valid values are `"query"` or `"header"`.
 <a name="securitySchemeScheme"></a>scheme | `string` | `http` | **Required.** The name of the HTTP Authorization scheme to be used in the [Authorization header as defined in RFC 7235](https://tools.ietf.org/html/rfc7235#section-4.2).
 <a name="securitySchemeBearerFormat"></a>bearerFormat | `string` | `http` (`"bearer"`) | A hint to the client to identify how the bearer token is formatted.  Bearer tokens are usually generated by an authorization server, so this information is primarily for documentation purposes.
-<a name="securitySchemeFlow"></a>flow | [OAuth Flows Object](#oauthFlowsObject) | `oauth2` | **Required.** An object containing configuration information for the flow types supported. 
-<a name="securitySchemeOpenIdConnectUrl"></a>openIdConnectUrl | `string` | `openIdConnect` | **Required.** OpenId Connect URL to discover OAuth2 configuration values. This MUST be in the form of a URL. 
+<a name="securitySchemeFlow"></a>flow | [OAuth Flows Object](#oauthFlowsObject) | `oauth2` | **Required.** An object containing configuration information for the flow types supported.
+<a name="securitySchemeOpenIdConnectUrl"></a>openIdConnectUrl | `string` | `openIdConnect` | **Required.** OpenId Connect URL to discover OAuth2 configuration values. This MUST be in the form of a URL.
 
-This object can be extended with [Specification Extensions](#specificationExtensions). 
+This object can be extended with [Specification Extensions](#specificationExtensions).
 
 ##### Security Scheme Object Example
 
@@ -3346,7 +3346,7 @@ bearerFormat: JWT
 
 ```yaml
 type: oauth2
-flow: 
+flow:
   implicit:
     authorizationUrl: https://example.com/api/oauth/dialog
     scopes:
@@ -3361,12 +3361,12 @@ Allows configuration of the supported OAuth Flows.
 ##### Fixed Fields
 Field Name | Type | Description
 ---|:---:|---
-<a name="oauthFlowImplicit"></a>implicit| [OAuth Flow Object](#oauthFlowObject) | Configuration for the OAuth Implicit flow 
-<a name="oauthFlowPassword"></a>password| [OAuth Flow Object](#oauthFlowObject) | Configuration for the OAuth Resource Owner Password flow 
+<a name="oauthFlowImplicit"></a>implicit| [OAuth Flow Object](#oauthFlowObject) | Configuration for the OAuth Implicit flow
+<a name="oauthFlowPassword"></a>password| [OAuth Flow Object](#oauthFlowObject) | Configuration for the OAuth Resource Owner Password flow
 <a name="oauthFlowClientCredentials"></a>clientCredentials| [OAuth Flow Object](#oauthFlowObject) | Configuration for the OAuth Client Credentials flow.  Previously called `application` in OpenAPI 2.0.
 <a name="oauthFlowAuthorizationCode"></a>authorizationCode| [OAuth Flow Object](#oauthFlowObject) | Configuration for the OAuth Authorization Code flow.  Previously called `accessCode` in OpenAPI 2.0.
 
-This object can be extended with [Specification Extensions](#specificationExtensions). 
+This object can be extended with [Specification Extensions](#specificationExtensions).
 
 #### <a name="oauthFlowObject"></a>OAuth Flow Object
 
@@ -3380,7 +3380,7 @@ Field Name | Type | Validity | Description
 <a name="securitySchemeRefreshUrl"></a>refreshUrl | `string` | `oauth2` | The URL to be used for obtaining refresh tokens. This MUST be in the form of a URL.
 <a name="securitySchemeScopes"></a>scopes | [Scopes Object](#scopesObject) | `oauth2` | **Required.** The available scopes for the OAuth2 security scheme.
 
-This object can be extended with [Specification Extensions](#specificationExtensions). 
+This object can be extended with [Specification Extensions](#specificationExtensions).
 
 ##### OAuth Flow Object Examples
 
@@ -3409,7 +3409,7 @@ This object can be extended with [Specification Extensions](#specificationExtens
 
 ```YAML
 type: oauth2
-flow: 
+flow:
   implicit:
     authorizationUrl: https://example.com/api/oauth/dialog
     scopes:
@@ -3420,7 +3420,7 @@ flow:
     tokenUrl: https://example.com/api/oauth/token
     scopes:
       write:pets: modify pets in your account
-      read:pets: read your pets 
+      read:pets: read your pets
 ```
 
 #### <a name="scopesObject"></a>Scopes Object
@@ -3433,7 +3433,7 @@ Field Pattern | Type | Description
 ---|:---:|---
 <a name="scopesName"></a>{name} | `string` | Maps between a name of a scope to a short description of it (as the value of the property).
 
-This object can be extended with [Specification Extensions](#specificationExtensions). 
+This object can be extended with [Specification Extensions](#specificationExtensions).
 
 ##### Scopes Object Example
 
@@ -3457,7 +3457,7 @@ The name used for each property MUST correspond to a security scheme declared in
 Security Requirement Objects that contain multiple schemes require that all schemes MUST be satisfied for a request to be authorized.
 This enables support for scenarios where there multiple query parameters or HTTP headers are required to convey security information.
 
-When a list of Security Requirement Objects is defined on the [Open API object](#oasObject) or [Operation Object](#operationObject), only one of Security Requirement Objects in the list needs to be satisfied to authorize.  
+When a list of Security Requirement Objects is defined on the [Open API object](#oasObject) or [Operation Object](#operationObject), only one of Security Requirement Objects in the list needs to be satisfied to authorize.
 
 ##### Patterned Fields
 
@@ -3510,7 +3510,7 @@ The extensions may or may not be supported by the available tooling, but those m
 
 ### <a name="securityFiltering"></a>Security Filtering
 
-Some objects in the OpenAPI Specification MAY be declared and remain empty, or completely be removed, even though they are inherently the core of the API documentation. 
+Some objects in the OpenAPI Specification MAY be declared and remain empty, or completely be removed, even though they are inherently the core of the API documentation.
 
 The reasoning behind it is to allow an additional layer of access control over the documentation itself.
 While not part of the specification itself, certain libraries MAY choose to allow access to parts of the documentation based on some form of authentication/authorization.


### PR DESCRIPTION
This removes trailing spaces in the whole document.

~~(This PR includes the changes from #1015, because there are conflicts due to changes on neighboring lines. Merging this one first would automatically merge #1015, merging #1015 first will make the diff here clearer to contain only the whitespace changes. If #1015 is rejected, I can rebase this to not include those changes.)~~