### PR TITLE
sync `security` logic with swagger.io

### DIFF
--- a/versions/2.0.md
+++ b/versions/2.0.md
@@ -118,7 +118,7 @@ Field Name | Type | Description
 <a name="swaggerParameters"></a>parameters | [Parameters Definitions Object](#parametersDefinitionsObject) | An object to hold parameters that can be used across operations. This property *does not* define global parameters for all operations.
 <a name="swaggerResponses"></a>responses | [Responses Definitions Object](#responsesDefinitionsObject) | An object to hold responses that can be used across operations. This property *does not* define global responses for all operations.
 <a name="swaggerSecurityDefinitions"></a>securityDefinitions | [Security Definitions Object](#securityDefinitionsObject) | Security scheme definitions that can be used across the specification.
-<a name="swaggerSecurity"></a>security | [[Security Requirement Object](#securityRequirementObject)] | A declaration of which security schemes are applied for the API as a whole. The list of values describes alternative security schemes that can be used (that is, there is a logical OR between the security requirements). Individual operations can override this definition.
+<a name="swaggerSecurity"></a>security | [[Security Requirement Object](#securityRequirementObject)] | A declaration of which security schemes are applied for the API as a whole. The list of values describes alternative security schemes that can be used (that is, there is a logical OR and AND between the security requirements). Individual operations can override this definition.
 <a name="swaggerTags"></a>tags | [[Tag Object](#tagObject)] | A list of tags used by the specification with additional metadata. The order of the tags can be used to reflect on their order by the parsing tools. Not all tags that are used by the [Operation Object](#operationObject) must be declared. The tags that are not declared may be organized randomly or based on the tools' logic. Each tag name in the list MUST be unique.
 <a name="swaggerExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation.
 
@@ -421,7 +421,7 @@ Field Name | Type | Description
 <a name="operationResponses"></a>responses | [Responses Object](#responsesObject) | **Required.** The list of possible responses as they are returned from executing this operation.
 <a name="operationSchemes"></a>schemes | [`string`] | The transfer protocol for the operation. Values MUST be from the list: `"http"`, `"https"`, `"ws"`, `"wss"`. The value overrides the Swagger Object [`schemes`](#swaggerSchemes) definition. 
 <a name="operationDeprecated"></a>deprecated | `boolean` | Declares this operation to be deprecated. Usage of the declared operation should be refrained. Default value is `false`.
-<a name="operationSecurity"></a>security | [[Security Requirement Object](#securityRequirementObject)] | A declaration of which security schemes are applied for this operation. The list of values describes alternative security schemes that can be used (that is, there is a logical OR between the security requirements). This definition overrides any declared top-level [`security`](#swaggerSecurity). To remove a top-level security declaration, an empty array can be used.
+<a name="operationSecurity"></a>security | [[Security Requirement Object](#securityRequirementObject)] | A declaration of which security schemes are applied for this operation. The list of values describes alternative security schemes that can be used (that is, there is a logical OR and AND between the security requirements). This definition overrides any declared top-level [`security`](#swaggerSecurity). To remove a top-level security declaration, an empty array can be used.
 
 ##### Patterned Objects 
 
@@ -2237,7 +2237,7 @@ read:pets: read your pets
 
 #### <a name="securityRequirementObject"></a>Security Requirement Object
 
-Lists the required security schemes to execute this operation. The object can have multiple security schemes declared in it which are all required (that is, there is a logical AND between the schemes).
+Lists the required security schemes to execute this operation. The object can have multiple security schemes declared in it which are all required (that is, there is a logical OR and AND between the schemes).
 
 The name used for each property MUST correspond to a security scheme declared in the [Security Definitions](#securityDefinitionsObject).
 
@@ -2276,6 +2276,33 @@ api_key: []
 petstore_auth:
 - write:pets
 - read:pets
+```
+```
+
+###### Using Multiple Authentication Types
+
+Some REST APIs support several authentication types.
+The `security` section lets you combine the security requirements using logical OR and AND to achieve the desired result.
+`security` uses the following logic:
+
+```yml
+security:    # A OR B
+  - A
+  - B
+```
+
+```yml
+security:    # A AND B
+  - A
+    B
+```
+
+```yml
+security:    # (A AND B) OR (C AND D)
+  - A
+    B
+  - C
+    D
 ```
 
 ### <a name="vendorExtensions"></a>Specification Extensions


### PR DESCRIPTION
I noticed inconsistent `security` logic in the Swagger 2.0 Markdown (OR vs AND), and found (what I believe to be) the accurate description of `security` logic here: https://swagger.io/docs/specification/2-0/authentication/#multiple

This request synchronizes `security` logic, and copies the description and samples from swagger.io into the `Security Requirement Object` section.