### PR TITLE
Fix missing schema type in YAML example spec

### DIFF
--- a/examples/v2.0/yaml/petstore-expanded.yaml
+++ b/examples/v2.0/yaml/petstore-expanded.yaml
@@ -109,6 +109,7 @@ paths:
             $ref: '#/definitions/Error'
 definitions:
   Pet:
+    type: "object"
     allOf:
       - $ref: '#/definitions/NewPet'
       - required:
@@ -119,6 +120,7 @@ definitions:
             format: int64
 
   NewPet:
+    type: "object"
     required:
       - name  
     properties:
@@ -128,6 +130,7 @@ definitions:
         type: string    
 
   Error:
+    type: "object"
     required:
       - code
       - message

--- a/examples/v2.0/yaml/petstore-expanded.yaml
+++ b/examples/v2.0/yaml/petstore-expanded.yaml
@@ -109,11 +109,11 @@ paths:
             $ref: '#/definitions/Error'
 definitions:
   Pet:
-    type: "object"
     allOf:
       - $ref: '#/definitions/NewPet'
       - required:
         - id
+        type: "object"
         properties:
           id:
             type: integer

--- a/examples/v2.0/yaml/petstore.yaml
+++ b/examples/v2.0/yaml/petstore.yaml
@@ -74,6 +74,7 @@ paths:
             $ref: '#/definitions/Error'
 definitions:
   Pet:
+    type: "object"
     required:
       - id
       - name
@@ -90,6 +91,7 @@ definitions:
     items:
       $ref: '#/definitions/Pet'
   Error:
+    type: "object"
     required:
       - code
       - message


### PR DESCRIPTION
These were fixed for the JSON version of the examples back in [mid 2015](https://github.com/OAI/OpenAPI-Specification/commit/94924733c072fb4784a35be529c37947ea99ed83#diff-c3f2d48f1c40a088bbac6fdff2f9895a), but some are still missing for the YAML versions. This is the root cause for Yelp/bravado#416.