### PR TITLE
Add koa2-oas3 / oas3-remote-refs to implementations

### DIFF
--- a/IMPLEMENTATIONS.md
+++ b/IMPLEMENTATIONS.md
@@ -17,6 +17,7 @@ These tools are not endorsed by the OAI.
 | odata-openapi | [github/oasis-tcs/odata-openapi](https://github.com/oasis-tcs/odata-openapi) | XSLT | OData 4.0 to OpenAPI 3.0.0 converter |
 | openapi3_parser | [github/kevindew/openapi3_parser](https://github.com/kevindew/openapi3_parser) | Ruby | A Ruby implementation of parser and validator for the OpenAPI 3 Specification |
 | oas_parser | [github/Nexmo/oas_parser](https://github.com/Nexmo/oas_parser) | Ruby | An open source OpenAPI Spec 3 Definition Parser writen in Ruby |
+| oas3-remote-refs | [github//OverSpeedIO/oas3-remote-refs](https://github.com/OverSpeedIO/oas3-remote-refs) | Node.js | Tool to pull remote refernences and merge them into the definitions of the provided OpenAPI3 speicfication.
 
 
 #### Editors

--- a/IMPLEMENTATIONS.md
+++ b/IMPLEMENTATIONS.md
@@ -47,6 +47,7 @@ These tools are not endorsed by the OAI.
 | Vert.x Web API Contract | [github/vert-x3/vertx-web](http://vertx.io/docs/#web) | Java, Kotlin, JavaScript, Groovy, Ruby, Ceylon & Scala | Create an API endpoint with Vert.x 3 and OpenAPI 3 with automatic requests validation
 | Fusio | [github/apioo/fusio](https://github.com/apioo/fusio) | PHP, JavaScript | Build API endpoints based on OpenAPI 3
 | Modern | [github/modern-project/modern-ruby](https://github.com/modern-project/modern-ruby) | Ruby | OpenAPI 3-based Rack framework with automatic OAS generation and requests/response validation
+| Koa2-OAS3 | [github/OverSpeedIO/koa2-oas3](https://github.com/OverSpeedIO/koa2-oas3) | Node.js | OpenAPI 3 request validation middleware for Koa2 based apps.
 
 #### Code Generators
 


### PR DESCRIPTION
Supports OpenAPI 3 request validation with Koa2 and Node.js 8+.
https://github.com/OverSpeedIO/koa2-oas3

Tool to merge remote references into a single document to help with offline middleware request validation.
https://github.com/OverSpeedIO/oas3-remote-refs

Hoping to get these into the official implementations list.

Cheers!