### PR TITLE
Consistent use of property name in schema examples: `petType` vs `pet_type`

### DIFF
--- a/versions/3.0.2.md
+++ b/versions/3.0.2.md
@@ -2707,15 +2707,15 @@ MyResponseType:
   - $ref: '#/components/schemas/Dog'
   - $ref: '#/components/schemas/Lizard'
   discriminator:
-    propertyName: pet_type
+    propertyName: petType
 ```
 
-The expectation now is that a property with name `pet_type` _MUST_ be present in the response payload, and the value will correspond to the name of a schema defined in the OAS document.  Thus the response payload:
+The expectation now is that a property with name `petType` _MUST_ be present in the response payload, and the value will correspond to the name of a schema defined in the OAS document.  Thus the response payload:
 
 ```json
 {
   "id": 12345,
-  "pet_type": "Cat"
+  "petType": "Cat"
 }
 ```
 
@@ -2731,7 +2731,7 @@ MyResponseType:
   - $ref: '#/components/schemas/Lizard'
   - $ref: 'https://gigantic-server.com/schemas/Monster/schema.json'
   discriminator:
-    propertyName: pet_type
+    propertyName: petType
     mapping:
       dog: '#/components/schemas/Dog'
       monster: 'https://gigantic-server.com/schemas/Monster/schema.json'
@@ -2751,12 +2751,12 @@ components:
     Pet:
       type: object
       required:
-      - pet_type
+      - petType
       properties:
-        pet_type:
+        petType:
           type: string
       discriminator:
-        propertyName: pet_type
+        propertyName: petType
         mapping:
           dog: Dog
     Cat:
@@ -2789,7 +2789,7 @@ a payload like this:
 
 ```json
 {
-  "pet_type": "Cat",
+  "petType": "Cat",
   "name": "misty"
 }
 ```
@@ -2798,7 +2798,7 @@ will indicate that the `Cat` schema be used.  Likewise this schema:
 
 ```json
 {
-  "pet_type": "dog",
+  "petType": "dog",
   "bark": "soft"
 }
 ```


### PR DESCRIPTION
* Pet Schema in the MediaTypes Examples and Schema Object Examples uses the camelCase notation: `petType`,
* While Pets from the Discriminator Object use snake_case: `pet_type`.

It's inconsistent.

I chose the camelCase notation because it's used for propertyNames by the OpenAPI specification itself.