### PR TITLE
Define behaviour for specification extensions with null values

### DIFF
--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -3381,7 +3381,7 @@ The extensions properties are implemented as patterned fields that are always pr
 
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="infoExtensions"></a>^x- | Any | Allows extensions to the OpenAPI Schema. The field name MUST begin with `x-`, for example, `x-internal-id`. Field names beginning `x-oas-` are reserved for uses defined by the [OpenAPI Initiative](https://www.openapis.org/). The value can be `null`, a primitive, an array or an object. Can have any valid JSON format value.
+<a name="infoExtensions"></a>^x- | Any | Allows extensions to the OpenAPI Schema. The field name MUST begin with `x-`, for example, `x-internal-id`. Field names beginning `x-oas-` are reserved for uses defined by the [OpenAPI Initiative](https://www.openapis.org/). The value can be `null`, a primitive, an array or an object. Can have any valid JSON format value. A value of `null` SHOULD be treated the same as if the extension was not present.
 
 The extensions may or may not be supported by the available tooling, but those may be extended as well to add requested support (if tools are internal or open-sourced).
 


### PR DESCRIPTION
Makes the application of the tentative overlay proposal in #1722 easier to reason about, but is a good cleanup regardless.