### PR TITLE
[gh-pages] Hand-craft API templates for leaner output

### DIFF
--- a/api/alternative-schema.json
+++ b/api/alternative-schema.json
@@ -1,4 +1,12 @@
 ---
 ---
-{{ site.alternative-schema | jsonify }}
-
+{
+{% for page in site.alternative-schema %}"{{ page.slug }}": {
+  "slug": "{{ page.slug }}",
+  "title": "{{ page.title }}",
+  "issue": "{{ page.issue }}",
+  "description": "{{ page.description }}",
+  "owner": "{{ page.owner }}"
+}{% unless forloop.last %},{% endunless %}
+{% endfor %}
+}

--- a/api/draft-feature.json
+++ b/api/draft-feature.json
@@ -1,4 +1,12 @@
 ---
 ---
-{{ site.draft-feature | jsonify }}
-
+{
+{% for page in site.draft-feature %}"{{ page.slug }}": {
+  "slug": "{{ page.slug }}",
+  "title": "{{ page.title }}",
+  "issue": "{{ page.issue }}",
+  "description": "{{ page.description }}",
+  "owner": "{{ page.owner }}"
+}{% unless forloop.last %},{% endunless %}
+{% endfor %}
+}

--- a/api/extension.json
+++ b/api/extension.json
@@ -1,4 +1,14 @@
 ---
 ---
-{{ site.extension | jsonify }}
-
+{
+{% for page in site.extension %}"{{ page.slug }}": {
+  "slug": "{{ page.slug }}",
+  "title": "{{ page.title }}",
+  "issue": "{{ page.issue }}",
+  "description": "{{ page.description }}",
+  "owner": "{{ page.owner }}",
+  "objects": {{ page.objects | jsonify }},
+  "schema": {{ page.schema | jsonify }}
+}{% unless forloop.last %},{% endunless %}
+{% endfor %}
+}

--- a/api/format.json
+++ b/api/format.json
@@ -1,4 +1,13 @@
 ---
 ---
-{{ site.format | jsonify }}
-
+{
+{% for page in site.format %}"{{ page.slug }}": {
+  "slug": "{{ page.slug }}",
+  "title": "{{ page.title }}",
+  "issue": "{{ page.issue }}",
+  "description": "{{ page.description }}",
+  "owner": "{{ page.owner }}",
+  "base_type": "{{ page.base_type" }}"
+}{% unless forloop.last %},{% endunless %}
+{% endfor %}
+}

--- a/api/registries.json
+++ b/api/registries.json
@@ -1,4 +1,6 @@
 ---
 ---
-{{ site.collections | jsonify }}
-
+[
+{% for collection in site.collections %}"{{ collection.slug }}"{% unless forloop.last %},{% endunless %}
+{% endfor %}
+]

--- a/registries/_alternative-schema/jsonSchema.md
+++ b/registries/_alternative-schema/jsonSchema.md
@@ -1,5 +1,5 @@
 ---
-owner: darrel_miller
+owner: darrelmiller
 issue: 1532
 description: JSON Schema
 layout: default

--- a/registries/_alternative-schema/xmlSchema.md
+++ b/registries/_alternative-schema/xmlSchema.md
@@ -1,5 +1,5 @@
 ---
-owner: darrel_miller
+owner: darrelmiller
 issue: 1532
 description: xml Schema
 layout: default

--- a/registries/_draft-feature/alternativeSchema.md
+++ b/registries/_draft-feature/alternativeSchema.md
@@ -1,5 +1,5 @@
 ---
-owner: darrel_miller
+owner: darrelmiller
 issue: 1532
 description: x-oas-draft-alternativeSchema
 

--- a/registries/_extension/x-twitter.md
+++ b/registries/_extension/x-twitter.md
@@ -1,13 +1,10 @@
 ---
-slug: x-twitter
-name: x-twitter
-owner: mike_ralphson
+owner: MikeRalphson
 issue:
 description: Used to hold a reference to the API provider's Twitter account.
 schema:
   type: string
 objects: [ "contactObject" ]
-
 layout: default
 ---
 

--- a/registries/_format/commonmark.md
+++ b/registries/_format/commonmark.md
@@ -1,7 +1,8 @@
 ---
-slug: commonmark
 owner: MikeRalphson
 description: commonmark-formatted text
+base_type: string
+issue:
 layout: default
 ---
 
@@ -9,7 +10,7 @@ layout: default
 
 ## {{ page.slug }} - {{ page.description }}
 
-Base type: `string`.
+Base type: `{{ page.base_type }}`.
 
 The `{{page.slug}}` format represents [CommonMark](https://commonmark.org/) formatted text.
 

--- a/registries/_format/html.md
+++ b/registries/_format/html.md
@@ -1,6 +1,8 @@
 ---
 owner: MikeRalphson
 description: HTML-formatted text
+base_type: string
+issue:
 layout: default
 ---
 
@@ -8,7 +10,7 @@ layout: default
 
 ## {{ page.slug }} - {{ page.description }}
 
-Base type: `string`.
+Base type: `{{ page.base_type}}`.
 
 The `{{page.slug}}` format represents HTML-formatted text.
 

--- a/registries/_format/int8.md
+++ b/registries/_format/int8.md
@@ -2,6 +2,7 @@
 owner: MikeRalphson
 issue: 845
 description: signed 8-bit integer
+base_type: number
 layout: default
 ---
 
@@ -9,7 +10,7 @@ layout: default
 
 ## {{ page.slug }} - {{ page.description }}
 
-Base type: `number`.
+Base type: `{{ page.base_type }}`.
 
 The `{{page.slug}}` format represents a signed 8-bit integer, with the range -128 to 127.
 

--- a/registries/_format/uint8.md
+++ b/registries/_format/uint8.md
@@ -2,6 +2,7 @@
 owner: MikeRalphson
 issue: 845
 description: unsigned 8-bit integer
+base_type: number
 layout: default
 ---
 
@@ -9,7 +10,7 @@ layout: default
 
 ## {{ page.slug }} - {{ page.description }}
 
-Base type: `number`.
+Base type: `{{ page.base_type }}`.
 
 The `{{page.slug}}` format represents an unsigned 8-bit integer, with the range 0 to 255.
 


### PR DESCRIPTION
This PR rewrites the 'default' API templates (which included the HTML representations of the generated pages) with hand-crafted JSON output of the key metadata for each registry type.

An example can be seen at https://mikeralphson.github.io/OpenAPI-Specification/api/format.json

It also corrects a few `owner` property values, and moves `base_type` into the metadata for `format`s.

* [ ] Should `description` in the front-matter be renamed to `summary` to align closer with the spec.?
* [ ] Is an `array` more useful than a `map` in the API responses?