### PR TITLE
Paths MAY contain fragments

### DIFF
--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -657,7 +657,7 @@ The path is appended to the URL from the [`Server Object`](#serverObject) in ord
 
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="pathsPath"></a>/{path} | [Path Item Object](#pathItemObject) | A relative path to an individual endpoint. The field name MUST begin with a slash. The path is **appended** (no relative URL resolution) to the expanded URL from the [`Server Object`](#serverObject)'s `url` field in order to construct the full URL. [Path templating](#pathTemplating) is allowed. When matching URLs, concrete (non-templated) paths would be matched before their templated counterparts. Templated paths with the same hierarchy but different templated names MUST NOT exist as they are identical. In case of ambiguous matching, it's up to the tooling to decide which one to use.
+<a name="pathsPath"></a>/{path} | [Path Item Object](#pathItemObject) | A relative path to an individual endpoint. The field name MUST begin with a slash. The path is **appended** (no relative URL resolution) to the expanded URL from the [`Server Object`](#serverObject)'s `url` field in order to construct the full URL. [Path templating](#pathTemplating) is allowed. When matching URLs, concrete (non-templated) paths would be matched before their templated counterparts. Templated paths with the same hierarchy but different templated names MUST NOT exist as they are identical. In case of ambiguous matching, it's up to the tooling to decide which one to use. Paths MAY contain fragments as defined in [RFC3986](https://tools.ietf.org/html/rfc3986#section-3.5). Paths with different fragments are considered different.
 
 This object MAY be extended with [Specification Extensions](#specificationExtensions).
 
@@ -675,6 +675,12 @@ The following paths are considered identical and invalid:
 ```
   /pets/{petId}
   /pets/{name}
+```
+
+The following paths are considered different and valid:
+```
+  /pets/{petId}#IdentifiedById
+  /pets/{name}#IdentifiedByName
 ```
 
 The following may lead to ambiguous resolution:


### PR DESCRIPTION
This PR is based on discussion in https://github.com/OAI/OpenAPI-Specification/issues/1635

Paths MAY contain fragments as defined in [RFC3986](https://tools.ietf.org/html/rfc3986#section-3.5). Paths with different fragments are considered different.

This feature can be used to further divide resources under same endpoint.