### PR TITLE
Implement GitHub Actions workflow for automatically updating the example JSON files

### DIFF
--- a/.github/workflows/yaml2json.yml
+++ b/.github/workflows/yaml2json.yml
@@ -35,11 +35,9 @@ jobs:
         for file in *.yaml ; do
             target=`basename -s .yaml $file`.json
             echo "converting  $file  to  $target  ..."
-            if [ "$file" != "api-with-examples.yaml" ] ; then
-                vendor/bin/php-openapi convert --read-yaml $file --write-json $target
-                vendor/bin/indent --tabs --tabstop=4 $target
-                vendor/bin/indent --spaces --tabstop=2 $target
-            fi
+            vendor/bin/php-openapi convert --read-yaml $file --write-json $target
+            vendor/bin/indent --tabs --tabstop=4 $target
+            vendor/bin/indent --spaces --tabstop=2 $target
         done
         
     - name: cleanup
@@ -51,7 +49,7 @@ jobs:
       run: |
         cd examples/v3.0
         git add *.json
-        git diff --staged
+        git --no-pager -c color.diff=always diff --staged
 
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v1

--- a/.github/workflows/yaml2json.yml
+++ b/.github/workflows/yaml2json.yml
@@ -12,7 +12,6 @@ on:
   push:
     branches:    
       - master
-      - try-github-actions
 
 jobs:
   yaml2json:

--- a/.github/workflows/yaml2json.yml
+++ b/.github/workflows/yaml2json.yml
@@ -1,0 +1,70 @@
+name: YAML2JSON
+
+#
+# This workflow updates the *.json files in the examples/v3.0 directory,
+# when the corresponding *.yaml files change.
+# JSON example files are automatically generated from the YAML example files.
+# Only the YAML files should be adjusted manually.
+#
+
+# run this on push to master
+on:
+  push:
+    branches:    
+      - master
+      - try-github-actions
+
+jobs:
+  yaml2json:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1 # checkout repo content
+      
+    - name: Install dependencies
+      run: |
+        cd examples/v3.0 
+        echo '{}' > composer.json
+        # fix versions to ensure reproduceable runs
+        composer require cebe/php-openapi:1.3.1 symfony/yaml:4.2.12 cebe/indent:1.1.0
+
+    - name: convert YAML examples to JSON
+      run: |
+        cd examples/v3.0
+        for file in *.yaml ; do
+            target=`basename -s .yaml $file`.json
+            echo "converting  $file  to  $target  ..."
+            if [ "$file" != "api-with-examples.yaml" ] ; then
+                vendor/bin/php-openapi convert --read-yaml $file --write-json $target
+                vendor/bin/indent --tabs --tabstop=4 $target
+                vendor/bin/indent --spaces --tabstop=2 $target
+            fi
+        done
+        
+    - name: cleanup
+      run: |
+        cd examples/v3.0
+        rm -rf vendor/ composer.*
+
+    - name: git diff
+      run: |
+        cd examples/v3.0
+        git add *.json
+        git diff --staged
+
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        branch-suffix: none
+        branch: update-json-examples
+        title: Update JSON example files
+        commit-message: Update JSON example files
+        body: |
+          This pull request is automatically triggered by github actions [create-pull-request][1].
+          
+          It seems the OpenAPI example YAML files have changed, so the JSON files are automatically being adjusted.
+          
+            [1]: https://github.com/peter-evans/create-pull-request
+

--- a/examples/v3.0/api-with-examples.yaml
+++ b/examples/v3.0/api-with-examples.yaml
@@ -13,9 +13,10 @@ paths:
             200 response
           content:
             application/json:
-              examples: 
+              examples:
                 foo:
-                  value: {
+                  value:
+                    {
                     "versions": [
                         {
                             "status": "CURRENT",
@@ -40,15 +41,15 @@ paths:
                             ]
                         }
                     ]
-                 }
+                    }
         '300':
           description: |-
             300 response
           content:
-            application/json: 
-              examples: 
+            application/json:
+              examples:
                 foo:
-                  value: |
+                  value:
                    {
                     "versions": [
                           {
@@ -74,7 +75,7 @@ paths:
                             ]
                         }
                     ]
-                   }
+                    }
   /v2:
     get:
       operationId: getVersionDetailsv2
@@ -84,10 +85,11 @@ paths:
           description: |-
             200 response
           content:
-            application/json: 
+            application/json:
               examples:
                 foo:
-                  value: {
+                  value:
+                    {
                     "version": {
                       "status": "CURRENT",
                       "updated": "2011-01-21T11:33:21Z",
@@ -124,15 +126,16 @@ paths:
                           }
                       ]
                     }
-                  }
+                    }
         '203':
           description: |-
             203 response
           content:
-            application/json: 
+            application/json:
               examples:
                 foo:
-                  value: {
+                  value:
+                    {
                     "version": {
                       "status": "CURRENT",
                       "updated": "2011-01-21T11:33:21Z",
@@ -164,4 +167,4 @@ paths:
                           }
                       ]
                     }
-                  }
+                    }


### PR DESCRIPTION
As discussed in #1385 the example `.json` files for version 3 should be automatically generated from the `.yaml` example files.

I thought this was a good case for trying out Github Actions and the result is the following:

- When a push to `master` (or any other branch we wish to include) is made, a Github Actions Workflow is triggered ([example](https://github.com/cebe/OpenAPI-Specification/commit/9c98e819ae876af92c2a9112dcfa6dfcb929e7dc/checks?check_suite_id=331067708))
- it will generate new JSON files from the YAML examples
- if there are any changes, it will create a pull request to the branch that triggered the Workflow ([example](https://github.com/cebe/OpenAPI-Specification/pull/3))
