### PR TITLE
Fix link to #securityDefinitionsObject

### DIFF
--- a/versions/2.0.md
+++ b/versions/2.0.md
@@ -2245,7 +2245,7 @@ The name used for each property MUST correspond to a security scheme declared in
 
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="securityRequirementsName"></a>{name} | [`string`] | Each name must correspond to a security scheme which is declared in the [Security Definitions](#securityDefinitions). If the security scheme is of type `"oauth2"`, then the value is a list of scope names required for the execution. For other security scheme types, the array MUST be empty.
+<a name="securityRequirementsName"></a>{name} | [`string`] | Each name must correspond to a security scheme which is declared in the [Security Definitions](#securityDefinitionsObject). If the security scheme is of type `"oauth2"`, then the value is a list of scope names required for the execution. For other security scheme types, the array MUST be empty.
 
 ##### Security Requirement Object Examples
 


### PR DESCRIPTION
Fix to version 2 documentation link.

Within the section [Security Requirement Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#security-requirement-object) there are two links to `Security Definitions`, the second of which has the wrong URL.

This PR has the fix for that link.