### PR TITLE
Use semver for API version in example

### DIFF
--- a/examples/v3.0/api-with-examples.yaml
+++ b/examples/v3.0/api-with-examples.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.0"
 info:
   title: Simple API overview
-  version: v2
+  version: 2.0.0
 paths:
   /:
     get:


### PR DESCRIPTION
The specification recommends using semver for version specifications here: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#versions