### PR TITLE
Fix version in path for petstore server

### DIFF
--- a/examples/v2.0/yaml/petstore.yaml
+++ b/examples/v2.0/yaml/petstore.yaml
@@ -5,7 +5,7 @@ info:
   license:
     name: MIT
 host: petstore.swagger.io
-basePath: /v1
+basePath: /v2
 schemes:
   - http
 consumes:

--- a/examples/v3.0/petstore.yaml
+++ b/examples/v3.0/petstore.yaml
@@ -5,7 +5,7 @@ info:
   license:
     name: MIT
 servers:
-  - url: http://petstore.swagger.io/v1
+  - url: http://petstore.swagger.io/v2
 paths:
   /pets:
     get:


### PR DESCRIPTION
This PR fixes the petstore example to use /v2 in the path rather than /v1, that at the time of writing 404s every request.

c.f. #1144