### PR TITLE
Fix nvm install on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,11 @@ matrix:
     - env: VALIDATORS=tv4
 install:
   - rm -rf ~/.nvm
+  - mkdir -p ~/.nvm
   - curl -L https://raw.githubusercontent.com/creationix/nvm/master/install.sh | sh
   - source ~/.nvm/nvm.sh
-  - nvm install 6.1
-  - nvm use 6.1
+  - nvm install 8
+  - nvm use 8
 script:
   - npm install
   - node node_modules/mdv/mdv versions/3.*.md


### PR DESCRIPTION
* Recreate `~/.nvm` directory before use
* Take opportunity to upgrade LTS node.js version from 6.1 to 8.x
* Working travis setup is a pre-requisite for bikeshed/respec integration