### PR TITLE
Fix indents in the links example

### DIFF
--- a/versions/3.0.1.md
+++ b/versions/3.0.1.md
@@ -2018,13 +2018,13 @@ paths:
                   uuid: # the unique user id
                     type: string
                     format: uuid
-        links:
-          address:
-            # the target link operationId
-            operationId: getUserAddress
-            parameters:
-              # get the `id` field from the request path parameter named `id`
-              userId: $request.path.id
+          links:
+            address:
+              # the target link operationId
+              operationId: getUserAddress
+              parameters:
+                # get the `id` field from the request path parameter named `id`
+                userId: $request.path.id
   # the path item of the linked operation
   /users/{userid}/address:
     parameters:
@@ -2034,12 +2034,12 @@ paths:
       description: the user identifier, as userId 
       schema:
         type: string
-      # linked operation
-      get:
-        operationId: getUserAddress
-        responses:
-          '200':
-            description: the user's address
+    # linked operation
+    get:
+      operationId: getUserAddress
+      responses:
+        '200':
+          description: the user's address
 ```
 
 When a runtime expression fails to evaluate, no parameter value is passed to the target operation.


### PR DESCRIPTION
This PR fixes indentation in [this example](https://github.com/OAI/OpenAPI-Specification/blob/v3.0.1/versions/3.0.1.md#examples) in the "Link Object" section:

* `links` needs more indent,
* linked operation needs less indent.