### PR TITLE
Fixes for USPTO example

### DIFF
--- a/examples/v3.0/uspto.yaml
+++ b/examples/v3.0/uspto.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.0
+openapi: 3.0.1
 servers:
   - url: '{scheme}://developer.uspto.gov/ds-api'
     variables:
@@ -78,22 +78,22 @@ paths:
       parameters:
         - name: dataset
           in: path
-          description: 'Name of the dataset. In this case, the default value is oa_citations'
+          description: 'Name of the dataset.'
           required: true
+          example: "oa_citations"
           schema:
             type: string
-            default: oa_citations
         - name: version
           in: path
           description: Version of the dataset.
           required: true
+          example: "v1"
           schema:
             type: string
-            default: v1
       responses:
         '200':
           description: >-
-            The dataset api for the given version is found and it is accessible
+            The dataset API for the given version is found and it is accessible
             to consume.
           content:
             application/json:


### PR DESCRIPTION
incremented version to `3.0.1`
leveraged `example` instead of `default` in `schema` for illustrating what an example value might be. 
misc minor fixes