### PR TITLE
Fix schemas/Error code property in Uber example

### DIFF
--- a/examples/v3.0/uber.yaml
+++ b/examples/v3.0/uber.yaml
@@ -289,8 +289,7 @@ components:
     Error:
       properties:
         code:
-          type: integer
-          format: int32
+          type: string
         message:
           type: string
         fields:


### PR DESCRIPTION
The [live API returns][Uber products GET] e.g.:

    {
        "message": "No authentication provided.",
        "code": "unauthorized"
    }

This commit corrects the schema for `code` to be of `type: string`.

[Uber products GET]: https://api.uber.com/v1/products