### PR TITLE
Correct white space for several code blocks

### DIFF
--- a/versions/1.2.md
+++ b/versions/1.2.md
@@ -852,19 +852,19 @@ Field Name | Type | Description
 - If [`paramType`](#parameterParamType) is `"path"`, and assuming the `path` is `"/pet/{id}"`:
 
     ```js
-"name": "id"
+    "name": "id"
     ```
 
 - If [`paramType`](#parameterParamType) is `"query"`, and assuming the URL call is `"http://host/resource?limit=100"` (that is, there's a query parameter called `"limit"`):
 
     ```js
-"name": "limit"
+    "name": "limit"
     ```
 
 - If [`paramType`](#parameterParamType) is `"body"`:
 
     ```js
-"name": "body"
+    "name": "body"
     ```
 
 ##### 5.2.4.2 Object Example


### PR DESCRIPTION
There was a slight white space error causing the example code to be rendered outside the code block. 