### PR TITLE
Fix example response reference

### DIFF
--- a/examples/v3.0/petstore.yaml
+++ b/examples/v3.0/petstore.yaml
@@ -72,7 +72,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Pets"
+                $ref: "#/components/schemas/Pet"
         default:
           description: unexpected error
           content:


### PR DESCRIPTION
`GET /pets/{petId}` returns a pet, not pets.