### PR TITLE
actions: add mdv to replace Travis

### DIFF
--- a/.github/workflows/validate-markdown.yaml
+++ b/.github/workflows/validate-markdown.yaml
@@ -1,0 +1,27 @@
+name: validate-markdown
+
+# Author: @MikeRalphson
+# Issue: https://github.com/OAI/OpenAPI-Specification/issues/2130
+
+#
+# This workflow validates files in the versions directory matching 3.*.md
+# Versions before 3.0 are not validated, as they contain linking errors
+# where it is not currently planned to go back and fix them
+#
+
+# run this on push to any branch and creation of pull-requests
+on: [push, pull_request]
+
+jobs:
+  mdv:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1 # checkout repo content
+    - uses: actions/setup-node@v1 # setup Node.js
+      with:
+        node-version: '12.x'
+    - name: Validate markdown
+      run: npx mdv versions/3.*.md
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-sudo: false
-language: node_js
-node_js:
-  - "node"
-script:
-  - node node_modules/mdv/mdv versions/3.*.md

--- a/package.json
+++ b/package.json
@@ -18,9 +18,7 @@
     "schemas/*"
   ],
   "dependencies": {},
-  "devDependencies": {
-    "mdv": "^1.0.7"
-  },
+  "devDependencies": {},
   "keywords": [
     "OpenAPI",
     "OAS",


### PR DESCRIPTION
As discussed in the TSC call 2020/02/13 we agreed to move from Travis-CI to GitHub actions as we will need more distinct actions going forward (JSON examples, JSON schema, ReSpec publishing etc).

This PR:
* Adds a GitHub action to validate the markdown links using `mdv` as before
* Removes the `.travis.yml` file from the repo root
* Removes `mdv` as a direct dependency in `package.json`

Examples of a [failing run with a deliberately introduced error](https://github.com/MikeRalphson/OpenAPI-Specification/actions/runs/39833098) and a [successful run](https://github.com/MikeRalphson/OpenAPI-Specification/actions/runs/39825699)