### PR TITLE
Update Schema Objects to JSON Schema Draft 2019-09

### DIFF
--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -139,10 +139,9 @@ It is RECOMMENDED that the root OpenAPI document be named: `openapi.json` or `op
 
 ### <a name="dataTypes"></a>Data Types
 
-Primitive data types in the OAS are based on the types supported by the [JSON Schema Specification Wright Draft 00](https://tools.ietf.org/html/draft-wright-json-schema-00#section-4.2). 
+Primitive data types in the OAS are based on the types supported by the [JSON Schema Specification Draft 2019-09](http://json-schema.org/draft/2019-09/json-schema-core.html#rfc.section.4.2). 
 Note that `integer` as a type is also supported and is defined as a JSON number without a fraction or exponent part. 
-`null` is not supported as a type (see [`nullable`](#schemaNullable) for an alternative solution).
-Models are defined using the [Schema Object](#schemaObject), which is an extended subset of JSON Schema Specification Wright Draft 00.
+Models are defined using the [Schema Object](#schemaObject), which is a superset of JSON Schema Specification Draft 2019-09.
 
 <a name="dataTypeFormat"></a>Primitives have an optional modifier property: `format`.
 OAS uses several known formats to define in fine detail the data type being used.
@@ -2322,7 +2321,7 @@ The following properties are taken from the JSON Schema definition but their def
 
 Alternatively, any time a Schema Object can be used, a [Reference Object](#referenceObject) can be used in its place. This allows referencing definitions instead of defining them inline.
 
-In addition to the JSON Schema fields, the following OpenAPI vocabulary properties MAY be used for further schema documentation:
+In addition to the JSON Schema properties, the following OpenAPI vocabulary properties MAY be used for further schema documentation:
 
 ##### Fixed Fields
 
@@ -2334,7 +2333,9 @@ Field Name | Type | Description
 <a name="schemaExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation for this schema.
 <a name="schemaExample"></a>example | Any | A free-form property to include an example of an instance for this schema. To represent examples that cannot be naturally represented in JSON or YAML, a string value can be used to contain the example with escaping where necessary.<br><br>**Deprecated:** The `example` property has been deprecated in favor of the JSON Schema `examples` keyword. Use of `example` is discouraged, and later versions of this specification may remove it.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specificationExtensions). 
+
+In previous versions of OpenAPI, Specification Extensions were the only way to add properties, but since v3.1.0 matches JSON Schema in allowing any properties to be used inside the Schema Object. These properties could be defined in their own vocabulary, or entirely arbitrary, and they do not need to follow any specific naming pattern or convention. 
 
 ###### <a name="schemaComposition"></a>Composition and Inheritance (Polymorphism)
 

--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -2276,39 +2276,7 @@ Unless stated otherwise, the property definitions follow the JSON Schema.
 
 ##### Properties
 
-The OpenAPI Schema Object is a JSON Schema vocabulary which extends JSON Schema Core and Validation vocabularies. As such any keyword available for those vocabularies is by definition available in OpenAPI, and will work the exact same way, including but not limited to:
-
-- $schema
-- $id
-- title
-- required
-- multipleOf
-- maximum
-- minimum
-- maxLength
-- minLength
-- pattern (This string SHOULD be a valid regular expression, according to the [ECMA 262 regular expression](https://www.ecma-international.org/ecma-262/5.1/#sec-7.8.5) dialect)
-- maxItems
-- minItems
-- uniqueItems
-- maxProperties
-- minProperties
-- enum
-- propertyNames
-- contains
-- const
-- examples
-- if / then / else
-- dependentRequired / dependentSchemas
-- deprecated
-- additionalItems
-- additionalProperties
-- unevaluatedItems
-- unevaluatedProperties
-- maxContains
-- minContains
-- readOnly
-- writeOnly
+The OpenAPI Schema Object is a JSON Schema vocabulary which extends JSON Schema Core and Validation vocabularies. As such any keyword available for those vocabularies is by definition available in OpenAPI, and will work the exact same way.
 
 The following properties are taken from the JSON Schema definition but their definitions were adjusted to the OpenAPI Specification.
 

--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -2317,7 +2317,6 @@ The following properties are taken from the JSON Schema definition but their def
 - exclusiveMaximum - Value can be a numeric value just like JSON Schema, or for backwards compatibility with older drafts it can accept a boolean to act as a modifier to the `minimum` keyword. The numeric value usage is recommended.
 - description - [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
 - format - See [Data Type Formats](#dataTypeFormat) for further details. While relying on JSON Schema's defined formats, the OAS offers a few additional predefined formats.
-- default - The default value represents what would be assumed by the consumer of the input as the value of the schema if one is not provided. Unlike JSON Schema, the value MUST conform to the defined type for the Schema Object defined at the same level. For example, if `type` is `string`, then `default` can be `"foo"` but cannot be `1`.
 
 Alternatively, any time a Schema Object can be used, a [Reference Object](#referenceObject) can be used in its place. This allows referencing definitions instead of defining them inline.
 

--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -2321,7 +2321,7 @@ The following properties are taken from the JSON Schema definition but their def
 
 Alternatively, any time a Schema Object can be used, a [Reference Object](#referenceObject) can be used in its place. This allows referencing definitions instead of defining them inline.
 
-In addition to the JSON Schema properties defined in the JSON Schema Core and JSON Schema Validation vocabularies, any properties can be used from any vocabularies, or entirely arbitrary keywords. OpenAPI has its own vocabulary properties which MAY be used for further schema description:
+In addition to the JSON Schema properties defined in the vocabularies defined in the JSON Schema Core and JSON Schema Validation specifications, any properties can be used from any vocabularies, or entirely arbitrary keywords. The OpenAPI Specification defines an additional vocabulary of keywords which MAY be used along with the JSON Schema vocabulary keywords for further schema description:
 
 ##### Fixed Fields
 

--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -2269,23 +2269,23 @@ $ref: definitions.yaml#/Pet
 
 #### <a name="schemaObject"></a>Schema Object
 
-The Schema Object allows the definition of input and output data types.
-These types can be objects, but also primitives and arrays.
-This object is an extended subset of the [JSON Schema Specification Wright Draft 00](https://json-schema.org/).
+The Schema Object allows the definition of input and output data types. These types can be objects, but also primitives and arrays. This object is a superset of the [JSON Schema Draft 2019-09](http://json-schema.org/) specification.
 
-For more information about the properties, see [JSON Schema Core](https://tools.ietf.org/html/draft-wright-json-schema-00) and [JSON Schema Validation](https://tools.ietf.org/html/draft-wright-json-schema-validation-00).
+For more information about the properties, see [JSON Schema Core](https://json-schema.org/draft/2019-09/json-schema-core.html) and [JSON Schema Validation](https://json-schema.org/draft/2019-09/json-schema-validation.html).
+
 Unless stated otherwise, the property definitions follow the JSON Schema.
 
-##### Properties 
+##### Properties
 
-The following properties are taken directly from the JSON Schema definition and follow the same specifications:
+The OpenAPI Schema Object is a JSON Schema vocabulary which extends JSON Schema Core and Validation vocabularies. As such any keyword available for those vocabularies is by definition available in OpenAPI, and will work the exact same way, including but not limited to:
 
+- $schema
+- $id
 - title
+- required
 - multipleOf
 - maximum
-- exclusiveMaximum
 - minimum
-- exclusiveMinimum
 - maxLength
 - minLength
 - pattern (This string SHOULD be a valid regular expression, according to the [ECMA 262 regular expression](https://www.ecma-international.org/ecma-262/5.1/#sec-7.8.5) dialect)
@@ -2294,46 +2294,52 @@ The following properties are taken directly from the JSON Schema definition and 
 - uniqueItems
 - maxProperties
 - minProperties
-- required
 - enum
+- propertyNames
+- contains
+- const
+- examples
+- if / then / else
+- dependentRequired / dependentSchemas
+- deprecated
+- additionalItems
+- additionalProperties
+- unevaluatedItems
+- unevaluatedProperties
+- maxContains
+- minContains
+- readOnly
+- writeOnly
 
-The following properties are taken from the JSON Schema definition but their definitions were adjusted to the OpenAPI Specification. 
-- type - Value MUST be a string. Multiple types via an array are not supported.
-- allOf - Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard JSON Schema.
-- oneOf - Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard JSON Schema.
-- anyOf - Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard JSON Schema.
-- not - Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard JSON Schema.
-- items - Value MUST be an object and not an array. Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard JSON Schema. `items` MUST be present if the `type` is `array`.
-- properties - Property definitions MUST be a [Schema Object](#schemaObject) and not a standard JSON Schema (inline or referenced).
-- additionalProperties - Value can be boolean or object. Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard JSON Schema. Consistent with JSON Schema, `additionalProperties` defaults to `true`.
-- description - [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
+The following properties are taken from the JSON Schema definition but their definitions were adjusted to the OpenAPI Specification.
+
+- type - Used to restrict the allowed types as specified in JSON Schema, but may be modified by the [`nullable`](#schemaNullable) keyword.
+- exclusiveMinimum - Value can be a numeric value just like JSON Schema, or for backwards compatibility with older drafts it can accept a boolean to act as a modifier to the `minimum` keyword. The numeric value usage is recommended.
+- exclusiveMaximum - Value can be a numeric value just like JSON Schema, or for backwards compatibility with older drafts it can accept a boolean to act as a modifier to the `minimum` keyword. The numeric value usage is recommended.
+- description - [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
 - format - See [Data Type Formats](#dataTypeFormat) for further details. While relying on JSON Schema's defined formats, the OAS offers a few additional predefined formats.
 - default - The default value represents what would be assumed by the consumer of the input as the value of the schema if one is not provided. Unlike JSON Schema, the value MUST conform to the defined type for the Schema Object defined at the same level. For example, if `type` is `string`, then `default` can be `"foo"` but cannot be `1`.
 
 Alternatively, any time a Schema Object can be used, a [Reference Object](#referenceObject) can be used in its place. This allows referencing definitions instead of defining them inline.
 
-Additional properties defined by the JSON Schema specification that are not mentioned here are strictly unsupported.
-
-Other than the JSON Schema subset fields, the following fields MAY be used for further schema documentation:
+In addition to the JSON Schema fields, the following OpenAPI vocabulary properties MAY be used for further schema documentation:
 
 ##### Fixed Fields
+
 Field Name | Type | Description
 ---|:---:|---
-<a name="schemaNullable"></a>nullable | `boolean` | Allows sending a `null` value for the defined schema. Default value is `false`.
+<a name="schemaNullable"></a>nullable | `boolean` | Allows sending a `null` value for the defined schema. Default value is `false`.<br><br>A `nullable` value of `true` allows `null` in addition to other specified `type` values only if `nullable` and `type` are both specified within the same schema object. The effect of `"nullable" : true` is limited to its expansion of the set of allowed types, within the scope of its containing schema. An `enum`, `const`, `allOf`, or other keyword can independently prohibit `null` values, effectively overriding `"nullable" : true`.<br><br>A `nullable` value of `false` leaves the specified or default `type` unmodified. It has no effect on the schema object.<br><br>**Deprecated:** The `type` property now allows "null" as a type, alone or within a type array. This is the standard way to allow null values in JSON Schema. Use of `nullable` is discouraged, and later versions of this specification may remove it.
 <a name="schemaDiscriminator"></a>discriminator | [Discriminator Object](#discriminatorObject) | Adds support for polymorphism. The discriminator is an object name that is used to differentiate between other schemas which may satisfy the payload description. See [Composition and Inheritance](#schemaComposition) for more details.
-<a name="schemaReadOnly"></a>readOnly | `boolean` | Relevant only for Schema `"properties"` definitions. Declares the property as "read only". This means that it MAY be sent as part of a response but SHOULD NOT be sent as part of the request. If the property is marked as `readOnly` being `true` and is in the `required` list, the `required` will take effect on the response only. A property MUST NOT be marked as both `readOnly` and `writeOnly` being `true`. Default value is `false`.
-<a name="schemaWriteOnly"></a>writeOnly | `boolean` | Relevant only for Schema `"properties"` definitions. Declares the property as "write only". Therefore, it MAY be sent as part of a request but SHOULD NOT be sent as part of the response. If the property is marked as `writeOnly` being `true` and is in the `required` list, the `required` will take effect on the request only. A property MUST NOT be marked as both `readOnly` and `writeOnly` being `true`. Default value is `false`.
 <a name="schemaXml"></a>xml | [XML Object](#xmlObject) | This MAY be used only on properties schemas. It has no effect on root schemas. Adds additional metadata to describe the XML representation of this property.
-<a name="schemaExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation for this schema. 
-<a name="schemaExample"></a>example | Any | A free-form property to include an example of an instance for this schema. To represent examples that cannot be naturally represented in JSON or YAML, a string value can be used to contain the example with escaping where necessary.
-<a name="schemaDeprecated"></a> deprecated | `boolean` | Specifies that a schema is deprecated and SHOULD be transitioned out of usage. Default value is `false`.
+<a name="schemaExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation for this schema.
+<a name="schemaExample"></a>example | Any | A free-form property to include an example of an instance for this schema. To represent examples that cannot be naturally represented in JSON or YAML, a string value can be used to contain the example with escaping where necessary.<br><br>**Deprecated:** The `example` property has been deprecated in favor of the JSON Schema `examples` keyword. Use of `example` is discouraged, and later versions of this specification may remove it.
 
 This object MAY be extended with [Specification Extensions](#specificationExtensions).
 
 ###### <a name="schemaComposition"></a>Composition and Inheritance (Polymorphism)
 
 The OpenAPI Specification allows combining and extending model definitions using the `allOf` property of JSON Schema, in effect offering model composition.
-`allOf` takes an array of object definitions that are validated *independently* but together compose a single object. 
+`allOf` takes an array of object definitions that are validated *independently* but together compose a single object.
 
 While composition offers model extensibility, it does not imply a hierarchy between the models.
 To support polymorphism, the OpenAPI Specification adds the `discriminator` field.

--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -2321,7 +2321,7 @@ The following properties are taken from the JSON Schema definition but their def
 
 Alternatively, any time a Schema Object can be used, a [Reference Object](#referenceObject) can be used in its place. This allows referencing definitions instead of defining them inline.
 
-In addition to the JSON Schema properties, the following OpenAPI vocabulary properties MAY be used for further schema documentation:
+In addition to the JSON Schema properties defined in the JSON Schema Core and JSON Schema Validation vocabularies, any properties can be used from any vocabularies, or entirely arbitrary keywords. OpenAPI has its own vocabulary properties which MAY be used for further schema description:
 
 ##### Fixed Fields
 
@@ -2334,8 +2334,6 @@ Field Name | Type | Description
 <a name="schemaExample"></a>example | Any | A free-form property to include an example of an instance for this schema. To represent examples that cannot be naturally represented in JSON or YAML, a string value can be used to contain the example with escaping where necessary.<br><br>**Deprecated:** The `example` property has been deprecated in favor of the JSON Schema `examples` keyword. Use of `example` is discouraged, and later versions of this specification may remove it.
 
 This object MAY be extended with [Specification Extensions](#specificationExtensions). 
-
-In previous versions of OpenAPI, Specification Extensions were the only way to add properties, but since v3.1.0 matches JSON Schema in allowing any properties to be used inside the Schema Object. These properties could be defined in their own vocabulary, or entirely arbitrary, and they do not need to follow any specific naming pattern or convention. 
 
 ###### <a name="schemaComposition"></a>Composition and Inheritance (Polymorphism)
 

--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -2286,8 +2286,6 @@ The following properties are taken from the JSON Schema definition but their def
 - description - [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
 - format - See [Data Type Formats](#dataTypeFormat) for further details. While relying on JSON Schema's defined formats, the OAS offers a few additional predefined formats.
 
-Alternatively, any time a Schema Object can be used, a [Reference Object](#referenceObject) can be used in its place. This allows referencing definitions instead of defining them inline.
-
 In addition to the JSON Schema properties defined in the vocabularies defined in the JSON Schema Core and JSON Schema Validation specifications, any properties can be used from any vocabularies, or entirely arbitrary keywords. The OpenAPI Specification defines an additional vocabulary of keywords which MAY be used along with the JSON Schema vocabulary keywords for further schema description:
 
 ##### Fixed Fields


### PR DESCRIPTION
Fixes #333
Fixes #397
Fixes #470
Fixes #1026
Fixes #1238
Fixes #1313
Fixes #1368
Fixes #1389
Fixes #1494
Fixes #1523
Fixes #1666
Fixes #1719
Fixes #1766
Fixes #1869
Fixes #1985

Checklist items from #1766 so we can close.
* [x] @handrews "We should probably make sure none of the formats added in the newer draft conflict with the ones OpenAPI defines."
* [x] @handrews "At most you might want to check if we have any slight incompatibilities for readOnly and writeOnly which were moved/added to the validation spec in [Draft 07]"

Picking up from where https://github.com/OAI/OpenAPI-Specification/pull/1766  left off, this PR is helping OpenAPI v3.1 make a non-breaking change, to catch up with JSON Schema's latest draft. 

Instead of OpenAPI continuing to confuse everyone by being a JSON Schema draft 05 sub-set, and a super-set, with some notable differences to watch out for, it will now be a JSON Schema draft 2019-09 superset. [More info on that here](https://apisyouwonthate.com/blog/openapi-and-json-schema-divergence-part-1).

The goal here is to help people write pure JSON Schema for their data model if they want to, or write OpenAPI-flavoured JSON Schema if they want to, but we are closing the gaps on what these two things mean. The list of differences is now tiny, only 4 extra keywords, with 2 notes about how `exlusiveMinimum` and `exclusiveMaximum` can be used in two ways (in order to maintain BC with OpenAPI v3.0).

## Alternative Solutions

Alternative Schemas are a big topic which needs [more work to be done](https://github.com/OAI/OpenAPI-Specification/issues/1943). We should address the JSON Schema divergence issue to make the v3.x branch a happy place to be, and follow up with Alternative Schemas for v3.2 or v4.0, so our XML using friends can play with XML Schema, and all the other good things.

## Risks

There are concerns that tooling vendors who work with static languages will have a hard time adding some of JSON Schemas newer more dynamic features. I understand this in theory, but most of JSON Schema's new features like if/then/else, and the old "type can be an array" issue, are just [sugar for allOf/anyOf/oneOf](https://github.com/OAI/OpenAPI-Specification/pull/1766#issuecomment-442652805), as can be seen in [wework/json-schema-to-openapi-schema](https://github.com/wework/json-schema-to-openapi-schema). 

Seeing as allOf, anyOf, oneOf already exist in OpenAPI v3.0, whatever tooling vendors are doing to support that, should be done to support these keywords. Other new things like `const` are just an enum of 1. 

Nothing should be that scary, yet people seem scared, but I think we can overcome in. We need to. JSON is a dynamic format, a property can contain a string one minute, and an object another, and this is pretty common practice for those [using evolution](https://apisyouwonthate.com/blog/api-evolution-for-rest-http-apis). You might start out with a simple string, then decide you need more information and offer an object, deprecating the old way of doing things, and folks move over to use the object. This was an issue for reading JSON in Go for a while, then better JSON tooling came out and its not an issue. 

OpenAPI tooling should be able to deal with this too. For example, ReDoc is an awesome open-source documentation generator, and it has no trouble at all with showing oneOf:

<img width="599" alt="Screen Shot 2019-07-18 at 17 19 32" src="https://user-images.githubusercontent.com/67381/61469870-46307680-a980-11e9-9af1-b3574b210b54.png">
<img width="504" alt="Screen Shot 2019-07-18 at 17 19 35" src="https://user-images.githubusercontent.com/67381/61469871-46307680-a980-11e9-91c5-d8b328def620.png">

The argument I keep hearing is "tooling vendors are complaining about anyOf, allOf, oneOf, because it's hard, so lets not add any more keywords... Meh? Which is the priority here, making lives slightly easier for the tooling vendors by not adding new features, or making lives substantially less confusing for all the users of all the OpenAPI tools by letting them not have to unpack the differences between OpenAPI and JSON Schema? I lose 10% of every day helping people navigate this mess on APIs You Won't Hate, and I'm a tooling vendor at [Stoplight.io](http://stoplight.io/). I'd rather have a few more complex keywords to figure out for the tooling, than have all the users of that tooling be constantly confused about which keywords they can use when, and how to convert from one to the other because different tools need OpenAPI or JSON Schema.

Anyhow, the tools that support advanced features will end up being more popular than the tools which do not. 🤷‍♂️

Life for tooling vendors trying to add these new keywords can be simplified in a few ways: 

- Provide guidance in the form of blog posts (I got this)
- Common tooling (Stoplight got this for JS)
- JSON Schema tools can now be used directly, instead of building OpenAPI-based tooling which is similar then tweaking it... 🤦‍♂ 

I'd like to dig into this fear of adopting actual JSON Schema further on the OpenAPI slack, so please swing by and throw examples at me. I have heard vague concerns about `patternProperties`, but would love to sink my teeth into concrete examples. 