### PR TITLE
added example

### DIFF
--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -1168,6 +1168,51 @@ schema:
 style: form
 ```
 
+A complex parameter using `content` to define serialization:
+
+```json
+{
+  "in": "query",
+  "name": "coordinates",
+  "content": {
+    "application/json": {
+      "schema": {
+        "type": "object",
+        "required": [
+          "lat",
+          "long"
+        ],
+        "properties": {
+          "lat": {
+            "type": "number"
+          },
+          "long": {
+            "type": "number"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+```yaml
+in: query
+name: coordinates
+content:
+  application/json:
+    schema:
+      type: object
+      required:
+        - lat
+        - long
+      properties:
+        lat:
+          type: number
+        long:
+          type: number
+```
+
 #### <a name="requestBodyObject"></a>Request Body Object
 
 Describes a single request body.


### PR DESCRIPTION
Fixes #996.

@MikeRalphson - I’ve added an example of what a query parameter with `content` looks like. 

This does not cover how different parameter locations may be serialized, but that should be covered by the `style` examples (and that’s unrelated to the `content`).