### PR TITLE
[Consistency] Fix 'Security Scheme Object' definition with OAuth 2.0 grant types.

### DIFF
--- a/versions/3.0.3.md
+++ b/versions/3.0.3.md
@@ -3171,7 +3171,7 @@ animals:
 #### <a name="securitySchemeObject"></a>Security Scheme Object
 
 Defines a security scheme that can be used by the operations.
-Supported schemes are HTTP authentication, an API key (either as a header, a cookie parameter or as a query parameter), OAuth2's common flows (implicit, password, application and access code) as defined in [RFC6749](https://tools.ietf.org/html/rfc6749), and [OpenID Connect Discovery](https://tools.ietf.org/html/draft-ietf-oauth-discovery-06).
+Supported schemes are HTTP authentication, an API key (either as a header, a cookie parameter or as a query parameter), OAuth2's common flows (implicit, password, client credentials and authorization code) as defined in [RFC6749](https://tools.ietf.org/html/rfc6749), and [OpenID Connect Discovery](https://tools.ietf.org/html/draft-ietf-oauth-discovery-06).
 
 ##### Fixed Fields
 Field Name | Type | Applies To | Description


### PR DESCRIPTION
During the move from 2.0 to 3.0.0 some OAuth 2.0 flows have been renamed to have a better **alignment** with the OAuth 2.0 'authorization grant types' as defined in RFC 6749 (*):
- 'application' -> 'clientCredentials' (as 'client credentials' is the term used used in OAuth 2.0 RFC 6749)
- 'accessCode' -> 'authorizationCode' (as 'authorization code' is the term used used in OAuth 2.0 RFC 6749)

Remark: the flow 'password' has been kept, while strictly speaking the OAuth 2.0 RFC 6749 is using the term 'resource owner password credentials'. I guess that the short form 'password' has been kept for convenience, while the mapping with OAuth 2.0 RFC 6749 is pretty obvious.

However, within the 'Security Scheme Object' definition, these two renamings have not been done, let's fix that.

(*) https://tools.ietf.org/html/rfc6749#section-1.3