### PR TITLE
Removing type confusion

### DIFF
--- a/versions/3.0.2.md
+++ b/versions/3.0.2.md
@@ -151,19 +151,22 @@ Types that are not accompanied by a `format` property follow the type definition
 
 The formats defined by the OAS are:
 
-Common Name | [`type`](#dataTypes) | [`format`](#dataTypeFormat) | Comments
------------ | ------ | -------- | --------
-integer | `integer` | `int32` | signed 32 bits
-long | `integer` | `int64` | signed 64 bits
-float | `number` | `float` | |
-double | `number` | `double` | |
-string | `string` | | |
-byte | `string` | `byte` | base64 encoded characters
-binary | `string` | `binary` | any sequence of octets
-boolean | `boolean` | | |
-date | `string` | `date` | As defined by `full-date` - [RFC3339](https://xml2rfc.ietf.org/public/rfc/html/rfc3339.html#anchor14)
-dateTime | `string` | `date-time` | As defined by `date-time` - [RFC3339](https://xml2rfc.ietf.org/public/rfc/html/rfc3339.html#anchor14)
-password | `string` | `password` | A hint to UIs to obscure input.
+[`type`](#dataTypes) | [`format`](#dataTypeFormat) | Comments
+------ | -------- | --------
+`integer` | `int32` | signed 32 bits
+`integer` | `int64` | signed 64 bits (a.k.a long)
+`number` | `float` | |
+`number` | `double` | |
+`string` | | |
+`string` | `byte` | base64 encoded characters
+`string` | `binary` | any sequence of octets
+`boolean` | | |
+`string` | `date` | As defined by `full-date` -
+[RFC3339](https://xml2rfc.ietf.org/public/rfc/html/rfc3339.html#anchor14)
+`string` | `date-time` | As defined by `date-time` -
+[RFC3339](https://xml2rfc.ietf.org/public/rfc/html/rfc3339.html#anchor14)
+`string` | `password` | A hint to UIs to obscure input.
+
 
 ### <a name="richText"></a>Rich Text Formatting
 Throughout the specification `description` fields are noted as supporting CommonMark markdown formatting.

--- a/versions/3.0.2.md
+++ b/versions/3.0.2.md
@@ -161,10 +161,8 @@ The formats defined by the OAS are:
 `string` | `byte` | base64 encoded characters
 `string` | `binary` | any sequence of octets
 `boolean` | | |
-`string` | `date` | As defined by `full-date` -
-[RFC3339](https://xml2rfc.ietf.org/public/rfc/html/rfc3339.html#anchor14)
-`string` | `date-time` | As defined by `date-time` -
-[RFC3339](https://xml2rfc.ietf.org/public/rfc/html/rfc3339.html#anchor14)
+`string` | `date` | As defined by `full-date` - [RFC3339](https://xml2rfc.ietf.org/public/rfc/html/rfc3339.html#anchor14)
+`string` | `date-time` | As defined by `date-time` - [RFC3339](https://xml2rfc.ietf.org/public/rfc/html/rfc3339.html#anchor14)
 `string` | `password` | A hint to UIs to obscure input.
 
 


### PR DESCRIPTION
The "Common Name" field was confusing people

So many people were considering dateTime, etc to be an OpenAPI type that tool vendors were implementing functionality to normalize this.

https://github.com/mikunn/openapi-schema-to-json-schema/issues/4

I too in the past have thought I was meant to use dateTime in the format, not date-time. Let's just get rid of this column, it serves no real purpose as far as I can tell.