### PR TITLE
[WIP] Alternative OAS3 JSON Schema

### DIFF
--- a/schemas/v3.0/README.md
+++ b/schemas/v3.0/README.md
@@ -1,0 +1,16 @@
+OpenAPI 3.0.X JSON Schema
+---
+
+Here you can find the JSON Schema for validating OpenAPI definitions of versions 3.0.X.
+
+As a reminder, the JSON Schema is not the source of truth for the Specification. In cases of conflicts between the Specification itself and the JSON Schema, the Specification wins. Also, some Specification constraints cannot be represented with the JSON Schema so it's highly recommended to employ other methods to ensure compliance.
+
+The iteration version of the JSON Schema can be found in the `id` field. For example, the value of `id: https://spec.openapis.org/oas/3.0/schema/2019-04-02` means this iteration was created on April 2nd, 2019.
+
+To submit improvements to the schema, modify the schema.yaml file only.
+
+The TSC will then:
+- Run tests on the updates schema
+- Update the iteration version
+- Convert the schema.yaml to schema.json
+- Publish the new version

--- a/schemas/v3.0/README.md
+++ b/schemas/v3.0/README.md
@@ -10,7 +10,7 @@ The iteration version of the JSON Schema can be found in the `id` field. For exa
 To submit improvements to the schema, modify the schema.yaml file only.
 
 The TSC will then:
-- Run tests on the updates schema
+- Run tests on the updated schema
 - Update the iteration version
 - Convert the schema.yaml to schema.json
 - Publish the new version

--- a/schemas/v3.0/schema.json
+++ b/schemas/v3.0/schema.json
@@ -1,0 +1,1654 @@
+{
+  "id": "https://spec.openapis.org/oas/3.0/schema/2019-04-02",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Validation schema for OpenAPI Specification 3.0.X.",
+  "type": "object",
+  "required": [
+    "openapi",
+    "info",
+    "paths"
+  ],
+  "properties": {
+    "openapi": {
+      "type": "string",
+      "pattern": "^3\\.0\\.\\d(-.+)?$"
+    },
+    "info": {
+      "$ref": "#/definitions/Info"
+    },
+    "externalDocs": {
+      "$ref": "#/definitions/ExternalDocumentation"
+    },
+    "servers": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Server"
+      }
+    },
+    "security": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/SecurityRequirement"
+      }
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Tag"
+      },
+      "uniqueItems": true
+    },
+    "paths": {
+      "$ref": "#/definitions/Paths"
+    },
+    "components": {
+      "$ref": "#/definitions/Components"
+    }
+  },
+  "patternProperties": {
+    "^x-": {
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "Reference": {
+      "type": "object",
+      "required": [
+        "$ref"
+      ],
+      "patternProperties": {
+        "^\\$ref$": {
+          "type": "string",
+          "format": "uri-reference"
+        }
+      }
+    },
+    "Info": {
+      "type": "object",
+      "required": [
+        "title",
+        "version"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "termsOfService": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "contact": {
+          "$ref": "#/definitions/Contact"
+        },
+        "license": {
+          "$ref": "#/definitions/License"
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      },
+      "additionalProperties": false
+    },
+    "Contact": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      },
+      "additionalProperties": false
+    },
+    "License": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri-reference"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      },
+      "additionalProperties": false
+    },
+    "Server": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "properties": {
+        "url": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "variables": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/ServerVariable"
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      },
+      "additionalProperties": false
+    },
+    "ServerVariable": {
+      "type": "object",
+      "required": [
+        "default"
+      ],
+      "properties": {
+        "enum": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "default": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      },
+      "additionalProperties": false
+    },
+    "Components": {
+      "type": "object",
+      "properties": {
+        "schemas": {
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9\\.\\-_]+$": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/Schema"
+                },
+                {
+                  "$ref": "#/definitions/Reference"
+                }
+              ]
+            }
+          }
+        },
+        "responses": {
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9\\.\\-_]+$": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/Reference"
+                },
+                {
+                  "$ref": "#/definitions/Response"
+                }
+              ]
+            }
+          }
+        },
+        "parameters": {
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9\\.\\-_]+$": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/Reference"
+                },
+                {
+                  "$ref": "#/definitions/Parameter"
+                }
+              ]
+            }
+          }
+        },
+        "examples": {
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9\\.\\-_]+$": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/Reference"
+                },
+                {
+                  "$ref": "#/definitions/Example"
+                }
+              ]
+            }
+          }
+        },
+        "requestBodies": {
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9\\.\\-_]+$": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/Reference"
+                },
+                {
+                  "$ref": "#/definitions/RequestBody"
+                }
+              ]
+            }
+          }
+        },
+        "headers": {
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9\\.\\-_]+$": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/Reference"
+                },
+                {
+                  "$ref": "#/definitions/Header"
+                }
+              ]
+            }
+          }
+        },
+        "securitySchemes": {
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9\\.\\-_]+$": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/Reference"
+                },
+                {
+                  "$ref": "#/definitions/SecurityScheme"
+                }
+              ]
+            }
+          }
+        },
+        "links": {
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9\\.\\-_]+$": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/Reference"
+                },
+                {
+                  "$ref": "#/definitions/Link"
+                }
+              ]
+            }
+          }
+        },
+        "callbacks": {
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9\\.\\-_]+$": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/Reference"
+                },
+                {
+                  "$ref": "#/definitions/Callback"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      },
+      "additionalProperties": false
+    },
+    "Schema": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "multipleOf": {
+          "type": "number",
+          "minimum": 0,
+          "exclusiveMinimum": true
+        },
+        "maximum": {
+          "type": "number"
+        },
+        "exclusiveMaximum": {
+          "type": "boolean",
+          "default": false
+        },
+        "minimum": {
+          "type": "number"
+        },
+        "exclusiveMinimum": {
+          "type": "boolean",
+          "default": false
+        },
+        "maxLength": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "minLength": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 0
+        },
+        "pattern": {
+          "type": "string",
+          "format": "regex"
+        },
+        "maxItems": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "minItems": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 0
+        },
+        "uniqueItems": {
+          "type": "boolean",
+          "default": false
+        },
+        "maxProperties": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "minProperties": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 0
+        },
+        "required": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "enum": {
+          "type": "array",
+          "items": {
+          },
+          "minItems": 1,
+          "uniqueItems": false
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "array",
+            "boolean",
+            "integer",
+            "number",
+            "object",
+            "string"
+          ]
+        },
+        "not": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Schema"
+            },
+            {
+              "$ref": "#/definitions/Reference"
+            }
+          ]
+        },
+        "allOf": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Schema"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          }
+        },
+        "oneOf": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Schema"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          }
+        },
+        "anyOf": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Schema"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          }
+        },
+        "items": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Schema"
+            },
+            {
+              "$ref": "#/definitions/Reference"
+            }
+          ]
+        },
+        "properties": {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Schema"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          }
+        },
+        "additionalProperties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Schema"
+            },
+            {
+              "$ref": "#/definitions/Reference"
+            },
+            {
+              "type": "boolean"
+            }
+          ],
+          "default": true
+        },
+        "description": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "default": {
+        },
+        "nullable": {
+          "type": "boolean",
+          "default": false
+        },
+        "discriminator": {
+          "$ref": "#/definitions/Discriminator"
+        },
+        "readOnly": {
+          "type": "boolean",
+          "default": false
+        },
+        "writeOnly": {
+          "type": "boolean",
+          "default": false
+        },
+        "example": {
+        },
+        "externalDocs": {
+          "$ref": "#/definitions/ExternalDocumentation"
+        },
+        "deprecated": {
+          "type": "boolean",
+          "default": false
+        },
+        "xml": {
+          "$ref": "#/definitions/XML"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      },
+      "additionalProperties": false
+    },
+    "Discriminator": {
+      "type": "object",
+      "required": [
+        "propertyName"
+      ],
+      "properties": {
+        "propertyName": {
+          "type": "string"
+        },
+        "mapping": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "XML": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "namespace": {
+          "type": "string",
+          "format": "uri"
+        },
+        "prefix": {
+          "type": "string"
+        },
+        "attribute": {
+          "type": "boolean",
+          "default": false
+        },
+        "wrapped": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      },
+      "additionalProperties": false
+    },
+    "Response": {
+      "type": "object",
+      "required": [
+        "description"
+      ],
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "headers": {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Header"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          }
+        },
+        "content": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/MediaType"
+          }
+        },
+        "links": {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Link"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      },
+      "additionalProperties": false
+    },
+    "MediaType": {
+      "type": "object",
+      "properties": {
+        "schema": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Schema"
+            },
+            {
+              "$ref": "#/definitions/Reference"
+            }
+          ]
+        },
+        "example": {
+        },
+        "examples": {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Example"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          }
+        },
+        "encoding": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Encoding"
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      },
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "$ref": "#/definitions/ExampleXORExamples"
+        }
+      ]
+    },
+    "Example": {
+      "type": "object",
+      "properties": {
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "value": {
+        },
+        "externalValue": {
+          "type": "string",
+          "format": "uri-reference"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      },
+      "additionalProperties": false
+    },
+    "Header": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "required": {
+          "type": "boolean",
+          "default": false
+        },
+        "deprecated": {
+          "type": "boolean",
+          "default": false
+        },
+        "allowEmptyValue": {
+          "type": "boolean",
+          "default": false
+        },
+        "style": {
+          "type": "string",
+          "enum": [
+            "simple"
+          ],
+          "default": "simple"
+        },
+        "explode": {
+          "type": "boolean"
+        },
+        "allowReserved": {
+          "type": "boolean",
+          "default": false
+        },
+        "schema": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Schema"
+            },
+            {
+              "$ref": "#/definitions/Reference"
+            }
+          ]
+        },
+        "content": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/MediaType"
+          },
+          "minProperties": 1,
+          "maxProperties": 1
+        },
+        "example": {
+        },
+        "examples": {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Example"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      },
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "$ref": "#/definitions/ExampleXORExamples"
+        },
+        {
+          "$ref": "#/definitions/SchemaXORContent"
+        }
+      ]
+    },
+    "Paths": {
+      "type": "object",
+      "patternProperties": {
+        "^\\/": {
+          "$ref": "#/definitions/PathItem"
+        },
+        "^x-": {
+        }
+      },
+      "additionalProperties": false
+    },
+    "PathItem": {
+      "type": "object",
+      "properties": {
+        "$ref": {
+          "type": "string"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "servers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Server"
+          }
+        },
+        "parameters": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Parameter"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          },
+          "uniqueItems": true
+        }
+      },
+      "patternProperties": {
+        "^(get|put|post|delete|options|head|patch|trace)$": {
+          "$ref": "#/definitions/Operation"
+        },
+        "^x-": {
+        }
+      },
+      "additionalProperties": false
+    },
+    "Operation": {
+      "type": "object",
+      "required": [
+        "responses"
+      ],
+      "properties": {
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "externalDocs": {
+          "$ref": "#/definitions/ExternalDocumentation"
+        },
+        "operationId": {
+          "type": "string"
+        },
+        "parameters": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Parameter"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          },
+          "uniqueItems": true
+        },
+        "requestBody": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RequestBody"
+            },
+            {
+              "$ref": "#/definitions/Reference"
+            }
+          ]
+        },
+        "responses": {
+          "$ref": "#/definitions/Responses"
+        },
+        "callbacks": {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Callback"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          }
+        },
+        "deprecated": {
+          "type": "boolean",
+          "default": false
+        },
+        "security": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SecurityRequirement"
+          }
+        },
+        "servers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Server"
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      },
+      "additionalProperties": false
+    },
+    "Responses": {
+      "type": "object",
+      "properties": {
+        "default": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Response"
+            },
+            {
+              "$ref": "#/definitions/Reference"
+            }
+          ]
+        }
+      },
+      "patternProperties": {
+        "^[1-5](?:\\d{2}|XX)$": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Response"
+            },
+            {
+              "$ref": "#/definitions/Reference"
+            }
+          ]
+        },
+        "^x-": {
+        }
+      },
+      "minProperties": 1,
+      "additionalProperties": false
+    },
+    "SecurityRequirement": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    },
+    "Tag": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "externalDocs": {
+          "$ref": "#/definitions/ExternalDocumentation"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      },
+      "additionalProperties": false
+    },
+    "ExternalDocumentation": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri-reference"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      },
+      "additionalProperties": false
+    },
+    "ExampleXORExamples": {
+      "description": "Example and examples are mutually exclusive",
+      "not": {
+        "required": [
+          "example",
+          "examples"
+        ]
+      }
+    },
+    "SchemaXORContent": {
+      "description": "Schema and content are mutually exclusive, at least one is required",
+      "not": {
+        "required": [
+          "schema",
+          "content"
+        ]
+      },
+      "oneOf": [
+        {
+          "required": [
+            "schema"
+          ]
+        },
+        {
+          "required": [
+            "content"
+          ],
+          "description": "Some properties are not allowed if content is present",
+          "allOf": [
+            {
+              "not": {
+                "required": [
+                  "style"
+                ]
+              }
+            },
+            {
+              "not": {
+                "required": [
+                  "explode"
+                ]
+              }
+            },
+            {
+              "not": {
+                "required": [
+                  "allowReserved"
+                ]
+              }
+            },
+            {
+              "not": {
+                "required": [
+                  "example"
+                ]
+              }
+            },
+            {
+              "not": {
+                "required": [
+                  "examples"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "Parameter": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "in": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "required": {
+          "type": "boolean",
+          "default": false
+        },
+        "deprecated": {
+          "type": "boolean",
+          "default": false
+        },
+        "allowEmptyValue": {
+          "type": "boolean",
+          "default": false
+        },
+        "style": {
+          "type": "string"
+        },
+        "explode": {
+          "type": "boolean"
+        },
+        "allowReserved": {
+          "type": "boolean",
+          "default": false
+        },
+        "schema": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Schema"
+            },
+            {
+              "$ref": "#/definitions/Reference"
+            }
+          ]
+        },
+        "content": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/MediaType"
+          },
+          "minProperties": 1,
+          "maxProperties": 1
+        },
+        "example": {
+        },
+        "examples": {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Example"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "in"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ExampleXORExamples"
+        },
+        {
+          "$ref": "#/definitions/SchemaXORContent"
+        },
+        {
+          "$ref": "#/definitions/ParameterLocation"
+        }
+      ]
+    },
+    "ParameterLocation": {
+      "description": "Parameter location",
+      "oneOf": [
+        {
+          "description": "Parameter in path",
+          "required": [
+            "required"
+          ],
+          "properties": {
+            "in": {
+              "enum": [
+                "path"
+              ]
+            },
+            "style": {
+              "enum": [
+                "matrix",
+                "label",
+                "simple"
+              ],
+              "default": "simple"
+            },
+            "required": {
+              "enum": [
+                true
+              ]
+            }
+          }
+        },
+        {
+          "description": "Parameter in query",
+          "properties": {
+            "in": {
+              "enum": [
+                "query"
+              ]
+            },
+            "style": {
+              "enum": [
+                "form",
+                "spaceDelimited",
+                "pipeDelimited",
+                "deepObject"
+              ],
+              "default": "form"
+            }
+          }
+        },
+        {
+          "description": "Parameter in header",
+          "properties": {
+            "in": {
+              "enum": [
+                "header"
+              ]
+            },
+            "style": {
+              "enum": [
+                "simple"
+              ],
+              "default": "simple"
+            }
+          }
+        },
+        {
+          "description": "Parameter in cookie",
+          "properties": {
+            "in": {
+              "enum": [
+                "cookie"
+              ]
+            },
+            "style": {
+              "enum": [
+                "form"
+              ],
+              "default": "form"
+            }
+          }
+        }
+      ]
+    },
+    "RequestBody": {
+      "type": "object",
+      "required": [
+        "content"
+      ],
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "content": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/MediaType"
+          }
+        },
+        "required": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      },
+      "additionalProperties": false
+    },
+    "SecurityScheme": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/APIKeySecurityScheme"
+        },
+        {
+          "$ref": "#/definitions/HTTPSecurityScheme"
+        },
+        {
+          "$ref": "#/definitions/OAuth2SecurityScheme"
+        },
+        {
+          "$ref": "#/definitions/OpenIdConnectSecurityScheme"
+        }
+      ]
+    },
+    "APIKeySecurityScheme": {
+      "type": "object",
+      "required": [
+        "type",
+        "name",
+        "in"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "apiKey"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "in": {
+          "type": "string",
+          "enum": [
+            "header",
+            "query",
+            "cookie"
+          ]
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      },
+      "additionalProperties": false
+    },
+    "HTTPSecurityScheme": {
+      "type": "object",
+      "required": [
+        "scheme",
+        "type"
+      ],
+      "properties": {
+        "scheme": {
+          "type": "string"
+        },
+        "bearerFormat": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "http"
+          ]
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      },
+      "additionalProperties": false,
+      "oneOf": [
+        {
+          "description": "Bearer",
+          "properties": {
+            "scheme": {
+              "enum": [
+                "bearer"
+              ]
+            }
+          }
+        },
+        {
+          "description": "Non Bearer",
+          "not": {
+            "required": [
+              "bearerFormat"
+            ]
+          },
+          "properties": {
+            "scheme": {
+              "not": {
+                "enum": [
+                  "bearer"
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
+    "OAuth2SecurityScheme": {
+      "type": "object",
+      "required": [
+        "type",
+        "flows"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "oauth2"
+          ]
+        },
+        "flows": {
+          "$ref": "#/definitions/OAuthFlows"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      },
+      "additionalProperties": false
+    },
+    "OpenIdConnectSecurityScheme": {
+      "type": "object",
+      "required": [
+        "type",
+        "openIdConnectUrl"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "openIdConnect"
+          ]
+        },
+        "openIdConnectUrl": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      },
+      "additionalProperties": false
+    },
+    "OAuthFlows": {
+      "type": "object",
+      "properties": {
+        "implicit": {
+          "$ref": "#/definitions/ImplicitOAuthFlow"
+        },
+        "password": {
+          "$ref": "#/definitions/PasswordOAuthFlow"
+        },
+        "clientCredentials": {
+          "$ref": "#/definitions/ClientCredentialsFlow"
+        },
+        "authorizationCode": {
+          "$ref": "#/definitions/AuthorizationCodeOAuthFlow"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      },
+      "additionalProperties": false
+    },
+    "ImplicitOAuthFlow": {
+      "type": "object",
+      "required": [
+        "authorizationUrl",
+        "scopes"
+      ],
+      "properties": {
+        "authorizationUrl": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "refreshUrl": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "scopes": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      },
+      "additionalProperties": false
+    },
+    "PasswordOAuthFlow": {
+      "type": "object",
+      "required": [
+        "tokenUrl"
+      ],
+      "properties": {
+        "tokenUrl": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "refreshUrl": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "scopes": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      },
+      "additionalProperties": false
+    },
+    "ClientCredentialsFlow": {
+      "type": "object",
+      "required": [
+        "tokenUrl"
+      ],
+      "properties": {
+        "tokenUrl": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "refreshUrl": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "scopes": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      },
+      "additionalProperties": false
+    },
+    "AuthorizationCodeOAuthFlow": {
+      "type": "object",
+      "required": [
+        "authorizationUrl",
+        "tokenUrl"
+      ],
+      "properties": {
+        "authorizationUrl": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "tokenUrl": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "refreshUrl": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "scopes": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      },
+      "additionalProperties": false
+    },
+    "Link": {
+      "type": "object",
+      "properties": {
+        "operationId": {
+          "type": "string"
+        },
+        "operationRef": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "parameters": {
+          "type": "object",
+          "additionalProperties": {
+          }
+        },
+        "requestBody": {
+        },
+        "description": {
+          "type": "string"
+        },
+        "server": {
+          "$ref": "#/definitions/Server"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      },
+      "additionalProperties": false,
+      "not": {
+        "description": "Operation Id and Operation Ref are mutually exclusive",
+        "required": [
+          "operationId",
+          "operationRef"
+        ]
+      }
+    },
+    "Callback": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/PathItem"
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      }
+    },
+    "Encoding": {
+      "type": "object",
+      "properties": {
+        "contentType": {
+          "type": "string"
+        },
+        "headers": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Header"
+          }
+        },
+        "style": {
+          "type": "string",
+          "enum": [
+            "form",
+            "spaceDelimited",
+            "pipeDelimited",
+            "deepObject"
+          ]
+        },
+        "explode": {
+          "type": "boolean"
+        },
+        "allowReserved": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/schemas/v3.0/schema.yaml
+++ b/schemas/v3.0/schema.yaml
@@ -634,7 +634,9 @@ definitions:
       callbacks:
         type: object
         additionalProperties:
-          $ref: '#/definitions/Callback'
+          oneOf:
+            - $ref: '#/definitions/Callback'
+            - $ref: '#/definitions/Reference'
       deprecated:
         type: boolean
         default: false

--- a/schemas/v3.0/schema.yaml
+++ b/schemas/v3.0/schema.yaml
@@ -1315,7 +1315,7 @@ definitions:
     type: object
     required:
       - type
-      - openIdConnect
+      - openIdConnectUrl
     properties:
       type:
         type: string
@@ -1472,7 +1472,6 @@ definitions:
       $ref: '#/definitions/PathItem'
     patternProperties:
       '^x-': {}
-    additionalProperties: false
 
   Encoding:
     type: object

--- a/schemas/v3.0/schema.yaml
+++ b/schemas/v3.0/schema.yaml
@@ -1,0 +1,1400 @@
+type: object
+required:
+  - openapi
+  - info
+  - paths
+properties:
+  openapi:
+    type: string
+    enum:
+      - 3.0.0
+  info:
+    $ref: '#/definitions/Info'
+  externalDocs:
+    $ref: '#/definitions/ExternalDocumentation'
+  servers:
+    type: array
+    items:
+      $ref: '#/definitions/Server'
+  security:
+    type: array
+    items:
+      $ref: '#/definitions/SecurityRequirement'
+  tags:
+    type: array
+    items:
+      $ref: '#/definitions/Tag'
+  paths:
+    $ref: '#/definitions/Paths'
+  components:
+    $ref: '#/definitions/Components'
+patternProperties:
+  '^x-': {}
+additionalProperties: false
+definitions:
+  Reference:
+    type: object
+    properties:
+      $ref:
+        type: string
+        format: uri-ref
+  Info:
+    type: object
+    required:
+      - title
+      - version
+    properties:
+      title:
+        type: string
+      description:
+        type: string
+      termsOfService:
+        type: string
+        format: uri-ref
+      contact:
+        $ref: '#/definitions/Contact'
+      license:
+        $ref: '#/definitions/License'
+      version:
+        type: string
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+
+  Contact:
+    type: object
+    properties:
+      name:
+        type: string
+      url:
+        type: string
+        format: uri-ref
+      email:
+        type: string
+        format: email
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false    
+
+  License:
+    type: object
+    required:
+      - name
+    properties:
+      name:
+        type: string
+      url:
+        type: string
+        format: uri-ref
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  Server:
+    type: object
+    required:
+      - url
+    properties:
+      url:
+        type: string
+        format: uri-ref
+      description:
+        type: string
+      variables:
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/ServerVariable'
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  ServerVariable:
+    type: object
+    required:
+      - default
+    properties:
+      enum:
+        type: string
+      default:
+        type: string
+      description:
+        type: string
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  Components:
+    type: object
+    properties:
+      schemas:
+        type: object
+        patternProperties:
+          '^[a-zA-Z0-9\.\-_]+$':
+            oneOf:
+              - $ref: '#/definitions/Reference'
+              - $ref: '#/definitions/Schema'
+      responses:
+        type: object
+        patternProperties:
+          '^[a-zA-Z0-9\.\-_]+$':
+            oneOf:
+              - $ref: '#/definitions/Reference'
+              - $ref: '#/definitions/Response'
+      parameters:
+        type: object
+        patternProperties:
+          '^[a-zA-Z0-9\.\-_]+$':
+            oneOf:
+              - $ref: '#/definitions/Reference'
+              - $ref: '#/definitions/Parameter'
+      examples:
+        type: object
+        patternProperties:
+          '^[a-zA-Z0-9\.\-_]+$':
+            oneOf:
+              - $ref: '#/definitions/Reference'
+              - $ref: '#/definitions/Example'
+      requestBodies:
+        type: object
+        patternProperties:
+          '^[a-zA-Z0-9\.\-_]+$':
+            oneOf:
+              - $ref: '#/definitions/Reference'
+              - $ref: '#/definitions/RequestBody'
+      headers:
+        type: object
+        patternProperties:
+          '^[a-zA-Z0-9\.\-_]+$':
+            oneOf:
+              - $ref: '#/definitions/Reference'
+              - $ref: '#/definitions/Header'
+      securitySchemes:
+        type: object
+        patternProperties:
+          '^[a-zA-Z0-9\.\-_]+$':
+            oneOf:
+              - $ref: '#/definitions/Reference'
+              - $ref: '#/definitions/SecurityScheme'
+      links:
+        type: object
+        patternProperties:
+          '^[a-zA-Z0-9\.\-_]+$':
+            oneOf:
+              - $ref: '#/definitions/Reference'
+              - $ref: '#/definitions/Link'
+      callbacks:
+        type: object
+        patternProperties:
+          '^[a-zA-Z0-9\.\-_]+$':
+            oneOf:
+              - $ref: '#/definitions/Reference'
+              - $ref: '#/definitions/Callback'
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  Schema:
+    type: object
+    properties:
+      title:
+        type: string
+      multipleOf:
+        type: number
+        minimum: 0
+        exclusiveMinimum: true
+      maximum:
+        type: number
+      exclusiveMaximum:
+        type: boolean
+        default: false
+      minimum:
+        type: number
+      exclusiveMinimum:
+        type: boolean
+        default: false
+      maxLength:
+        type: integer
+        minimum: 0
+      minLength:
+        type: integer
+        minimum: 0
+        default: 0
+      pattern:
+        type: string
+        format: regex
+      maxItems:
+        type: integer
+        minimum: 0
+      minItems:
+        type: integer
+        minimum: 0
+        default: 0
+      uniqueItems:
+        type: boolean
+        default: false
+      maxProperties:
+        type: integer
+        minimum: 0
+      minProperties:
+        type: integer
+        minimum: 0
+        default: 0
+      required:
+        type: array
+        items:
+          type: string
+        minItems: 1
+        uniqueItems: true
+      enum:
+        type: array
+        items: {}
+        minItems: 1
+        uniqueItems: true
+      type:
+        type: string
+        enum:
+         - array
+         - boolean
+         - integer
+         - number
+         - object
+         - string
+      not:
+        $ref: '#/definitions/Schema'
+      properties:
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/Schema'
+      additionalProperties:
+        oneOf:
+          - $ref: '#/definitions/Schema'
+          - type: boolean
+        default: true
+      description:
+        type: string
+      format:
+        type: string
+      default: {}
+      $ref:
+        type: string
+        format: uri-ref
+      nullable:
+        type: boolean
+        default: false
+      discriminator:
+        $ref: '#/definitions/Discriminator'
+      readOnly:
+        type: boolean
+        default: false
+      writeOnly:
+        type: boolean
+        default: false
+      example: {}
+      externalDocs:
+        $ref: '#/definitions/ExternalDocumentation'
+      deprecated:
+        type: boolean
+        default: false
+      xml:
+        $ref: '#/definitions/XML'
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false        
+  
+  Discriminator:
+    type: object
+    required:
+      - propertyName
+    properties:
+      propertyName:
+        type: string
+      mapping:
+        type: object
+        additionalProperties:
+          type: string
+
+  XML:
+    type: object
+    properties:
+      name:
+        type: string
+      namespace:
+        type: string
+        format: url
+      prefix:
+        type: string
+      attribute:
+        type: boolean
+        default: false
+      wrapperd:
+        type: boolean
+        default: false
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  Response:
+    type: object
+    required:
+      - description
+    properties:
+      description:
+        type: string
+      headers:
+        additionalProperties:
+          oneOf:
+            - $ref: '#/definitions/Header'
+            - $ref: '#/definitions/Reference'
+      content:
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/MediaType'
+      links:
+        type: object
+        additionalProperties:
+          oneOf:
+            - $ref: '#/definitions/Link'
+            - $ref: '#/definitions/Reference'
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  MediaType:
+    oneOf:
+      - $ref: '#/definitions/MediaTypeWithExample'
+      - $ref: '#/definitions/MediaTypeWithExamples'
+
+  MediaTypeWithExample:
+    type: object
+    properties:
+      schema:
+        oneOf:
+          - $ref: '#/definitions/Schema'
+          - $ref: '#/definitions/Reference'
+      example: {}
+      encoding:
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/Encoding'
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false 
+
+  MediaTypeWithExamples:
+    type: object
+    properties:
+      schema:
+        oneOf:
+          - $ref: '#/definitions/Schema'
+          - $ref: '#/definitions/Reference'
+      examples:
+        type: object
+        additionalProperties:
+          oneOf:
+            - $ref: '#/definitions/Example'
+            - $ref: '#/definitions/Reference'
+      encoding:
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/Encoding'
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false 
+
+  Example:
+    type: object
+    properties:
+      summary:
+        type: string
+      description:
+        type: string
+      value:
+        type: string
+      externalValue:
+        type: string
+        format: uri-ref
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  Header:
+    type: object
+    properties:
+      description:
+        type: string
+      required:
+        type: boolean
+        default: false
+      deprecated:
+        type: boolean
+        default: false
+      allowEmptyValue:
+        type: boolean
+        default: false
+      style:
+        type: string
+        enum:
+          - simple
+        default: simple
+      explode:
+        type: boolean
+        enum:
+          - false
+        default: false
+      schema:
+        oneOf:
+          - $ref: '#/definitions/Schema'
+          - $ref: '#/definitions/Reference'
+      examples:
+        type: array
+        items:
+          oneOf:
+            - $ref: '#/definitions/Example'
+            - $ref: '#/definitions/Reference'
+      example: {}
+      content:
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/MediaType'
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  Paths:
+    type: object
+    patternProperties:
+      '^\/': 
+        $ref: '#/definitions/PathItem'
+      '^x-': {}
+    additionalProperties: false
+
+  PathItem:
+    type: object
+    properties:
+      $ref:
+        type: string
+      summary:
+        type: string
+      description:
+        type: string
+      get:
+        $ref: '#/definitions/Operation'
+      put:
+        $ref: '#/definitions/Operation'
+      post:
+        $ref: '#/definitions/Operation'
+      delete:
+        $ref: '#/definitions/Operation'
+      options:
+        $ref: '#/definitions/Operation'
+      head:
+        $ref: '#/definitions/Operation'
+      patch:
+        $ref: '#/definitions/Operation'
+      trace:
+        $ref: '#/definitions/Operation'
+      servers:
+        type: array
+        items:
+          $ref: '#/definitions/Server'
+      parameters:
+        type: array
+        items:
+          oneOf:
+            - $ref: '#/definitions/Parameter'
+            - $ref: '#/definitions/Reference'
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  Operation:
+    type: object
+    required:
+      - responses
+    properties:
+      tags:
+        type: array
+        items:
+          type: string
+      summary:
+        type: string
+      description:
+        type: string
+      externalDocs:
+        $ref: '#/definitions/ExternalDocumentation'
+      operationId:
+        type: string
+      parameters:
+        type: array
+        items:
+          oneOf:
+            - $ref: '#/definitions/Parameter'
+            - $ref: '#/definitions/Reference'
+      requestBody:
+        oneOf:
+          - $ref: '#/definitions/RequestBody'
+          - $ref: '#/definitions/Reference'
+      responses:
+        $ref: '#/definitions/Responses'
+      callbacks:
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/Callback'
+      deprecated:
+        type: boolean
+        default: false
+      security:
+        type: array
+        items:
+          $ref: '#/definitions/SecurityRequirement'
+      servers:
+        type: array
+        items:
+          $ref: '#/definitions/Server'
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  Responses:
+    allOf:
+      - $ref: '#/definitions/Extensions'    
+    type: object
+    properties:
+      default:
+        oneOf:
+          - $ref: '#/definitions/Response'
+          - $ref: '#/definitions/Reference'
+    patternProperties:
+      '[1-5](?:\d{2}|XX)':
+        oneOf:
+          - $ref: '#/definitions/Response'
+          - $ref: '#/definitions/Reference'
+      '^x-': {}
+    minProperties: 1
+    additionalProperties: false
+    not:
+      type: object
+      patternProperties:
+        '^x-': {}
+ 
+
+  SecurityRequirement:
+    type: object
+    additionalProperties:
+      type: array
+      items:
+        type: string
+
+  Tag:
+    type: object
+    required:
+      - name
+    properties:
+      name:
+        type: string
+      description:
+        type: string
+      externalDocs:
+        $ref: '#/definitions/ExternalDocumentation'
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  ExternalDocumentation:
+    type: object
+    required:
+      - url
+    properties:
+      description:
+        type: string
+      url:
+        type: string
+        format: uri-ref
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  Parameter:
+    oneOf:
+      - $ref: '#/definitions/ParameterWithSchema'
+      - $ref: '#/definitions/ParameterWithContent'
+  
+  ParameterWithSchema:
+    oneOf:
+      - $ref: '#/definitions/ParameterWithSchemaWithExample'
+      - $ref: '#/definitions/ParameterWithSchemaWithExamples'
+
+  ParameterWithSchemaWithExample:
+    oneOf:
+      - $ref: '#/definitions/ParameterWithSchemaWithExampleInPath'
+      - $ref: '#/definitions/ParameterWithSchemaWithExampleInQuery'
+      - $ref: '#/definitions/ParameterWithSchemaWithExampleInHeader'
+      - $ref: '#/definitions/ParameterWithSchemaWithExampleInCookie'
+
+  ParameterWithSchemaWithExampleInPath:
+    type: object
+    required:
+      - name
+      - in
+      - schema
+      - required
+    properties:
+      name:
+        type: string
+      in:
+        type: string
+        enum:
+          - path
+      description:
+        type: string
+      required:
+        type: boolean
+        enum:
+          - true
+      deprecated:
+        type: boolean
+        default: false
+      allowEmptyValue:
+        type: boolean
+        default: false
+      style:
+        type: string
+        enum:
+          - matrix
+          - label
+          - simple
+        default: simple
+      explode:
+        type: boolean
+      allowReserved:
+        type: boolean
+        default: false
+      schema:
+        oneOf:
+          - $ref: '#/definitions/Schema'
+          - $ref: '#/definitions/Reference'
+      example: {}
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  ParameterWithSchemaWithExampleInQuery:
+    type: object
+    required:
+      - name
+      - in
+      - schema
+    properties:
+      name:
+        type: string
+      in:
+        type: string
+        enum:
+          - query
+      description:
+        type: string
+      required:
+        type: boolean
+        default: false
+      deprecated:
+        type: boolean
+        default: false
+      allowEmptyValue:
+        type: boolean
+        default: false
+      style:
+        type: string
+        enum:
+          - form
+          - spaceDelimited
+          - pipeDelimited
+          - deepObject
+        default: form
+      explode:
+        type: boolean
+      allowReserved:
+        type: boolean
+        default: false
+      schema:
+        oneOf:
+          - $ref: '#/definitions/Schema'
+          - $ref: '#/definitions/Reference'
+      example: {}
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false    
+
+  ParameterWithSchemaWithExampleInHeader:
+    type: object
+    required:
+      - name
+      - in
+      - schema
+    properties:
+      name:
+        type: string
+      in:
+        type: string
+        enum:
+          - header
+      description:
+        type: string
+      required:
+        type: boolean
+        default: false
+      deprecated:
+        type: boolean
+        default: false
+      allowEmptyValue:
+        type: boolean
+        default: false
+      style:
+        type: string
+        enum:
+          - simple
+        default: simple
+      explode:
+        type: boolean
+      allowReserved:
+        type: boolean
+        default: false
+      schema:
+        oneOf:
+          - $ref: '#/definitions/Schema'
+          - $ref: '#/definitions/Reference'
+      example: {}
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false    
+
+  ParameterWithSchemaWithExampleInCookie:
+    type: object
+    required:
+      - name
+      - in
+      - schema
+    properties:
+      name:
+        type: string
+      in:
+        type: string
+        enum:
+          - cookie
+      description:
+        type: string
+      required:
+        type: boolean
+        default: false
+      deprecated:
+        type: boolean
+        default: false
+      allowEmptyValue:
+        type: boolean
+        default: false
+      style:
+        type: string
+        enum:
+          - form
+        default: form
+      explode:
+        type: boolean
+      allowReserved:
+        type: boolean
+        default: false
+      schema:
+        oneOf:
+          - $ref: '#/definitions/Schema'
+          - $ref: '#/definitions/Reference'
+      example: {}
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false  
+
+  ParameterWithSchemaWithExamples:
+    oneOf:
+      - $ref: '#/definitions/ParameterWithSchemaWithExamplesInPath'
+      - $ref: '#/definitions/ParameterWithSchemaWithExamplesInQuery'
+      - $ref: '#/definitions/ParameterWithSchemaWithExamplesInHeader'
+      - $ref: '#/definitions/ParameterWithSchemaWithExamplesInCookie'
+
+  ParameterWithSchemaWithExamplesInPath:
+    type: object
+    required:
+      - name
+      - in
+      - schema
+      - required
+    properties:
+      name:
+        type: string
+      in:
+        type: string
+        enum:
+          - path
+      description:
+        type: string
+      required:
+        type: boolean
+        enum:
+          - true
+      deprecated:
+        type: boolean
+        default: false
+      allowEmptyValue:
+        type: boolean
+        default: false
+      style:
+        type: string
+        enum:
+          - matrix
+          - label
+          - simple
+        default: simple
+      explode:
+        type: boolean
+      allowReserved:
+        type: boolean
+        default: false
+      schema:
+        oneOf:
+          - $ref: '#/definitions/Schema'
+          - $ref: '#/definitions/Reference'
+      examples:
+        type: object
+        additionalProperties:
+          oneOf:
+            - $ref: '#/definitions/Example'
+            - $ref: '#/definitions/Reference'
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  ParameterWithSchemaWithExamplesInQuery:
+    type: object
+    required:
+      - name
+      - in
+      - schema
+    properties:
+      name:
+        type: string
+      in:
+        type: string
+        enum:
+          - query
+      description:
+        type: string
+      required:
+        type: boolean
+        default: false
+      deprecated:
+        type: boolean
+        default: false
+      allowEmptyValue:
+        type: boolean
+        default: false
+      style:
+        type: string
+        enum:
+          - form
+          - spaceDelimited
+          - pipeDelimited
+          - deepObject
+        default: form
+      explode:
+        type: boolean
+      allowReserved:
+        type: boolean
+        default: false
+      schema:
+        oneOf:
+          - $ref: '#/definitions/Schema'
+          - $ref: '#/definitions/Reference'
+      examples:
+        type: object
+        additionalProperties:
+          oneOf:
+            - $ref: '#/definitions/Example'
+            - $ref: '#/definitions/Reference'
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false    
+
+  ParameterWithSchemaWithExamplesInHeader:
+    type: object
+    required:
+      - name
+      - in
+      - schema
+    properties:
+      name:
+        type: string
+      in:
+        type: string
+        enum:
+          - header
+      description:
+        type: string
+      required:
+        type: boolean
+        default: false
+      deprecated:
+        type: boolean
+        default: false
+      allowEmptyValue:
+        type: boolean
+        default: false
+      style:
+        type: string
+        enum:
+          - simple
+        default: simple
+      explode:
+        type: boolean
+      allowReserved:
+        type: boolean
+        default: false
+      schema:
+        oneOf:
+          - $ref: '#/definitions/Schema'
+          - $ref: '#/definitions/Reference'
+      examples:
+        type: object
+        additionalProperties:
+          oneOf:
+            - $ref: '#/definitions/Example'
+            - $ref: '#/definitions/Reference'
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false    
+
+  ParameterWithSchemaWithExamplesInCookie:
+    type: object
+    required:
+      - name
+      - in
+      - schema
+    properties:
+      name:
+        type: string
+      in:
+        type: string
+        enum:
+          - cookie
+      description:
+        type: string
+      required:
+        type: boolean
+        default: false
+      deprecated:
+        type: boolean
+        default: false
+      allowEmptyValue:
+        type: boolean
+        default: false
+      style:
+        type: string
+        enum:
+          - form
+        default: form
+      explode:
+        type: boolean
+      allowReserved:
+        type: boolean
+        default: false
+      schema:
+        oneOf:
+          - $ref: '#/definitions/Schema'
+          - $ref: '#/definitions/Reference'
+      examples:
+        type: object
+        additionalProperties:
+          oneOf:
+            - $ref: '#/definitions/Example'
+            - $ref: '#/definitions/Reference'
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  ParameterWithContent:
+    oneOf:
+      - $ref: '#/definitions/ParameterWithContentInPath'
+      - $ref: '#/definitions/ParameterWithContentNotInPath'
+
+  ParameterWithContentInPath:
+    type: object
+    required:
+      - name
+      - in
+      - content
+    properties:
+      name:
+        type: string
+      in:
+        type: string
+        enum:
+          - path
+      description:
+        type: string
+      required:
+        type: boolean
+        enum:
+          - true
+      deprecated:
+        type: boolean
+        default: false
+      allowEmptyValue:
+        type: boolean
+        default: false
+      content:
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/MediaType'
+        minProperties: 1
+        maxProperties: 1
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  ParameterWithContentNotInPath:
+    type: object
+    required:
+      - name
+      - in
+      - content
+    properties:
+      name:
+        type: string
+      in:
+        type: string
+        enum:
+          - query
+          - header
+          - cookie
+      description:
+        type: string
+      required:
+        type: boolean
+        default: false
+      deprecated:
+        type: boolean
+        default: false
+      allowEmptyValue:
+        type: boolean
+        default: false
+      content:
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/MediaType'
+        minProperties: 1
+        maxProperties: 1
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  RequestBody:
+    type: object
+    required:
+      - content
+    properties:
+      description:
+        type: string
+      content:
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/MediaType'
+      required:
+        type: boolean
+        default: false
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  SecurityScheme:
+    oneOf:
+      - $ref: '#/definitions/APIKeySecurityScheme'
+      - $ref: '#/definitions/HTTPSecurityScheme'
+      - $ref: '#/definitions/OAuth2SecurityScheme'
+      - $ref: '#/definitions/OpenIdConnectSecurityScheme'
+  
+  APIKeySecurityScheme:
+    type: object
+    required:
+      - type
+      - name
+      - in
+    properties:
+      type:
+        type: string
+        enum:
+          - apiKey      
+      name:
+        type: string
+      in:
+        type: string
+        enum:
+          - header
+          - query
+          - cookie
+      description:
+        type: string
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+  
+  HTTPSecurityScheme:
+    oneOf:
+      - $ref: '#/definitions/NonBearerHTTPSecurityScheme'
+      - $ref: '#/definitions/BearerHTTPSecurityScheme'
+
+  NonBearerHTTPSecurityScheme:
+    not:
+      type: object
+      properties:
+        scheme:
+          type: string
+          enum:
+            - bearer
+    type: object
+    required:
+      - scheme
+      - type
+    properties:
+      scheme:
+        type: string
+      description:
+        type: string
+      type:
+        type: string
+        enum:
+          - http
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  BearerHTTPSecurityScheme:
+    type: object
+    required:
+      - type
+      - scheme
+    properties:
+      scheme:
+        type: string
+        enum:
+          - bearer
+      bearerFormat:
+        type: string
+      type:
+        type: string
+          enum:
+            - http
+      description:
+        type: string
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  OAuth2SecurityScheme:
+    type: object
+    required:
+      - type
+      - flows
+    properties:
+      type:
+        type: string
+        enum:
+          - oauth2
+      flows:
+        $ref: '#/definitions/OAuthFlows'
+      description:
+        type: string
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  OpenIdConnectSecurityScheme:
+    type: object
+    required:
+      - type
+      - openIdConnect
+    properties:
+      type:
+        type: string
+        enum:
+          - openIdConnect      
+      openIdConnectUrl:
+        type: string
+        format: url
+      description:
+        type: string
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  OAuthFlows:
+    type: object
+    properties:
+      implicit:
+        $ref: '#/definitions/ImplicitOAuthFlow'
+      password:
+        $ref: '#/definitions/PasswordOAuthFlow'
+      clientCredentials:
+        $ref: '#/definitions/ClientCredentialsFlow'
+      authorizationCode:
+        $ref: '#/definitions/AuthorizationCodeOAuthFlow'
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  ImplicitOAuthFlow:
+    type: object
+    required:
+      - authorizationUrl
+      - scopes
+    properties:
+      authorizationUrl:
+        type: string
+        format: uri-ref
+      refreshUrl:
+        type: string
+        format: uri-ref
+      scopes:
+        type: object
+        additionalProperties:
+          type: string
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  PasswordOAuthFlow:
+    type: object
+    required:
+      - tokenUrl
+    properties:
+      tokenUrl:
+        type: string
+        format: uri-ref
+      refreshUrl:
+        type: string
+        format: uri-ref
+      scopes:
+        type: object
+        additionalProperties:
+          type: string
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  ClientCredentialsFlow:
+    type: object
+    required:
+      - tokenUrl
+    properties:
+      tokenUrl:
+        type: string
+        format: uri-ref
+      refreshUrl:
+        type: string
+        format: uri-ref
+      scopes:
+        type: object
+        additionalProperties:
+          type: string
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  AuthorizationCodeOAuthFlow:
+    type: object
+    required:
+      - authorizationUrl
+      - tokenUrl
+    properties:
+      authorizationUrl:
+        type: string
+        format: uri-ref
+      tokenUrl:
+        type: string
+        format: uri-ref
+      refreshUrl:
+        type: string
+        format: uri-ref
+      scopes:
+        type: object
+        additionalProperties:
+          type: string
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  Link:
+    oneOf:
+      - $ref: '#/definitions/LinkWithOperationRef'
+      - $ref: '#/definitions/LinkWithOperationId'
+
+  LinkWithOperationRef:
+    type: object
+    properties:
+      operationRef:
+        type: string
+        format: uri-ref
+      parameters:
+        type: object
+        additionalProperties: {}
+      requestBody: {}
+      description:
+        type: string
+      server:
+        $ref: '#/definitions/Server'
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  LinkWithOperationId:
+    type: object
+    properties:
+      operationId:
+        type: string
+      parameters:
+        type: object
+        additionalProperties: {}
+      requestBody: {}
+      description:
+        type: string
+      server:
+        $ref: '#/definitions/Server'
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  Callback:
+    type: object
+    additionalProperties:
+      $ref: '#/definitions/PathItem'
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  Encoding:
+    type: object
+    properties:
+      contentType:
+        type: string
+      headers:
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/Header'
+      style:
+        type: string
+        enum:
+          - form
+          - spaceDelimited
+          - pipeDelimited
+          - deepObject
+      explode:
+        type: boolean
+      allowReserved:
+        type: boolean
+        default: false
+    additionalProperties: false

--- a/schemas/v3.0/schema.yaml
+++ b/schemas/v3.0/schema.yaml
@@ -99,7 +99,6 @@ definitions:
     properties:
       url:
         type: string
-        format: uriref
       description:
         type: string
       variables:

--- a/schemas/v3.0/schema.yaml
+++ b/schemas/v3.0/schema.yaml
@@ -6,8 +6,7 @@ required:
 properties:
   openapi:
     type: string
-    enum:
-      - 3.0.0
+    pattern: ^3\.0\.\d(-.+)?$
   info:
     $ref: '#/definitions/Info'
   externalDocs:
@@ -34,10 +33,12 @@ additionalProperties: false
 definitions:
   Reference:
     type: object
+    required:
+      - $ref
     properties:
       $ref:
         type: string
-        format: uri-ref
+        format: uriref
   Info:
     type: object
     required:
@@ -50,7 +51,7 @@ definitions:
         type: string
       termsOfService:
         type: string
-        format: uri-ref
+        format: uriref
       contact:
         $ref: '#/definitions/Contact'
       license:
@@ -69,7 +70,7 @@ definitions:
         type: string
       url:
         type: string
-        format: uri-ref
+        format: uriref
       email:
         type: string
         format: email
@@ -86,7 +87,7 @@ definitions:
         type: string
       url:
         type: string
-        format: uri-ref
+        format: uriref
     patternProperties:
       '^x-': {}
     additionalProperties: false
@@ -98,7 +99,7 @@ definitions:
     properties:
       url:
         type: string
-        format: uri-ref
+        format: uriref
       description:
         type: string
       variables:
@@ -254,21 +255,50 @@ definitions:
       type:
         type: string
         enum:
-         - array
-         - boolean
-         - integer
-         - number
-         - object
-         - string
+          - array
+          - boolean
+          - integer
+          - number
+          - object
+          - string
       not:
-        $ref: '#/definitions/Schema'
+        oneOf:
+          - $ref: '#/definitions/Schema'
+          - $ref: '#/definitions/Reference'
+      allOf:
+        type: array
+        items:
+          oneOf:
+            - $ref: '#/definitions/Schema'
+            - $ref: '#/definitions/Reference'
+      oneOf:
+        type: array
+        items:
+          oneOf:
+            - $ref: '#/definitions/Schema'
+            - $ref: '#/definitions/Reference'
+      anyOf:
+        type: array
+        items:
+          oneOf:
+            - $ref: '#/definitions/Schema'
+            - $ref: '#/definitions/Reference'
+      items:
+        type: array
+        items:
+          oneOf:
+            - $ref: '#/definitions/Schema'
+            - $ref: '#/definitions/Reference'
       properties:
         type: object
         additionalProperties:
-          $ref: '#/definitions/Schema'
+          oneOf:
+            - $ref: '#/definitions/Schema'
+            - $ref: '#/definitions/Reference'
       additionalProperties:
         oneOf:
           - $ref: '#/definitions/Schema'
+          - $ref: '#/definitions/Reference'
           - type: boolean
         default: true
       description:
@@ -276,9 +306,6 @@ definitions:
       format:
         type: string
       default: {}
-      $ref:
-        type: string
-        format: uri-ref
       nullable:
         type: boolean
         default: false
@@ -327,7 +354,7 @@ definitions:
       attribute:
         type: boolean
         default: false
-      wrapperd:
+      wrapped:
         type: boolean
         default: false
     patternProperties:
@@ -383,6 +410,8 @@ definitions:
 
   MediaTypeWithExamples:
     type: object
+    required:
+      - examples
     properties:
       schema:
         oneOf:
@@ -409,17 +438,28 @@ definitions:
         type: string
       description:
         type: string
-      value:
-        type: string
+      value: {}
       externalValue:
         type: string
-        format: uri-ref
+        format: uriref
     patternProperties:
       '^x-': {}
     additionalProperties: false
 
   Header:
+    oneOf:
+      - $ref: '#/definitions/HeaderWithSchema'
+      - $ref: '#/definitions/HeaderWithContent'
+
+  HeaderWithSchema:
+    oneOf:
+      - $ref: '#/definitions/HeaderWithSchemaWithExample'
+      - $ref: '#/definitions/HeaderWithSchemaWithExamples'
+
+  HeaderWithSchemaWithExample:
     type: object
+    required:
+      - schema
     properties:
       description:
         type: string
@@ -439,24 +479,81 @@ definitions:
         default: simple
       explode:
         type: boolean
+      allowReserved:
+        type: boolean
+        default: false
+      schema:
+        oneOf:
+          - $ref: '#/definitions/Schema'
+          - $ref: '#/definitions/Reference'
+      example: {}
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false  
+
+  HeaderWithSchemaWithExamples:
+    type: object
+    required:
+      - schema
+      - examples
+    properties:
+      description:
+        type: string
+      required:
+        type: boolean
+        default: false
+      deprecated:
+        type: boolean
+        default: false
+      allowEmptyValue:
+        type: boolean
+        default: false
+      style:
+        type: string
         enum:
-          - false
+          - simple
+        default: simple
+      explode:
+        type: boolean
+      allowReserved:
+        type: boolean
         default: false
       schema:
         oneOf:
           - $ref: '#/definitions/Schema'
           - $ref: '#/definitions/Reference'
       examples:
-        type: array
-        items:
+        type: object
+        additionalProperties:
           oneOf:
             - $ref: '#/definitions/Example'
             - $ref: '#/definitions/Reference'
-      example: {}
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  HeaderWithContent:
+    type: object
+    required:
+      - content
+    properties:
+      description:
+        type: string
+      required:
+        type: boolean
+        default: false
+      deprecated:
+        type: boolean
+        default: false
+      allowEmptyValue:
+        type: boolean
+        default: false
       content:
         type: object
         additionalProperties:
           $ref: '#/definitions/MediaType'
+        minProperties: 1
+        maxProperties: 1
     patternProperties:
       '^x-': {}
     additionalProperties: false
@@ -557,8 +654,6 @@ definitions:
     additionalProperties: false
 
   Responses:
-    allOf:
-      - $ref: '#/definitions/Extensions'    
     type: object
     properties:
       default:
@@ -577,6 +672,7 @@ definitions:
       type: object
       patternProperties:
         '^x-': {}
+      additionalProperties: false
  
 
   SecurityRequirement:
@@ -610,7 +706,7 @@ definitions:
         type: string
       url:
         type: string
-        format: uri-ref
+        format: uriref
     patternProperties:
       '^x-': {}
     additionalProperties: false
@@ -825,6 +921,7 @@ definitions:
       - in
       - schema
       - required
+      - examples
     properties:
       name:
         type: string
@@ -876,6 +973,7 @@ definitions:
       - name
       - in
       - schema
+      - examples
     properties:
       name:
         type: string
@@ -927,6 +1025,7 @@ definitions:
       - name
       - in
       - schema
+      - examples
     properties:
       name:
         type: string
@@ -975,6 +1074,7 @@ definitions:
       - name
       - in
       - schema
+      - examples
     properties:
       name:
         type: string
@@ -1187,8 +1287,8 @@ definitions:
         type: string
       type:
         type: string
-          enum:
-            - http
+        enum:
+          - http
       description:
         type: string
     patternProperties:
@@ -1255,10 +1355,10 @@ definitions:
     properties:
       authorizationUrl:
         type: string
-        format: uri-ref
+        format: uriref
       refreshUrl:
         type: string
-        format: uri-ref
+        format: uriref
       scopes:
         type: object
         additionalProperties:
@@ -1274,10 +1374,10 @@ definitions:
     properties:
       tokenUrl:
         type: string
-        format: uri-ref
+        format: uriref
       refreshUrl:
         type: string
-        format: uri-ref
+        format: uriref
       scopes:
         type: object
         additionalProperties:
@@ -1293,10 +1393,10 @@ definitions:
     properties:
       tokenUrl:
         type: string
-        format: uri-ref
+        format: uriref
       refreshUrl:
         type: string
-        format: uri-ref
+        format: uriref
       scopes:
         type: object
         additionalProperties:
@@ -1313,13 +1413,13 @@ definitions:
     properties:
       authorizationUrl:
         type: string
-        format: uri-ref
+        format: uriref
       tokenUrl:
         type: string
-        format: uri-ref
+        format: uriref
       refreshUrl:
         type: string
-        format: uri-ref
+        format: uriref
       scopes:
         type: object
         additionalProperties:
@@ -1338,7 +1438,7 @@ definitions:
     properties:
       operationRef:
         type: string
-        format: uri-ref
+        format: uriref
       parameters:
         type: object
         additionalProperties: {}

--- a/schemas/v3.0/schema.yaml
+++ b/schemas/v3.0/schema.yaml
@@ -284,11 +284,9 @@ definitions:
             - $ref: '#/definitions/Schema'
             - $ref: '#/definitions/Reference'
       items:
-        type: array
-        items:
-          oneOf:
-            - $ref: '#/definitions/Schema'
-            - $ref: '#/definitions/Reference'
+        oneOf:
+          - $ref: '#/definitions/Schema'
+          - $ref: '#/definitions/Reference'
       properties:
         type: object
         additionalProperties:

--- a/schemas/v3.0/schema.yaml
+++ b/schemas/v3.0/schema.yaml
@@ -115,7 +115,9 @@ definitions:
       - default
     properties:
       enum:
-        type: string
+        type: array
+        items:
+          type: string
       default:
         type: string
       description:

--- a/schemas/v3.0/schema.yaml
+++ b/schemas/v3.0/schema.yaml
@@ -1,3 +1,6 @@
+id: https://spec.openapis.org/oas/3.0/schema/2019-04-02
+$schema: http://json-schema.org/draft-04/schema#
+description: Validation schema for OpenAPI Specification 3.0.X.
 type: object
 required:
   - openapi


### PR DESCRIPTION
This is a proposal for an alternative JSON Schema provided by #1236.

The work done in #1236 is good but:
- It is too permissive - it allows things that should not validate, for example, a parameter with both `content` and `schema` (and a few other cases).
- It doesn't cover types properly.
- As far as I understand, it adds a couple of restrictions that are not provided in the spec itself.

The reasons for creating a new PR instead of suggesting fixes to #1236:
- Editing JSON Schemas can be a pain, and trying to navigate through different styles is not easy.
- The amount of changes to make it less permissive is quite large.
- I had about 80% of the schema ready...

Odd things about this version:
- It's a JSON Schema written in YAML.  It's just easier to write and edit and.. read. Easy enough to convert to JSON if this PR is accepted.
- To make it more restrictive, there are somewhat a lot of duplication in the schema. Using `allOf` to reuse things didn't work for me due to `additionalProperties: false`. If anyone wants to take a crack and minimizing it, by all means... I just wanted to get a working version.

What's missing:
- It doesn't cover checking of `style`/`explode` inside Request Bodies where it's multipart. That was just too much for me for now.
- Testing. I'm willing to bet there are bugs in it.
- JSON Schema decorations (version, id, $schema and so on).

Pinging @darrelmiller as he asked to be pinged.

Pinging @MikeRalphson for assistance in testing - would really appreciate if you can take a crack at it.

I'm sure converting the YAML to JSON is going to be easy enough.