### PR TITLE
fix OIDC url and OAuth2 requirements

### DIFF
--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -124,16 +124,16 @@ The schema exposes two types of fields: Fixed fields, which have a declared name
 
 Patterned fields MUST have unique names within the containing object. 
 
-In order to preserve the ability to round-trip between YAML and JSON formats, YAML version [1.2](http://www.yaml.org/spec/1.2/spec.html) is RECOMMENDED along with some additional constraints:
+In order to preserve the ability to round-trip between YAML and JSON formats, YAML version [1.2](https://www.yaml.org/spec/1.2/spec.html) is RECOMMENDED along with some additional constraints:
 
-- Tags MUST be limited to those allowed by the [JSON Schema ruleset](http://www.yaml.org/spec/1.2/spec.html#id2803231).
-- Keys used in YAML maps MUST be limited to a scalar string, as defined by the [YAML Failsafe schema ruleset](http://yaml.org/spec/1.2/spec.html#id2802346).
+- Tags MUST be limited to those allowed by the [JSON Schema ruleset](https://www.yaml.org/spec/1.2/spec.html#id2803231).
+- Keys used in YAML maps MUST be limited to a scalar string, as defined by the [YAML Failsafe schema ruleset](https://yaml.org/spec/1.2/spec.html#id2802346).
 
 **Note:** While APIs may be defined by OpenAPI documents in either YAML or JSON format, the API request and response bodies and other content are not required to be JSON or YAML.
 
 ### <a name="documentStructure"></a>Document Structure
 
-An OpenAPI document MAY be made up of a single document or be divided into multiple, connected parts at the discretion of the user. In the latter case, `$ref` fields MUST be used in the specification to reference those parts as follows from the [JSON Schema](http://json-schema.org) definitions.
+An OpenAPI document MAY be made up of a single document or be divided into multiple, connected parts at the discretion of the user. In the latter case, `$ref` fields MUST be used in the specification to reference those parts as follows from the [JSON Schema](https://json-schema.org) definitions.
 
 It is RECOMMENDED that the root OpenAPI document be named: `openapi.json` or `openapi.yaml`.
 
@@ -169,7 +169,7 @@ The formats defined by the OAS are:
 
 ### <a name="richText"></a>Rich Text Formatting
 Throughout the specification `description` fields are noted as supporting CommonMark markdown formatting.
-Where OpenAPI tooling renders rich text it MUST support, at a minimum, markdown syntax as described by [CommonMark 0.27](http://spec.commonmark.org/0.27/). Tooling MAY choose to ignore some CommonMark features to address security concerns. 
+Where OpenAPI tooling renders rich text it MUST support, at a minimum, markdown syntax as described by [CommonMark 0.27](https://spec.commonmark.org/0.27/). Tooling MAY choose to ignore some CommonMark features to address security concerns. 
 
 ### <a name="relativeReferences"></a>Relative References in URLs
 
@@ -212,7 +212,7 @@ Field Name | Type | Description
 ---|:---:|---
 <a name="infoTitle"></a>title | `string` | **REQUIRED**. The title of the application.
 <a name="infoSummary"></a>summary | `string` | A short summary of the application.
-<a name="infoDescription"></a>description | `string` | A verbose explanation of the application. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
+<a name="infoDescription"></a>description | `string` | A verbose explanation of the application. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
 <a name="infoTermsOfService"></a>termsOfService | `string` | A URL to the Terms of Service for the API. MUST be in the format of a URL.
 <a name="infoContact"></a>contact | [Contact Object](#contactObject) | The contact information for the exposed API.
 <a name="infoLicense"></a>license | [License Object](#licenseObject) | The license information for the exposed API.
@@ -228,10 +228,10 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
   "title": "Sample Pet Store App",
   "summary": "A pet store manager.",
   "description": "This is a sample server for a pet store.",
-  "termsOfService": "http://example.com/terms/",
+  "termsOfService": "https://example.com/terms/",
   "contact": {
     "name": "API Support",
-    "url": "http://www.example.com/support",
+    "url": "https://www.example.com/support",
     "email": "support@example.com"
   },
   "license": {
@@ -246,10 +246,10 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
 title: Sample Pet Store App
 summary: A pet store manager.
 description: This is a sample server for a pet store.
-termsOfService: http://example.com/terms/
+termsOfService: https://example.com/terms/
 contact:
   name: API Support
-  url: http://www.example.com/support
+  url: https://www.example.com/support
   email: support@example.com
 license:
   name: Apache 2.0
@@ -276,14 +276,14 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
 ```json
 {
   "name": "API Support",
-  "url": "http://www.example.com/support",
+  "url": "https://www.example.com/support",
   "email": "support@example.com"
 }
 ```
 
 ```yaml
 name: API Support
-url: http://www.example.com/support
+url: https://www.example.com/support
 email: support@example.com
 ```
 
@@ -323,7 +323,7 @@ An object representing a Server.
 Field Name | Type | Description
 ---|:---:|---
 <a name="serverUrl"></a>url | `string` | **REQUIRED**. A URL to the target host.  This URL supports Server Variables and MAY be relative, to indicate that the host location is relative to the location where the OpenAPI document is being served. Variable substitutions will be made when a variable is named in `{`brackets`}`.
-<a name="serverDescription"></a>description | `string` | An optional string describing the host designated by the URL. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
+<a name="serverDescription"></a>description | `string` | An optional string describing the host designated by the URL. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
 <a name="serverVariables"></a>variables | Map[`string`, [Server Variable Object](#serverVariableObject)] | A map between a variable name and its value.  The value is used for substitution in the server's URL template.
 
 This object MAY be extended with [Specification Extensions](#specificationExtensions).
@@ -434,7 +434,7 @@ Field Name | Type | Description
 ---|:---:|---
 <a name="serverVariableEnum"></a>enum | [`string`] | An enumeration of string values to be used if the substitution options are from a limited set.
 <a name="serverVariableDefault"></a>default | `string` |  **REQUIRED**. The default value to use for substitution, which SHALL be sent if an alternate value is _not_ supplied. Note this behavior is different than the [Schema Object's](#schemaObject) treatment of default values, because in those cases parameter values are optional.
-<a name="serverVariableDescription"></a>description | `string` | An optional description for the server variable. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
+<a name="serverVariableDescription"></a>description | `string` | An optional description for the server variable. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
 
 This object MAY be extended with [Specification Extensions](#specificationExtensions).
 
@@ -564,7 +564,7 @@ my.org.User
       "type": "oauth2",
       "flows": {
         "implicit": {
-          "authorizationUrl": "http://example.org/api/oauth/dialog",
+          "authorizationUrl": "https://example.org/api/oauth/dialog",
           "scopes": {
             "write:pets": "modify pets in your account",
             "read:pets": "read your pets"
@@ -640,7 +640,7 @@ components:
       type: oauth2
       flows: 
         implicit:
-          authorizationUrl: http://example.org/api/oauth/dialog
+          authorizationUrl: https://example.org/api/oauth/dialog
           scopes:
             write:pets: modify pets in your account
             read:pets: read your pets
@@ -737,7 +737,7 @@ Field Name | Type | Description
 ---|:---:|---
 <a name="pathItemRef"></a>$ref | `string` | Allows for an external definition of this path item. The referenced structure MUST be in the format of a [Path Item Object](#pathItemObject). If there are conflicts between the referenced definition and this Path Item's definition, the behavior is *undefined*.
 <a name="pathItemSummary"></a>summary| `string` | An optional, string summary, intended to apply to all operations in this path.
-<a name="pathItemDescription"></a>description | `string` | An optional, string description, intended to apply to all operations in this path. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
+<a name="pathItemDescription"></a>description | `string` | An optional, string description, intended to apply to all operations in this path. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
 <a name="pathItemGet"></a>get | [Operation Object](#operationObject) | A definition of a GET operation on this path.
 <a name="pathItemPut"></a>put | [Operation Object](#operationObject) | A definition of a PUT operation on this path.
 <a name="pathItemPost"></a>post | [Operation Object](#operationObject) | A definition of a POST operation on this path.
@@ -846,7 +846,7 @@ Field Name | Type | Description
 ---|:---:|---
 <a name="operationTags"></a>tags | [`string`] | A list of tags for API documentation control. Tags can be used for logical grouping of operations by resources or any other qualifier.
 <a name="operationSummary"></a>summary | `string` | A short summary of what the operation does.
-<a name="operationDescription"></a>description | `string` | A verbose explanation of the operation behavior. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
+<a name="operationDescription"></a>description | `string` | A verbose explanation of the operation behavior. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
 <a name="operationExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation for this operation.
 <a name="operationId"></a>operationId | `string` | Unique string used to identify the operation. The id MUST be unique among all operations described in the API. The operationId value is **case-sensitive**. Tools and libraries MAY use the operationId to uniquely identify an operation, therefore, it is RECOMMENDED to follow common programming naming conventions.
 <a name="operationParameters"></a>parameters | [[Parameter Object](#parameterObject) \| [Reference Object](#referenceObject)] | A list of parameters that are applicable for this operation. If a parameter is already defined at the [Path Item](#pathItemParameters), the new definition will override it but can never remove it. The list MUST NOT include duplicated parameters. A unique parameter is defined by a combination of a [name](#parameterName) and [location](#parameterIn). The list can use the [Reference Object](#referenceObject) to link to parameters that are defined at the [OpenAPI Object's components/parameters](#componentsParameters).
@@ -977,7 +977,7 @@ Allows referencing an external resource for extended documentation.
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="externalDocDescription"></a>description | `string` | A short description of the target documentation. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
+<a name="externalDocDescription"></a>description | `string` | A short description of the target documentation. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
 <a name="externalDocUrl"></a>url | `string` | **REQUIRED**. The URL for the target documentation. Value MUST be in the format of a URL.
 
 This object MAY be extended with [Specification Extensions](#specificationExtensions).
@@ -1015,7 +1015,7 @@ Field Name | Type | Description
 ---|:---:|---
 <a name="parameterName"></a>name | `string` | **REQUIRED**. The name of the parameter. Parameter names are *case sensitive*. <ul><li>If [`in`](#parameterIn) is `"path"`, the `name` field MUST correspond to the associated path segment from the [path](#pathsPath) field in the [Paths Object](#pathsObject). See [Path Templating](#pathTemplating) for further information.<li>If [`in`](#parameterIn) is `"header"` and the `name` field is `"Accept"`, `"Content-Type"` or `"Authorization"`, the parameter definition SHALL be ignored.<li>For all other cases, the `name` corresponds to the parameter name used by the [`in`](#parameterIn) property.</ul>
 <a name="parameterIn"></a>in | `string` | **REQUIRED**. The location of the parameter. Possible values are "query", "header", "path" or "cookie".
-<a name="parameterDescription"></a>description | `string` | A brief description of the parameter. This could contain examples of use.  [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
+<a name="parameterDescription"></a>description | `string` | A brief description of the parameter. This could contain examples of use.  [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
 <a name="parameterRequired"></a>required | `boolean` | Determines whether this parameter is mandatory. If the [parameter location](#parameterIn) is "path", this property is **REQUIRED** and its value MUST be `true`. Otherwise, the property MAY be included and its default value is `false`.
 <a name="parameterDeprecated"></a> deprecated | `boolean` | Specifies that a parameter is deprecated and SHOULD be transitioned out of usage. Default value is `false`.
 <a name="parameterAllowEmptyValue"></a> allowEmptyValue | `boolean` | Sets the ability to pass empty-valued parameters. This is valid only for `query` parameters and allows sending a parameter with an empty value. Default value is `false`. If [`style`](#parameterStyle) is used, and if behavior is `n/a` (cannot be serialized), the value of `allowEmptyValue` SHALL be ignored. Use of this property is NOT RECOMMENDED, as it is likely to be removed in a later revision.
@@ -1247,7 +1247,7 @@ Describes a single request body.
 ##### Fixed Fields
 Field Name | Type | Description
 ---|:---:|---
-<a name="requestBodyDescription"></a>description | `string` | A brief description of the request body. This could contain examples of use.  [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
+<a name="requestBodyDescription"></a>description | `string` | A brief description of the request body. This could contain examples of use.  [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
 <a name="requestBodyContent"></a>content | Map[`string`, [Media Type Object](#mediaTypeObject)] | **REQUIRED**. The content of the request body. The key is a media type or [media type range](https://tools.ietf.org/html/rfc7231#appendix-D) and the value describes it.  For requests that match multiple keys, only the most specific key is applicable. e.g. text/plain overrides text/*
 <a name="requestBodyRequired"></a>required | `boolean` | Determines if the request body is required in the request. Defaults to `false`.
 
@@ -1268,7 +1268,7 @@ A request body with a referenced model definition.
       "examples": {
           "user" : {
             "summary": "User Example", 
-            "externalValue": "http://foo.bar/examples/user-example.json"
+            "externalValue": "https://foo.bar/examples/user-example.json"
           } 
         }
     },
@@ -1279,7 +1279,7 @@ A request body with a referenced model definition.
       "examples": {
           "user" : {
             "summary": "User example in XML",
-            "externalValue": "http://foo.bar/examples/user-example.xml"
+            "externalValue": "https://foo.bar/examples/user-example.xml"
           }
         }
     },
@@ -1287,7 +1287,7 @@ A request body with a referenced model definition.
       "examples": {
         "user" : {
             "summary": "User example in Plain text",
-            "externalValue": "http://foo.bar/examples/user-example.txt" 
+            "externalValue": "https://foo.bar/examples/user-example.txt" 
         }
       } 
     },
@@ -1295,7 +1295,7 @@ A request body with a referenced model definition.
       "examples": {
         "user" : {
             "summary": "User example in other format",
-            "externalValue": "http://foo.bar/examples/user-example.whatever"
+            "externalValue": "https://foo.bar/examples/user-example.whatever"
         }
       }
     }
@@ -1312,24 +1312,24 @@ content:
     examples:
       user:
         summary: User Example
-        externalValue: 'http://foo.bar/examples/user-example.json'
+        externalValue: 'https://foo.bar/examples/user-example.json'
   'application/xml':
     schema:
       $ref: '#/components/schemas/User'
     examples:
       user:
         summary: User Example in XML
-        externalValue: 'http://foo.bar/examples/user-example.xml'
+        externalValue: 'https://foo.bar/examples/user-example.xml'
   'text/plain':
     examples:
       user:
         summary: User example in text plain format
-        externalValue: 'http://foo.bar/examples/user-example.txt'
+        externalValue: 'https://foo.bar/examples/user-example.txt'
   '*/*':
     examples:
       user: 
         summary: User example in other format
-        externalValue: 'http://foo.bar/examples/user-example.whatever'
+        externalValue: 'https://foo.bar/examples/user-example.whatever'
 ```
 
 A body parameter that is an array of string values:
@@ -1707,7 +1707,7 @@ Describes a single response from an API Operation, including design-time, static
 ##### Fixed Fields
 Field Name | Type | Description
 ---|:---:|---
-<a name="responseDescription"></a>description | `string` | **REQUIRED**. A short description of the response. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
+<a name="responseDescription"></a>description | `string` | **REQUIRED**. A short description of the response. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
 <a name="responseHeaders"></a>headers | Map[`string`, [Header Object](#headerObject)  \| [Reference Object](#referenceObject)] |  Maps a header name to its definition. [RFC7230](https://tools.ietf.org/html/rfc7230#page-22) states header names are case insensitive. If a response header is defined with the name `"Content-Type"`, it SHALL be ignored.
 <a name="responseContent"></a>content | Map[`string`, [Media Type Object](#mediaTypeObject)] | A map containing descriptions of potential response payloads. The key is a media type or [media type range](https://tools.ietf.org/html/rfc7231#appendix-D) and the value describes it.  For responses that match multiple keys, only the most specific key is applicable. e.g. text/plain overrides text/*
 <a name="responseLinks"></a>links | Map[`string`, [Link Object](#linkObject) \| [Reference Object](#referenceObject)] | A map of operations links that can be followed from the response. The key of the map is a short name for the link, following the naming constraints of the names for [Component Objects](#componentsObject). 
@@ -1860,36 +1860,36 @@ This includes accessing any part of a body that a JSON Pointer [RFC6901](https:/
 For example, given the following HTTP request:
 
 ```http
-POST /subscribe/myevent?queryUrl=http://clientdomain.com/stillrunning HTTP/1.1
+POST /subscribe/myevent?queryUrl=https://clientdomain.com/stillrunning HTTP/1.1
 Host: example.org
 Content-Type: application/json
 Content-Length: 187
 
 {
-  "failedUrl" : "http://clientdomain.com/failed",
+  "failedUrl" : "https://clientdomain.com/failed",
   "successUrls" : [
-    "http://clientdomain.com/fast",
-    "http://clientdomain.com/medium",
-    "http://clientdomain.com/slow"
+    "https://clientdomain.com/fast",
+    "https://clientdomain.com/medium",
+    "https://clientdomain.com/slow"
   ] 
 }
 
 201 Created
-Location: http://example.org/subscription/1
+Location: https://example.org/subscription/1
 ```
 
 The following examples show how the various expressions evaluate, assuming the callback operation has a path parameter named `eventType` and a query parameter named `queryUrl`.
 
 Expression | Value 
 ---|:---
-$url | http://example.org/subscribe/myevent?queryUrl=http://clientdomain.com/stillrunning
+$url | https://example.org/subscribe/myevent?queryUrl=https://clientdomain.com/stillrunning
 $method | POST
 $request.path.eventType | myevent
-$request.query.queryUrl | http://clientdomain.com/stillrunning
+$request.query.queryUrl | https://clientdomain.com/stillrunning
 $request.header.content-Type | application/json
-$request.body#/failedUrl | http://clientdomain.com/failed
-$request.body#/successUrls/2 | http://clientdomain.com/medium
-$response.header.Location | http://example.org/subscription/1
+$request.body#/failedUrl | https://clientdomain.com/failed
+$request.body#/successUrls/2 | https://clientdomain.com/medium
+$response.header.Location | https://example.org/subscription/1
 
 
 ##### Callback Object Example
@@ -1898,7 +1898,7 @@ The following example shows a callback to the URL specified by the `id` and `ema
 
 ```yaml
 myWebhook:
-  'http://notificationServer.com?transactionId={$request.body#/id}&email={$request.body#/email}':
+  'https://notificationServer.com?transactionId={$request.body#/id}&email={$request.body#/email}':
     post:
       requestBody:
         description: Callback payload
@@ -1918,7 +1918,7 @@ myWebhook:
 Field Name | Type | Description
 ---|:---:|---
 <a name="exampleSummary"></a>summary | `string` | Short description for the example.
-<a name="exampleDescription"></a>description | `string` | Long description for the example. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
+<a name="exampleDescription"></a>description | `string` | Long description for the example. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
 <a name="exampleValue"></a>value | Any | Embedded literal example. The `value` field and `externalValue` field are mutually exclusive. To represent examples of media types that cannot naturally represented in JSON or YAML, use a string value to contain the example, escaping where necessary.
 <a name="exampleExternalValue"></a>externalValue | `string` | A URL that points to the literal example. This provides the capability to reference examples that cannot easily be included in JSON or YAML documents.  The `value` field and `externalValue` field are mutually exclusive. 
 
@@ -1939,7 +1939,7 @@ schemas:
       type: string
       examples:
         name:
-          $ref: http://example.org/petapi-examples/openapi.json#/components/examples/name-example
+          $ref: https://example.org/petapi-examples/openapi.json#/components/examples/name-example
 ```
 
 In a request body:
@@ -1961,12 +1961,12 @@ requestBody:
       examples: 
         xmlExample:
           summary: This is an example in XML
-          externalValue: 'http://example.org/examples/address-example.xml'
+          externalValue: 'https://example.org/examples/address-example.xml'
     'text/plain':
       examples:
         textExample: 
           summary: This is a text example
-          externalValue: 'http://foo.bar/examples/address-example.txt'
+          externalValue: 'https://foo.bar/examples/address-example.txt'
 ```
 
 In a parameter:
@@ -2016,7 +2016,7 @@ Field Name  |  Type  | Description
 <a name="linkOperationId"></a>operationId  | `string` | The name of an _existing_, resolvable OAS operation, as defined with a unique `operationId`.  This field is mutually exclusive of the `operationRef` field.  
 <a name="linkParameters"></a>parameters   | Map[`string`, Any \| [{expression}](#runtimeExpression)] | A map representing parameters to pass to an operation as specified with `operationId` or identified via `operationRef`. The key is the parameter name to be used, whereas the value can be a constant or an expression to be evaluated and passed to the linked operation.  The parameter name can be qualified using the [parameter location](#parameterIn) `[{in}.]{name}` for operations that use the same parameter name in different locations (e.g. path.id).
 <a name="linkRequestBody"></a>requestBody | Any \| [{expression}](#runtimeExpression) | A literal value or [{expression}](#runtimeExpression) to use as a request body when calling the target operation.
-<a name="linkDescription"></a>description  | `string` | A description of the link. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
+<a name="linkDescription"></a>description  | `string` | A description of the link. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
 <a name="linkServer"></a>server       | [Server Object](#serverObject) | A server object to be used by the target operation.
 
 This object MAY be extended with [Specification Extensions](#specificationExtensions).
@@ -2198,7 +2198,7 @@ It is not mandatory to have a Tag Object per tag defined in the Operation Object
 Field Name | Type | Description
 ---|:---:|---
 <a name="tagName"></a>name | `string` | **REQUIRED**. The name of the tag.
-<a name="tagDescription"></a>description | `string` | A short description for the tag. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
+<a name="tagDescription"></a>description | `string` | A short description for the tag. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
 <a name="tagExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation for this tag.
 
 This object MAY be extended with [Specification Extensions](#specificationExtensions).
@@ -2271,7 +2271,7 @@ $ref: definitions.yaml#/Pet
 
 The Schema Object allows the definition of input and output data types.
 These types can be objects, but also primitives and arrays.
-This object is an extended subset of the [JSON Schema Specification Wright Draft 00](http://json-schema.org/).
+This object is an extended subset of the [JSON Schema Specification Wright Draft 00](https://json-schema.org/).
 
 For more information about the properties, see [JSON Schema Core](https://tools.ietf.org/html/draft-wright-json-schema-00) and [JSON Schema Validation](https://tools.ietf.org/html/draft-wright-json-schema-validation-00).
 Unless stated otherwise, the property definitions follow the JSON Schema.
@@ -2306,7 +2306,7 @@ The following properties are taken from the JSON Schema definition but their def
 - items - Value MUST be an object and not an array. Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard JSON Schema. `items` MUST be present if the `type` is `array`.
 - properties - Property definitions MUST be a [Schema Object](#schemaObject) and not a standard JSON Schema (inline or referenced).
 - additionalProperties - Value can be boolean or object. Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard JSON Schema. Consistent with JSON Schema, `additionalProperties` defaults to `true`.
-- description - [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
+- description - [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
 - format - See [Data Type Formats](#dataTypeFormat) for further details. While relying on JSON Schema's defined formats, the OAS offers a few additional predefined formats.
 - default - The default value represents what would be assumed by the consumer of the input as the value of the schema if one is not provided. Unlike JSON Schema, the value MUST conform to the defined type for the Schema Object defined at the same level. For example, if `type` is `string`, then `default` can be `"foo"` but cannot be `1`.
 
@@ -2925,7 +2925,7 @@ In this example, a full model definition is shown.
       "name": {
         "type": "string",
         "xml": {
-          "namespace": "http://example.com/schema/sample",
+          "namespace": "https://example.com/schema/sample",
           "prefix": "sample"
         }
       }
@@ -2946,13 +2946,13 @@ Person:
     name:
       type: string
       xml:
-        namespace: http://example.com/schema/sample
+        namespace: https://example.com/schema/sample
         prefix: sample
 ```
 
 ```xml
 <Person id="123">
-    <sample:name xmlns:sample="http://example.com/schema/sample">example</sample:name>
+    <sample:name xmlns:sample="https://example.com/schema/sample">example</sample:name>
 </Person>
 ```
 
@@ -3168,19 +3168,20 @@ animals:
 #### <a name="securitySchemeObject"></a>Security Scheme Object
 
 Defines a security scheme that can be used by the operations.
-Supported schemes are HTTP authentication, an API key (either as a header, a cookie parameter or as a query parameter), mutual TLS (use of a client certificate), OAuth2's common flows (implicit, password, application and access code) as defined in [RFC6749](https://tools.ietf.org/html/rfc6749), and [OpenID Connect Discovery](https://tools.ietf.org/html/draft-ietf-oauth-discovery-06).
+Supported schemes are HTTP authentication, an API key (either as a header, a cookie parameter or as a query parameter), mutual TLS (use of a client certificate), OAuth2's common flows (implicit, password, application and access code) as defined in [RFC6749](https://tools.ietf.org/html/rfc6749), and [OpenID Connect](https://openid.net/specs/openid-connect-core-1_0.html). 
+ Please note that currently (2019) the implicit flow is about to be deprecated [OAuth 2.0 Security Best Current Practice](https://tools.ietf.org/id/draft-ietf-oauth-security-topics). Recommended for most use case is Authorization Code Grant flow with PKCE.
 
 ##### Fixed Fields
 Field Name | Type | Applies To | Description
 ---|:---:|---|---
 <a name="securitySchemeType"></a>type | `string` | Any | **REQUIRED**. The type of the security scheme. Valid values are `"apiKey"`, `"http"`, `"mutualTLS"`, `"oauth2"`, `"openIdConnect"`.
-<a name="securitySchemeDescription"></a>description | `string` | Any | A short description for security scheme. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
+<a name="securitySchemeDescription"></a>description | `string` | Any | A short description for security scheme. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
 <a name="securitySchemeName"></a>name | `string` | `apiKey` | **REQUIRED**. The name of the header, query or cookie parameter to be used.
 <a name="securitySchemeIn"></a>in | `string` | `apiKey` | **REQUIRED**. The location of the API key. Valid values are `"query"`, `"header"` or `"cookie"`.
 <a name="securitySchemeScheme"></a>scheme | `string` | `http` | **REQUIRED**. The name of the HTTP Authorization scheme to be used in the [Authorization header as defined in RFC7235](https://tools.ietf.org/html/rfc7235#section-5.1).
 <a name="securitySchemeBearerFormat"></a>bearerFormat | `string` | `http` (`"bearer"`) | A hint to the client to identify how the bearer token is formatted.  Bearer tokens are usually generated by an authorization server, so this information is primarily for documentation purposes.
 <a name="securitySchemeFlows"></a>flows | [OAuth Flows Object](#oauthFlowsObject) | `oauth2` | **REQUIRED**. An object containing configuration information for the flow types supported.
-<a name="securitySchemeOpenIdConnectUrl"></a>openIdConnectUrl | `string` | `openIdConnect` | **REQUIRED**. OpenId Connect URL to discover OAuth2 configuration values. This MUST be in the form of a URL.
+<a name="securitySchemeOpenIdConnectUrl"></a>openIdConnectUrl | `string` | `openIdConnect` | **REQUIRED**. OpenId Connect URL to discover OAuth2 configuration values. This MUST be in the form of a URL. The OpenID Connect standard requires the use of TLS.
 
 This object MAY be extended with [Specification Extensions](#specificationExtensions).
 
@@ -3280,9 +3281,9 @@ Configuration details for a supported OAuth Flow
 ##### Fixed Fields
 Field Name | Type | Applies To | Description
 ---|:---:|---|---
-<a name="oauthFlowAuthorizationUrl"></a>authorizationUrl | `string` | `oauth2` (`"implicit"`, `"authorizationCode"`) | **REQUIRED**. The authorization URL to be used for this flow. This MUST be in the form of a URL.
-<a name="oauthFlowTokenUrl"></a>tokenUrl | `string` | `oauth2` (`"password"`, `"clientCredentials"`, `"authorizationCode"`) | **REQUIRED**. The token URL to be used for this flow. This MUST be in the form of a URL.
-<a name="oauthFlowRefreshUrl"></a>refreshUrl | `string` | `oauth2` | The URL to be used for obtaining refresh tokens. This MUST be in the form of a URL.
+<a name="oauthFlowAuthorizationUrl"></a>authorizationUrl | `string` | `oauth2` (`"implicit"`, `"authorizationCode"`) | **REQUIRED**. The authorization URL to be used for this flow. This MUST be in the form of a URL. The OAuth2 standard requires the use of TLS.
+<a name="oauthFlowTokenUrl"></a>tokenUrl | `string` | `oauth2` (`"password"`, `"clientCredentials"`, `"authorizationCode"`) | **REQUIRED**. The token URL to be used for this flow. This MUST be in the form of a URL. The OAuth2 standard requires the use of TLS.
+<a name="oauthFlowRefreshUrl"></a>refreshUrl | `string` | `oauth2` | The URL to be used for obtaining refresh tokens. This MUST be in the form of a URL. The OAuth2 standard requires the use of TLS.
 <a name="oauthFlowScopes"></a>scopes | Map[`string`, `string`] | `oauth2` | **REQUIRED**. The available scopes for the OAuth2 security scheme. A map between the scope name and a short description for it.
 
 This object MAY be extended with [Specification Extensions](#specificationExtensions).


### PR DESCRIPTION
Signed-off-by: Axel Nennker <axel.nennker@telekom.de>

OAuth2 requires the use of TLS
OpenID Connect requires the use of TLS
Fixed the url to the OpenID Connect standard
Changed all links to external references from http to https
Changed all links to example endpoints from http to https