### PR TITLE
Consistent use of the word 'API' within the 'Info Object' definition.

### DIFF
--- a/versions/3.0.3.md
+++ b/versions/3.0.3.md
@@ -210,8 +210,8 @@ The metadata MAY be used by the clients if needed, and MAY be presented in editi
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="infoTitle"></a>title | `string` | **REQUIRED**. The title of the application.
-<a name="infoDescription"></a>description | `string` | A short description of the application. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
+<a name="infoTitle"></a>title | `string` | **REQUIRED**. The title of the API.
+<a name="infoDescription"></a>description | `string` | A short description of the API. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
 <a name="infoTermsOfService"></a>termsOfService | `string` | A URL to the Terms of Service for the API. MUST be in the format of a URL.
 <a name="infoContact"></a>contact | [Contact Object](#contactObject) | The contact information for the exposed API.
 <a name="infoLicense"></a>license | [License Object](#licenseObject) | The license information for the exposed API.


### PR DESCRIPTION
The fields _title_ and _description_ of _Info Object_ are defined using the word **application**, while the other fields - _termsOfService_, _contact_, _license_ and _version_ - are defined using the word **API**.
I propose to align all the definitions by consistently using the word **API**.
