### PR TITLE
Update 3.0.0.md

### DIFF
--- a/versions/3.0.0.md
+++ b/versions/3.0.0.md
@@ -1737,7 +1737,7 @@ Response with a string type:
 
 ```yaml
 description: A simple string response
-representations:
+content:
   text/plain:
     schema:
       type: string


### PR DESCRIPTION
this looks like a typo to me.

should be `content:` ?
not sure `representations:` is correct

all others are `content`
also `representations` is not part of the openapi specification