### PR TITLE
security; widen use of scopes array to other securityScheme types

### DIFF
--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -3340,7 +3340,7 @@ When a list of Security Requirement Objects is defined on the [OpenAPI Object](#
 
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="securityRequirementsName"></a>{name} | [`string`] | Each name MUST correspond to a security scheme which is declared in the [Security Schemes](#componentsSecuritySchemes) under the [Components Object](#componentsObject). If the security scheme is of type `"oauth2"` or `"openIdConnect"`, then the value is a list of scope names required for the execution. For other security scheme types, the array MUST be empty.
+<a name="securityRequirementsName"></a>{name} | [`string`] | Each name MUST correspond to a security scheme which is declared in the [Security Schemes](#componentsSecuritySchemes) under the [Components Object](#componentsObject). If the security scheme is of type `"oauth2"` or `"openIdConnect"`, then the value is a list of scope names required for the execution. For other security scheme types, the array MAY contain a list of role names which are required for the execution, but are not otherwise defined or exchanged in-band.
 
 ##### Security Requirement Object Examples
 


### PR DESCRIPTION
Split off from #1764 as discussed. In summary, I believe the outstanding issue is to find a non-contentious term possibly in preference to `scopes` or `roles` and to check this makes sense for all securityScheme types, including `http`'s subtypes.