### PR TITLE
introduce schema definition SchemaReference

### DIFF
--- a/schemas/v3.0/schema.yaml
+++ b/schemas/v3.0/schema.yaml
@@ -43,6 +43,14 @@ definitions:
       '^\$ref$':
         type: string
         format: uri-reference
+  SchemaReference:
+    type: object
+    required:
+      - $ref
+    patternProperties:
+      '^\$ref$':
+        type: string
+        format: uri-reference
   Info:
     type: object
     required:
@@ -139,7 +147,7 @@ definitions:
           '^[a-zA-Z0-9\.\-_]+$':
             oneOf:
               - $ref: '#/definitions/Schema'
-              - $ref: '#/definitions/Reference'
+              - $ref: '#/definitions/SchemaReference'
       responses:
         type: object
         patternProperties:
@@ -269,39 +277,39 @@ definitions:
       not:
         oneOf:
           - $ref: '#/definitions/Schema'
-          - $ref: '#/definitions/Reference'
+          - $ref: '#/definitions/SchemaReference'
       allOf:
         type: array
         items:
           oneOf:
             - $ref: '#/definitions/Schema'
-            - $ref: '#/definitions/Reference'
+            - $ref: '#/definitions/SchemaReference'
       oneOf:
         type: array
         items:
           oneOf:
             - $ref: '#/definitions/Schema'
-            - $ref: '#/definitions/Reference'
+            - $ref: '#/definitions/SchemaReference'
       anyOf:
         type: array
         items:
           oneOf:
             - $ref: '#/definitions/Schema'
-            - $ref: '#/definitions/Reference'
+            - $ref: '#/definitions/SchemaReference'
       items:
         oneOf:
           - $ref: '#/definitions/Schema'
-          - $ref: '#/definitions/Reference'
+          - $ref: '#/definitions/SchemaReference'
       properties:
         type: object
         additionalProperties:
           oneOf:
             - $ref: '#/definitions/Schema'
-            - $ref: '#/definitions/Reference'
+            - $ref: '#/definitions/SchemaReference'
       additionalProperties:
         oneOf:
           - $ref: '#/definitions/Schema'
-          - $ref: '#/definitions/Reference'
+          - $ref: '#/definitions/SchemaReference'
           - type: boolean
         default: true
       description:
@@ -397,7 +405,7 @@ definitions:
       schema:
         oneOf:
           - $ref: '#/definitions/Schema'
-          - $ref: '#/definitions/Reference'
+          - $ref: '#/definitions/SchemaReference'
       example: {}
       examples:
         type: object
@@ -457,7 +465,7 @@ definitions:
       schema:
         oneOf:
           - $ref: '#/definitions/Schema'
-          - $ref: '#/definitions/Reference'
+          - $ref: '#/definitions/SchemaReference'
       content:
         type: object
         additionalProperties:
@@ -669,7 +677,7 @@ definitions:
       schema:
         oneOf:
           - $ref: '#/definitions/Schema'
-          - $ref: '#/definitions/Reference'
+          - $ref: '#/definitions/SchemaReference'
       content:
         type: object
         additionalProperties:


### PR DESCRIPTION
I'm working on tooling which relies on the openapi schema for implementing openapi functionality. schemas are handled, of course, quite differently than other structures which may be pointed to by a Reference such as a Parameter or Header.

in order to identify what is a schema and what is not, using this openapi schema, having a separate Reference particular to Schema references would be very helpful.

I can do a workaround where I examine the target of a reference and see if its schema is `#/definitions/Schema`, but it's much simpler, from my point of view, to just have schema references be their own thing.