### PR TITLE
Add quotes around response statuses in standalone 3.0 examples

### DIFF
--- a/examples/v3.0/api-with-examples.yaml
+++ b/examples/v3.0/api-with-examples.yaml
@@ -8,7 +8,7 @@ paths:
       operationId: listVersionsv2
       summary: List API versions
       responses:
-        200:
+        "200":
           description: |-
             200 response
           content:
@@ -41,7 +41,7 @@ paths:
                         }
                     ]
                  }
-        300:
+        "300":
           description: |-
             300 response
           content:
@@ -80,7 +80,7 @@ paths:
       operationId: getVersionDetailsv2
       summary: Show API version details
       responses:
-        200:
+        "200":
           description: |-
             200 response
           content:
@@ -125,7 +125,7 @@ paths:
                       ]
                     }
                   }
-        203:
+        "203":
           description: |-
             203 response
           content:

--- a/examples/v3.0/api-with-examples.yaml
+++ b/examples/v3.0/api-with-examples.yaml
@@ -8,7 +8,7 @@ paths:
       operationId: listVersionsv2
       summary: List API versions
       responses:
-        "200":
+        '200':
           description: |-
             200 response
           content:
@@ -41,7 +41,7 @@ paths:
                         }
                     ]
                  }
-        "300":
+        '300':
           description: |-
             300 response
           content:
@@ -80,7 +80,7 @@ paths:
       operationId: getVersionDetailsv2
       summary: Show API version details
       responses:
-        "200":
+        '200':
           description: |-
             200 response
           content:
@@ -125,7 +125,7 @@ paths:
                       ]
                     }
                   }
-        "203":
+        '203':
           description: |-
             203 response
           content:

--- a/examples/v3.0/petstore-expanded.yaml
+++ b/examples/v3.0/petstore-expanded.yaml
@@ -40,7 +40,7 @@ paths:
             type: integer
             format: int32
       responses:
-        200:
+        '200':
           description: pet response
           content:
             application/json:
@@ -65,7 +65,7 @@ paths:
             schema:
               $ref: '#/components/schemas/NewPet'
       responses:
-        200:
+        '200':
           description: pet response
           content:
             application/json:
@@ -90,7 +90,7 @@ paths:
             type: integer
             format: int64
       responses:
-        200:
+        '200':
           description: pet response
           content:
             application/json:
@@ -114,7 +114,7 @@ paths:
             type: integer
             format: int64
       responses:
-        204:
+        '204':
           description: pet deleted
         default:
           description: unexpected error

--- a/examples/v3.0/petstore.yaml
+++ b/examples/v3.0/petstore.yaml
@@ -22,7 +22,7 @@ paths:
             type: integer
             format: int32
       responses:
-        200:
+        '200':
           description: An paged array of pets
           headers:
             x-next:
@@ -45,7 +45,7 @@ paths:
       tags:
         - pets
       responses:
-        201:
+        '201':
           description: Null response
         default:
           description: unexpected error
@@ -67,7 +67,7 @@ paths:
           schema:
             type: string
       responses:
-        200:
+        '200':
           description: Expected response to a valid request
           content:
             application/json:

--- a/examples/v3.0/uber.yaml
+++ b/examples/v3.0/uber.yaml
@@ -32,7 +32,7 @@ paths:
       tags: 
         - Products
       responses:  
-        200:
+        "200":
           description: An array of products
           content:
             application/json:
@@ -80,7 +80,7 @@ paths:
       tags: 
         - Estimates
       responses:  
-        200:
+        "200":
           description: An array of price estimates by product
           content:
             application/json:
@@ -127,7 +127,7 @@ paths:
       tags: 
         - Estimates
       responses:  
-        200:
+        "200":
           description: An array of products
           content:
             application/json:
@@ -148,7 +148,7 @@ paths:
       tags: 
         - User
       responses:
-        200:
+        "200":
           description: Profile information for a user
           content:
             application/json:
@@ -180,7 +180,7 @@ paths:
       tags: 
         - User
       responses:
-        200:
+        "200":
           description: History information for the given user
           content:
             application/json:

--- a/examples/v3.0/uber.yaml
+++ b/examples/v3.0/uber.yaml
@@ -32,7 +32,7 @@ paths:
       tags: 
         - Products
       responses:  
-        "200":
+        '200':
           description: An array of products
           content:
             application/json:
@@ -80,7 +80,7 @@ paths:
       tags: 
         - Estimates
       responses:  
-        "200":
+        '200':
           description: An array of price estimates by product
           content:
             application/json:
@@ -127,7 +127,7 @@ paths:
       tags: 
         - Estimates
       responses:  
-        "200":
+        '200':
           description: An array of products
           content:
             application/json:
@@ -148,7 +148,7 @@ paths:
       tags: 
         - User
       responses:
-        "200":
+        '200':
           description: Profile information for a user
           content:
             application/json:
@@ -180,7 +180,7 @@ paths:
       tags: 
         - User
       responses:
-        "200":
+        '200':
           description: History information for the given user
           content:
             application/json:


### PR DESCRIPTION
According to the 3.0 Specification, response status codes must be quoted. This PR fixes the examples in the `examples\v3.0` folder.

Single vs double quotes: Some examples use `"` for quoting and others use `'`. I used the same quote character as in the rest of each file.