### PR TITLE
fix difference between yaml and json in Response Object Examples

### DIFF
--- a/versions/3.0.3.md
+++ b/versions/3.0.3.md
@@ -1772,7 +1772,8 @@ Plain text response with headers:
   "content": {
     "text/plain": {
       "schema": {
-        "type": "string"
+        "type": "string",
+        "example": "whoa!"
       }
     }
   },


### PR DESCRIPTION
`example` is missed.