### PR TITLE
Initial batch of minor schema fixes

### DIFF
--- a/schemas/v3.0/schema.yaml
+++ b/schemas/v3.0/schema.yaml
@@ -600,6 +600,7 @@ definitions:
           oneOf:
             - $ref: '#/definitions/Parameter'
             - $ref: '#/definitions/Reference'
+        uniqueItems: true
     patternProperties:
       '^x-': {}
     additionalProperties: false
@@ -627,6 +628,7 @@ definitions:
           oneOf:
             - $ref: '#/definitions/Parameter'
             - $ref: '#/definitions/Reference'
+        uniqueItems: true
       requestBody:
         oneOf:
           - $ref: '#/definitions/RequestBody'

--- a/schemas/v3.0/schema.yaml
+++ b/schemas/v3.0/schema.yaml
@@ -38,7 +38,7 @@ definitions:
     properties:
       $ref:
         type: string
-        format: uriref
+        format: uri-reference
   Info:
     type: object
     required:
@@ -51,7 +51,7 @@ definitions:
         type: string
       termsOfService:
         type: string
-        format: uriref
+        format: uri-reference
       contact:
         $ref: '#/definitions/Contact'
       license:
@@ -70,7 +70,7 @@ definitions:
         type: string
       url:
         type: string
-        format: uriref
+        format: uri-reference
       email:
         type: string
         format: email
@@ -87,7 +87,7 @@ definitions:
         type: string
       url:
         type: string
-        format: uriref
+        format: uri-reference
     patternProperties:
       '^x-': {}
     additionalProperties: false
@@ -347,7 +347,7 @@ definitions:
         type: string
       namespace:
         type: string
-        format: url
+        format: uri-reference
       prefix:
         type: string
       attribute:
@@ -440,7 +440,7 @@ definitions:
       value: {}
       externalValue:
         type: string
-        format: uriref
+        format: uri-reference
     patternProperties:
       '^x-': {}
     additionalProperties: false
@@ -707,7 +707,7 @@ definitions:
         type: string
       url:
         type: string
-        format: uriref
+        format: uri-reference
     patternProperties:
       '^x-': {}
     additionalProperties: false
@@ -1326,7 +1326,7 @@ definitions:
           - openIdConnect      
       openIdConnectUrl:
         type: string
-        format: url
+        format: uri-reference
       description:
         type: string
     patternProperties:
@@ -1356,10 +1356,10 @@ definitions:
     properties:
       authorizationUrl:
         type: string
-        format: uriref
+        format: uri-reference
       refreshUrl:
         type: string
-        format: uriref
+        format: uri-reference
       scopes:
         type: object
         additionalProperties:
@@ -1375,10 +1375,10 @@ definitions:
     properties:
       tokenUrl:
         type: string
-        format: uriref
+        format: uri-reference
       refreshUrl:
         type: string
-        format: uriref
+        format: uri-reference
       scopes:
         type: object
         additionalProperties:
@@ -1394,10 +1394,10 @@ definitions:
     properties:
       tokenUrl:
         type: string
-        format: uriref
+        format: uri-reference
       refreshUrl:
         type: string
-        format: uriref
+        format: uri-reference
       scopes:
         type: object
         additionalProperties:
@@ -1414,13 +1414,13 @@ definitions:
     properties:
       authorizationUrl:
         type: string
-        format: uriref
+        format: uri-reference
       tokenUrl:
         type: string
-        format: uriref
+        format: uri-reference
       refreshUrl:
         type: string
-        format: uriref
+        format: uri-reference
       scopes:
         type: object
         additionalProperties:
@@ -1439,7 +1439,7 @@ definitions:
     properties:
       operationRef:
         type: string
-        format: uriref
+        format: uri-reference
       parameters:
         type: object
         additionalProperties: {}

--- a/schemas/v3.0/schema.yaml
+++ b/schemas/v3.0/schema.yaml
@@ -252,7 +252,7 @@ definitions:
         type: array
         items: {}
         minItems: 1
-        uniqueItems: true
+        uniqueItems: false
       type:
         type: string
         enum:

--- a/schemas/v3.0/schema.yaml
+++ b/schemas/v3.0/schema.yaml
@@ -35,8 +35,8 @@ definitions:
     type: object
     required:
       - $ref
-    properties:
-      $ref:
+    patternProperties:
+      '^\$ref$':
         type: string
         format: uri-reference
   Info:

--- a/schemas/v3.0/schema.yaml
+++ b/schemas/v3.0/schema.yaml
@@ -669,6 +669,7 @@ definitions:
         oneOf:
           - $ref: '#/definitions/Response'
           - $ref: '#/definitions/Reference'
+      '^x-': {}
     minProperties: 1
     additionalProperties: false
  

--- a/schemas/v3.0/schema.yaml
+++ b/schemas/v3.0/schema.yaml
@@ -666,14 +666,8 @@ definitions:
         oneOf:
           - $ref: '#/definitions/Response'
           - $ref: '#/definitions/Reference'
-      '^x-': {}
     minProperties: 1
     additionalProperties: false
-    not:
-      type: object
-      patternProperties:
-        '^x-': {}
-      additionalProperties: false
  
 
   SecurityRequirement:
@@ -1250,13 +1244,6 @@ definitions:
       - $ref: '#/definitions/BearerHTTPSecurityScheme'
 
   NonBearerHTTPSecurityScheme:
-    not:
-      type: object
-      properties:
-        scheme:
-          type: string
-          enum:
-            - bearer
     type: object
     required:
       - scheme
@@ -1264,6 +1251,9 @@ definitions:
     properties:
       scheme:
         type: string
+        not:
+          enum:
+            - bearer
       description:
         type: string
       type:

--- a/schemas/v3.0/schema.yaml
+++ b/schemas/v3.0/schema.yaml
@@ -369,6 +369,7 @@ definitions:
       description:
         type: string
       headers:
+        type: object
         additionalProperties:
           oneOf:
             - $ref: '#/definitions/Header'

--- a/schemas/v3.0/schema.yaml
+++ b/schemas/v3.0/schema.yaml
@@ -665,7 +665,7 @@ definitions:
           - $ref: '#/definitions/Response'
           - $ref: '#/definitions/Reference'
     patternProperties:
-      '[1-5](?:\d{2}|XX)':
+      '^[1-5](?:\d{2}|XX)$':
         oneOf:
           - $ref: '#/definitions/Response'
           - $ref: '#/definitions/Reference'

--- a/schemas/v3.0/schema.yaml
+++ b/schemas/v3.0/schema.yaml
@@ -23,6 +23,7 @@ properties:
     type: array
     items:
       $ref: '#/definitions/Tag'
+    uniqueItems: true
   paths:
     $ref: '#/definitions/Paths'
   components:

--- a/schemas/v3.0/schema.yaml
+++ b/schemas/v3.0/schema.yaml
@@ -347,7 +347,7 @@ definitions:
         type: string
       namespace:
         type: string
-        format: uri-reference
+        format: uri
       prefix:
         type: string
       attribute:


### PR DESCRIPTION
Several small fixes to get started, you can look at each as a separate commit if you want, but here are all of the commit messages for convenience (apologies for the duplication around draft support weirdness, I wrote the messages to each make sense on their own).  I tested this by validating it against the draft-04 meta-schema, but have not tried using it to validate any OAS documents yet.

-----

Use "uri-reference", not "url" or "uriref"

There is no way to tell a validator that a schema is
using draft-wright-json-schema-validation-00, which is the
only draft with a "uriref" format.  Validators either
interpret schemas as the previous draft (fge-04), which does
not have this concept at all, or the following draft (wright-01)
which has "uri-reference".

Since there are no options that will automatically work correctly,
using the later form seems to be the best.  Many validators allow
registering extensions, and we can just document that we are
using the wright-01+ syntax.  You often need to register format
handlers to get *any* format validation with many validators
anyway, so this does not seem overly burdensome.

-----

Fix usage of "not"

Constructs such as:

type: object
not:
  type: object

will always fail, so remove the type inside the not.

The "not" usage around "^x-" patterns for responses is
unnecessary, as the existing

patternProperties:
    "[1-5]..."
additionalProperties: false

prevents all property that do not start with 1, 2, 3, 4, or 5
from being allowed already.

-----

Use patternProperties for $ref

While draft-wright-json-schema-00 forbids JSON References except
where a schema is expected, no validators implement this until
draft-writght-json-schema-01.  wright-00 schemas are in practice
processed as draft-04 schemas, meaning that "$ref" is always
considered a JSON Reference.  Or, at least, some validators do
that.

We can work around this by using a pattern that only matches "$ref".
There is no problem with the $ref in the "required" keyword, as
only "$ref" as a property name is recognized as a reference.