### PR TITLE
832 add info.summary

### DIFF
--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -211,6 +211,7 @@ The metadata MAY be used by the clients if needed, and MAY be presented in editi
 Field Name | Type | Description
 ---|:---:|---
 <a name="infoTitle"></a>title | `string` | **REQUIRED**. The title of the application.
+<a name="infoSummary"></a>summary | `string` | A short, plain-text summary of the application.
 <a name="infoDescription"></a>description | `string` | A short description of the application. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
 <a name="infoTermsOfService"></a>termsOfService | `string` | A URL to the Terms of Service for the API. MUST be in the format of a URL.
 <a name="infoContact"></a>contact | [Contact Object](#contactObject) | The contact information for the exposed API.
@@ -225,6 +226,7 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
 ```json
 {
   "title": "Sample Pet Store App",
+  "summary": "A pet store manager.",
   "description": "This is a sample server for a pet store.",
   "termsOfService": "http://example.com/terms/",
   "contact": {
@@ -242,6 +244,7 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
 
 ```yaml
 title: Sample Pet Store App
+summary: A pet store manager.
 description: This is a sample server for a pet store.
 termsOfService: http://example.com/terms/
 contact:

--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -211,8 +211,8 @@ The metadata MAY be used by the clients if needed, and MAY be presented in editi
 Field Name | Type | Description
 ---|:---:|---
 <a name="infoTitle"></a>title | `string` | **REQUIRED**. The title of the application.
-<a name="infoSummary"></a>summary | `string` | A short, plain-text summary of the application.
-<a name="infoDescription"></a>description | `string` | A short description of the application. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
+<a name="infoSummary"></a>summary | `string` | A short summary of the application.
+<a name="infoDescription"></a>description | `string` | A verbose explanation of the application. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
 <a name="infoTermsOfService"></a>termsOfService | `string` | A URL to the Terms of Service for the API. MUST be in the format of a URL.
 <a name="infoContact"></a>contact | [Contact Object](#contactObject) | The contact information for the exposed API.
 <a name="infoLicense"></a>license | [License Object](#licenseObject) | The license information for the exposed API.


### PR DESCRIPTION
## This PR

Adds  `info.summary` field to be a service description (eg. for catalog purposes). The field:

 - is optional
 - it's plain-text (no markdown, which is allowed in `info.description` instead, eg [uspto](https://github.com/OAI/OpenAPI-Specification/blob/master/examples/v3.0/uspto.yaml#L12))
 - there's no enforced limit

## Note

To make an analogy with a product:

```
  title: "Ferrari Testarossa"
  summary: "A 12-cylinder mid-engine sports car manufactured by Ferrari"
  description: |-
    A longer description using markdown, eg. see [uspto]
￼￼
```  

See: https://github.com/OAI/OpenAPI-Specification/issues/832#issuecomment-407108439

