### PR TITLE
Fix callback-example.yaml

### DIFF
--- a/examples/v3.0/callback-example.yaml
+++ b/examples/v3.0/callback-example.yaml
@@ -1,3 +1,7 @@
+openapi: 3.0.0
+info: 
+  title: Callback Example
+  version: 1.0.0
 paths:
   /streams:
     post:
@@ -32,7 +36,7 @@ paths:
         onData:
           # when data is sent, it will be sent to the `callbackUrl` provided
           # when making the subscription PLUS the suffix `/data`
-          {$request.query.callbackUrl}/data:
+          '{$request.query.callbackUrl}/data':
             post:
               requestBody:
                 description: subscription payload

--- a/examples/v3.0/callback-example.yaml
+++ b/examples/v3.0/callback-example.yaml
@@ -1,7 +1,4 @@
-openapi: 3.0.0
-info: 
-  title: Callback Example
-  version: 1.0.0
+# ...
 paths:
   /streams:
     post:
@@ -48,7 +45,7 @@ paths:
                           type: string
                           format: date-time
                         userData:
-                          $ref: '#/components/schemas/UserLogData'
+                          type: string
               responses:
                 '202':
                   description: |


### PR DESCRIPTION
The runtime expression [must be quoted](http://www.yaml.org/spec/1.2/spec.html#id2788859) as it starts with a '{' - an [indicator character](http://www.yaml.org/spec/1.2/spec.html#c-indicator), otherwise it's invalid YAML.

I also added the 'openapi' and 'info' properties because they are required and, thus, the spec file is invalid without them.