### PR TITLE
examples; fix licenses etc

### DIFF
--- a/examples/v2.0/json/petstore-expanded.json
+++ b/examples/v2.0/json/petstore-expanded.json
@@ -7,12 +7,12 @@
     "termsOfService": "http://swagger.io/terms/",
     "contact": {
       "name": "Swagger API Team",
-      "email": "foo@example.com",
-      "url": "http://madskristensen.net"
+      "email": "apiteam@swagger.io",
+      "url": "http://swagger.io"
     },
     "license": {
-      "name": "MIT",
-      "url": "http://github.com/gruntjs/grunt/blob/master/LICENSE-MIT"
+      "name": "Apache 2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     }
   },
   "host": "petstore.swagger.io",

--- a/examples/v2.0/json/petstore-separate/spec/swagger.json
+++ b/examples/v2.0/json/petstore-separate/spec/swagger.json
@@ -4,18 +4,18 @@
     "version": "1.0.0",
     "title": "Swagger Petstore",
     "description": "A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification",
-    "termsOfService": "http://helloreverb.com/terms/",
+    "termsOfService": "http://swagger.io/terms/",
     "contact": {
-      "name": "Wordnik API Team",
-      "email": "foo@example.com",
-      "url": "http://madskristensen.net"
+      "name": "Swagger API Team",
+      "email": "apiteam@swagger.io",
+      "url": "http://swagger.io"
     },
     "license": {
-      "name": "MIT",
-      "url": "http://github.com/gruntjs/grunt/blob/master/LICENSE-MIT"
+      "name": "Apache 2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     }
   },
-  "host": "petstore.swagger.wordnik.com",
+  "host": "petstore.swagger.io",
   "basePath": "/api",
   "schemes": [
     "http"

--- a/examples/v2.0/json/petstore-with-external-docs.json
+++ b/examples/v2.0/json/petstore-with-external-docs.json
@@ -11,8 +11,8 @@
       "url": "http://swagger.io"
     },
     "license": {
-      "name": "MIT",
-      "url": "http://github.com/gruntjs/grunt/blob/master/LICENSE-MIT"
+      "name": "Apache 2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     }
   },
   "externalDocs": {

--- a/examples/v2.0/yaml/petstore-expanded.yaml
+++ b/examples/v2.0/yaml/petstore-expanded.yaml
@@ -6,11 +6,11 @@ info:
   termsOfService: http://swagger.io/terms/
   contact:
     name: Swagger API Team
-    email: foo@example.com
-    url: http://madskristensen.net
+    email: apiteam@swagger.io
+    url: http://swagger.io
   license:
-    name: MIT
-    url: http://github.com/gruntjs/grunt/blob/master/LICENSE-MIT
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
 host: petstore.swagger.io
 basePath: /api
 schemes:

--- a/examples/v2.0/yaml/petstore-separate/spec/swagger.yaml
+++ b/examples/v2.0/yaml/petstore-separate/spec/swagger.yaml
@@ -3,15 +3,15 @@ info:
   version: 1.0.0
   title: Swagger Petstore
   description: A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification
-  termsOfService: http://helloreverb.com/terms/
+  termsOfService: http://swagger.io/terms/
   contact:
-    name: Wordnik API Team
-    email: foo@example.com
-    url: http://madskristensen.net
+    name: Swagger API Team
+    email: apiteam@swagger.io
+    url: http://swagger.io
   license:
-    name: MIT
-    url: http://github.com/gruntjs/grunt/blob/master/LICENSE-MIT
-host: petstore.swagger.wordnik.com
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+host: petstore.swagger.io
 basePath: /api
 schemes:
   - http

--- a/examples/v2.0/yaml/petstore-with-external-docs.yaml
+++ b/examples/v2.0/yaml/petstore-with-external-docs.yaml
@@ -10,8 +10,8 @@
       email: "apiteam@swagger.io"
       url: "http://swagger.io"
     license: 
-      name: "MIT"
-      url: "http://github.com/gruntjs/grunt/blob/master/LICENSE-MIT"
+      name: "Apache 2.0"
+      url: "https://www.apache.org/licenses/LICENSE-2.0.html"
   externalDocs: 
     description: "find more info here"
     url: "https://swagger.io/about"

--- a/examples/v3.0/petstore-expanded.yaml
+++ b/examples/v3.0/petstore-expanded.yaml
@@ -6,11 +6,11 @@ info:
   termsOfService: http://swagger.io/terms/
   contact:
     name: Swagger API Team
-    email: foo@example.com
-    url: http://madskristensen.net
+    email: apiteam@swagger.io
+    url: http://swagger.io
   license:
-    name: MIT
-    url: http://github.com/gruntjs/grunt/blob/master/LICENSE-MIT
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
 servers:
   - url: http://petstore.swagger.io/api
 paths:


### PR DESCRIPTION
A few cleanups

* The petstore demo appears to be licensed under Apache 2.0, not MIT
* License URLs betrayed signs of having been defaulted by ApiMatic tools
* Fix contact names
* Fix contact emails
* Fix contact urls