### PR TITLE
Remove guidance on summary length

### DIFF
--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -763,7 +763,7 @@ Describes a single API operation on a path.
 Field Name | Type | Description
 ---|:---:|---
 <a name="operationTags"></a>tags | [`string`] | A list of tags for API documentation control. Tags can be used for logical grouping of operations by resources or any other qualifier.
-<a name="operationSummary"></a>summary | `string` | A short summary of what the operation does. For maximum readability in editing or documentation generation tools, this field SHOULD be less than 120 characters.
+<a name="operationSummary"></a>summary | `string` | A short summary of what the operation does.
 <a name="operationDescription"></a>description | `string` | A verbose explanation of the operation behavior. [CommonMark syntax](http://spec.commonmark.org/) can be used for rich text representation.
 <a name="operationExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation for this operation.
 <a name="operationId"></a>operationId | `string` | Unique string used to identify the operation. The id MUST be unique among all operations described in the API. Tools and libraries MAY use the operationId to uniquely identify an operation, therefore, it is recommended to follow common programming naming conventions.


### PR DESCRIPTION
Per TDC discussion on PR #1009, this removes the guidance that had advised keeping length under 120 characters guidance (from v2)