### PR TITLE
Support for tagging a persona to an API operation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ target
 atlassian-ide-plugin.xml
 node_modules/
 Gemfile.lock
+pr.md

--- a/examples/v3.0/personae.yaml
+++ b/examples/v3.0/personae.yaml
@@ -1,0 +1,167 @@
+openapi: "3.0.0"
+info:
+  title: Simple API overview
+  version: v2
+paths:
+  /:
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        '200':
+          description: |-
+            200 response
+          content:
+            application/json:
+              examples: 
+                foo:
+                  value: {
+                    "versions": [
+                        {
+                            "status": "CURRENT",
+                            "updated": "2011-01-21T11:33:21Z",
+                            "id": "v2.0",
+                            "links": [
+                                {
+                                    "href": "http://127.0.0.1:8774/v2/",
+                                    "rel": "self"
+                                }
+                            ]
+                        },
+                        {
+                            "status": "EXPERIMENTAL",
+                            "updated": "2013-07-23T11:33:21Z",
+                            "id": "v3.0",
+                            "links": [
+                                {
+                                    "href": "http://127.0.0.1:8774/v3/",
+                                    "rel": "self"
+                                }
+                            ]
+                        }
+                    ]
+                 }
+        '300':
+          description: |-
+            300 response
+          content:
+            application/json: 
+              examples: 
+                foo:
+                  value: |
+                   {
+                    "versions": [
+                          {
+                            "status": "CURRENT",
+                            "updated": "2011-01-21T11:33:21Z",
+                            "id": "v2.0",
+                            "links": [
+                                {
+                                    "href": "http://127.0.0.1:8774/v2/",
+                                    "rel": "self"
+                                }
+                            ]
+                        },
+                        {
+                            "status": "EXPERIMENTAL",
+                            "updated": "2013-07-23T11:33:21Z",
+                            "id": "v3.0",
+                            "links": [
+                                {
+                                    "href": "http://127.0.0.1:8774/v3/",
+                                    "rel": "self"
+                                }
+                            ]
+                        }
+                    ]
+                   }
+  /v2:
+    get:
+      operationId: getVersionDetailsv2
+      summary: Show API version details
+      responses:
+        '200':
+          description: |-
+            200 response
+          content:
+            application/json: 
+              examples:
+                foo:
+                  value: {
+                    "version": {
+                      "status": "CURRENT",
+                      "updated": "2011-01-21T11:33:21Z",
+                      "media-types": [
+                          {
+                              "base": "application/xml",
+                              "type": "application/vnd.openstack.compute+xml;version=2"
+                          },
+                          {
+                              "base": "application/json",
+                              "type": "application/vnd.openstack.compute+json;version=2"
+                          }
+                      ],
+                      "id": "v2.0",
+                      "links": [
+                          {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                          },
+                          {
+                              "href": "http://docs.openstack.org/api/openstack-compute/2/os-compute-devguide-2.pdf",
+                              "type": "application/pdf",
+                              "rel": "describedby"
+                          },
+                          {
+                              "href": "http://docs.openstack.org/api/openstack-compute/2/wadl/os-compute-2.wadl",
+                              "type": "application/vnd.sun.wadl+xml",
+                              "rel": "describedby"
+                          },
+                          {
+                            "href": "http://docs.openstack.org/api/openstack-compute/2/wadl/os-compute-2.wadl",
+                            "type": "application/vnd.sun.wadl+xml",
+                            "rel": "describedby"
+                          }
+                      ]
+                    }
+                  }
+        '203':
+          description: |-
+            203 response
+          content:
+            application/json: 
+              examples:
+                foo:
+                  value: {
+                    "version": {
+                      "status": "CURRENT",
+                      "updated": "2011-01-21T11:33:21Z",
+                      "media-types": [
+                          {
+                              "base": "application/xml",
+                              "type": "application/vnd.openstack.compute+xml;version=2"
+                          },
+                          {
+                              "base": "application/json",
+                              "type": "application/vnd.openstack.compute+json;version=2"
+                          }
+                      ],
+                      "id": "v2.0",
+                      "links": [
+                          {
+                              "href": "http://23.253.228.211:8774/v2/",
+                              "rel": "self"
+                          },
+                          {
+                              "href": "http://docs.openstack.org/api/openstack-compute/2/os-compute-devguide-2.pdf",
+                              "type": "application/pdf",
+                              "rel": "describedby"
+                          },
+                          {
+                              "href": "http://docs.openstack.org/api/openstack-compute/2/wadl/os-compute-2.wadl",
+                              "type": "application/vnd.sun.wadl+xml",
+                              "rel": "describedby"
+                          }
+                      ]
+                    }
+                  }

--- a/examples/v3.0/personae.yaml
+++ b/examples/v3.0/personae.yaml
@@ -1,167 +1,115 @@
 openapi: "3.0.0"
 info:
-  title: Simple API overview
-  version: v2
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
 paths:
-  /:
+  /pets:
     get:
-      operationId: listVersionsv2
-      summary: List API versions
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            format: int32
       responses:
         '200':
-          description: |-
-            200 response
+          description: A paged array of pets
+          headers:
+            x-next:
+              description: A link to the next page of responses
+              schema:
+                type: string
+          content:
+            application/json:    
+              schema:
+                $ref: "#/components/schemas/Pets"
+        default:
+          description: unexpected error
           content:
             application/json:
-              examples: 
-                foo:
-                  value: {
-                    "versions": [
-                        {
-                            "status": "CURRENT",
-                            "updated": "2011-01-21T11:33:21Z",
-                            "id": "v2.0",
-                            "links": [
-                                {
-                                    "href": "http://127.0.0.1:8774/v2/",
-                                    "rel": "self"
-                                }
-                            ]
-                        },
-                        {
-                            "status": "EXPERIMENTAL",
-                            "updated": "2013-07-23T11:33:21Z",
-                            "id": "v3.0",
-                            "links": [
-                                {
-                                    "href": "http://127.0.0.1:8774/v3/",
-                                    "rel": "self"
-                                }
-                            ]
-                        }
-                    ]
-                 }
-        '300':
-          description: |-
-            300 response
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      summary: Create a pet
+      operationId: createPets
+      tags:
+        - pets
+      responses:
+        '201':
+          description: Null response
+        default:
+          description: unexpected error
           content:
-            application/json: 
-              examples: 
-                foo:
-                  value: |
-                   {
-                    "versions": [
-                          {
-                            "status": "CURRENT",
-                            "updated": "2011-01-21T11:33:21Z",
-                            "id": "v2.0",
-                            "links": [
-                                {
-                                    "href": "http://127.0.0.1:8774/v2/",
-                                    "rel": "self"
-                                }
-                            ]
-                        },
-                        {
-                            "status": "EXPERIMENTAL",
-                            "updated": "2013-07-23T11:33:21Z",
-                            "id": "v3.0",
-                            "links": [
-                                {
-                                    "href": "http://127.0.0.1:8774/v3/",
-                                    "rel": "self"
-                                }
-                            ]
-                        }
-                    ]
-                   }
-  /v2:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+      personae:
+        - registered-user
+        - admin
+  /pets/{petId}:
     get:
-      operationId: getVersionDetailsv2
-      summary: Show API version details
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
       responses:
         '200':
-          description: |-
-            200 response
+          description: Expected response to a valid request
           content:
-            application/json: 
-              examples:
-                foo:
-                  value: {
-                    "version": {
-                      "status": "CURRENT",
-                      "updated": "2011-01-21T11:33:21Z",
-                      "media-types": [
-                          {
-                              "base": "application/xml",
-                              "type": "application/vnd.openstack.compute+xml;version=2"
-                          },
-                          {
-                              "base": "application/json",
-                              "type": "application/vnd.openstack.compute+json;version=2"
-                          }
-                      ],
-                      "id": "v2.0",
-                      "links": [
-                          {
-                              "href": "http://127.0.0.1:8774/v2/",
-                              "rel": "self"
-                          },
-                          {
-                              "href": "http://docs.openstack.org/api/openstack-compute/2/os-compute-devguide-2.pdf",
-                              "type": "application/pdf",
-                              "rel": "describedby"
-                          },
-                          {
-                              "href": "http://docs.openstack.org/api/openstack-compute/2/wadl/os-compute-2.wadl",
-                              "type": "application/vnd.sun.wadl+xml",
-                              "rel": "describedby"
-                          },
-                          {
-                            "href": "http://docs.openstack.org/api/openstack-compute/2/wadl/os-compute-2.wadl",
-                            "type": "application/vnd.sun.wadl+xml",
-                            "rel": "describedby"
-                          }
-                      ]
-                    }
-                  }
-        '203':
-          description: |-
-            203 response
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pets"
+        default:
+          description: unexpected error
           content:
-            application/json: 
-              examples:
-                foo:
-                  value: {
-                    "version": {
-                      "status": "CURRENT",
-                      "updated": "2011-01-21T11:33:21Z",
-                      "media-types": [
-                          {
-                              "base": "application/xml",
-                              "type": "application/vnd.openstack.compute+xml;version=2"
-                          },
-                          {
-                              "base": "application/json",
-                              "type": "application/vnd.openstack.compute+json;version=2"
-                          }
-                      ],
-                      "id": "v2.0",
-                      "links": [
-                          {
-                              "href": "http://23.253.228.211:8774/v2/",
-                              "rel": "self"
-                          },
-                          {
-                              "href": "http://docs.openstack.org/api/openstack-compute/2/os-compute-devguide-2.pdf",
-                              "type": "application/pdf",
-                              "rel": "describedby"
-                          },
-                          {
-                              "href": "http://docs.openstack.org/api/openstack-compute/2/wadl/os-compute-2.wadl",
-                              "type": "application/vnd.sun.wadl+xml",
-                              "rel": "describedby"
-                          }
-                      ]
-                    }
-                  }
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+      personae:
+        - registered-user
+        - admin      
+components:
+  schemas:
+    Pet:
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+    Pets:
+      type: array
+      items:
+        $ref: "#/components/schemas/Pet"
+    Error:
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/fixtures/v1.2/helloworld/server/.classpath
+++ b/fixtures/v1.2/helloworld/server/.classpath
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" output="target/classes" path="src/main/scala">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/scala">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="target/generated-sources/annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="m2e-apt" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="target/generated-test-sources/test-annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="m2e-apt" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/fixtures/v1.2/helloworld/server/.project
+++ b/fixtures/v1.2/helloworld/server/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>swagger-demo</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/fixtures/v1.2/helloworld/server/.settings/org.eclipse.jdt.apt.core.prefs
+++ b/fixtures/v1.2/helloworld/server/.settings/org.eclipse.jdt.apt.core.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.apt.aptEnabled=false

--- a/fixtures/v1.2/helloworld/server/.settings/org.eclipse.jdt.core.prefs
+++ b/fixtures/v1.2/helloworld/server/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,9 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.5
+org.eclipse.jdt.core.compiler.compliance=1.5
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=ignore
+org.eclipse.jdt.core.compiler.processAnnotations=disabled
+org.eclipse.jdt.core.compiler.release=disabled
+org.eclipse.jdt.core.compiler.source=1.5

--- a/schemas/v3.0/schemas.yaml
+++ b/schemas/v3.0/schemas.yaml
@@ -1,0 +1,1018 @@
+id: https://spec.openapis.org/oas/3.0/schema/2019-04-02
+$schema: http://json-schema.org/draft-04/schema#
+description: Validation schema for OpenAPI Specification 3.0.X.
+type: object
+required:
+  - openapi
+  - info
+  - paths
+properties:
+  openapi:
+    type: string
+    pattern: ^3\.0\.\d(-.+)?$
+  info:
+    $ref: '#/definitions/Info'
+  externalDocs:
+    $ref: '#/definitions/ExternalDocumentation'
+  servers:
+    type: array
+    items:
+      $ref: '#/definitions/Server'
+  security:
+    type: array
+    items:
+      $ref: '#/definitions/SecurityRequirement'
+  tags:
+    type: array
+    items:
+      $ref: '#/definitions/Tag'
+    uniqueItems: true
+  paths:
+    $ref: '#/definitions/Paths'
+  components:
+    $ref: '#/definitions/Components'
+  personae:
+    $ref: '#/definitions/Personae'
+patternProperties:
+  '^x-': {}
+additionalProperties: false
+definitions:
+  Reference:
+    type: object
+    required:
+      - $ref
+    patternProperties:
+      '^\$ref$':
+        type: string
+        format: uri-reference
+  Info:
+    type: object
+    required:
+      - title
+      - version
+    properties:
+      title:
+        type: string
+      description:
+        type: string
+      termsOfService:
+        type: string
+        format: uri-reference
+      contact:
+        $ref: '#/definitions/Contact'
+      license:
+        $ref: '#/definitions/License'
+      version:
+        type: string
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  Contact:
+    type: object
+    properties:
+      name:
+        type: string
+      url:
+        type: string
+        format: uri-reference
+      email:
+        type: string
+        format: email
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  License:
+    type: object
+    required:
+      - name
+    properties:
+      name:
+        type: string
+      url:
+        type: string
+        format: uri-reference
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  Server:
+    type: object
+    required:
+      - url
+    properties:
+      url:
+        type: string
+      description:
+        type: string
+      variables:
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/ServerVariable'
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  ServerVariable:
+    type: object
+    required:
+      - default
+    properties:
+      enum:
+        type: array
+        items:
+          type: string
+      default:
+        type: string
+      description:
+        type: string
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  Components:
+    type: object
+    properties:
+      schemas:
+        type: object
+        patternProperties:
+          '^[a-zA-Z0-9\.\-_]+$':
+            oneOf:
+              - $ref: '#/definitions/Schema'
+              - $ref: '#/definitions/Reference'
+      responses:
+        type: object
+        patternProperties:
+          '^[a-zA-Z0-9\.\-_]+$':
+            oneOf:
+              - $ref: '#/definitions/Reference'
+              - $ref: '#/definitions/Response'
+      parameters:
+        type: object
+        patternProperties:
+          '^[a-zA-Z0-9\.\-_]+$':
+            oneOf:
+              - $ref: '#/definitions/Reference'
+              - $ref: '#/definitions/Parameter'
+      examples:
+        type: object
+        patternProperties:
+          '^[a-zA-Z0-9\.\-_]+$':
+            oneOf:
+              - $ref: '#/definitions/Reference'
+              - $ref: '#/definitions/Example'
+      requestBodies:
+        type: object
+        patternProperties:
+          '^[a-zA-Z0-9\.\-_]+$':
+            oneOf:
+              - $ref: '#/definitions/Reference'
+              - $ref: '#/definitions/RequestBody'
+      headers:
+        type: object
+        patternProperties:
+          '^[a-zA-Z0-9\.\-_]+$':
+            oneOf:
+              - $ref: '#/definitions/Reference'
+              - $ref: '#/definitions/Header'
+      securitySchemes:
+        type: object
+        patternProperties:
+          '^[a-zA-Z0-9\.\-_]+$':
+            oneOf:
+              - $ref: '#/definitions/Reference'
+              - $ref: '#/definitions/SecurityScheme'
+      links:
+        type: object
+        patternProperties:
+          '^[a-zA-Z0-9\.\-_]+$':
+            oneOf:
+              - $ref: '#/definitions/Reference'
+              - $ref: '#/definitions/Link'
+      callbacks:
+        type: object
+        patternProperties:
+          '^[a-zA-Z0-9\.\-_]+$':
+            oneOf:
+              - $ref: '#/definitions/Reference'
+              - $ref: '#/definitions/Callback'
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  Schema:
+    type: object
+    properties:
+      title:
+        type: string
+      multipleOf:
+        type: number
+        minimum: 0
+        exclusiveMinimum: true
+      maximum:
+        type: number
+      exclusiveMaximum:
+        type: boolean
+        default: false
+      minimum:
+        type: number
+      exclusiveMinimum:
+        type: boolean
+        default: false
+      maxLength:
+        type: integer
+        minimum: 0
+      minLength:
+        type: integer
+        minimum: 0
+        default: 0
+      pattern:
+        type: string
+        format: regex
+      maxItems:
+        type: integer
+        minimum: 0
+      minItems:
+        type: integer
+        minimum: 0
+        default: 0
+      uniqueItems:
+        type: boolean
+        default: false
+      maxProperties:
+        type: integer
+        minimum: 0
+      minProperties:
+        type: integer
+        minimum: 0
+        default: 0
+      required:
+        type: array
+        items:
+          type: string
+        minItems: 1
+        uniqueItems: true
+      enum:
+        type: array
+        items: {}
+        minItems: 1
+        uniqueItems: false
+      type:
+        type: string
+        enum:
+          - array
+          - boolean
+          - integer
+          - number
+          - object
+          - string
+      not:
+        oneOf:
+          - $ref: '#/definitions/Schema'
+          - $ref: '#/definitions/Reference'
+      allOf:
+        type: array
+        items:
+          oneOf:
+            - $ref: '#/definitions/Schema'
+            - $ref: '#/definitions/Reference'
+      oneOf:
+        type: array
+        items:
+          oneOf:
+            - $ref: '#/definitions/Schema'
+            - $ref: '#/definitions/Reference'
+      anyOf:
+        type: array
+        items:
+          oneOf:
+            - $ref: '#/definitions/Schema'
+            - $ref: '#/definitions/Reference'
+      items:
+        oneOf:
+          - $ref: '#/definitions/Schema'
+          - $ref: '#/definitions/Reference'
+      properties:
+        type: object
+        additionalProperties:
+          oneOf:
+            - $ref: '#/definitions/Schema'
+            - $ref: '#/definitions/Reference'
+      additionalProperties:
+        oneOf:
+          - $ref: '#/definitions/Schema'
+          - $ref: '#/definitions/Reference'
+          - type: boolean
+        default: true
+      description:
+        type: string
+      format:
+        type: string
+      default: {}
+      nullable:
+        type: boolean
+        default: false
+      discriminator:
+        $ref: '#/definitions/Discriminator'
+      readOnly:
+        type: boolean
+        default: false
+      writeOnly:
+        type: boolean
+        default: false
+      example: {}
+      externalDocs:
+        $ref: '#/definitions/ExternalDocumentation'
+      deprecated:
+        type: boolean
+        default: false
+      xml:
+        $ref: '#/definitions/XML'
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  Discriminator:
+    type: object
+    required:
+      - propertyName
+    properties:
+      propertyName:
+        type: string
+      mapping:
+        type: object
+        additionalProperties:
+          type: string
+
+  XML:
+    type: object
+    properties:
+      name:
+        type: string
+      namespace:
+        type: string
+        format: uri
+      prefix:
+        type: string
+      attribute:
+        type: boolean
+        default: false
+      wrapped:
+        type: boolean
+        default: false
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  Response:
+    type: object
+    required:
+      - description
+    properties:
+      description:
+        type: string
+      headers:
+        type: object
+        additionalProperties:
+          oneOf:
+            - $ref: '#/definitions/Header'
+            - $ref: '#/definitions/Reference'
+      content:
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/MediaType'
+      links:
+        type: object
+        additionalProperties:
+          oneOf:
+            - $ref: '#/definitions/Link'
+            - $ref: '#/definitions/Reference'
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  MediaType:
+    type: object
+    properties:
+      schema:
+        oneOf:
+          - $ref: '#/definitions/Schema'
+          - $ref: '#/definitions/Reference'
+      example: {}
+      examples:
+        type: object
+        additionalProperties:
+          oneOf:
+            - $ref: '#/definitions/Example'
+            - $ref: '#/definitions/Reference'
+      encoding:
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/Encoding'
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+    allOf:
+      - $ref: '#/definitions/ExampleXORExamples'
+
+  Example:
+    type: object
+    properties:
+      summary:
+        type: string
+      description:
+        type: string
+      value: {}
+      externalValue:
+        type: string
+        format: uri-reference
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  Header:
+    type: object
+    properties:
+      description:
+        type: string
+      required:
+        type: boolean
+        default: false
+      deprecated:
+        type: boolean
+        default: false
+      allowEmptyValue:
+        type: boolean
+        default: false
+      style:
+        type: string
+        enum:
+          - simple
+        default: simple
+      explode:
+        type: boolean
+      allowReserved:
+        type: boolean
+        default: false
+      schema:
+        oneOf:
+          - $ref: '#/definitions/Schema'
+          - $ref: '#/definitions/Reference'
+      content:
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/MediaType'
+        minProperties: 1
+        maxProperties: 1
+      example: {}
+      examples:
+        type: object
+        additionalProperties:
+          oneOf:
+            - $ref: '#/definitions/Example'
+            - $ref: '#/definitions/Reference'
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+    allOf:
+      - $ref: '#/definitions/ExampleXORExamples'
+      - $ref: '#/definitions/SchemaXORContent'
+
+  Paths:
+    type: object
+    patternProperties:
+      '^\/':
+        $ref: '#/definitions/PathItem'
+      '^x-': {}
+    additionalProperties: false
+
+  PathItem:
+    type: object
+    properties:
+      $ref:
+        type: string
+      summary:
+        type: string
+      description:
+        type: string
+      servers:
+        type: array
+        items:
+          $ref: '#/definitions/Server'
+      parameters:
+        type: array
+        items:
+          oneOf:
+            - $ref: '#/definitions/Parameter'
+            - $ref: '#/definitions/Reference'
+        uniqueItems: true
+      personae:
+          type: array
+          items:
+              $ref: '#/definitions/Persona'
+    patternProperties:
+      '^(get|put|post|delete|options|head|patch|trace)$':
+        $ref: '#/definitions/Operation'
+      '^x-': {}
+    additionalProperties: false
+
+  Operation:
+    type: object
+    required:
+      - responses
+    properties:
+      tags:
+        type: array
+        items:
+          type: string
+      summary:
+        type: string
+      description:
+        type: string
+      externalDocs:
+        $ref: '#/definitions/ExternalDocumentation'
+      operationId:
+        type: string
+      parameters:
+        type: array
+        items:
+          oneOf:
+            - $ref: '#/definitions/Parameter'
+            - $ref: '#/definitions/Reference'
+        uniqueItems: true
+      requestBody:
+        oneOf:
+          - $ref: '#/definitions/RequestBody'
+          - $ref: '#/definitions/Reference'
+      responses:
+        $ref: '#/definitions/Responses'
+      callbacks:
+        type: object
+        additionalProperties:
+          oneOf:
+            - $ref: '#/definitions/Callback'
+            - $ref: '#/definitions/Reference'
+      deprecated:
+        type: boolean
+        default: false
+      security:
+        type: array
+        items:
+          $ref: '#/definitions/SecurityRequirement'
+      servers:
+        type: array
+        items:
+          $ref: '#/definitions/Server'
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  Responses:
+    type: object
+    properties:
+      default:
+        oneOf:
+          - $ref: '#/definitions/Response'
+          - $ref: '#/definitions/Reference'
+    patternProperties:
+      '^[1-5](?:\d{2}|XX)$':
+        oneOf:
+          - $ref: '#/definitions/Response'
+          - $ref: '#/definitions/Reference'
+      '^x-': {}
+    minProperties: 1
+    additionalProperties: false
+
+  SecurityRequirement:
+    type: object
+    additionalProperties:
+      type: array
+      items:
+        type: string
+
+  Tag:
+    type: object
+    required:
+      - name
+    properties:
+      name:
+        type: string
+      description:
+        type: string
+      externalDocs:
+        $ref: '#/definitions/ExternalDocumentation'
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  ExternalDocumentation:
+    type: object
+    required:
+      - url
+    properties:
+      description:
+        type: string
+      url:
+        type: string
+        format: uri-reference
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  ExampleXORExamples:
+    description: Example and examples are mutually exclusive
+    not:
+      required: [example, examples]
+
+  SchemaXORContent:
+    description: Schema and content are mutually exclusive, at least one is required
+    not:
+      required: [schema, content]
+    oneOf:
+      - required: [schema]
+      - required: [content]
+        description: Some properties are not allowed if content is present
+        allOf:
+          - not:
+              required: [style]
+          - not:
+              required: [explode]
+          - not:
+              required: [allowReserved]
+          - not:
+              required: [example]
+          - not:
+              required: [examples]
+
+  Parameter:
+    type: object
+    properties:
+      name:
+        type: string
+      in:
+        type: string
+      description:
+        type: string
+      required:
+        type: boolean
+        default: false
+      deprecated:
+        type: boolean
+        default: false
+      allowEmptyValue:
+        type: boolean
+        default: false
+      style:
+        type: string
+      explode:
+        type: boolean
+      allowReserved:
+        type: boolean
+        default: false
+      schema:
+        oneOf:
+          - $ref: '#/definitions/Schema'
+          - $ref: '#/definitions/Reference'
+      content:
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/MediaType'
+        minProperties: 1
+        maxProperties: 1
+      example: {}
+      examples:
+        type: object
+        additionalProperties:
+          oneOf:
+            - $ref: '#/definitions/Example'
+            - $ref: '#/definitions/Reference'
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+    required:
+      - name
+      - in
+    allOf:
+      - $ref: '#/definitions/ExampleXORExamples'
+      - $ref: '#/definitions/SchemaXORContent'
+      - $ref: '#/definitions/ParameterLocation'
+
+  ParameterLocation:
+    description: Parameter location
+    oneOf:
+      - description: Parameter in path
+        required:
+          - required
+        properties:
+          in:
+            enum: [path]
+          style:
+            enum: [matrix, label, simple]
+            default: simple
+          required:
+            enum: [true]
+
+      - description: Parameter in query
+        properties:
+          in:
+            enum: [query]
+          style:
+            enum: [form, spaceDelimited, pipeDelimited, deepObject]
+            default: form
+
+      - description: Parameter in header
+        properties:
+          in:
+            enum: [header]
+          style:
+            enum: [simple]
+            default: simple
+
+      - description: Parameter in cookie
+        properties:
+          in:
+            enum: [cookie]
+          style:
+            enum: [form]
+            default: form
+
+  RequestBody:
+    type: object
+    required:
+      - content
+    properties:
+      description:
+        type: string
+      content:
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/MediaType'
+      required:
+        type: boolean
+        default: false
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  SecurityScheme:
+    oneOf:
+      - $ref: '#/definitions/APIKeySecurityScheme'
+      - $ref: '#/definitions/HTTPSecurityScheme'
+      - $ref: '#/definitions/OAuth2SecurityScheme'
+      - $ref: '#/definitions/OpenIdConnectSecurityScheme'
+
+  APIKeySecurityScheme:
+    type: object
+    required:
+      - type
+      - name
+      - in
+    properties:
+      type:
+        type: string
+        enum:
+          - apiKey
+      name:
+        type: string
+      in:
+        type: string
+        enum:
+          - header
+          - query
+          - cookie
+      description:
+        type: string
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  HTTPSecurityScheme:
+    type: object
+    required:
+      - scheme
+      - type
+    properties:
+      scheme:
+        type: string
+      bearerFormat:
+        type: string
+      description:
+        type: string
+      type:
+        type: string
+        enum:
+          - http
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+    oneOf:
+      - description: Bearer
+        properties:
+          scheme:
+            enum: [bearer]
+
+      - description: Non Bearer
+        not:
+          required: [bearerFormat]
+        properties:
+          scheme:
+            not:
+              enum: [bearer]
+
+  OAuth2SecurityScheme:
+    type: object
+    required:
+      - type
+      - flows
+    properties:
+      type:
+        type: string
+        enum:
+          - oauth2
+      flows:
+        $ref: '#/definitions/OAuthFlows'
+      description:
+        type: string
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  OpenIdConnectSecurityScheme:
+    type: object
+    required:
+      - type
+      - openIdConnectUrl
+    properties:
+      type:
+        type: string
+        enum:
+          - openIdConnect
+      openIdConnectUrl:
+        type: string
+        format: uri-reference
+      description:
+        type: string
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  OAuthFlows:
+    type: object
+    properties:
+      implicit:
+        $ref: '#/definitions/ImplicitOAuthFlow'
+      password:
+        $ref: '#/definitions/PasswordOAuthFlow'
+      clientCredentials:
+        $ref: '#/definitions/ClientCredentialsFlow'
+      authorizationCode:
+        $ref: '#/definitions/AuthorizationCodeOAuthFlow'
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  ImplicitOAuthFlow:
+    type: object
+    required:
+      - authorizationUrl
+      - scopes
+    properties:
+      authorizationUrl:
+        type: string
+        format: uri-reference
+      refreshUrl:
+        type: string
+        format: uri-reference
+      scopes:
+        type: object
+        additionalProperties:
+          type: string
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  PasswordOAuthFlow:
+    type: object
+    required:
+      - tokenUrl
+    properties:
+      tokenUrl:
+        type: string
+        format: uri-reference
+      refreshUrl:
+        type: string
+        format: uri-reference
+      scopes:
+        type: object
+        additionalProperties:
+          type: string
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  ClientCredentialsFlow:
+    type: object
+    required:
+      - tokenUrl
+    properties:
+      tokenUrl:
+        type: string
+        format: uri-reference
+      refreshUrl:
+        type: string
+        format: uri-reference
+      scopes:
+        type: object
+        additionalProperties:
+          type: string
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  AuthorizationCodeOAuthFlow:
+    type: object
+    required:
+      - authorizationUrl
+      - tokenUrl
+    properties:
+      authorizationUrl:
+        type: string
+        format: uri-reference
+      tokenUrl:
+        type: string
+        format: uri-reference
+      refreshUrl:
+        type: string
+        format: uri-reference
+      scopes:
+        type: object
+        additionalProperties:
+          type: string
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  Link:
+    type: object
+    properties:
+      operationId:
+        type: string
+      operationRef:
+        type: string
+        format: uri-reference
+      parameters:
+        type: object
+        additionalProperties: {}
+      requestBody: {}
+      description:
+        type: string
+      server:
+        $ref: '#/definitions/Server'
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+    not:
+      description: Operation Id and Operation Ref are mutually exclusive
+      required: [operationId, operationRef]
+
+  Callback:
+    type: object
+    additionalProperties:
+      $ref: '#/definitions/PathItem'
+    patternProperties:
+      '^x-': {}
+
+  Encoding:
+    type: object
+    properties:
+      contentType:
+        type: string
+      headers:
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/Header'
+      style:
+        type: string
+        enum:
+          - form
+          - spaceDelimited
+          - pipeDelimited
+          - deepObject
+      explode:
+        type: boolean
+      allowReserved:
+        type: boolean
+        default: false
+    additionalProperties: false
+
+  Persona:
+    type: object
+    properties:
+      name:
+        type: string
+        default: 'any'
+      location:
+        type: string
+        default: 'any'
+    additionalProperties: false

--- a/schemas/v3.0/schemas.yaml
+++ b/schemas/v3.0/schemas.yaml
@@ -507,10 +507,6 @@ definitions:
             - $ref: '#/definitions/Parameter'
             - $ref: '#/definitions/Reference'
         uniqueItems: true
-      personae:
-          type: array
-          items:
-              $ref: '#/definitions/Persona'
     patternProperties:
       '^(get|put|post|delete|options|head|patch|trace)$':
         $ref: '#/definitions/Operation'
@@ -564,6 +560,11 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/Server'
+      personae:
+        type: array
+        items:
+            $ref: '#/definitions/Persona'
+
     patternProperties:
       '^x-': {}
     additionalProperties: false
@@ -1006,13 +1007,13 @@ definitions:
         default: false
     additionalProperties: false
 
-  Persona:
+  Personae:
     type: object
     properties:
       name:
         type: string
         default: 'any'
       location:
-        type: string
+        type: array
         default: 'any'
     additionalProperties: false

--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -858,6 +858,7 @@ Field Name | Type | Description
 <a name="operationDeprecated"></a>deprecated | `boolean` | Declares this operation to be deprecated. Consumers SHOULD refrain from usage of the declared operation. Default value is `false`.
 <a name="operationSecurity"></a>security | [[Security Requirement Object](#securityRequirementObject)] | A declaration of which security mechanisms can be used for this operation. The list of values includes alternative security requirement objects that can be used. Only one of the security requirement objects need to be satisfied to authorize a request. This definition overrides any declared top-level [`security`](#oasSecurity). To remove a top-level security declaration, an empty array can be used.
 <a name="operationServers"></a>servers | [[Server Object](#serverObject)] | An alternative `server` array to service this operation. If an alternative `server` object is specified at the Path Item Object or Root level, it will be overridden by this value.
+<a name="personae"></a>personae | [[Persona Object](#personaObject)] | A persona array that defines access to a given API operation.
 
 This object MAY be extended with [Specification Extensions](#specificationExtensions).
 
@@ -896,7 +897,7 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
                 "type": "string"
              }
            },
-        "required": ["status"] 
+        "required": ["status"]
         }
       }
     }
@@ -924,6 +925,9 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
         "read:pets"
       ]
     }
+  ],
+  "personae" : [
+    "registered-user", "admin"
   ]
 }
 ```
@@ -997,7 +1001,7 @@ description: Find more info here
 url: https://example.com
 ```
 
-#### <a name="personaeObject"></a>Persona Object
+#### <a name="personaObject"></a>Persona Object
 
 Describes a persona that is authorized to invoke an API.
 
@@ -1005,12 +1009,26 @@ Describes a persona that is authorized to invoke an API.
 
 #### Fixed fields
 
+---|:---:|---
+<a name="persona"></a>Persona | `string` | **REQUIRED**. A short description of the persona who is authorized to invoke the API.
+<a name="location"></a>Location | `array` | An array of strings that identifies locations and qualifies the persona.
+
+This object MAY be extended with [Specification Extensions](#specificationExtensions).
+
 #### Examples
 
 ```json
+{
+  "persona" : "supervisors-plant-1",
+  "location" : ["plant-1"]
+}
 ```
 
 ```yaml
+persona: general-manager
+location:
+  - all-plants
+  - roaming
 ```
 
 #### <a name="parameterObject"></a>Parameter Object
@@ -2184,8 +2202,8 @@ Expressions can be embedded into string values by surrounding the expression wit
 The Header Object follows the structure of the [Parameter Object](#parameterObject) with the following changes:
 
 1. `name` MUST NOT be specified, it is given in the corresponding `headers` map.
-1. `in` MUST NOT be specified, it is implicitly in `header`.
-1. All traits that are affected by the location MUST be applicable to a location of `header` (for example, [`style`](#parameterStyle)).
+2. `in` MUST NOT be specified, it is implicitly in `header`.
+3. All traits that are affected by the location MUST be applicable to a location of `header` (for example, [`style`](#parameterStyle)).
 
 ##### Header Object Example
 

--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -972,6 +972,9 @@ security:
 - petstore_auth:
   - write:pets
   - read:pets
+personae:
+- registered-user
+- admin
 ```
 
 #### <a name="externalDocumentationObject"></a>External Documentation Object

--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -39,6 +39,7 @@ An OpenAPI definition can then be used by documentation generation tools to disp
 		- [Path Item Object](#pathItemObject)
 		- [Operation Object](#operationObject)
 		- [External Documentation Object](#externalDocumentationObject)
+		- [Personae Object](#PersonaeObject)
 		- [Parameter Object](#parameterObject)
 		- [Request Body Object](#requestBodyObject)
 		- [Media Type Object](#mediaTypeObject)
@@ -198,6 +199,7 @@ Field Name | Type | Description
 <a name="oasSecurity"></a>security | [[Security Requirement Object](#securityRequirementObject)] | A declaration of which security mechanisms can be used across the API. The list of values includes alternative security requirement objects that can be used. Only one of the security requirement objects need to be satisfied to authorize a request. Individual operations can override this definition.
 <a name="oasTags"></a>tags | [[Tag Object](#tagObject)] | A list of tags used by the specification with additional metadata. The order of the tags can be used to reflect on their order by the parsing tools. Not all tags that are used by the [Operation Object](#operationObject) must be declared. The tags that are not declared MAY be organized randomly or based on the tools' logic. Each tag name in the list MUST be unique.
 <a name="oasExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation.
+<a name="oasPersonae"></a>personae | [[Personae Object](#personaeObject)] | A list of persoae who are authorized to invoke an API.
 
 This object MAY be extended with [Specification Extensions](#specificationExtensions).
 
@@ -968,7 +970,6 @@ security:
   - read:pets
 ```
 
-
 #### <a name="externalDocumentationObject"></a>External Documentation Object
 
 Allows referencing an external resource for extended documentation.
@@ -994,6 +995,22 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
 ```yaml
 description: Find more info here
 url: https://example.com
+```
+
+#### <a name="personaeObject"></a>Persona Object
+
+Describes a persona that is authorized to invoke an API.
+
+#### Persona locations
+
+#### Fixed fields
+
+#### Examples
+
+```json
+```
+
+```yaml
 ```
 
 #### <a name="parameterObject"></a>Parameter Object


### PR DESCRIPTION
# Introduction

This feature request (#2040) proposes to assign authorized personae with every API definition. Such a feature will serve as a clean bridge between a business process owner and a developer.

- [Introduction](#introduction)
  - [Development Process](#development-process)
    - [Specification Change Criteria evaluation](#specification-change-criteria-evaluation)
    - [Specification Change Process evaluation](#specification-change-process-evaluation)
  - [Proposal](#proposal)
    - [Personae](#personae)
    - [Specification change](#specification-change)
  - [Files changed](#files-changed)

## Development Process

The [Development Process document](../OpenAPI-Specification/DEVELOPMENT.md) calls out the following evaluations.

### Specification Change Criteria evaluation

* Clarity. _Not applicable_
* Consistency. _Not applicable_
* Necessary functionality. **Yes.**
* Forward-looking designs. _Not applicable_

### Specification Change Process evaluation

* Migration. **Easy.** Ideally, this feature should appear, at least, as an optional item with default value corresponding to the semantics of `any`. This means, APIs in older documents will be treated as if they can be invoked by `any`.
* Tooling. **Known.** Code generation may use popular authentication and authorization schemes such as JSON Web Token (JWT). For example, the `sub` and `aud` keys in JWT could be used to generate a snippet of JWT. See [JWT RFC](https://tools.ietf.org/html/rfc7519). The selection of the persona itself maybe via an organizational directory or an implementation of various personae (e.g. employee, administrator, public, etc.) schemas.
* Visualization. **Not sure.**

## Proposal

This proposal covers the following:

- the scope of personae
- its usage in the specification

### Personae

1. The personae can be either **registered users** or **unregistered users**. For example, registered users could be bank customers and unregistered users could be an entity - human or computer - running a web search.
   1. Multiple registered users may map to a single individual. For example, a bank employee may be a bank customer too.
   2. An API author MIGHT want to discriminate between human and system users.

2. A persona of the type, **registered user** MAY be qualified with a `location` attribute. For example, an employee may have limited access to functions if he/she is on a GPRS network through a corporate owned handheld device, BYOD, laptop, etc. Similarly, the same employee may have different level of access to functions if he/she connects to corporate LAN or WLAN via corporate owned handheld device, laptop, etc.
   1. It is possible that the device (corporate or personal) is configured with different persona in which case the `location` attribute maybe redundant.
   2. Where the `location` attribute is preferred to be used, it will be an array of identifiers. For example, an API maybe accessible from home and office for a particular persona in which case, the values of `location` attribute will be an array of strings e.g. `home` and `office`. For variations of identifiers e.g. location hierarchy, specification extensions may be used.

3. A persona of the type, **unregistered user** MAY be qualified with a `location` attribute to indicate all of internet or regions of internet, etc.

4. The details of the persona attribute will be implementation dependent. This feature request does not propose any particular schema. However, at a minimum, the attribute should carry the name of a persona (e.g. employee, department, contractor, developer, administrator, www) and location (e.g. office, home, field, corporate HQ, users from India, IP CIDR, etc.)

### Specification change

The change to the specification is proposed in two ways:

1. A new `personae` object
   1. Defined as `#/definitions/Personae`
   2. Referred to at `#/definitions/Operation`
2. Vendor extensions through `x-personae-` object.

## Files changed

| File | Remark |
| ---- | ------ |
| `schemas/v3.0/schemas.yaml` | Copied from the `master` branch and edited. |
| `examples/v3.0/personae.yaml` | New file added for an example with personae. |
| `versions/3.1.0.md` | Added reference to `personae` object. |
