### PR TITLE
Updates to rc1

### DIFF
--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -163,7 +163,7 @@ password | `string` | `password` | Used to hint UIs the input needs to be obscur
 ### <a name="relativeReferences"></a>Relative References in URLs
 
 Unless specified otherwise, all properties that are URLs MAY be relative references as defined by [RFC 3986](https://tools.ietf.org/html/rfc3986#section-4.2).
-Relative references are resolved using the URLs defined in the [`Server Object`](#serverObject) as a Base URI.
+Relative references are resolved using the URLs defined in the [`Server Object`](#serverObject) as a base URI.
 
 Relative references used in `$ref` are processed as per [JSON Reference](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03), i.e. using the URL of the current document as the base URI. See also the [Reference Object](#referenceObject).
 
@@ -3259,7 +3259,7 @@ Supported schemes are HTTP authentication, an API key (either as a header or as 
 ##### Fixed Fields
 Field Name | Type | Validity | Description
 ---|:---:|---|---
-<a name="securitySchemeType"></a>type | `string` | Any | **Required.** The type of the security scheme. Valid values are `"apiKey"`, `"http"`, `"oauth2"`, `"openIdConnect"`.
+<a name="securitySchemeType"></a>type | `string` | Any | **Required.** The type of the security scheme. Valid values are `"apiKey"`, `"http"`, `"oauth2"` or `"openIdConnect"`.
 <a name="securitySchemeDescription"></a>description | `string` | Any | A short description for security scheme.
 <a name="securitySchemeName"></a>name | `string` | `apiKey` | **Required.** The name of the header or query parameter to be used.
 <a name="securitySchemeIn"></a>in | `string` | `apiKey` | **Required.** The location of the API key. Valid values are `"query"` or `"header"`.

--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -3351,11 +3351,11 @@ Allows configuration of the supported OAuth Flows.
 
 ##### Fixed Fields
 Field Name | Type | Description
----|:---:|---|---
-<a name="oauthFlowImplicit"></a>implicit| [OAuth Flow Object](#oauthFlowObject) | Configuration for the OAuth Implicit flow 
-<a name="oauthFlowPassword"></a>password| [OAuth Flow Object](#oauthFlowObject) | Configuration for the OAuth Resource Owner Password flow 
-<a name="oauthFlowClientCredentials"></a>clientCredentials| [OAuth Flow Object](#oauthFlowObject) | Configuration for the OAuth Client Credentials flow.  Previously called `application` in OpenAPI 2.0.
-<a name="oauthFlowAuthorizationCode"></a>authorizationCode| [OAuth Flow Object](#oauthFlowObject) | Configuration for the OAuth Authorization Code flow.  Previously called `accessCode` in OpenAPI 2.0.
+---|:---:|---
+<a name="oauthFlowImplicit"></a>implicit | [OAuth Flow Object](#oauthFlowObject) | Configuration for the OAuth Implicit flow 
+<a name="oauthFlowPassword"></a>password | [OAuth Flow Object](#oauthFlowObject) | Configuration for the OAuth Resource Owner Password flow 
+<a name="oauthFlowClientCredentials"></a>clientCredentials | [OAuth Flow Object](#oauthFlowObject) | Configuration for the OAuth Client Credentials flow.  Previously called `application` in OpenAPI 2.0.
+<a name="oauthFlowAuthorizationCode"></a>authorizationCode | [OAuth Flow Object](#oauthFlowObject) | Configuration for the OAuth Authorization Code flow.  Previously called `accessCode` in OpenAPI 2.0.
 
 This object can be extended with [Specification Extensions](#specificationExtensions). 
 

--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -1487,9 +1487,7 @@ SHOULD be the response for a successful operation call.
 ##### Fixed Fields
 Field Name | Type | Description
 ---|:---:|---
-<a name="responsesDefault"></a>default | [Response Object](#responseObject) <span>&#124;</span> [Reference Object](#referenceObject) | The documentation of responses other than the ones declared for specific HTTP response codes.
-It can be used to cover undeclared responses.
-[Reference Object](#referenceObject) can be used to link to a response that is defined at the [OpenAPI Object's responses](#oasResponses) section.
+<a name="responsesDefault"></a>default | [Response Object](#responseObject) <span>&#124;</span> [Reference Object](#referenceObject) | The documentation of responses other than the ones declared for specific HTTP response codes. It can be used to cover undeclared responses. [Reference Object](#referenceObject) can be used to link to a response that is defined at the [OpenAPI Object's responses](#oasResponses) section.
 
 ##### Patterned Fields
 Field Pattern | Type | Description

--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -3306,7 +3306,7 @@ in: header
 
 ```json
 {
-  "type": "scheme",
+  "type": "http",
   "scheme": "bearer",
   "bearerFormat": "JWT",
 }

--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -20,51 +20,51 @@ Additional utilities can also take advantage of the resulting files, such as tes
 <!-- TOC depthFrom:1 depthTo:3 withLinks:1 updateOnSave:1 orderedList:0 -->
 
 - [Definitions](#definitions)
-	- [Path Templating](#pathTemplating)
-	- [Media Types](#mediaTypes)
-	- [HTTP Status Codes](#httpCodes)
+  - [Path Templating](#pathTemplating)
+  - [Media Types](#mediaTypes)
+  - [HTTP Status Codes](#httpCodes)
 - [Specification](#specification)
-	- [Format](#format)
-	- [File Structure](#fileStructure)
-	- [Data Types](#dataTypes)
-	- [Relative References In URLs](#relativeReferences)
-	- [Schema](#schema)
-		- [OpenAPI Object](#oasObject)
-		- [Info Object](#infoObject)
-		- [Contact Object](#contactObject)
-		- [License Object](#licenseObject)
-		- [Server Object](#serverObject)
-        - [Server Variables Object](#serverVariablesObject)
-        - [Server Variable Object](#serverVariableObject)
-		- [Components Object](#componentsObject)
-		- [Paths Object](#pathsObject)
-		- [Path Item Object](#pathItemObject)
-		- [Operation Object](#operationObject)
-		- [External Documentation Object](#externalDocumentationObject)
-		- [Parameter Object](#parameterObject)
-		- [Request Body Object](#requestBodyObject)
-		- [Content Object](#contentObject)
-		- [Media Type Object](#mediaTypeObject)
-		- [Responses Object](#responsesObject)
-		- [Response Object](#responseObject)
-		- [Headers Object](#headersObject)
-		- [Example Object](#exampleObject)
-		- [Links Object](#linksObject)
-		- [Link Object](#linkObject)
-		- [Link Parameters Object](#linkParametersObject)
-		- [Header Object](#headerObject)
-		- [Tag Object](#tagObject)
-		- [Examples Object](#examplesObject)
-		- [Reference Object](#referenceObject)
-		- [Schema Object](#schemaObject)
-		- [XML Object](#xmlObject)
-		- [Security Scheme Object](#securitySchemeObject)
-		- [Scopes Object](#scopesObject)
-		- [Security Requirement Object](#securityRequirementObject)
-	- [Specification Extensions](#specificationExtensions)
-	- [Security Filtering](#securityFiltering)
+  - [Format](#format)
+  - [File Structure](#fileStructure)
+  - [Data Types](#dataTypes)
+  - [Relative References In URLs](#relativeReferences)
+  - [Schema](#schema)
+    - [OpenAPI Object](#oasObject)
+    - [Info Object](#infoObject)
+    - [Contact Object](#contactObject)
+    - [License Object](#licenseObject)
+    - [Server Object](#serverObject)
+    - [Server Variables Object](#serverVariablesObject)
+    - [Server Variable Object](#serverVariableObject)
+    - [Components Object](#componentsObject)
+    - [Paths Object](#pathsObject)
+    - [Path Item Object](#pathItemObject)
+    - [Operation Object](#operationObject)
+    - [External Documentation Object](#externalDocumentationObject)
+    - [Parameter Object](#parameterObject)
+    - [Request Body Object](#requestBodyObject)
+    - [Content Object](#contentObject)
+    - [Media Type Object](#mediaTypeObject)
+    - [Responses Object](#responsesObject)
+    - [Response Object](#responseObject)
+    - [Headers Object](#headersObject)
+    - [Example Object](#exampleObject)
+    - [Links Object](#linksObject)
+    - [Link Object](#linkObject)
+    - [Link Parameters Object](#linkParametersObject)
+    - [Header Object](#headerObject)
+    - [Tag Object](#tagObject)
+    - [Examples Object](#examplesObject)
+    - [Reference Object](#referenceObject)
+    - [Schema Object](#schemaObject)
+    - [XML Object](#xmlObject)
+    - [Security Scheme Object](#securitySchemeObject)
+    - [Scopes Object](#scopesObject)
+    - [Security Requirement Object](#securityRequirementObject)
+  - [Specification Extensions](#specificationExtensions)
+  - [Security Filtering](#securityFiltering)
 - [Appendix A: Revision History](#revisionHistory)
-	
+  
 
 <!-- /TOC -->
 
@@ -2334,8 +2334,8 @@ This object can be extended with [Specification Extensions](#specificationExtens
 
 ```json
 {
-	"name": "pet",
-	"description": "Pets operations"
+  "name": "pet",
+  "description": "Pets operations"
 }
 ```
 
@@ -2422,7 +2422,7 @@ This object cannot be extended with additional properties and any properties add
 
 ```json
 {
-	"$ref": "#/components/schemas/Pet"
+  "$ref": "#/components/schemas/Pet"
 }
 ```
 


### PR DESCRIPTION
While reviewing the spec I came across a number of small issues:

* ~~There was a ton of extra trailing whitespace scattered throughout the spec. My ide cleans that up automatically, figured it might be a good addition?~~
* Cleaned up a few tabs 
* `OAuth Flows Object` was missing a space and made it so the markdown wouldn't render.
* Fixed the `JWT Bearer` json sample so it mirrored the yaml sample
* Made a couple small grammar fixes.
* ~~`ResponseObject.responseHeader` is an array of header objects, so added brackets around the type.~~