### PR TITLE
Fix spec example: Plain text response with headers

### DIFF
--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -1732,15 +1732,21 @@ Plain text response with headers:
   "headers": {
     "X-Rate-Limit-Limit": {
       "description": "The number of allowed requests in the current period",
-      "type": "integer"
+      "schema": {
+        "type": "integer"
+      }
     },
     "X-Rate-Limit-Remaining": {
       "description": "The number of remaining requests in the current period",
-      "type": "integer"
+      "schema": {
+        "type": "integer"
+      }
     },
     "X-Rate-Limit-Reset": {
       "description": "The number of seconds left in the current period",
-      "type": "integer"
+      "schema": {
+        "type": "integer"
+      }
     }
   }
 }
@@ -1756,13 +1762,16 @@ content:
 headers:
   X-Rate-Limit-Limit:
     description: The number of allowed requests in the current period
-    type: integer
+    schema:
+      type: integer
   X-Rate-Limit-Remaining:
     description: The number of remaining requests in the current period
-    type: integer
+    schema:
+      type: integer
   X-Rate-Limit-Reset:
     description: The number of seconds left in the current period
-    type: integer
+    schema:
+      type: integer
 ```
 
 Response with no return value:


### PR DESCRIPTION
We have two different representations of the Header Object is the specification: 
* [Plain text response with headers](https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#response-object-examples) defines the `type` directly in the Header Object:
```yaml
description: The number of allowed requests in the current period
type: integer
```
*  [Headers Object Example](https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#headers-object-example) puts the `type` inside the `schema` element:
```yaml
description: The number of allowed requests in the current period
schema:
  type: integer
```


I believe only the latter is correct as 1) The Header Object follows the structure of the [Parameter Object](https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#parameter-object), 2) Parameter Object has `schema` property which defines the `type`. 
=> This PR updates the "Plain text response with headers" example by moving the header's `type` into the `schema` object.