### PR TITLE
Correct comment on the link object

### DIFF
--- a/versions/3.0.0.md
+++ b/versions/3.0.0.md
@@ -2051,7 +2051,7 @@ links:
   address:
     operationId: getUserAddressByUUID
     parameters:
-      # get the `id` field from the request path parameter named `id`
+      # get the `uuid` field from the `uuid` field in the response body
       userUuid: $response.body#/uuid
 ```
 


### PR DESCRIPTION
The example referencing the response body had the same comment as the one referencing the request path.

This one replaces #1381, which seems messed up after changing the base.