### PR TITLE
Make PathItem operation properties specific

### DIFF
--- a/schemas/v3.0/schema.yaml
+++ b/schemas/v3.0/schema.yaml
@@ -495,6 +495,22 @@ definitions:
         type: string
       description:
         type: string
+      get:
+        $ref: '#/definitions/Operation'
+      put:
+        $ref: '#/definitions/Operation'
+      post:
+        $ref: '#/definitions/Operation'
+      delete:
+        $ref: '#/definitions/Operation'
+      options:
+        $ref: '#/definitions/Operation'
+      head:
+        $ref: '#/definitions/Operation'
+      patch:
+        $ref: '#/definitions/Operation'
+      trace:
+        $ref: '#/definitions/Operation'
       servers:
         type: array
         items:
@@ -507,8 +523,6 @@ definitions:
             - $ref: '#/definitions/Reference'
         uniqueItems: true
     patternProperties:
-      '^(get|put|post|delete|options|head|patch|trace)$':
-        $ref: '#/definitions/Operation'
       '^x-': {}
     additionalProperties: false
 


### PR DESCRIPTION
PR for #2126.

Move the Operations properties definitions from `patternProperties` to the `properties` set, explicitly defining all of them. The goal is to get better coding tools completion - IntelliJ IDEA does - and to improve the spec quality with a purer spec schema usage.

Changes are 100% backwards compatible, all validating schemas will validate and all non validating schemas won't validate after merge. After merge, coding tools will get more information because of replacing a pattern with a defined literal set.
