### PR TITLE
Adding support for operation versioning

### DIFF
--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -826,6 +826,7 @@ Describes a single API operation on a path.
 Field Name | Type | Description
 ---|:---:|---
 <a name="operationTags"></a>tags | [`string`] | A list of tags for API documentation control. Tags can be used for logical grouping of operations by resources or any other qualifier.
+<a name="operationVersion"></a>version | `string` | The version of the operation using [Semantic Versioning 2.0.0](http://semver.org/spec/v2.0.0.html) (semver).
 <a name="operationSummary"></a>summary | `string` | A short summary of what the operation does.
 <a name="operationDescription"></a>description | `string` | A verbose explanation of the operation behavior. [CommonMark syntax](http://spec.commonmark.org/) can be used for rich text representation.
 <a name="operationExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation for this operation.
@@ -847,6 +848,7 @@ This object can be extended with [Specification Extensions](#specificationExtens
   "tags": [
     "pet"
   ],
+  "version": "1.0.0",
   "summary": "Updates a pet in the store with form data",
   "operationId": "updatePetWithForm",
   "parameters": [


### PR DESCRIPTION
This new **version** property allows us to specify what version of the operation is behind the route.

BTW, thanks for all the work pals!