### PR TITLE
Moved 'links' object to response object

### DIFF
--- a/versions/3.0.0.md
+++ b/versions/3.0.0.md
@@ -2018,13 +2018,13 @@ paths:
                   uuid: # the unique user id
                     type: string
                     format: uuid
-        links:
-          address:
-            # the target link operationId
-            operationId: getUserAddress
-            parameters:
-              # get the `id` field from the request path parameter named `id`
-              userId: $request.path.id
+          links:
+            address:
+              # the target link operationId
+              operationId: getUserAddress
+              parameters:
+                # get the `id` field from the request path parameter named `id`
+                userId: $request.path.id
   # the path item of the linked operation
   /users/{userid}/address:
     parameters:


### PR DESCRIPTION
Updated the link object example. According to the specification, 'links' should be inside of a response object.