### PR TITLE
Fixes #1539. Use the most common X-RateLimit-* instead of X-Rate-Limit-*

### DIFF
--- a/versions/3.0.2.md
+++ b/versions/3.0.2.md
@@ -1619,7 +1619,7 @@ requestBody:
           # only accept png/jpeg
           contentType: image/png, image/jpeg
           headers:
-            X-Rate-Limit-Limit:
+            X-RateLimit-Limit:
               description: The number of allowed requests in the current period
               schema:
                 type: integer
@@ -1777,19 +1777,19 @@ Plain text response with headers:
     }
   },
   "headers": {
-    "X-Rate-Limit-Limit": {
+    "X-RateLimit-Limit": {
       "description": "The number of allowed requests in the current period",
       "schema": {
         "type": "integer"
       }
     },
-    "X-Rate-Limit-Remaining": {
+    "X-RateLimit-Remaining": {
       "description": "The number of remaining requests in the current period",
       "schema": {
         "type": "integer"
       }
     },
-    "X-Rate-Limit-Reset": {
+    "X-RateLimit-Reset": {
       "description": "The number of seconds left in the current period",
       "schema": {
         "type": "integer"
@@ -1807,15 +1807,15 @@ content:
       type: string
     example: 'whoa!'
 headers:
-  X-Rate-Limit-Limit:
+  X-RateLimit-Limit:
     description: The number of allowed requests in the current period
     schema:
       type: integer
-  X-Rate-Limit-Remaining:
+  X-RateLimit-Remaining:
     description: The number of remaining requests in the current period
     schema:
       type: integer
-  X-Rate-Limit-Reset:
+  X-RateLimit-Reset:
     description: The number of seconds left in the current period
     schema:
       type: integer


### PR DESCRIPTION
## This PR

  - just replace X-Rate-Limit-* with X-RateLimit

## Because

  - the X-RateLimit is more common (see #1539) 
  - this avoid confusion when copy-paste part of the specs to create new services.