### PR TITLE
Remove invalid component name example

### DIFF
--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -433,7 +433,6 @@ User_1
 User_Name
 user-name
 my.org.User
-my\org\User
 ```
 
 ##### Components Object Example


### PR DESCRIPTION
As per @darrelmiller in #994 

> The slash prior to the hyphen was an escape character, not an allowance of slashes!