### PR TITLE
Server variable enum values must be strings

### DIFF
--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -395,7 +395,7 @@ An object representing a Server Variable for server URL template substitution.
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="serverVariableEnum"></a>enum | [`string`] | An enumeration of primitive type values to be used if the substitution options are from a limited set.
+<a name="serverVariableEnum"></a>enum | [`string`] | An enumeration of string values to be used if the substitution options are from a limited set.
 <a name="serverVariableDefault"></a>default | `string` |  **Required.** The default value to use for substitution if an alternate value is not specified, and will be sent if an alternative value is _not_ supplied. Unlike the [Schema Object's](#schemaObject) `default`, this value MUST be provided by the consumer.
 <a name="serverVariableDescription"></a>description | `string` | An optional description for the server variable. [CommonMark syntax](http://spec.commonmark.org/) can be used for rich text representation.
 


### PR DESCRIPTION
... not primitive types. Make description match definition.