### PR TITLE
First pass at 3.1 schema object meta-schema

### DIFF
--- a/schemas/v3.1/meta/extensions.json
+++ b/schemas/v3.1/meta/extensions.json
@@ -1,0 +1,114 @@
+{
+    "$id": "https://spec.openapis.org/oas/3.1/meta/extensions/2019-10",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$vocabulary": {
+        "https://spec.openapis.org/oas/3.1/vocab/extensions/2019-10": true
+    },
+    "$recursiveAnchor": true,
+
+    "type": ["object", "boolean"],
+    "properties": {
+        "example": true,
+        "exclusiveMinimum": {
+            "type": ["number", "boolean"]
+        },
+        "exclusiveMaximum": {
+            "type": ["number", "boolean"]
+        },
+        "nullable": {
+            "type": "boolean",
+            "default": false
+        },
+        "discriminator": {
+            "$ref": "#/$defs/Discriminator"
+        },
+        "externalDocs": {
+            "$ref": "#/$defs/ExternalDocs"
+        },
+        "xml": {
+            "$ref": "#/$defs/Xml"
+        }
+    },
+    "patternProperties": {
+        "^x-": true
+    },
+    "allOf": [
+        {
+            "if": {
+                "required": ["exclusiveMinimum"],
+                 "exclusiveMinimum": {"type": "boolean"}
+            },
+            "then": {
+                "required": ["minimum"]
+            }
+        },
+        {
+            "if": {
+                "required": ["exclusiveMaximum"],
+                 "exclusiveMaximum": {"type": "boolean"}
+            },
+            "then": {
+                "required": ["maximum"]
+            }
+        }
+    ],
+    "$defs": {
+        "Discriminator": {
+            "type": "object",
+            "required": ["propertyName"],
+            "properties": {
+                "propertyName": {
+                    "type": "string"
+                },
+                "mapping": {
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                }
+            },
+            "additionalProperties": false
+        },
+        "ExternalDocs": {
+            "type": "object",
+            "required": ["url"],
+            "properties": {
+                "url": {
+                    "type": "string",
+                    "format": "uri-reference"
+                },
+                "description": {
+                    "type": "string"
+                }
+            },
+            "patternProperties": {
+                "^x-": true
+            },
+            "additionalProperties": false
+        },
+        "Xml": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "namespace": {
+                    "type": "string",
+                    "format": "uri"
+                },
+                "prefix": {
+                    "type": "string"
+                },
+                "attribute": {
+                    "type": "boolean"
+                },
+                "wrapped": {
+                    "type": "boolean"
+                }
+            },
+            "patternProperties": {
+                "^x-": true
+            },
+            "additionalProperties": false
+        }
+    }
+}

--- a/schemas/v3.1/meta/extensions.json
+++ b/schemas/v3.1/meta/extensions.json
@@ -36,7 +36,9 @@
         {
             "if": {
                 "required": ["exclusiveMinimum"],
-                 "exclusiveMinimum": {"type": "boolean"}
+                "properties": {
+                    "exclusiveMinimum": {"type": "boolean"}
+                }
             },
             "then": {
                 "required": ["minimum"]
@@ -45,7 +47,9 @@
         {
             "if": {
                 "required": ["exclusiveMaximum"],
-                 "exclusiveMaximum": {"type": "boolean"}
+                "properties": {
+                    "exclusiveMaximum": {"type": "boolean"}
+                }
             },
             "then": {
                 "required": ["maximum"]

--- a/schemas/v3.1/meta/schema-object.json
+++ b/schemas/v3.1/meta/schema-object.json
@@ -1,0 +1,28 @@
+{
+    "$id": "https://spec.openapis.org/oas/3.1/meta/schema-object/2019-10",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$vocabulary": {
+        "https://json-schema.org/draft/2019-09/vocab/core": true,
+        "https://json-schema.org/draft/2019-09/vocab/applicator": true,
+        "https://json-schema.org/draft/2019-09/vocab/validation": true,
+        "https://json-schema.org/draft/2019-09/vocab/meta-data": true,
+        "https://json-schema.org/draft/2019-09/vocab/format": false,
+        "https://json-schema.org/draft/2019-09/vocab/content": true,
+        "https://spec.openapis.org/oas/3.1/vocab/extensions/2019-10": true
+    },
+    "$recursiveAnchor": true,
+
+    "title": "Core and Validation specifications meta-schema",
+    "$comment": "Note that while the standard validation vocabulary is used, an alternate meta-schema for that vocabulary is used in order to faciliate compatibility with past versions of the OpenAPI Specification.",
+    "allOf": [
+        {"$ref": "https://json-schema.org/draft/2019-09/core"},
+        {"$ref": "https://json-schema.org/draft/2019-09/applicator"},
+        {"$ref": "https://json-schema.org/draft/2019-09/meta-data"},
+        {"$ref": "https://json-schema.org/draft/2019-09/format"},
+        {"$ref": "https://json-schema.org/draft/2019-09/content"},
+        {"$ref": "https://spec.openapis.org/oas/3.1/meta/validation/2019-10"},
+        {"$ref": "https://spec.openapis.org/oas/3.1/meta/extensions/2019-10"}
+    ],
+    "type": ["object", "boolean"],
+    "unevaluatedProperties": false
+}

--- a/schemas/v3.1/meta/validation.json
+++ b/schemas/v3.1/meta/validation.json
@@ -1,0 +1,94 @@
+{
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$id": "https://spec.openapis.org/oas/3.1/meta/validation/2019-10",
+    "$vocabulary": {
+        "https://json-schema.org/draft/2019-09/vocab/validation": true
+    },
+    "$recursiveAnchor": true,
+
+    "$comment": "This is an alternate meta-schema for the standard validation vocabulary.  It is identical to the standard validation meta-schema except that it omits exclusiveMinimum and exclusiveMaximum, which are described by the OpenAPI extensions meta-schema.",
+
+    "title": "Validation vocabulary meta-schema",
+    "type": ["object", "boolean"],
+    "properties": {
+        "multipleOf": {
+            "type": "number",
+            "exclusiveMinimum": 0
+        },
+        "maximum": {
+            "type": "number"
+        },
+        "minimum": {
+            "type": "number"
+        },
+        "maxLength": { "$ref": "#/$defs/nonNegativeInteger" },
+        "minLength": { "$ref": "#/$defs/nonNegativeIntegerDefault0" },
+        "pattern": {
+            "type": "string",
+            "format": "regex"
+        },
+        "maxItems": { "$ref": "#/$defs/nonNegativeInteger" },
+        "minItems": { "$ref": "#/$defs/nonNegativeIntegerDefault0" },
+        "uniqueItems": {
+            "type": "boolean",
+            "default": false
+        },
+        "maxContains": { "$ref": "#/$defs/nonNegativeInteger" },
+        "minContains": {
+            "$ref": "#/$defs/nonNegativeInteger",
+            "default": 1
+        },
+        "maxProperties": { "$ref": "#/$defs/nonNegativeInteger" },
+        "minProperties": { "$ref": "#/$defs/nonNegativeIntegerDefault0" },
+        "required": { "$ref": "#/$defs/stringArray" },
+        "dependentRequired": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/$defs/stringArray"
+            }
+        },
+        "const": true,
+        "enum": {
+            "type": "array",
+            "items": true
+        },
+        "type": {
+            "anyOf": [
+                { "$ref": "#/$defs/simpleTypes" },
+                {
+                    "type": "array",
+                    "items": { "$ref": "#/$defs/simpleTypes" },
+                    "minItems": 1,
+                    "uniqueItems": true
+                }
+            ]
+        }
+    },
+    "$defs": {
+        "nonNegativeInteger": {
+            "type": "integer",
+            "minimum": 0
+        },
+        "nonNegativeIntegerDefault0": {
+            "$ref": "#/$defs/nonNegativeInteger",
+            "default": 0
+        },
+        "simpleTypes": {
+            "enum": [
+                "array",
+                "boolean",
+                "integer",
+                "null",
+                "number",
+                "object",
+                "string"
+            ]
+        },
+        "stringArray": {
+            "type": "array",
+            "items": { "type": "string" },
+            "uniqueItems": true,
+            "default": []
+        }
+    }
+}


### PR DESCRIPTION
This is just for the Schema Object, done in JSON Schema 2019-09
with its vocabulary concept.

This just takes a guess at appropriate $id URIs, and puts in
2019-10 as a placeholder for now.

Note that `$vocabulary` URIs are identifiers- there is no actual file/resource for them.  They just identify _semantics_.

In terms of semantics, the OpenAPI 3.1 Schema Object uses all of the standard core and validation vocabulary semantics from JSON Schema `2019-09`, and adds its own extension semantics (`discriminator`, `nullable`, `example`, `externalDocs`, `xml`, the boolean form of `exclusiveMaximum` and `exclusiveMinimum`, additional values for `format`, and the designation of `x-`-prefixed fields as legal extension fields)

The meta-schemas describe _syntax_.  They are broken up by vocabulary, and then all of the appropriate per-vocabulary meta-schemas are combined in the top-level meta-schema, 

* Most of the standard `2019-09` meta-schemas are referenced just as they are in the standard general-purpose `2019-09` meta-schema
* There is a replacement for validation to allow the dual syntax for `exclusiveMaximum` and `exclusiveMinimum`
* The extension schema includes all of the extensions, including the `exclusive*` syntax.  There is nothing special for `format` because `format` values do not appear in meta-schemas
* The top-level Schema Object meta-schema uses `"unevaluatedProperties": false` to ensure that only `^x-` properties (as described in the extension meta-schema) can be added
* The `"$recursiveAnchor": true` (and `"$recursiveRef": "#"` in the standard applicator meta-schema) [ensure](http://json-schema.org/draft/2019-09/json-schema-core.html#rfc.appendix.C) that keywords in a Schema Object that take a schema value will only accept a valid Schema Object.

Note that if we really want to we can pack all of this and the main OAS schema into a single file, it's just a lot easier to see what's going on with the Schema Object alone this way.  I put these things in a "meta" directory because (unlike the OAS schema as a whole) they really do function as meta-schemas.