### PR TITLE
discriminator is now an object, not an attribute

### DIFF
--- a/versions/3.0.2.md
+++ b/versions/3.0.2.md
@@ -2685,7 +2685,7 @@ Field Name | Type | Description
 <a name="propertyName"></a>propertyName | `string` | **REQUIRED**. The name of the property in the payload that will hold the discriminator value.
 <a name="discriminatorMapping"></a> mapping | Map[`string`, `string`] | An object to hold mappings between payload values and schema names or references.
 
-The discriminator attribute is legal only when using one of the composite keywords `oneOf`, `anyOf`, `allOf`.
+The discriminator object is legal only when using one of the composite keywords `oneOf`, `anyOf`, `allOf`.
 
 In OAS 3.0, a response payload MAY be described to be exactly one of any number of types:
 


### PR DESCRIPTION
Wording fix only. Separate PR to follow to allow specification extensions within `discriminator` object.