### PR TITLE
Make ABNF for runtime expressions complete

### DIFF
--- a/versions/3.0.3.md
+++ b/versions/3.0.3.md
@@ -2126,18 +2126,26 @@ This mechanism is used by [Link Objects](#linkObject) and [Callback Objects](#ca
 
 The runtime expression is defined by the following [ABNF](https://tools.ietf.org/html/rfc5234) syntax
 
-```
-      expression = ( "$url" | "$method" | "$statusCode" | "$request." source | "$response." source )
-      source = ( header-reference | query-reference | path-reference | body-reference )  
+```abnf
+      expression = ( "$url" / "$method" / "$statusCode" / "$request." source / "$response." source )
+      source = ( header-reference / query-reference / path-reference / body-reference )
       header-reference = "header." token
       query-reference = "query." name  
       path-reference = "path." name
-      body-reference = "body" ["#" fragment]
-      fragment = a JSON Pointer [RFC 6901](https://tools.ietf.org/html/rfc6901)  
-      name = *( char )
-      char = as per RFC [7159](https://tools.ietf.org/html/rfc7159#section-7)
-      token = as per RFC [7230](https://tools.ietf.org/html/rfc7230#section-3.2.6)
+      body-reference = "body" ["#" json-pointer ]
+      json-pointer    = *( "/" reference-token )
+      reference-token = *( unescaped / escaped )
+      unescaped       = %x00-2E / %x30-7D / %x7F-10FFFF
+         ; %x2F ('/') and %x7E ('~') are excluded from 'unescaped'
+      escaped         = "~" ( "0" / "1" )
+        ; representing '~' and '/', respectively
+      name = *( CHAR )
+      token = 1*tchar
+      tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." /
+        "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA
 ```
+
+Here, `json-pointer` is taken from [RFC 6901](https://tools.ietf.org/html/rfc6901), `char` from [RFC 7159](https://tools.ietf.org/html/rfc7159#section-7) and `token` from [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2.6).
 
 The `name` identifier is case-sensitive, whereas `token` is not. 
 


### PR DESCRIPTION
Include referenced sub-syntaxes so we get down to terminal definitions and the example can be parsed / highlighted correctly.