### PR TITLE
State explicitly: `additionalProperties : true` is the default

### DIFF
--- a/versions/3.0.2.md
+++ b/versions/3.0.2.md
@@ -2301,7 +2301,7 @@ The following properties are taken from the JSON Schema definition but their def
 - not - Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard JSON Schema.
 - items - Value MUST be an object and not an array. Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard JSON Schema. `items` MUST be present if the `type` is `array`.
 - properties - Property definitions MUST be a [Schema Object](#schemaObject) and not a standard JSON Schema (inline or referenced).
-- additionalProperties - Value can be boolean or object. Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard JSON Schema. Consistent with JSON Schema, `additionalProperties` defaults to `true` or an empty schema, allowing additional properties with any legal value.
+- additionalProperties - Value can be boolean or object. Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard JSON Schema. Consistent with JSON Schema, `additionalProperties` defaults to `true`.
 - description - [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
 - format - See [Data Type Formats](#dataTypeFormat) for further details. While relying on JSON Schema's defined formats, the OAS offers a few additional predefined formats.
 - default - The default value represents what would be assumed by the consumer of the input as the value of the schema if one is not provided. Unlike JSON Schema, the value MUST conform to the defined type for the Schema Object defined at the same level. For example, if `type` is `string`, then `default` can be `"foo"` but cannot be `1`.

--- a/versions/3.0.2.md
+++ b/versions/3.0.2.md
@@ -2301,7 +2301,7 @@ The following properties are taken from the JSON Schema definition but their def
 - not - Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard JSON Schema.
 - items - Value MUST be an object and not an array. Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard JSON Schema. `items` MUST be present if the `type` is `array`.
 - properties - Property definitions MUST be a [Schema Object](#schemaObject) and not a standard JSON Schema (inline or referenced).
-- additionalProperties - Value can be boolean or object. Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard JSON Schema.
+- additionalProperties - Value can be boolean or object. Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard JSON Schema. Consistent with JSON Schema, `additionalProperties` defaults to `true` or empty schema, allowing additional properties with any legal value.
 - description - [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
 - format - See [Data Type Formats](#dataTypeFormat) for further details. While relying on JSON Schema's defined formats, the OAS offers a few additional predefined formats.
 - default - The default value represents what would be assumed by the consumer of the input as the value of the schema if one is not provided. Unlike JSON Schema, the value MUST conform to the defined type for the Schema Object defined at the same level. For example, if `type` is `string`, then `default` can be `"foo"` but cannot be `1`.

--- a/versions/3.0.2.md
+++ b/versions/3.0.2.md
@@ -2301,7 +2301,7 @@ The following properties are taken from the JSON Schema definition but their def
 - not - Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard JSON Schema.
 - items - Value MUST be an object and not an array. Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard JSON Schema. `items` MUST be present if the `type` is `array`.
 - properties - Property definitions MUST be a [Schema Object](#schemaObject) and not a standard JSON Schema (inline or referenced).
-- additionalProperties - Value can be boolean or object. Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard JSON Schema. Consistent with JSON Schema, `additionalProperties` defaults to `true` or empty schema, allowing additional properties with any legal value.
+- additionalProperties - Value can be boolean or object. Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard JSON Schema. Consistent with JSON Schema, `additionalProperties` defaults to `true` or an empty schema, allowing additional properties with any legal value.
 - description - [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
 - format - See [Data Type Formats](#dataTypeFormat) for further details. While relying on JSON Schema's defined formats, the OAS offers a few additional predefined formats.
 - default - The default value represents what would be assumed by the consumer of the input as the value of the schema if one is not provided. Unlike JSON Schema, the value MUST conform to the defined type for the Schema Object defined at the same level. For example, if `type` is `string`, then `default` can be `"foo"` but cannot be `1`.


### PR DESCRIPTION
Address #715 - State (explicitly) whether Open API schema object definitions are open or closed for extension.

This was the topic of many discussions around OpenAPI 2.0 and earlier Swagger specifications.  Here are some of them:
* Make it clear that `additionalProperties` can only have a schema value #668
* JSON Schema Support Proposal #741
* State whether Open API schema object definitions are open or closed for extension #715
* NullPointerException in parser with additionalProperties: false [(swagger-api/swagger-core#1437)](https://github.com/swagger-api/swagger-core/issues/1437)

OpenAPI 2.0 assumed `additionalProperties: false` as the default, and disallowed explicit use of a boolean `additionalProperties` value. This was never fully documented, only stated in out-of-band comments. And those comments were never really reconciled with `allOf` semantics, which magically continued to work as though `additionalProperties: true` were the default. 

I wasn't aware, and I'm guessing that some others also weren't aware, that this changed intentionally in the 3.0 spec. The current 3.0.1 spec explicitly states that boolean values are allowed, but doesn't explicitly state that the _default_ is now `additionalProperties: true`. 

I think it's worth making this explicit now, because anyone who got caught up in the 2.0 `additionalProperties` confusion is likely to need some assurance that this change is intentional, and not subject to informal amendments or clarifications made outside of the spec. 

@handrews and I were both looking for that assurance, and couldn't find it. So I'm suggesting this small change. 