### PR TITLE
Re-target two commits from 3.0.1.md to 3.0.2.md

### DIFF
--- a/versions/3.0.1.md
+++ b/versions/3.0.1.md
@@ -118,7 +118,6 @@ For example, if a field has an array value, the JSON array representation will b
 }
 ```
 All field names in the specification are **case sensitive**.
-This includes all fields that are used as keys in a map, except where explicitly noted that keys are **case insensitive**
 
 The schema exposes two types of fields: Fixed fields, which have a declared name, and Patterned fields, which declare a regex pattern for the field name.
 
@@ -824,7 +823,7 @@ Field Name | Type | Description
 <a name="operationSummary"></a>summary | `string` | A short summary of what the operation does.
 <a name="operationDescription"></a>description | `string` | A verbose explanation of the operation behavior. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
 <a name="operationExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation for this operation.
-<a name="operationId"></a>operationId | `string` | Unique string used to identify the operation. The id MUST be unique among all operations described in the API. The operationId value is **case-sensitive**. Tools and libraries MAY use the operationId to uniquely identify an operation, therefore, it is RECOMMENDED to follow common programming naming conventions.
+<a name="operationId"></a>operationId | `string` | Unique string used to identify the operation. The id MUST be unique among all operations described in the API. Tools and libraries MAY use the operationId to uniquely identify an operation, therefore, it is RECOMMENDED to follow common programming naming conventions.
 <a name="operationParameters"></a>parameters | [[Parameter Object](#parameterObject) \| [Reference Object](#referenceObject)] | A list of parameters that are applicable for this operation. If a parameter is already defined at the [Path Item](#pathItemParameters), the new definition will override it but can never remove it. The list MUST NOT include duplicated parameters. A unique parameter is defined by a combination of a [name](#parameterName) and [location](#parameterIn). The list can use the [Reference Object](#referenceObject) to link to parameters that are defined at the [OpenAPI Object's components/parameters](#componentsParameters).
 <a name="operationRequestBody"></a>requestBody | [Request Body Object](#requestBodyObject) \| [Reference Object](#referenceObject) | The request body applicable for this operation.  The `requestBody` is only supported in HTTP methods where the HTTP 1.1 specification [RFC7231](https://tools.ietf.org/html/rfc7231#section-4.3.1) has explicitly defined semantics for request bodies.  In other cases where the HTTP spec is vague, `requestBody` SHALL be ignored by consumers.
 <a name="operationResponses"></a>responses | [Responses Object](#responsesObject) | **REQUIRED**. The list of possible responses as they are returned from executing this operation.

--- a/versions/3.0.1.md
+++ b/versions/3.0.1.md
@@ -118,7 +118,7 @@ For example, if a field has an array value, the JSON array representation will b
 }
 ```
 All field names in the specification are **case sensitive**.
-This includes all fields that are used as keys in a map, except where explicitly noted that keys are **case insensitive**.
+This includes all fields that are used as keys in a map, except where explicitly noted that keys are **case insensitive**
 
 The schema exposes two types of fields: Fixed fields, which have a declared name, and Patterned fields, which declare a regex pattern for the field name.
 

--- a/versions/3.0.2.md
+++ b/versions/3.0.2.md
@@ -118,6 +118,7 @@ For example, if a field has an array value, the JSON array representation will b
 }
 ```
 All field names in the specification are **case sensitive**.
+This includes all fields that are used as keys in a map, except where explicitly noted that keys are **case insensitive**
 
 The schema exposes two types of fields: Fixed fields, which have a declared name, and Patterned fields, which declare a regex pattern for the field name.
 
@@ -844,7 +845,7 @@ Field Name | Type | Description
 <a name="operationSummary"></a>summary | `string` | A short summary of what the operation does.
 <a name="operationDescription"></a>description | `string` | A verbose explanation of the operation behavior. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
 <a name="operationExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation for this operation.
-<a name="operationId"></a>operationId | `string` | Unique string used to identify the operation. The id MUST be unique among all operations described in the API. Tools and libraries MAY use the operationId to uniquely identify an operation, therefore, it is RECOMMENDED to follow common programming naming conventions.
+<a name="operationId"></a>operationId | `string` | Unique string used to identify the operation. The id MUST be unique among all operations described in the API. The operationId value is **case-sensitive**. Tools and libraries MAY use the operationId to uniquely identify an operation, therefore, it is RECOMMENDED to follow common programming naming conventions.
 <a name="operationParameters"></a>parameters | [[Parameter Object](#parameterObject) \| [Reference Object](#referenceObject)] | A list of parameters that are applicable for this operation. If a parameter is already defined at the [Path Item](#pathItemParameters), the new definition will override it but can never remove it. The list MUST NOT include duplicated parameters. A unique parameter is defined by a combination of a [name](#parameterName) and [location](#parameterIn). The list can use the [Reference Object](#referenceObject) to link to parameters that are defined at the [OpenAPI Object's components/parameters](#componentsParameters).
 <a name="operationRequestBody"></a>requestBody | [Request Body Object](#requestBodyObject) \| [Reference Object](#referenceObject) | The request body applicable for this operation.  The `requestBody` is only supported in HTTP methods where the HTTP 1.1 specification [RFC7231](https://tools.ietf.org/html/rfc7231#section-4.3.1) has explicitly defined semantics for request bodies.  In other cases where the HTTP spec is vague, `requestBody` SHALL be ignored by consumers.
 <a name="operationResponses"></a>responses | [Responses Object](#responsesObject) | **REQUIRED**. The list of possible responses as they are returned from executing this operation.

--- a/versions/3.0.2.md
+++ b/versions/3.0.2.md
@@ -118,7 +118,7 @@ For example, if a field has an array value, the JSON array representation will b
 }
 ```
 All field names in the specification are **case sensitive**.
-This includes all fields that are used as keys in a map, except where explicitly noted that keys are **case insensitive**
+This includes all fields that are used as keys in a map, except where explicitly noted that keys are **case insensitive**.
 
 The schema exposes two types of fields: Fixed fields, which have a declared name, and Patterned fields, which declare a regex pattern for the field name.
 


### PR DESCRIPTION
Two commits (3e7d0a8c and 4c79d31f3) were correctly made on the `v3.0.2-dev` branch, but inadvertently against the wrong file (`versions/3.0.1.md` instead of `versions/3.0.2.md`).

This series of commits reverts the two original commits in reverse order, then applies the same diffs to the correct target file.

All metadata from the original commits has been preserved.