### PR TITLE
Fix typo in spec example: `securitySchemas`->`securitySchemes`

### DIFF
--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -570,7 +570,7 @@ components:
         application/json
           schema:
             $ref: '#/components/schemas/GeneralError'
-  securitySchemas:
+  securitySchemes:
     api_key:
       type: apiKey
       name: api_key


### PR DESCRIPTION
Fix typo in spec example: `securitySchemas`->`securitySchemes`
JSON example is correct.