### PR TITLE
Clarified supported Ecma edition for regex

### DIFF
--- a/versions/3.0.2.md
+++ b/versions/3.0.2.md
@@ -2285,7 +2285,7 @@ The following properties are taken directly from the JSON Schema definition and 
 - exclusiveMinimum
 - maxLength
 - minLength
-- pattern (This string SHOULD be a valid regular expression, according to the [ECMA 262 regular expression](https://www.ecma-international.org/ecma-262/5.1/#sec-7.8.5) dialect)
+- pattern (This string SHOULD be a valid regular expression, according to the [Ecma-262 Edition 5.1](https://www.ecma-international.org/ecma-262/5.1/#sec-7.8.5) regular expression dialect)
 - maxItems
 - minItems
 - uniqueItems


### PR DESCRIPTION
Added supported Ecma edition (5.1) for regular expressions in the link text and used the formal name: [Ecma-262 Edition 5.1](https://www.ecma-international.org/ecma-262/5.1/).

See also: OAI#1687