### PR TITLE
Fix examples object example and api-with-examples

### DIFF
--- a/examples/v3.0/api-with-examples.yaml
+++ b/examples/v3.0/api-with-examples.yaml
@@ -14,7 +14,8 @@ paths:
           content:
             application/json:
               examples: 
-                - {
+                foo:
+                  value: {
                     "versions": [
                         {
                             "status": "CURRENT",
@@ -46,10 +47,11 @@ paths:
           content:
             application/json: 
               examples: 
-                - |
-                 {
+                foo:
+                  value: |
+                   {
                     "versions": [
-                        {
+                          {
                             "status": "CURRENT",
                             "updated": "2011-01-21T11:33:21Z",
                             "id": "v2.0",
@@ -72,7 +74,7 @@ paths:
                             ]
                         }
                     ]
-                 }
+                   }
   /v2:
     get:
       operationId: getVersionDetailsv2
@@ -84,7 +86,8 @@ paths:
           content:
             application/json: 
               examples:
-                - {
+                foo:
+                  value: {
                     "version": {
                       "status": "CURRENT",
                       "updated": "2011-01-21T11:33:21Z",
@@ -128,7 +131,8 @@ paths:
           content:
             application/json: 
               examples:
-                - {
+                foo:
+                  value: {
                     "version": {
                       "status": "CURRENT",
                       "updated": "2011-01-21T11:33:21Z",

--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -2205,21 +2205,25 @@ schemas:
       example:
         $ref: http://foo.bar#/examples/name-example
 
-# in a request body, note the plural `examples` as the Content-Type is set to `*`:
+# in a request body, note the plural `examples`
   requestBody:
     content:
       'application/json':
         schema:
           $ref: '#/components/schemas/Address'
-        examples: 
-          - {"foo": "bar"}
-          - {"bar": "baz"}
+        examples:
+          foo:
+            value: {"foo": "bar"}
+          bar:
+            value: {"bar": "baz"}
       'application/xml':
-        examples: 
-          - $ref: 'http://foo.bar#/examples/address-example.xml' 
+        examples:
+          xml:
+            externalValue: 'http://foo.bar/examples/address-example.xml'
       'text/plain':
-        examples: 
-          - $ref: 'http://foo.bar#/examples/address-example.txt' 
+        examples:
+          text:
+            externalValue: 'http://foo.bar/examples/address-example.txt'
         
 # in a parameter
   parameters:
@@ -2230,7 +2234,8 @@ schemas:
         format: 'zip-code'
         example: 
           $ref: 'http://foo.bar#/examples/zip-example'
-# in a response, note the plural `examples`:
+
+# in a response, note the singular `example`:
   responses:
     '200':
       description: your car appointment has been booked


### PR DESCRIPTION
Fixes a few issues:

* misleading comments
* `examples` is no longer an array anywhere
* use of `$ref`s in `examples` (as opposed to `example`) - have preferred `externalValue` when refererencing whole files (which may not be json/yaml) and `$ref` in `example` which can have a fragment id. Think this is the intent.

Refs #1116