### PR TITLE
Corrected pattern regex dialect link

### DIFF
--- a/versions/3.0.3.md
+++ b/versions/3.0.3.md
@@ -2293,7 +2293,7 @@ The following properties are taken directly from the JSON Schema definition and 
 - exclusiveMinimum
 - maxLength
 - minLength
-- pattern (This string SHOULD be a valid regular expression, according to the [ECMA 262 regular expression](https://www.ecma-international.org/ecma-262/5.1/#sec-7.8.5) dialect)
+- pattern (This string SHOULD be a valid regular expression, according to the [ECMA 262 regular expression](https://www.ecma-international.org/ecma-262/5.1/#sec-15.10.1) dialect)
 - maxItems
 - minItems
 - uniqueItems


### PR DESCRIPTION
Fixes #1985 

As per the discussion there and in the associated issue https://github.com/json-schema-org/json-schema-spec/issues/774 and fix https://github.com/json-schema-org/json-schema-spec/issues/775 the correct section of ECMA 262 to describe the accepted regular expression dialect for the `pattern` element is 15.10.1 not 7.8.5.

This corrects the link in the OpenAPI specification to avoid the misunderstanding that the `pattern` field should accept an ECMA 262 regex literal when it only accepts a regex body pattern.