### PR TITLE
Fix callback-example.yaml

### DIFF
--- a/examples/v3.0/callback-example.yaml
+++ b/examples/v3.0/callback-example.yaml
@@ -32,7 +32,7 @@ paths:
         onData:
           # when data is sent, it will be sent to the `callbackUrl` provided
           # when making the subscription PLUS the suffix `/data`
-          {$request.query.callbackUrl}/data:
+          '{$request.query.callbackUrl}/data':
             post:
               requestBody:
                 description: subscription payload


### PR DESCRIPTION
This fix adds quotes around `{$request.query.callbackUrl}/data` to make it valid YAML.

`{` is a special character that starts a mapping, so string literals beginning with `{` need to be escaped.

**UPD:** Now that 3.0 is released, should the PR target `master` or `OpenAPI.next`?