### PR TITLE
[Implementations] Add lincoln and serverless-openapi-documentation projects

### DIFF
--- a/IMPLEMENTATIONS.md
+++ b/IMPLEMENTATIONS.md
@@ -32,6 +32,7 @@ These tools are not necessarily endorsed by the OAI.
 |----------------|--------------|----------|---------------------|
 | openapi-viewer | [GitHub/koumoul/openapi-viewer](https://github.com/koumoul-dev/openapi-viewer) | Vue.js | Browse and test a REST API described with the OpenAPI 3.0 Specification. |
 | swagger-ui | [GitHub/swagger-api](https://github.com/swagger-api/swagger-UI) | JavaScript | Web-Based interface for visualizing and testing OpenAPI\Swagger definitions |
+| lincoln | [GitHub/temando/open-api-renderer](https://github.com/temando/open-api-renderer)| React.js| A React renderer for Open API v3 |
 
 
 #### Server Implementations
@@ -43,3 +44,4 @@ These tools are not necessarily endorsed by the OAI.
 |----------------|--------------|----------|---------------------|
 | baucis-openapi3 | [Github/metadevpro/baucis-openapi3](https://github.com/metadevpro/baucis-openapi3) | Node.js | [Baucis.js](https://github.com/wprl/baucis) plugin for generating OpenAPI 3.0 compliant API contracts. |
 | Google Gnostic | [GitHub/googleapis/gnostic](https://github.com/googleapis/gnostic) | Go | Compile OpenAPI descriptions into equivalent Protocol Buffer representations. |
+| serverless-openapi-documentation | [GitHub/temando/serverless-openapi-documentation](https://github.com/temando/serverless-openapi-documentation) | Typescript | Serverless 1.0 plugin to generate OpenAPI V3 documentation from serverless configuration |


### PR DESCRIPTION
Duplicate of #1272, but this time against `master` instead of `OpenAPI.next`