### PR TITLE
Adding API Version for an operation in Swagger 2.0 Schema

### DIFF
--- a/schemas/v2.0/schema.json
+++ b/schemas/v2.0/schema.json
@@ -254,6 +254,10 @@
           },
           "uniqueItems": true
         },
+        "version": {
+          "type": "string",
+          "description": "The API version of the operation"
+        },
         "summary": {
           "type": "string",
           "description": "A brief summary of the operation."


### PR DESCRIPTION
This new **version** property allows us to specify what version of the operation is behind the route.

BTW, thanks for all the work pals!