### PR TITLE
Update IMPLEMENTATIONS.md

### DIFF
--- a/IMPLEMENTATIONS.md
+++ b/IMPLEMENTATIONS.md
@@ -10,6 +10,7 @@ These tools are not endorsed by the OAI.
 |----------------|--------------|----------|---------------------|
 | swagger-parser | [github/swagger-api](https://github.com/swagger-api/swagger-parser) | Java | Swagger 1.0, 1.1, 1.2, 2.0 to OpenAPI Specification converter |
 | swagger-models | [github/swagger-api](https://github.com/swagger-api/swagger-core/tree/master/modules/swagger-models) | Java | OpenAPI 3.0 Java Pojos |
+| springdoc-openapi | [github/springdoc/springdoc-openapi](https://github.com/springdoc/springdoc-openapi) | Java | Library that produces OpenAPI 3.x specification documentation for spring-boot applications.  |
 | KaiZen OpenAPI Parser | [github/RepreZen/KaiZen-OpenAPI-Parser](https://github.com/RepreZen/KaiZen-OpenAPI-Parser) | Java | High-performance Parser, Validator, and Java Object Model for OpenAPI 3.x |
 | openapi3-ts | [github/metadevpro/openapi3-ts](https://github.com/metadevpro/openapi3-ts) | TypeScript | TS Model & utils for OpenAPI 3.0.x contracts |
 | swagger2openapi | [github/mermade/swagger2openapi](https://github.com/mermade/swagger2openapi) | Node.js | An OpenAPI / Swagger 2.0 to OpenAPI 3.0.x converter and validator |


### PR DESCRIPTION
springdoc-openapi is a java library that produces OpenAPI 3.x specification documentation for spring-boot applications. 
It helps automating the generation of API documentation using spring boot projects.
It automatically deploys swagger-ui to a spring-boot application Documentation.

Automatically generates documentation in JSON/YAML and HTML format APIs. This documentation can be completed by comments using swagger-api annotations.

This library supports:

OpenAPI 3
Spring-boot 2
JSR-303, specifically for @NotNull, @Min, @Max, and @Size.
Swagger-ui
Oauth 2