### PR TITLE
Do not rely on auto-detection of fenced code block languages

### DIFF
--- a/versions/3.0.2.md
+++ b/versions/3.0.2.md
@@ -1372,7 +1372,7 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
 
 ##### Media Type Examples
 
-```js
+```json
 {
   "application/json": {
     "schema": {
@@ -2689,7 +2689,7 @@ The discriminator attribute is legal only when using one of the composite keywor
 
 In OAS 3.0, a response payload MAY be described to be exactly one of any number of types:
 
-```
+```yaml
 MyResponseType:
   oneOf:
   - $ref: '#/components/schemas/Cat'
@@ -2700,7 +2700,7 @@ MyResponseType:
 which means the payload _MUST_, by validation, match exactly one of the schemas described by `Cat`, `Dog`, or `Lizard`.  In this case, a discriminator MAY act as a "hint" to shortcut validation and selection of the matching schema which may be a costly operation, depending on the complexity of the schema. We can then describe exactly which field tells us which schema to use:
 
 
-```
+```yaml
 MyResponseType:
   oneOf:
   - $ref: '#/components/schemas/Cat'
@@ -2712,7 +2712,7 @@ MyResponseType:
 
 The expectation now is that a property with name `pet_type` _MUST_ be present in the response payload, and the value will correspond to the name of a schema defined in the OAS document.  Thus the response payload:
 
-```
+```json
 {
   "id": 12345,
   "pet_type": "Cat"
@@ -2723,7 +2723,7 @@ Will indicate that the `Cat` schema be used in conjunction with this payload.
 
 In scenarios where the value of the discriminator field does not match the schema name or implicit mapping is not possible, an optional `mapping` definition MAY be used:
 
-```
+```yaml
 MyResponseType:
   oneOf:
   - $ref: '#/components/schemas/Cat'
@@ -2745,7 +2745,7 @@ In both the `oneOf` and `anyOf` use cases, all possible schemas MUST be listed e
 
 For example:
 
-```
+```yaml
 components:
   schemas:
     Pet:
@@ -2787,7 +2787,7 @@ components:
 
 a payload like this:
 
-```
+```json
 {
   "pet_type": "Cat",
   "name": "misty"
@@ -2796,7 +2796,7 @@ a payload like this:
 
 will indicate that the `Cat` schema be used.  Likewise this schema:
 
-```
+```json
 {
   "pet_type": "cachorro",
   "bark": "soft"
@@ -3306,7 +3306,7 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
 }
 ```
 
-```YAML
+```yaml
 type: oauth2
 flows: 
   implicit:


### PR DESCRIPTION
Fixes a number of incorrect or missing language declarations on fenced code blocks / examples.

Related to #1564 