### PR TITLE
Fix link to RFC 2119

### DIFF
--- a/versions/2.0.md
+++ b/versions/2.0.md
@@ -3,7 +3,7 @@
 
 #### Version 2.0
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](http://www.ietf.org/rfc/rfc2119.txt).
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
 
 The Swagger specification is licensed under [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.html).
 


### PR DESCRIPTION
The link to http://www.ietf.org/rfc/rfc2119.txt is dead. Updated the link within the incorporation phrase to match the current standard—https://tools.ietf.org/html/rfc2119.