### PR TITLE
fix a typo in the Security Filtering section

### DIFF
--- a/versions/3.0.3.md
+++ b/versions/3.0.3.md
@@ -3392,7 +3392,7 @@ While not part of the specification itself, certain libraries MAY choose to allo
 Two examples of this:
 
 1. The [Paths Object](#pathsObject) MAY be empty. It may be counterintuitive, but this may tell the viewer that they got to the right place, but can't access any documentation. They'd still have access to the [Info Object](#infoObject) which may contain additional information regarding authentication.
-2. The [Path Item Object](#pathItemObject) MAY be empty. In this case, the viewer will be aware that the path exists, but will not be able to see any of its operations or parameters. This is different than hiding the path itself from the [Paths Object](#pathsObject), so the user will not be aware of its existence. This allows the documentation provider to finely control what the viewer can see.
+2. The [Path Item Object](#pathItemObject) MAY be empty. In this case, the viewer will be aware that the path exists, but will not be able to see any of its operations or parameters. This is different than hiding the path itself from the [Paths Object](#pathsObject), so the user will be aware of its existence. This allows the documentation provider to finely control what the viewer can see.
 
 ## <a name="revisionHistory"></a>Appendix A: Revision History
 

--- a/versions/3.0.3.md
+++ b/versions/3.0.3.md
@@ -3392,7 +3392,7 @@ While not part of the specification itself, certain libraries MAY choose to allo
 Two examples of this:
 
 1. The [Paths Object](#pathsObject) MAY be empty. It may be counterintuitive, but this may tell the viewer that they got to the right place, but can't access any documentation. They'd still have access to the [Info Object](#infoObject) which may contain additional information regarding authentication.
-2. The [Path Item Object](#pathItemObject) MAY be empty. In this case, the viewer will be aware that the path exists, but will not be able to see any of its operations or parameters. This is different than hiding the path itself from the [Paths Object](#pathsObject), so the user will be aware of its existence. This allows the documentation provider to finely control what the viewer can see.
+2. The [Path Item Object](#pathItemObject) MAY be empty. In this case, the viewer will be aware that the path exists, but will not be able to see any of its operations or parameters. This is different from hiding the path itself from the [Paths Object](#pathsObject), because the user will be aware of its existence. This allows the documentation provider to finely control what the viewer can see.
 
 ## <a name="revisionHistory"></a>Appendix A: Revision History
 


### PR DESCRIPTION
It seems to be a typo.
But I'm not convinced because I'm not English speaker.

In my interpretation, the sentence mention empty Path Item Objects, and then the user will be aware of existence of the path.