### PR TITLE
Updated Examples

### DIFF
--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -53,7 +53,6 @@ Additional utilities can also take advantage of the resulting files, such as tes
 		- [Callback Object](#callbackObject)
 		- [Headers Object](#headersObject)
 		- [Example Object](#exampleObject)
-		- [Described Example Object](#describedExampleObject)
 		- [Links Object](#linksObject)
 		- [Link Object](#linkObject)
 		- [Link Parameters Object](#linkParametersObject)
@@ -408,7 +407,7 @@ Field Name | Type | Description
 <a name="componentsSchemas"></a> schemas | Map[`string`, [Schema Object](#schemaObject)] | An object to hold reusable [Schema Objects](#schemaObject).
 <a name="componentsResponses"></a> responses | Map[`string`, [Response Object](#responseObject)] | An object to hold reusable [Response Objects](#responseObject).
 <a name="componentsParameters"></a> parameters | Map[`string`, [Parameter Object](#parameterObject)] | An object to hold reusable [Parameter Objects](#parameterObject).
-<a name="componentsExamples"></a> examples | Map[`string`, [Described Example Object](#describedExampleObject)] | An object to hold reusable [Described Example Objects](#describedExampleObject).
+<a name="componentsExamples"></a> examples | Map[`string`, [Example Object](#exampleObject)] | An object to hold reusable [Example Objects](#exampleObject).
 <a name="componentsRequestBodies"></a> requestBodies | Map[`string`, [Request Body Object](#requestBodyObject)] | An object to hold reusable [Request Body Objects](#requestBodyObject).
 <a name="componentsHeaders"></a> headers | Map[`string`, [Header object](#headerObject)] | An object to hold reusable [Header objects](#headerObject).
 <a name="componentsSecuritySchemes"></a> securitySchemes| Map[`string`, [Security Scheme Object](#securitySchemeObject)] | An object to hold reusable [Security Scheme Objects](#securitySchemeObject).
@@ -938,8 +937,8 @@ Field Name | Type | Description
 <a name="parameterExplode"></a>explode | `boolean` | When this is true, parameter values of type `array` or `object` generate separate parameters for each value of the array, or key-value-pair of the map.  For other types of parameters this property has no effect. When [`style`](#parameterStyle) is `form`, the default value is `true`. For all other styles, the default value is `false`.
 <a name="parameterAllowReserved"></a>allowReserved | `boolean` | Determines whether the parameter value SHOULD allow reserved characters, as defined by [RFC3986](https://tools.ietf.org/html/rfc3986#section-2.2) `:/?#[]@!$&'()*+,;=` to be included without percent-encoding. This property only applies to parameters with an `in` value of `query`. The default value is `false`.
 <a name="parameterSchema"></a>schema | [Schema Object](#schemaObject) \| [Reference Object](#referenceObject)] | The schema defining the type used for the parameter.
-<a name="parameterExample"></a>example | [Example Object](#exampleObject) | Example of the media type.  The example object SHOULD be in the correct format as specified in the parameter encoding.  The `example` object is mutually exclusive to the `examples` object.  Furthermore, if referencing a `schema` which contains an example, the `example` value SHALL _override_ the the example provided by the schema.
-<a name="parameterExamples"></a>examples | Map[ `string`, [Described Example Object](#describedExampleObject) \| [Reference Object](#referenceObject)] | Described Examples of the media type.  Each described example SHOULD contain a value in the correct format as specified in the parameter encoding.  The `examples` object is mutually exclusive to the `example` object.  Furthermore, if referencing a `schema` which contains an example, the `examples` value SHALL _override_ the example provided by the schema.
+<a name="parameterExample"></a>example | Any | Example of the media type.  The example object SHOULD be in the correct format as specified in the parameter encoding.  The `example` object is mutually exclusive to the `examples` object.  Furthermore, if referencing a `schema` which contains an example, the `example` value SHALL _override_ the the example provided by the schema. To represent examples of media types that cannot naturally represented in JSON or YAML, a string value can be used to contain the example with escaping where necessary.
+<a name="parameterExamples"></a>examples | Map[ `string`, [Example Object](#exampleObject) \| [Reference Object](#referenceObject)] | Examples of the media type.  Each example SHOULD contain a value in the correct format as specified in the parameter encoding.  The `examples` object is mutually exclusive to the `example` object.  Furthermore, if referencing a `schema` which contains an example, the `examples` value SHALL _override_ the example provided by the schema.
 
 For more complex scenarios a [Content Object](#contentObject) can be used to define the media type 
 and schema of the parameter.  This option is mutually exclusive with the simple scenario
@@ -1131,7 +1130,7 @@ A request body with a referenced model definition.
       "examples": {
           "user" : {
             "summary": "User Example", 
-            "valueUrl": "http://foo.bar/examples/user-example.json"
+            "externalValue": "http://foo.bar/examples/user-example.json"
           } 
         }
     },
@@ -1142,7 +1141,7 @@ A request body with a referenced model definition.
       "examples": {
           "user" : {
             "summary": "User example in XML",
-            "valueUrl": "http://foo.bar/examples/user-example.xml"
+            "externalValue": "http://foo.bar/examples/user-example.xml"
           }
         }
     },
@@ -1150,7 +1149,7 @@ A request body with a referenced model definition.
       "examples": {
         "user" : {
             "summary": "User example in Plain text",
-            "valueUrl": "http://foo.bar/examples/user-example.txt" 
+            "externalValue": "http://foo.bar/examples/user-example.txt" 
         }
       } 
     },
@@ -1158,7 +1157,7 @@ A request body with a referenced model definition.
       "examples": {
         "user" : {
             "summary": "User example in other format",
-            "valueUrl": "http://foo.bar/examples/user-example.whatever"
+            "externalValue": "http://foo.bar/examples/user-example.whatever"
         }
       }
     }
@@ -1175,24 +1174,24 @@ content:
     examples:
       user:
         summary: User Example
-        valueUrl: 'http://foo.bar/examples/user-example.json'
+        externalValue: 'http://foo.bar/examples/user-example.json'
   'application/xml':
     schema:
       $ref: '#/components/schemas/User'
     examples:
       user:
         summary: User Example in XML
-        valueUrl: 'http://foo.bar/examples/user-example.xml'
+        externalValue: 'http://foo.bar/examples/user-example.xml'
   'text/plain':
     examples:
       user:
         summary: User example in text plain format
-        valueUrl: 'http://foo.bar/examples/user-example.txt'
+        externalValue: 'http://foo.bar/examples/user-example.txt'
   '*/*':
     examples:
       user: 
         summary: User example in other format
-        valueUrl: 'http://foo.bar/examples/user-example.whatever'
+        externalValue: 'http://foo.bar/examples/user-example.whatever'
 ```
 
 A body parameter that is an array of string values:
@@ -1324,8 +1323,8 @@ Each Media Type Object provides schema and examples for a the media type identif
 Field Name | Type | Description
 ---|:---:|---
 <a name="mediaTypeSchema"></a>schema | [Schema Object](#schemaObject) \| [Reference Object](#referenceObject) | The schema defining the type used for the request body.
-<a name="mediaTypeExample"></a>example | [Example Object](#exampleObject) | Example of the media type.  The example object SHOULD be in the correct format as specified in the media type.  The `example` object is mutually exclusive to the `examples` object.  Furthermore, if referencing a `schema` which contains an example, the `example` value SHALL _override_ the the example provided by the schema.
-<a name="mediaTypeExamples"></a>examples | Map[ `string`, [Described Example Object](#describedExampleObject) \| [Reference Object](#referenceObject)] | Described Examples of the media type.  Each described example SHOULD contain a value in the correct format as specified in the media type.  The `examples` object is mutually exclusive to the `example` object.  Furthermore, if referencing a `schema` which contains an example, the `examples` value SHALL _override_ the example provided by the schema.
+<a name="mediaTypeExample"></a>example | Any | Example of the media type.  The example object SHOULD be in the correct format as specified in the media type.  The `example` object is mutually exclusive to the `examples` object.  Furthermore, if referencing a `schema` which contains an example, the `example` value SHALL _override_ the the example provided by the schema.
+<a name="mediaTypeExamples"></a>examples | Map[ `string`, [Example Object](#exampleObject) \| [Reference Object](#referenceObject)] | Examples of the media type.  Each example object SHOULD contain a value in the correct format as specified in the media type.  The `examples` object is mutually exclusive to the `example` object.  Furthermore, if referencing a `schema` which contains an example, the `examples` value SHALL _override_ the example provided by the schema.
 <a name="mediaTypeEncoding"></a>encoding | [Encoding Object](#encodingObject) | Encoding of the media type.  The encoding object SHOULD only apply to `requestBody` objects when the content type is `multipart`.
 
 This object can be extended with [Specification Extensions](#specificationExtensions). 
@@ -1894,41 +1893,13 @@ X-Rate-Limit-Reset:
 
 #### <a name="exampleObject"></a>Example Object
 
-Allows sharing examples for operation requests and responses. This literal value can either be any JSON or YAML object, array or primitive value.  To represent examples of media types that cannot naturally represented in the OpenAPI definition, a string value can be used to contain the example with escaping where necessary. 
-
-##### Example Object Example
-
-Example representation for application/json media type of a Pet data type:
-
-```json
-  {
-    "name": "Puma",
-    "type": "Dog",
-    "color": "Black",
-    "gender": "Female",
-    "breed": "Mixed"
-  }
-```
-
-```yaml
-
-name: Puma
-type: Dog
-color: Black
-gender: Female
-breed: Mixed
-
-```
-
-#### <a name="describedExampleObject"></a>Described Example Object
-
 ##### Fixed Fields
 Field Name | Type | Description
 ---|:---:|---
-<a name="describedExampleSummary"></a>summary | `string` | Short description for the example.
-<a name="describedExampleDescription"></a>description | `string` | Long description for the example.
-<a name="describedExampleValue"></a>value | [Example Object](#exampleObject) | Embedded literal example. The `value` field and `valueUrl` field are mutually exclusive.
-<a name="describedExampleValueUrl"></a>valueUrl | `string` | A URL that points to the literal example. This provides the ability to reference examples that cannot easily be included in JSON or YAML documents.  The `value` field and `valueUrl` field are mutually exclusive. 
+<a name="exampleSummary"></a>summary | `string` | Short description for the example.
+<a name="exampleDescription"></a>description | `string` | Long description for the example.
+<a name="exampleValue"></a>value | Any | Embedded literal example. The `value` field and `externalValue` field are mutually exclusive. To represent examples of media types that cannot naturally represented in JSON or YAML, a string value can be used to contain the example with escaping where necessary.
+<a name="exampleExternalValue"></a>externalValue | `string` | A URL that points to the literal example. This provides the ability to reference examples that cannot easily be included in JSON or YAML documents.  The `value` field and `externalValue` field are mutually exclusive. 
 
 This object can be extended with [Specification Extensions](#specificationExtensions). 
 
@@ -1937,7 +1908,7 @@ for the value that it is accompanying.  Tooling implementations MAY choose to
 validate compatibility automatically, and reject the example value(s) if they 
 are not compatible.
 
-##### Described Example Object Example
+##### Example Object Example
 
 ```yaml
 # in a model
@@ -1966,12 +1937,12 @@ schemas:
         examples: 
           xmlExample:
             summary: This is an example in XML
-            valueUrl: 'http://example.org/examples/address-example.xml'
+            externalValue: 'http://example.org/examples/address-example.xml'
       'text/plain':
         examples:
           textExample: 
             summary: This is a text example
-            valueUrl: 'http://foo.bar/examples/address-example.txt' 
+            externalValue: 'http://foo.bar/examples/address-example.txt' 
 
 
 # in a parameter
@@ -2667,7 +2638,7 @@ Field Name | Type | Description
 <a name="schemaWriteOnly"></a>writeOnly | `boolean` | Relevant only for Schema `"properties"` definitions. Declares the property as "write only". This means that it MAY be sent as part of a request but SHOULD NOT be sent as part of the response. If property is marked as `writeOnly` being `true` and is in the `required` list, the `required` will take effect on the request only. A property MUST NOT be marked as both `readOnly` and `writeOnly` being `true`. Default value is `false`.
 <a name="schemaXml"></a>xml | [XML Object](#xmlObject) | This MAY be used only on properties schemas. It has no effect on root schemas. Adds Additional metadata to describe the XML representation format of this property.
 <a name="schemaExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation for this schema. 
-<a name="schemaExample"></a>example | Any | A free-form property to include an example of an instance for this schema.
+<a name="schemaExample"></a>example | Any | A free-form property to include an example of an instance for this schema. To represent examples that cannot naturally represented in JSON or YAML, a string value can be used to contain the example with escaping where necessary.
 <a name="schemaDeprecated"></a> deprecated | `boolean` | Specifies that a schema is deprecated and SHOULD be transitioned out of usage.
 
 This object can be extended with [Specification Extensions](#specificationExtensions). 

--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -49,12 +49,12 @@ Additional utilities can also take advantage of the resulting files, such as tes
 		- [Response Object](#responseObject)
 		- [Headers Object](#headersObject)
 		- [Example Object](#exampleObject)
+		- [Described Example Object](#describedExampleObject)
 		- [Links Object](#linksObject)
 		- [Link Object](#linkObject)
 		- [Link Parameters Object](#linkParametersObject)
 		- [Header Object](#headerObject)
 		- [Tag Object](#tagObject)
-		- [Examples Object](#examplesObject)
 		- [Reference Object](#referenceObject)
 		- [Schema Object](#schemaObject)
 		- [XML Object](#xmlObject)
@@ -402,7 +402,7 @@ Field Name | Type | Description
 <a name="componentsSchemas"></a> schemas | Map[`string`, [Schema Object](#schemaObject)] | An object to hold reusable [Schema Objects](#schemaObject).
 <a name="componentsResponses"></a> responses | Map[`string`, [Response Object](#responseObject)] | An object to hold reusable [Response Objects](#responseObject).
 <a name="componentsParameters"></a> parameters | Map[`string`, [Parameter Object](#parameterObject)] | An object to hold reusable [Parameter Objects](#parameterObject).
-<a name="componentsExamples"></a> examples | Map[`string`, [Example Object](#exampleObject)] | An object to hold reusable [Example Objects](#exampleObject).
+<a name="componentsExamples"></a> examples | Map[`string`, [Described Example Object](#describedExampleObject)] | An object to hold reusable [Described Example Objects](#describedExampleObject).
 <a name="componentsRequestBodies"></a> requestBodies | Map[`string`, [Request Body Object](#requestBodyObject)] | An object to hold reusable [Request Body Objects](#requestBodyObject).
 <a name="componentsHeaders"></a> headers | Map[`string`, [Header object](#headerObject)] | An object to hold reusable [Header objects](#headerObject).
 <a name="componentsSecuritySchemes"></a> securitySchemes| Map[`string`, [Security Scheme Object](#securitySchemeObject)] | An object to hold reusable [Security Scheme Objects](#securitySchemeObject).
@@ -932,8 +932,8 @@ Field Name | Type | Description
 <a name="parameterExplode"></a>explode | `boolean` | When this is true, parameter values of type `array` or `object` generate separate parameters for each value of the array, or key-value-pair of the map.  For other types of parameters this property has no effect. When [`style`](#parameterStyle) is `form`, the default value is `true`. For all other styles, the default value is `false`.
 <a name="parameterAllowReserved"></a>allowReserved | `boolean` | Determines whether the parameter value SHOULD allow reserved characters, as defined by [RFC3986](https://tools.ietf.org/html/rfc3986#section-2.2) `:/?#[]@!$&'()*+,;=` to be included without percent-encoding. This property only applies to parameters with an `in` value of `query`. The default value is `false`.
 <a name="parameterSchema"></a>schema | [Schema Object](#schemaObject) <span>&#124;</span> [Reference Object](#referenceObject)] | The schema defining the type used for the parameter.
-<a name="parameterExamples"></a>examples | [[Example Object](#exampleObject) <span>&#124;</span> [Reference Object](#referenceObject)] | Examples of the content type.  Each example in the Examples array SHOULD be in the correct format as specified parameter encoding.  The `examples` object is mutually exclusive to the `example` object.  Furthermore, if referencing a `schema` which contains an example, the `examples` value SHALL _override_ the example provided by the schema.
-<a name="parameterExample"></a>example | [Example Object](#exampleObject) <span>&#124;</span> [Reference Object](#referenceObject) | Example of the content type.  The example object SHOULD be in the correct format as specified in the parameter encoding.  The `example` object is mutually exclusive to the `examples` object.  Furthermore, if referencing a `schema` which contains an example, the `example` value SHALL _override_ the example provided by the the schema.
+<a name="parameterExample"></a>example | [Example Object](#exampleObject) | Example of the media type.  The example object SHOULD be in the correct format as specified in the parameter encoding.  The `example` object is mutually exclusive to the `examples` object.  Furthermore, if referencing a `schema` which contains an example, the `example` value SHALL _override_ the the example provided by the schema.
+<a name="parameterExamples"></a>examples | Map[ `string`, [Described Example Object](#describedExampleObject) <span>&#124;</span> [Reference Object](#referenceObject)] | Described Examples of the media type.  Each described example SHOULD contain a value in the correct format as specified in the parameter encoding.  The `examples` object is mutually exclusive to the `example` object.  Furthermore, if referencing a `schema` which contains an example, the `examples` value SHALL _override_ the example provided by the schema.
 
 For more complex scenarios a [Content Object](#contentObject) can be used to define the media type 
 and schema of the parameter.  This option is mutually exclusive with the simple scenario
@@ -1258,9 +1258,9 @@ Each Media Type Object provides schema and examples for a the media type identif
 ##### Fixed Fields
 Field Name | Type | Description
 ---|:---:|---
-<a name="mediaTypeSchema"></a>schema | [Schema Object](#schemaObject) <span>&#124;</span> [Reference Object](#referenceObject)] | The schema defining the type used for the request body.
-<a name="mediaTypeExamples"></a>examples | [[Example Object](#exampleObject) <span>&#124;</span> [Reference Object](#referenceObject)] | Examples of the media type.  Each example in the Examples array SHOULD be in the correct format as specified in the media type.  The `examples` object is mutually exclusive to the `example` object.  Furthermore, if referencing a `schema` which contains an example, the `examples` value SHALL _override_ the example provided by the schema.
-<a name="mediaTypeExample"></a>example | [Example Object](#exampleObject) <span>&#124;</span> [Reference Object](#referenceObject) | Example of the media type.  The example object SHOULD be in the correct format as specified in the media type.  The `example` object is mutually exclusive to the `examples` object.  Furthermore, if referencing a `schema` which contains an example, the `example` value SHALL _override_ the the example provided by the schema.
+<a name="mediaTypeSchema"></a>schema | [Schema Object](#schemaObject) <span>&#124;</span> [Reference Object](#referenceObject) | The schema defining the type used for the request body.
+<a name="mediaTypeExample"></a>example | [Example Object](#exampleObject) | Example of the media type.  The example object SHOULD be in the correct format as specified in the media type.  The `example` object is mutually exclusive to the `examples` object.  Furthermore, if referencing a `schema` which contains an example, the `example` value SHALL _override_ the the example provided by the schema.
+<a name="mediaTypeExamples"></a>examples | Map[ `string`, [Described Example Object](#describedExampleObject) <span>&#124;</span> [Reference Object](#referenceObject)] | Described Examples of the media type.  Each described example SHOULD contain a value in the correct format as specified in the media type.  The `examples` object is mutually exclusive to the `example` object.  Furthermore, if referencing a `schema` which contains an example, the `examples` value SHALL _override_ the example provided by the schema.
 <a name="mediaTypeEncoding"></a>encoding | [Encoding Object](#encodingObject) | Encoding of the media type.  The encoding object SHOULD only apply to `requestBody` objects when the content type is `multipart`.
 
 This object can be extended with [Specification Extensions](#specificationExtensions). 
@@ -1273,14 +1273,23 @@ This object can be extended with [Specification Extensions](#specificationExtens
     "schema": {
          "$ref": "#/components/schemas/Pet"
     },
-    "examples": [{
-                  "name": "Fluffy",
-                  "petType": "Cat"
-                 },
-                 { 
-                   "name": "Rover",
-                   "petType": "Frog"
-                 }]
+    "examples": {
+      "cat" : {
+        "summary": "An example of a cat",
+        "value": 
+          {
+            "name": "Fluffy",
+            "petType": "Cat"
+          }
+      },
+      "frog": {
+        "summary": "An example of a frog with a dog's name",
+        "value" :  { 
+          "name": "Rover",
+          "petType": "Frog"
+        }
+      }
+    }
   }
 }
 ```
@@ -1290,11 +1299,18 @@ application/json:
   schema:
     $ref: "#/components/schemas/Pet"
   examples:
-    # converted directly from YAML to JSON
-    - name: Fluffy
-      petType: Cat
-    - {"name": "Rover", "petType": "Frog"}
-
+    cat:
+      summary: An example of a cat
+      value:
+        name: Fluffy
+        petType: Cat
+    frog:
+      summary: An example of a frog with a dog's name
+      value:
+        name: Rover
+        petType: Frog
+    dog:
+      $ref: "#/components/examples/dog-example"
 ```
 
 ##### Considerations for file uploads
@@ -1813,7 +1829,7 @@ X-Rate-Limit-Reset:
 
 #### <a name="exampleObject"></a>Example Object
 
-Allows sharing examples for operation requests and responses. This object can either be a freeform object, array or primitive value.  To represent examples of media types that cannot naturally represented in the OpenAPI definition, a string value can be used to contain the example with escaping where necessary. 
+Allows sharing examples for operation requests and responses. This literal value can either be any JSON or YAML object, array or primitive value.  To represent examples of media types that cannot naturally represented in the OpenAPI definition, a string value can be used to contain the example with escaping where necessary. 
 
 ##### Example Example
 
@@ -1837,6 +1853,82 @@ color: Black
 gender: Female
 breed: Mixed
 
+```
+
+#### <a name="describedExampleObject"></a>Described Example Object
+
+##### Fixed Fields
+Field Name | Type | Description
+---|:---:|---
+<a name="describedExampleSummary"></a>summary | `string` | Short description for the example.
+<a name="describedExampleDescription"></a>description | `string` | Long description for the example.
+<a name="describedExampleValue"></a>value | [Example Object](#exampleObject) | Embedded literal example. The `value` field and `valueUrl` field are mutually exclusive.
+<a name="describedExampleValueUrl"></a>valueUrl | `string` | A Url that points to the literal example. This provides the ability to reference examples that cannot easily be included in JSON or YAML documents.  The `value` field and `valueUrl` field are mutually exclusive. 
+
+This object can be extended with [Specification Extensions](#specificationExtensions). 
+
+In all cases, the example value is expected to be compatible with the type schema 
+for the value that it is accompanying.  Tooling implementations MAY choose to 
+validate compatibility automatically, and reject the example value(s) if they 
+are not compatible.
+
+##### Example Described Example
+
+```yaml
+# in a model
+schemas:
+  properties:
+    name:
+      type: string
+      example:
+        $ref: http://example.org/petapi-examples/OpenApi.json#/components/examples/name-example
+
+# in a request body, note the plural `examples` as the Content-Type is set to `*`:
+  requestBody:
+    content:
+      'application/json':
+        schema:
+          $ref: '#/components/schemas/Address'
+        examples: 
+          foo:
+            summary: A foo example
+            value: {"foo": "bar"}
+          bar:
+            summary: A bar example
+            value: {"bar": "baz"}
+      'application/xml':
+        examples: 
+          xmlExample:
+            summary: This is an example in XML
+            valueUrl: 'http://example.org/examples/address-example.xml'
+      'text/plain':
+        examples:
+          textExample: 
+            summary: This is a text example
+            valueUrl: 'http://foo.bar/examples/address-example.txt' 
+        
+# in a parameter
+  parameters:
+    - name: 'zipCode'
+      in: 'query'
+      schema:
+        type: 'string'
+        format: 'zip-code'
+        examples:
+          zip-example: 
+            $ref: '#/components/examples/zip-example'
+
+# in a response
+  responses:
+    200:
+      description: your car appointment has been booked
+      content: 
+        application/json:
+          schema:
+            $ref: '#/components/schemas/SuccessResponse'
+          examples:
+            confirmation-success:
+              $ref: '#/components/examples/confirmation-success'
 ```
 
 #### <a name="linksObject"></a>Links Object
@@ -2344,64 +2436,6 @@ name: pet
 description: Pets operations
 ```
 
-#### <a name="examplesObject"></a>Examples Object
-
-Anywhere an `example` may be given, a JSON Reference MAY be used, with the 
-explicit restriction that examples having a JSON format with object named 
-`$ref` are not allowed. This does mean that `example`, structurally, can be 
-either a string primitive or an object, similar to `additionalProperties`.
-
-In all cases, the payload is expected to be compatible with the type schema 
-for the value that it is accompanying.  Tooling implementations MAY choose to 
-validate compatibility automatically, and reject the example value(s) if they 
-are not compatible.
-
-```yaml
-# in a model
-schemas:
-  properties:
-    name:
-      type: string
-      example:
-        $ref: http://foo.bar#/examples/name-example
-
-# in a request body, note the plural `examples` as the Content-Type is set to `*`:
-  requestBody:
-    content:
-      'application/json':
-        schema:
-          $ref: '#/components/schemas/Address'
-        examples: 
-          - {"foo": "bar"}
-          - {"bar": "baz"}
-      'application/xml':
-        examples: 
-          - $ref: 'http://foo.bar#/examples/address-example.xml' 
-      'text/plain':
-        examples: 
-          - $ref: 'http://foo.bar#/examples/address-example.txt' 
-        
-# in a parameter
-
-  parameters:
-    - name: 'zipCode'
-      in: 'query'
-      schema:
-        type: 'string'
-        format: 'zip-code'
-        example: 
-          $ref: 'http://foo.bar#/examples/zip-example'
-# in a response, note the plural `examples`:
-  responses:
-    200:
-      description: your car appointment has been booked
-      content: 
-        application/json:
-          schema:
-            $ref: '#/components/schemas/SuccessResponse'
-          example:
-            $ref: http://foo.bar#/examples/address-example.json
-```
 
 #### <a name="referenceObject"></a>Reference Object
 
@@ -2509,7 +2543,6 @@ Field Name | Type | Description
 <a name="schemaXml"></a>xml | [XML Object](#xmlObject) | This MAY be used only on properties schemas. It has no effect on root schemas. Adds Additional metadata to describe the XML representation format of this property.
 <a name="schemaExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation for this schema. 
 <a name="schemaExample"></a>example | Any | A free-form property to include an example of an instance for this schema.
-<a name="schemaExamples"></a>examples | Any | An array of free-formed properties to include examples for this schema.
 <a name="schemaDeprecated"></a> deprecated | `boolean` | Specifies that a schema is deprecated and SHOULD be transitioned out of usage.
 
 This object can be extended with [Specification Extensions](#specificationExtensions). 

--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -674,7 +674,7 @@ This object can be extended with [Specification Extensions](#specificationExtens
       "200": {
         "description": "pet response",
         "content": {
-          "*": {
+          "*/*": {
             "schema": {
               "type": "array",
               "items": {
@@ -721,7 +721,7 @@ get:
     '200':
       description: pet response
       content:
-        *:
+        '*/*' :
           schema:
             type: array
             items:
@@ -1831,7 +1831,7 @@ X-Rate-Limit-Reset:
 
 Allows sharing examples for operation requests and responses. This literal value can either be any JSON or YAML object, array or primitive value.  To represent examples of media types that cannot naturally represented in the OpenAPI definition, a string value can be used to contain the example with escaping where necessary. 
 
-##### Example Example
+##### Example Object Example
 
 Example representation for application/json media type of a Pet data type:
 
@@ -1863,7 +1863,7 @@ Field Name | Type | Description
 <a name="describedExampleSummary"></a>summary | `string` | Short description for the example.
 <a name="describedExampleDescription"></a>description | `string` | Long description for the example.
 <a name="describedExampleValue"></a>value | [Example Object](#exampleObject) | Embedded literal example. The `value` field and `valueUrl` field are mutually exclusive.
-<a name="describedExampleValueUrl"></a>valueUrl | `string` | A Url that points to the literal example. This provides the ability to reference examples that cannot easily be included in JSON or YAML documents.  The `value` field and `valueUrl` field are mutually exclusive. 
+<a name="describedExampleValueUrl"></a>valueUrl | `string` | A URL that points to the literal example. This provides the ability to reference examples that cannot easily be included in JSON or YAML documents.  The `value` field and `valueUrl` field are mutually exclusive. 
 
 This object can be extended with [Specification Extensions](#specificationExtensions). 
 
@@ -1872,7 +1872,7 @@ for the value that it is accompanying.  Tooling implementations MAY choose to
 validate compatibility automatically, and reject the example value(s) if they 
 are not compatible.
 
-##### Example Described Example
+##### Described Example Object Example
 
 ```yaml
 # in a model
@@ -1906,7 +1906,8 @@ schemas:
           textExample: 
             summary: This is a text example
             valueUrl: 'http://foo.bar/examples/address-example.txt' 
-        
+
+
 # in a parameter
   parameters:
     - name: 'zipCode'
@@ -2435,7 +2436,6 @@ This object can be extended with [Specification Extensions](#specificationExtens
 name: pet
 description: Pets operations
 ```
-
 
 #### <a name="referenceObject"></a>Reference Object
 

--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -937,7 +937,7 @@ Field Name | Type | Description
 <a name="parameterExplode"></a>explode | `boolean` | When this is true, parameter values of type `array` or `object` generate separate parameters for each value of the array, or key-value-pair of the map.  For other types of parameters this property has no effect. When [`style`](#parameterStyle) is `form`, the default value is `true`. For all other styles, the default value is `false`.
 <a name="parameterAllowReserved"></a>allowReserved | `boolean` | Determines whether the parameter value SHOULD allow reserved characters, as defined by [RFC3986](https://tools.ietf.org/html/rfc3986#section-2.2) `:/?#[]@!$&'()*+,;=` to be included without percent-encoding. This property only applies to parameters with an `in` value of `query`. The default value is `false`.
 <a name="parameterSchema"></a>schema | [Schema Object](#schemaObject) \| [Reference Object](#referenceObject)] | The schema defining the type used for the parameter.
-<a name="parameterExample"></a>example | Any | Example of the media type.  The example object SHOULD be in the correct format as specified in the parameter encoding.  The `example` object is mutually exclusive to the `examples` object.  Furthermore, if referencing a `schema` which contains an example, the `example` value SHALL _override_ the the example provided by the schema. To represent examples of media types that cannot naturally represented in JSON or YAML, a string value can be used to contain the example with escaping where necessary.
+<a name="parameterExample"></a>example | Any | Example of the media type.  The example SHOULD match the specified schema and encoding properties if present.  The `example` object is mutually exclusive to the `examples` object.  Furthermore, if referencing a `schema` which contains an example, the `example` value SHALL _override_ the the example provided by the schema. To represent examples of media types that cannot naturally represented in JSON or YAML, a string value can be used to contain the example with escaping where necessary.
 <a name="parameterExamples"></a>examples | Map[ `string`, [Example Object](#exampleObject) \| [Reference Object](#referenceObject)] | Examples of the media type.  Each example SHOULD contain a value in the correct format as specified in the parameter encoding.  The `examples` object is mutually exclusive to the `example` object.  Furthermore, if referencing a `schema` which contains an example, the `examples` value SHALL _override_ the example provided by the schema.
 
 For more complex scenarios a [Content Object](#contentObject) can be used to define the media type 
@@ -1324,7 +1324,7 @@ Field Name | Type | Description
 ---|:---:|---
 <a name="mediaTypeSchema"></a>schema | [Schema Object](#schemaObject) \| [Reference Object](#referenceObject) | The schema defining the type used for the request body.
 <a name="mediaTypeExample"></a>example | Any | Example of the media type.  The example object SHOULD be in the correct format as specified in the media type.  The `example` object is mutually exclusive to the `examples` object.  Furthermore, if referencing a `schema` which contains an example, the `example` value SHALL _override_ the the example provided by the schema.
-<a name="mediaTypeExamples"></a>examples | Map[ `string`, [Example Object](#exampleObject) \| [Reference Object](#referenceObject)] | Examples of the media type.  Each example object SHOULD contain a value in the correct format as specified in the media type.  The `examples` object is mutually exclusive to the `example` object.  Furthermore, if referencing a `schema` which contains an example, the `examples` value SHALL _override_ the example provided by the schema.
+<a name="mediaTypeExamples"></a>examples | Map[ `string`, [Example Object](#exampleObject) \| [Reference Object](#referenceObject)] | Examples of the media type.  Each example object SHOULD  match the media type and specified schema if present.  The `examples` object is mutually exclusive to the `example` object.  Furthermore, if referencing a `schema` which contains an example, the `examples` value SHALL _override_ the example provided by the schema.
 <a name="mediaTypeEncoding"></a>encoding | [Encoding Object](#encodingObject) | Encoding of the media type.  The encoding object SHOULD only apply to `requestBody` objects when the content type is `multipart`.
 
 This object can be extended with [Specification Extensions](#specificationExtensions). 
@@ -1343,14 +1343,23 @@ This object can be extended with [Specification Extensions](#specificationExtens
         "value": 
           {
             "name": "Fluffy",
-            "petType": "Cat"
+            "petType": "Cat",
+            "color": "White",
+            "gender": "male",
+            "breed": "Persian"
           }
       },
-      "frog": {
-        "summary": "An example of a frog with a dog's name",
+      "dog": {
+        "summary": "An example of a dog with a cat's name",
         "value" :  { 
-          "name": "Rover",
-          "petType": "Frog"
+          "name": "Puma",
+          "petType": "Dog",
+          "color": "Black",
+          "gender": "Female",
+          "breed": "Mixed"
+        },
+      "frog": {
+          "$ref": "#/components/examples/frog-example"
         }
       }
     }
@@ -1368,13 +1377,19 @@ application/json:
       value:
         name: Fluffy
         petType: Cat
-    frog:
-      summary: An example of a frog with a dog's name
-      value:
-        name: Rover
-        petType: Frog
+        color: White
+        gender: male
+        breed: Persian
     dog:
-      $ref: "#/components/examples/dog-example"
+      summary: An example of a dog with a cat's name
+      value:
+        name: Puma
+        petType: Dog
+        color: Black
+        gender: Female
+        breed: Mixed
+    frog:
+      $ref: "#/components/examples/frog-example"
 ```
 
 ##### Considerations for file uploads
@@ -1918,9 +1933,9 @@ schemas:
       type: string
       examples:
         name:
-          $ref: http://example.org/petapi-examples/OpenApi.json#/components/examples/name-example
+          $ref: http://example.org/petapi-examples/openapi.json#/components/examples/name-example
 
-# in a request body, note the plural `examples` as the Content-Type is set to `*`:
+# in a request body:
   requestBody:
     content:
       'application/json':
@@ -2532,7 +2547,6 @@ schemas:
             $ref: http://foo.bar#/examples/address-example.json
 ```
 
->>>>>>> refs/remotes/origin/OpenAPI.next
 #### <a name="referenceObject"></a>Reference Object
 
 A simple object to allow referencing other components in the specification, internally and externally.
@@ -2790,65 +2804,6 @@ required:
 example:
   name: Puma
   id: 1
-```
-
-###### Model with Examples
-
-```json
-{
-  "type": "object",
-  "properties": {
-    "id": {
-      "type": "integer",
-      "format": "int64"
-    },
-    "name": {
-      "type": "string"
-    }
-  },
-  "required": [
-    "name"
-  ],
-  "examples": {
-    "cat": {
-      "summary": "Big cat example",
-      "value": {
-        "name": "Puma",
-        "id": 1
-      }
-    },
-    "dog": {
-      "summary": "Family dog example",
-      "value": {
-        "name": "Ferguson",
-        "id": 2
-      }
-    }
-  }
-}
-```
-
-```yaml
-type: object
-properties:
-  id:
-    type: integer
-    format: int64
-  name:
-    type: string
-required:
-- name
-examples:
-  cat:
-    summary: Big cat example
-    value:
-      name: Puma
-      id: 1
-  dog:
-    summary: Family Dog
-    value:
-      name: Ferguson
-      id: 2
 ```
 
 ###### Models with Composition

--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -1128,20 +1128,38 @@ A request body with a referenced model definition.
       "schema": {
         "$ref": "#/components/schemas/User"
       },
-      "examples": [ "http://foo.bar/examples/user-example.json" ]
+      "examples": {
+          "user" : {
+            "summary": "User Example", 
+            "valueUrl": "http://foo.bar/examples/user-example.json"
+          } 
+        }
     },
     "application/xml": {
       "schema": {
         "$ref": "#/components/schemas/User"
       },
-      "examples": [ "http://foo.bar/examples/user-example.xml" ]
+      "examples": {
+          "user" : {
+            "summary": "User example in XML",
+            "valueUrl": "http://foo.bar/examples/user-example.xml"
+          }
+        }
     },
     "text/plain": {
-      "examples": [ "http://foo.bar/examples/user-example.txt" ]
+      "examples": {
+        "user" : {
+            "summary": "User example in Plain text",
+            "valueUrl": "http://foo.bar/examples/user-example.txt" 
+        }
+      } 
     },
     "*/*": {
-      "example": {
-        "$ref": "http://foo.bar/examples/user-example.whatever"
+      "examples": {
+        "user" : {
+            "summary": "User example in other format",
+            "valueUrl": "http://foo.bar/examples/user-example.whatever"
+        }
       }
     }
   }
@@ -1155,18 +1173,26 @@ content:
     schema:
       $ref: '#/components/schemas/User'
     examples:
-      - 'http://foo.bar/examples/user-example.json'
+      user:
+        summary: User Example
+        valueUrl: 'http://foo.bar/examples/user-example.json'
   'application/xml':
     schema:
       $ref: '#/components/schemas/User'
     examples:
-      - 'http://foo.bar/examples/user-example.xml'
+      user:
+        summary: User Example in XML
+        valueUrl: 'http://foo.bar/examples/user-example.xml'
   'text/plain':
     examples:
-      - 'http://foo.bar/examples/user-example.txt'
+      user:
+        summary: User example in text plain format
+        valueUrl: 'http://foo.bar/examples/user-example.txt'
   '*/*':
-    example:
-      $ref: 'http://foo.bar/examples/user-example.whatever'
+    examples:
+      user: 
+        summary: User example in other format
+        valueUrl: 'http://foo.bar/examples/user-example.whatever'
 ```
 
 A body parameter that is an array of string values:
@@ -1216,22 +1242,40 @@ Each key in the Content Object is the media type of the [Media Type Object](#med
         "type": "string"
       }
     },
-    "examples": [
-      ["Bob","Diane","Mary","Bill"],
-      []
-     ]
+    "examples": {
+      "list": {
+        "summary": "List of names",
+        "value" : ["Bob","Diane","Mary","Bill"]
+        },
+      "empty":{
+        "summary": "Empty List",
+        "value": []
+      } 
+    }
   },
   "application/xml": {
-    "examples": [
-      "<Users><User name='Bob'/><User name='Diane'/><User name='Mary'/><User name='Bill'/></Users>",
-      "<Users/>"
-    ]
+    "examples": { 
+      "list": { 
+        "summary": "List of names",
+        "value": "<Users><User name='Bob'/><User name='Diane'/><User name='Mary'/><User name='Bill'/></Users>"
+      },
+      "empty": {
+        "summary":"Empty",
+        "value": "<Users/>"
+      }
+    }
   },
   "text/plain": {
-    "examples": [
-      "Bob,Diane,Mary,Bill",
-      ""
-    ]
+    "examples": {
+      "list": {
+        "summary": "List of names",
+        "value": "Bob,Diane,Mary,Bill"
+      },
+      "empty": {
+        "summary": "Empty",
+        "value" : ""
+      }
+    }
   }
 }
 ```
@@ -1244,21 +1288,33 @@ content:
       items:
         type: string
     examples:
-      - 
-        - Bob
-        - Diane
-        - Mary
-        - Bill
-      - {}
+      list:
+        summary: List of Names
+        value:
+          - Bob
+          - Diane
+          - Mary
+          - Bill
+      empty:
+        summary: Empty
+        value: {}
 
   'application/xml': 
     examples:
-      - "<Users><User name='Bob'/><User name='Diane'/><User name='Mary'/><User name='Bill'/></Users>"
-      - "<Users/>"
+      list:
+        summary: List of names
+        value: "<Users><User name='Bob'/><User name='Diane'/><User name='Mary'/><User name='Bill'/></Users>"
+      empty:
+        summmary: Empty list
+        value: "<Users/>"
   'text/plain':
     examples:
-      - "Bob,Diane,Mary,Bill"
-      - ""
+      list:
+        summary: List of names
+        value: "Bob,Diane,Mary,Bill"
+      empty:
+        summary: Empty
+        value: ""
 ```
 
 #### <a name="mediaTypeObject"></a>Media Type Object
@@ -1889,8 +1945,9 @@ schemas:
   properties:
     name:
       type: string
-      example:
-        $ref: http://example.org/petapi-examples/OpenApi.json#/components/examples/name-example
+      examples:
+        name:
+          $ref: http://example.org/petapi-examples/OpenApi.json#/components/examples/name-example
 
 # in a request body, note the plural `examples` as the Content-Type is set to `*`:
   requestBody:
@@ -2781,14 +2838,22 @@ example:
   "required": [
     "name"
   ],
-  "examples": [
-  {
-    "name": "Puma",
-    "id": 1
-  }, {
-    "name": "Ferguson",
-    "id": 2
-  }]
+  "examples": {
+    "cat": {
+      "summary": "Big cat example",
+      "value": {
+        "name": "Puma",
+        "id": 1
+      }
+    },
+    "dog": {
+      "summary": "Family dog example",
+      "value": {
+        "name": "Ferguson",
+        "id": 2
+      }
+    }
+  }
 }
 ```
 
@@ -2803,10 +2868,16 @@ properties:
 required:
 - name
 examples:
-  - name: Puma
-    id: 1
-  - name: Ferguson
-    id: 2
+  cat:
+    summary: Big cat example
+    value:
+      name: Puma
+      id: 1
+  dog:
+    summary: Family Dog
+    value:
+      name: Ferguson
+      id: 2
 ```
 
 ###### Models with Composition


### PR DESCRIPTION
This proposal attempts to address the issues raised in #488 

The "Example Object" has been updated.  This object now supports the following scenarios:
    a) multiple examples are required,
    b) when short `summary` or long `description` is needed, or 
    c) when an example needs to be reused using a reference object.

```yaml
examples:
  cat:
    summary: Big cat example
    value:
      name: Puma
      id: 1
  dog:
    summary: Family Dog
    description: This is the story about Ferguson the dog ...
    value:
      name: Ferguson
      id: 2
  frog:
    $ref: "#/components/examples/frog"
```

For simpler scenarios where only one example is required, you can inline a single example.

```yaml
example:
    name: Ferguson
    id: 2
```

For scenarios where the example is for a media type that is not JSON or YAML the value can be externalized using the `externalValue` property instead of the `value` property.  The value retrieved when dereferencing this URL must match the media type/ encoding associated with described example object.

```yaml
  'application/xml':
    examples:
      user:
        summary: User Example in XML
        externalValue: http://foo.bar/examples/user-example.xml
```

For Content Objects, Parameter Objects and Header Objects, you can use either a inline `example` or a map of described example objects called `examples` , but not both.  Schema objects only support inline `example` as in OpenAPI V2.  



