### PR TITLE
Fix petstore-expanded.yaml example - style

### DIFF
--- a/examples/v3.0/petstore-expanded.yaml
+++ b/examples/v3.0/petstore-expanded.yaml
@@ -27,7 +27,7 @@ paths:
           in: query
           description: tags to filter by
           required: false
-          style: simple
+          style: form
           schema:
             type: array
             items:


### PR DESCRIPTION
Style `simple` is only applicable to in: `header` or `path`.

Have assumed style of `form`.