### PR TITLE
Fixed JSON request example in "Key Expression"

### DIFF
--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -1837,7 +1837,7 @@ For example, given the following HTTP request:
 POST /subscribe/myevent?queryUrl=http://clientdomain.com/stillrunning HTTP/1.1
 Host: example.org
 Content-Type: application/json
-Content-Length: 123
+Content-Length: 187
 
 {
   "failedUrl" : "http://clientdomain.com/failed",

--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -1840,7 +1840,7 @@ Content-Type: application/json
 Content-Length: 123
 
 {
-  "failedUrl" : "http://clientdomain.com/failed"
+  "failedUrl" : "http://clientdomain.com/failed",
   "successUrls" : [
     "http://clientdomain.com/fast",
     "http://clientdomain.com/medium",


### PR DESCRIPTION
This PR fixes the sample request in the "Key Expression" section:
* added missing comma between the JSON fields,
* updated `Content-Length` to match the actual payload size.