### PR TITLE
#1133 - replace commaDelimited by simple.

### DIFF
--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -717,7 +717,7 @@ This object can be extended with [Specification Extensions](#specificationExtens
       "items": {
         "type": "string"
       },
-      "style": "commaDelimited"
+      "style": "simple"
     }
   ]
 }
@@ -749,7 +749,7 @@ parameters:
   description: ID of pet to use
   required: true
   type: array
-  format: form
+  style: simple
   items:
     type: string  
 ```
@@ -1016,7 +1016,7 @@ A header parameter with an array of 64 bit integer numbers:
       "format": "int64"
     }
   },
-  "style": "commaDelimited"
+  "style": "simple"
 }
 ```
 
@@ -1030,7 +1030,7 @@ schema:
   items:
     type: integer
     format: int64
-style: commaDelimited
+style: simple
 ```
 
 A path parameter of a string value:

--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -713,9 +713,11 @@ This object can be extended with [Specification Extensions](#specificationExtens
       "in": "path",
       "description": "ID of pet to use",
       "required": true,
-      "type": "array",
-      "items": {
-        "type": "string"
+      "schema": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
       },
       "style": "simple"
     }
@@ -748,10 +750,11 @@ parameters:
   in: path
   description: ID of pet to use
   required: true
-  type: array
-  style: simple
-  items:
-    type: string  
+  schema:
+    type: array
+    style: simple
+    items:
+      type: string  
 ```
 
 #### <a name="operationObject"></a>Operation Object


### PR DESCRIPTION
Also, in one example there was `format: form` for a parameter, which is totally bogus.

This fixes #1133 (even though that one is already closed).