### PR TITLE
minor clarification for operationId usage in link objects

### DIFF
--- a/versions/3.0.3.md
+++ b/versions/3.0.3.md
@@ -2093,7 +2093,7 @@ solely by the existence of a relationship.
 ##### OperationRef Examples
 
 As references to `operationId` MAY NOT be possible (the `operationId` is an optional 
-value), references MAY also be made through a relative `operationRef`:
+value in an [Operation Object](#operationObject)), references MAY also be made through a relative `operationRef`:
 
 ```yaml
 links:

--- a/versions/3.0.3.md
+++ b/versions/3.0.3.md
@@ -2093,7 +2093,7 @@ solely by the existence of a relationship.
 ##### OperationRef Examples
 
 As references to `operationId` MAY NOT be possible (the `operationId` is an optional 
-value in an [Operation Object](#operationObject)), references MAY also be made through a relative `operationRef`:
+field in an [Operation Object](#operationObject)), references MAY also be made through a relative `operationRef`:
 
 ```yaml
 links:


### PR DESCRIPTION
it's a bit confusing that both the id and the reference are called "operationId", so this tweak makes the text a bit more explicit.