### PR TITLE
Add missing object type to 3.0 examples

### DIFF
--- a/examples/v3.0/callback-example.yaml
+++ b/examples/v3.0/callback-example.yaml
@@ -43,6 +43,7 @@ paths:
                 content:
                   application/json:
                     schema:
+                      type: object
                       properties:
                         timestamp:
                           type: string

--- a/examples/v3.0/petstore-expanded.yaml
+++ b/examples/v3.0/petstore-expanded.yaml
@@ -127,7 +127,8 @@ components:
     Pet:
       allOf:
         - $ref: '#/components/schemas/NewPet'
-        - required:
+        - type: object
+          required:
           - id
           properties:
             id:
@@ -135,6 +136,7 @@ components:
               format: int64
 
     NewPet:
+      type: object
       required:
         - name  
       properties:
@@ -144,6 +146,7 @@ components:
           type: string    
 
     Error:
+      type: object
       required:
         - code
         - message

--- a/examples/v3.0/petstore.yaml
+++ b/examples/v3.0/petstore.yaml
@@ -82,6 +82,7 @@ paths:
 components:
   schemas:
     Pet:
+      type: object
       required:
         - id
         - name
@@ -98,6 +99,7 @@ components:
       items:
         $ref: "#/components/schemas/Pet"
     Error:
+      type: object
       required:
         - code
         - message


### PR DESCRIPTION
As discussed in #1923 I'm adding the `object` type to the 3.0 example specs where it's missing.