### PR TITLE
Revert "Correct comment on the link object"

### DIFF
--- a/versions/3.0.0.md
+++ b/versions/3.0.0.md
@@ -2051,7 +2051,7 @@ links:
   address:
     operationId: getUserAddressByUUID
     parameters:
-      # get the `uuid` field from the `uuid` field in the response body
+      # get the `id` field from the request path parameter named `id`
       userUuid: $response.body#/uuid
 ```
 


### PR DESCRIPTION
Reverts OAI/OpenAPI-Specification#1386 - the change was made against 3.0.0.md where it should have been made against 3.0.1.md - it was a mistake to merge it.

I'll reapply the change on the right file.