### PR TITLE
Fixed an invalid example (Encoding Object Example)

### DIFF
--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -1599,8 +1599,9 @@ requestBody:
           contentType: image/png, image/jpeg
           headers:
             X-Rate-Limit-Limit:
-            description: The number of allowed requests in the current period
-            type: integer
+              description: The number of allowed requests in the current period
+              schema:
+                type: integer
 ```
 
 #### <a name="responsesObject"></a>Responses Object


### PR DESCRIPTION
This is a fix for an invalid sample here:

https://github.com/OAI/OpenAPI-Specification/blob/3.0.0-rc2/versions/3.0.md#encoding-object-example

The tabbing was a bit off and it needed a "schema".