### PR TITLE
Revise 405 Response Object description to follow the RFC7231 Specification 's definition

### DIFF
--- a/versions/3.0.2.md
+++ b/versions/3.0.2.md
@@ -903,7 +903,7 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
       }
     },
     "405": {
-      "description": "Invalid input",
+      "description": "Method Not Allowed",
       "content": {
         "application/json": {},
         "application/xml": {}
@@ -953,7 +953,7 @@ responses:
       'application/json': {}
       'application/xml': {}
   '405':
-    description: Invalid input
+    description: Method Not Allowed
     content: 
       'application/json': {}
       'application/xml': {}


### PR DESCRIPTION
As the document says, [the key of a responses object's Patterned Fields ](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#patterned-fields-1) is  Http Status Code . 

and the document gives  responses object examples  like this at following part.

```
  "responses": {
    "405": {
      "description": "Invalid input",
      "content": {
        "application/json": {},
        "application/xml": {}
      }
    }
  }
```

As it defined in [ rfc7231 Specification](https://tools.ietf.org/html/rfc7231#section-6.5.5) , 405 indicates `Method Not Allowed` rather than `Invalid Input` .   

>  The 405 (Method Not Allowed) status code indicates that the method
   received in the request-line is known by the origin server but not
   supported by the target resource.  


I think we'd better follow the [ rfc7231 Specification](https://tools.ietf.org/html/rfc7231#section-6.5.5) 's definition

#1449 