### PR TITLE
Fix issues/1449: Modify description of 405 response object

### DIFF
--- a/versions/1.2.md
+++ b/versions/1.2.md
@@ -733,7 +733,7 @@ Field Name | Type | Description
             },
             {
               "code": 405,
-              "message": "Validation exception"
+              "message": "Method Not Allowed"
             }
           ]
         },
@@ -767,7 +767,7 @@ Field Name | Type | Description
           "responseMessages": [
             {
               "code": 405,
-              "message": "Invalid input"
+              "message": "Method Not Allowed"
             }
           ]
         }

--- a/versions/2.0.md
+++ b/versions/2.0.md
@@ -474,7 +474,7 @@ Field Pattern | Type | Description
       "description": "Pet updated."
     },
     "405": {
-      "description": "Invalid input"
+      "description": "Method Not Allowed"
     }
   },
   "security": [
@@ -519,7 +519,7 @@ responses:
   '200':
     description: Pet updated.
   '405':
-    description: Invalid input
+    description: Method Not Allowed
 security:
 - petstore_auth:
   - write:pets

--- a/versions/3.0.0.md
+++ b/versions/3.0.0.md
@@ -883,7 +883,7 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
       }
     },
     "405": {
-      "description": "Invalid input",
+      "description": "Method Not Allowed",
       "content": {
         "application/json": {},
         "application/xml": {}
@@ -933,7 +933,7 @@ responses:
       'application/json': {}
       'application/xml': {}
   '405':
-    description: Invalid input
+    description: Method Not Allowed
     content: 
       'application/json': {}
       'application/xml': {}

--- a/versions/3.0.1.md
+++ b/versions/3.0.1.md
@@ -883,7 +883,7 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
       }
     },
     "405": {
-      "description": "Invalid input",
+      "description": "Method Not Allowed",
       "content": {
         "application/json": {},
         "application/xml": {}
@@ -933,7 +933,7 @@ responses:
       'application/json': {}
       'application/xml': {}
   '405':
-    description: Invalid input
+    description: Method Not Allowed
     content: 
       'application/json': {}
       'application/xml': {}


### PR DESCRIPTION
Fix [issues/1449](https://github.com/OAI/OpenAPI-Specification/issues/1449)

modify description of 405 response object from  `Invalid Input` to `Method Not Allowed`, which follows the [RFC 7231 Specification](https://tools.ietf.org/html/rfc7231#section-6.5.5)