### PR TITLE
Clarify the spec to allow optional or unspecified OAuth scopes

### DIFF
--- a/versions/3.0.3.md
+++ b/versions/3.0.3.md
@@ -3286,13 +3286,13 @@ Field Name | Type | Applies To | Description
 <a name="oauthFlowAuthorizationUrl"></a>authorizationUrl | `string` | `oauth2` (`"implicit"`, `"authorizationCode"`) | **REQUIRED**. The authorization URL to be used for this flow. This MUST be in the form of a URL.
 <a name="oauthFlowTokenUrl"></a>tokenUrl | `string` | `oauth2` (`"password"`, `"clientCredentials"`, `"authorizationCode"`) | **REQUIRED**. The token URL to be used for this flow. This MUST be in the form of a URL.
 <a name="oauthFlowRefreshUrl"></a>refreshUrl | `string` | `oauth2` | The URL to be used for obtaining refresh tokens. This MUST be in the form of a URL.
-<a name="oauthFlowScopes"></a>scopes | Map[`string`, `string`] | `oauth2` | **REQUIRED**. The available scopes for the OAuth2 security scheme. A map between the scope name and a short description for it. If scope is optional, the map MAY include an entry with an empty string as its key to represent the default scope. If scope is not used in the authorization scheme, the map MAY be empty.
+<a name="oauthFlowScopes"></a>scopes | Map[`string`, `string`] | `oauth2` | **REQUIRED**. The available scopes for the OAuth2 security scheme. A map between the scope name and a short description for it. If scope is not required or not specified in the authorization scheme, the map MAY be empty.
 
 This object MAY be extended with [Specification Extensions](#specificationExtensions).
 
 ##### OAuth Flow Object Examples
 
-###### OAuth Flows with Required Scope
+###### OAuth Flows with Defined Scopes
 
 ```JSON
 {
@@ -3333,7 +3333,7 @@ flows:
       read:pets: read your pets 
 ```
 
-###### OAuth Flows with Unspecified and Optional Scope
+###### OAuth Flows with Optional or Unspecified Scope
 
 ```JSON
 {
@@ -3346,10 +3346,7 @@ flows:
     "authorizationCode": {
       "authorizationUrl": "https://example.com/api/oauth/dialog",
       "tokenUrl": "https://example.com/api/oauth/token",
-      "scopes": {
-        "write:pets": "modify pets in your account",
-        "": "default scope provides read-only access"
-      }
+      "scopes": {}
     }
   }
 }
@@ -3364,9 +3361,7 @@ flows:
   authorizationCode:
     authorizationUrl: https://example.com/api/oauth/dialog
     tokenUrl: https://example.com/api/oauth/token
-    scopes:
-      write:pets: modify pets in your account
-      "" : default scope provides read-only access
+    scopes: {}
 ```
 
 #### <a name="securityRequirementObject"></a>Security Requirement Object

--- a/versions/3.0.3.md
+++ b/versions/3.0.3.md
@@ -3286,7 +3286,7 @@ Field Name | Type | Applies To | Description
 <a name="oauthFlowAuthorizationUrl"></a>authorizationUrl | `string` | `oauth2` (`"implicit"`, `"authorizationCode"`) | **REQUIRED**. The authorization URL to be used for this flow. This MUST be in the form of a URL.
 <a name="oauthFlowTokenUrl"></a>tokenUrl | `string` | `oauth2` (`"password"`, `"clientCredentials"`, `"authorizationCode"`) | **REQUIRED**. The token URL to be used for this flow. This MUST be in the form of a URL.
 <a name="oauthFlowRefreshUrl"></a>refreshUrl | `string` | `oauth2` | The URL to be used for obtaining refresh tokens. This MUST be in the form of a URL.
-<a name="oauthFlowScopes"></a>scopes | Map[`string`, `string`] | `oauth2` | **REQUIRED**. The available scopes for the OAuth2 security scheme. A map between the scope name and a short description for it. If scope is not required or not specified in the authorization scheme, the map MAY be empty.
+<a name="oauthFlowScopes"></a>scopes | Map[`string`, `string`] | `oauth2` | **REQUIRED**. The available scopes for the OAuth2 security scheme. A map between the scope name and a short description for it. The map MAY be empty.
 
 This object MAY be extended with [Specification Extensions](#specificationExtensions).
 
@@ -3331,37 +3331,6 @@ flows:
     scopes:
       write:pets: modify pets in your account
       read:pets: read your pets 
-```
-
-###### OAuth Flows with Optional or Unspecified Scope
-
-```JSON
-{
-  "type": "oauth2",
-  "flows": {
-    "implicit": {
-      "authorizationUrl": "https://example.com/api/oauth/dialog",
-      "scopes": {}
-    },
-    "authorizationCode": {
-      "authorizationUrl": "https://example.com/api/oauth/dialog",
-      "tokenUrl": "https://example.com/api/oauth/token",
-      "scopes": {}
-    }
-  }
-}
-```
-
-```yaml
-type: oauth2
-flows:
-  implicit:
-    authorizationUrl: https://example.com/api/oauth/dialog
-    scopes: {}
-  authorizationCode:
-    authorizationUrl: https://example.com/api/oauth/dialog
-    tokenUrl: https://example.com/api/oauth/token
-    scopes: {}
 ```
 
 #### <a name="securityRequirementObject"></a>Security Requirement Object

--- a/versions/3.0.3.md
+++ b/versions/3.0.3.md
@@ -3292,8 +3292,6 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
 
 ##### OAuth Flow Object Examples
 
-###### OAuth Flows with Defined Scopes
-
 ```JSON
 {
   "type": "oauth2",

--- a/versions/3.0.3.md
+++ b/versions/3.0.3.md
@@ -3286,11 +3286,13 @@ Field Name | Type | Applies To | Description
 <a name="oauthFlowAuthorizationUrl"></a>authorizationUrl | `string` | `oauth2` (`"implicit"`, `"authorizationCode"`) | **REQUIRED**. The authorization URL to be used for this flow. This MUST be in the form of a URL.
 <a name="oauthFlowTokenUrl"></a>tokenUrl | `string` | `oauth2` (`"password"`, `"clientCredentials"`, `"authorizationCode"`) | **REQUIRED**. The token URL to be used for this flow. This MUST be in the form of a URL.
 <a name="oauthFlowRefreshUrl"></a>refreshUrl | `string` | `oauth2` | The URL to be used for obtaining refresh tokens. This MUST be in the form of a URL.
-<a name="oauthFlowScopes"></a>scopes | Map[`string`, `string`] | `oauth2` | **REQUIRED**. The available scopes for the OAuth2 security scheme. A map between the scope name and a short description for it.
+<a name="oauthFlowScopes"></a>scopes | Map[`string`, `string`] | `oauth2` | **REQUIRED**. The available scopes for the OAuth2 security scheme. A map between the scope name and a short description for it. If scope is optional, the map MAY include an entry with an empty string as its key to represent the default scope. If scope is not used in the authorization scheme, the map MAY be empty.
 
 This object MAY be extended with [Specification Extensions](#specificationExtensions).
 
 ##### OAuth Flow Object Examples
+
+###### OAuth Flows with Required Scope
 
 ```JSON
 {
@@ -3331,6 +3333,41 @@ flows:
       read:pets: read your pets 
 ```
 
+###### OAuth Flows with Unspecified and Optional Scope
+
+```JSON
+{
+  "type": "oauth2",
+  "flows": {
+    "implicit": {
+      "authorizationUrl": "https://example.com/api/oauth/dialog",
+      "scopes": {}
+    },
+    "authorizationCode": {
+      "authorizationUrl": "https://example.com/api/oauth/dialog",
+      "tokenUrl": "https://example.com/api/oauth/token",
+      "scopes": {
+        "write:pets": "modify pets in your account",
+        "": "default scope provides read-only access"
+      }
+    }
+  }
+}
+```
+
+```yaml
+type: oauth2
+flows:
+  implicit:
+    authorizationUrl: https://example.com/api/oauth/dialog
+    scopes: {}
+  authorizationCode:
+    authorizationUrl: https://example.com/api/oauth/dialog
+    tokenUrl: https://example.com/api/oauth/token
+    scopes:
+      write:pets: modify pets in your account
+      "" : default scope provides read-only access
+```
 
 #### <a name="securityRequirementObject"></a>Security Requirement Object
 
@@ -3346,7 +3383,7 @@ When a list of Security Requirement Objects is defined on the [OpenAPI Object](#
 
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="securityRequirementsName"></a>{name} | [`string`] | Each name MUST correspond to a security scheme which is declared in the [Security Schemes](#componentsSecuritySchemes) under the [Components Object](#componentsObject). If the security scheme is of type `"oauth2"` or `"openIdConnect"`, then the value is a list of scope names required for the execution. For other security scheme types, the array MUST be empty.
+<a name="securityRequirementsName"></a>{name} | [`string`] | Each name MUST correspond to a security scheme which is declared in the [Security Schemes](#componentsSecuritySchemes) under the [Components Object](#componentsObject). If the security scheme is of type `"oauth2"` or `"openIdConnect"`, then the value is a list of scope names required for the execution, and the list MAY be empty if authorization does not require a specified scope. For other security scheme types, the array MUST be empty.
 
 ##### Security Requirement Object Examples
 


### PR DESCRIPTION
Referencing issue #513. Clarify the spec to accommodate OAuth schemes where scope is optional in the authorization request, or where scope is not used at all.

The [OAuth Flow Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#oauth-flow-object) says that the scopes map is REQUIRED, and doesn't specify any meaning for an empty object value. We took this to mean that the `scopes` property is required to be present AND non-empty, otherwise an empty value would seem to be circumventing the intention of the spec.

This PR makes it explicit that the scopes map MAY be empty.

Likewise, [Security Requirement Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#securityRequirementObject) says:

> If the security scheme is of type "oauth2" or "openIdConnect", then the value is a list of scope names required for the execution. For other security scheme types, the array MUST be empty.

It doesn't explicitly disallow an empty scope list for an OAuth security requirement. But taken in context, it's easy to assume, mistakenly, that the scopes array must be non-empty, so this PR explicitly allows an empty scopes list on oauth2 security requirements.