### PR TITLE
#1292 Added a missing / separator after the paths in operationRef

### DIFF
--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -2069,7 +2069,7 @@ value), references MAY also be made through a relative `operationRef`:
 links:
   UserRepositories:
     # returns array of '#/components/schemas/repository'
-    operationRef: '#/paths/~12.0~1repositories~1/{username}/get'
+    operationRef: '#/paths/~12.0~1repositories~1{username}/get'
     parameters:
       username: $response.body#/username
 ```

--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -2069,7 +2069,7 @@ value), references MAY also be made through a relative `operationRef`:
 links:
   UserRepositories:
     # returns array of '#/components/schemas/repository'
-    operationRef: '#/paths~12.0~1repositories~1/{username}/get'
+    operationRef: '#/paths/~12.0~1repositories~1/{username}/get'
     parameters:
       username: $response.body#/username
 ```


### PR DESCRIPTION
Added a slash (`/`) after the `/paths`, so now it's `#/paths/~12.0~1repositories~1/{username}/get` == `#/paths/<'/2.0/repositories/{username}'.encode()>/get`. See #1292 for details.

There is a PR #1291 which renames 3.0.md to 3.0.0.md . 
In this PR, I am modifying 3.0.md file which is used on the current OpenAPI.next branch. Please let me know if I need to modify 3.0.0.md instead.