### PR TITLE
gh-pages: add v3.0.3.html

### DIFF
--- a/index.md
+++ b/index.md
@@ -13,4 +13,4 @@ This site contains the OpenAPI Initiative Registry and content for the HTML vers
 ## The Specification
 
 * [Markdown source-of-truth](https://github.com/OAI/OpenAPI-Specification)
-* [HTML Specification versions](https://openapis.org/specification)
+* [HTML Specification version](oas/v3.0.3.html)

--- a/oas/v3.0.3.html
+++ b/oas/v3.0.3.html
@@ -1,0 +1,4088 @@
+<html><head><meta charset="UTF-8"><title>OpenAPI Specification</title><script src="http://spec.openapis.org/js/respec-oai.js" class="remove"></script><script class="remove">var respecConfig = {"specStatus":"base","editors":[{"name":"Darrel Miller "},{"name":"Jeremy Whitlock "},{"name":"Marsh Gardiner "},{"name":"Mike Ralphson "},{"name":"Ron Ratovsky "},{"name":"Uri Sarid "}],"formerEditors":[{"name":"Jason Harmon "},{"name":"Tony Tam "}],"publishDate":"2020-02-20T00:00:00.000Z","subtitle":"Version 3.0.3","processVersion":2017,"edDraftURI":"http://github.com/OAI/OpenAPI-Specification/","github":{"repoURL":"https://github.com/OAI/OpenAPI-Specification/","branch":"master"},"shortName":"OAS","noTOC":false,"lint":false,"additionalCopyrightHolders":"the Linux Foundation","includePermalinks":true};</script></head><body><style>#respec-ui { visibility: hidden; }h1,h2,h3 { color: #629b34; }a[href] { color: #45512c; }body:not(.toc-inline) #toc h2 { color: #45512c; }table { display: block; width: 100%; overflow: auto; }table th { font-weight: 600; }table th, table td { padding: 6px 13px; border: 1px solid #dfe2e5; }table tr { background-color: #fff; border-top: 1px solid #c6cbd1; }table tr:nth-child(2n) { background-color: #f6f8fa; }pre { background-color: #f6f8fa !important; }/**  * GitHub Gist Theme  * Author : Louis Barranqueiro - https://github.com/LouisBarranqueiro  */  .hljs {   display: block;   background: white;   padding: 0.5em;   color: #333333;   overflow-x: auto; }  .hljs-comment, .hljs-meta {   color: #969896; }  .hljs-string, .hljs-variable, .hljs-template-variable, .hljs-strong, .hljs-emphasis, .hljs-quote {   color: #df5000; }  .hljs-keyword, .hljs-selector-tag, .hljs-type {   color: #a71d5d; }  .hljs-literal, .hljs-symbol, .hljs-bullet, .hljs-attribute {   color: #0086b3; }  .hljs-section, .hljs-name {   color: #63a35c; }  .hljs-tag {   color: #333333; }  .hljs-title, .hljs-attr, .hljs-selector-id, .hljs-selector-class, .hljs-selector-attr, .hljs-selector-pseudo {   color: #795da3; }  .hljs-addition {   color: #55a532;   background-color: #eaffea; }  .hljs-deletion {   color: #bd2c00;   background-color: #ffecec; }  .hljs-link {   text-decoration: underline; } </style><section id="abstract">The OpenAPI Specification (OAS) defines a standard, programming language-agnostic interface description for REST APIs, which allows both humans and computers to discover and understand the capabilities of a service without requiring access to source code, additional documentation, or inspection of network traffic. When properly defined via OpenAPI, a consumer can understand and interact with the remote service with a minimal amount of implementation logic. Similar to what interface descriptions have done for lower-level programming, the OpenAPI Specification removes guesswork in calling a service.</section><section class="notoc" id="sotd"><h2>Status of This Document</h2>The source-of-truth for the specification is the GitHub markdown file referenced above.</section>
+<section><h1>OpenAPI Specification</h1>
+<section><h3>Version 3.0.3</h3>
+<p>The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “NOT RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be interpreted as described in <a href="https://tools.ietf.org/html/bcp14">BCP 14</a> [[!RFC2119]] [[!RFC8174]] when, and only when, they appear in all capitals, as shown here.</p>
+<p>This document is licensed under <a href="https://www.apache.org/licenses/LICENSE-2.0.html">The Apache License, Version 2.0</a>.</p>
+</section></section></section><section><h1>Introduction</h1>
+<p>The OpenAPI Specification (OAS) defines a standard, language-agnostic interface to RESTful APIs which allows both humans and computers to discover and understand the capabilities of the service without access to source code, documentation, or through network traffic inspection. When properly defined, a consumer can understand and interact with the remote service with a minimal amount of implementation logic.</p>
+<p>An OpenAPI definition can then be used by documentation generation tools to display the API, code generation tools to generate servers and clients in various programming languages, testing tools, and many other use cases.</p>
+<!-- /TOC -->
+</section><section><h1><dfn>Definitions</dfn></h1>
+<section><h4><span id="oasDocument"><dfn>OpenAPI Document</dfn></span></h4>
+<p>A document (or set of documents) that defines or describes an API. An OpenAPI definition uses and conforms to the OpenAPI Specification.</p>
+</section><section><h4><span id="pathTemplating"><dfn>Path Templating</dfn></span></h4>
+<p>Path templating refers to the usage of template expressions, delimited by curly braces ({}), to mark a section of a URL path as replaceable using path parameters.</p>
+<p>Each template expression in the path MUST correspond to a path parameter that is included in the <a href="#path-item-object">Path Item</a> itself and/or in each of the Path Item’s <a href="#operation-object">Operations</a>.</p>
+</section><section><h4><span id="mediaTypes"><dfn>Media Types</dfn></span></h4>
+<p>Media type definitions are spread across several resources.
+The media type definitions SHOULD be in compliance with [[!RFC6838]].</p>
+<p>Some examples of possible media type definitions:</p>
+<pre class="highlight "><code>
+  text/plain; charset=utf-8
+  application/json
+  application/vnd.github+json
+  application/vnd.github.v3+json
+  application/vnd.github.v3.raw+json
+  application/vnd.github.v3.text+json
+  application/vnd.github.v3.html+json
+  application/vnd.github.v3.full+json
+  application/vnd.github.v3.diff
+  application/vnd.github.v3.patch
+</code></pre>
+</section><section><h4><span id="httpCodes"><dfn>HTTP Status Codes</dfn></span></h4>
+<p>The HTTP Status Codes are used to indicate the status of the executed operation.
+The available status codes are defined by [[!RFC7231]] and registered status codes are listed in the <a href="https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml">IANA Status Code Registry</a>.</p>
+</section></section></section></section><section><h1>Specification</h1>
+<section><h2>Versions</h2>
+<p>The OpenAPI Specification is versioned using <a href="https://semver.org/spec/v2.0.0.html">Semantic Versioning 2.0.0</a> (semver) and follows the semver specification.</p>
+<p>The <code>major</code>.<code>minor</code> portion of the semver (for example <code>3.0</code>) SHALL designate the OAS feature set. Typically, <em><code>.patch</code></em> versions address errors in this document, not the feature set. Tooling which supports OAS 3.0 SHOULD be compatible with all OAS 3.0.* versions. The patch version SHOULD NOT be considered by tooling, making no distinction between <code>3.0.0</code> and <code>3.0.1</code> for example.</p>
+<p>Each new minor version of the OpenAPI Specification SHALL allow any OpenAPI document that is valid against any previous minor version of the Specification, within the same major version, to be updated to the new Specification version with equivalent semantics. Such an update MUST only require changing the <code>openapi</code> property to the new minor version.</p>
+<p>For example, a valid OpenAPI 3.0.2 document, upon changing its <code>openapi</code> property to <code>3.1.0</code>, SHALL be a valid OpenAPI 3.1.0 document, semantically equivalent to the original OpenAPI 3.0.2 document. New minor versions of the OpenAPI Specification MUST be written to ensure this form of backward compatibility.</p>
+<p>An OpenAPI document compatible with OAS 3.*.* contains a required <a href="#oasVersion"><code>openapi</code></a> field which designates the semantic version of the OAS that it uses. (OAS 2.0 documents contain a top-level version field named <a href="https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#swaggerObject"><code>swagger</code></a> and value <code>&quot;2.0&quot;</code>.)</p>
+</section><section><h2>Format</h2>
+<p>An OpenAPI document that conforms to the OpenAPI Specification is itself a JSON object, which may be represented either in JSON or YAML format.</p>
+<p>For example, if a field has an array value, the JSON array representation will be used:</p>
+<pre class="nohighlight"><code>
+{
+   <span class="hljs-attr">"field"</span>: [ <span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span> ]
+}
+</code></pre>
+<p>All field names in the specification are <strong>case sensitive</strong>.
+This includes all fields that are used as keys in a map, except where explicitly noted that keys are <strong>case insensitive</strong>.</p>
+<p>The schema exposes two types of fields: Fixed fields, which have a declared name, and Patterned fields, which declare a regex pattern for the field name.</p>
+<p>Patterned fields MUST have unique names within the containing object.</p>
+<p>In order to preserve the ability to round-trip between YAML and JSON formats, YAML version <a href="https://yaml.org/spec/1.2/spec.html">1.2</a> is RECOMMENDED along with some additional constraints:</p>
+<ul>
+<li>Tags MUST be limited to those allowed by the <a href="https://yaml.org/spec/1.2/spec.html#id2803231">JSON Schema ruleset</a>.</li>
+<li>Keys used in YAML maps MUST be limited to a scalar string, as defined by the <a href="https://yaml.org/spec/1.2/spec.html#id2802346">YAML Failsafe schema ruleset</a>.</li>
+</ul>
+<p><strong>Note:</strong> While APIs may be defined by OpenAPI documents in either YAML or JSON format, the API request and response bodies and other content are not required to be JSON or YAML.</p>
+</section><section><h2><span id="documentStructure">Document Structure</span></h2>
+<p>An OpenAPI document MAY be made up of a single document or be divided into multiple, connected parts at the discretion of the user. In the latter case, <code>$ref</code> fields MUST be used in the specification to reference those parts as follows from the <a href="https://json-schema.org">JSON Schema</a> definitions.</p>
+<p>It is RECOMMENDED that the root OpenAPI document be named: <code>openapi.json</code> or <code>openapi.yaml</code>.</p>
+</section><section><h2><span id="dataTypes">Data Types</span></h2>
+<p>Primitive data types in the OAS are based on the types supported by the <a href="https://tools.ietf.org/html/draft-wright-json-schema-00#section-4.2">JSON Schema Specification Wright Draft 00</a>.
+Note that <code>integer</code> as a type is also supported and is defined as a JSON number without a fraction or exponent part.
+<code>null</code> is not supported as a type (see <a href="#schemaNullable"><code>nullable</code></a> for an alternative solution).
+Models are defined using the <a href="#schemaObject">Schema Object</a>, which is an extended subset of JSON Schema Specification Wright Draft 00.</p>
+<p><a id="dataTypeFormat"> </a>Primitives have an optional modifier property: <code>format</code>.
+OAS uses several known formats to define in fine detail the data type being used.
+However, to support documentation needs, the <code>format</code> property is an open <code>string</code>-valued property, and can have any value.
+Formats such as <code>&quot;email&quot;</code>, <code>&quot;uuid&quot;</code>, and so on, MAY be used even though undefined by this specification.
+Types that are not accompanied by a <code>format</code> property follow the type definition in the JSON Schema. Tools that do not recognize a specific <code>format</code> MAY default back to the <code>type</code> alone, as if the <code>format</code> is not specified.</p>
+<p>The formats defined by the OAS are:</p>
+<table>
+<thead>
+<tr>
+<th><a href="#dataTypes"><code>type</code></a></th>
+<th><a href="#dataTypeFormat"><code>format</code></a></th>
+<th>Comments</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>integer</code></td>
+<td><code>int32</code></td>
+<td>signed 32 bits</td>
+</tr>
+<tr>
+<td><code>integer</code></td>
+<td><code>int64</code></td>
+<td>signed 64 bits (a.k.a long)</td>
+</tr>
+<tr>
+<td><code>number</code></td>
+<td><code>float</code></td>
+<td></td>
+</tr>
+<tr>
+<td><code>number</code></td>
+<td><code>double</code></td>
+<td></td>
+</tr>
+<tr>
+<td><code>string</code></td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td><code>string</code></td>
+<td><code>byte</code></td>
+<td>base64 encoded characters</td>
+</tr>
+<tr>
+<td><code>string</code></td>
+<td><code>binary</code></td>
+<td>any sequence of octets</td>
+</tr>
+<tr>
+<td><code>boolean</code></td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td><code>string</code></td>
+<td><code>date</code></td>
+<td>As defined by <code>full-date</code> - [[!RFC3339]]</td>
+</tr>
+<tr>
+<td><code>string</code></td>
+<td><code>date-time</code></td>
+<td>As defined by <code>date-time</code> - [[!RFC3339]]</td>
+</tr>
+<tr>
+<td><code>string</code></td>
+<td><code>password</code></td>
+<td>A hint to UIs to obscure input.</td>
+</tr>
+</tbody>
+</table>
+</section><section><h2><span id="richText">Rich Text Formatting</span></h2>
+<p>Throughout the specification <code>description</code> fields are noted as supporting CommonMark markdown formatting.
+Where OpenAPI tooling renders rich text it MUST support, at a minimum, markdown syntax as described by <a href="https://spec.commonmark.org/0.27/">CommonMark 0.27</a>. Tooling MAY choose to ignore some CommonMark features to address security concerns.</p>
+</section><section><h2><span id="relativeReferences">Relative References in URLs</span></h2>
+<p>Unless specified otherwise, all properties that are URLs MAY be relative references as defined by [[!RFC3986]].
+Relative references are resolved using the URLs defined in the <a href="#serverObject"><code>Server Object</code></a> as a Base URI.</p>
+<p>Relative references used in <code>$ref</code> are processed as per <a href="https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03">JSON Reference</a>, using the URL of the current document as the base URI. See also the <a href="#referenceObject">Reference Object</a>.</p>
+</section><section><h2>Schema</h2>
+<p>In the following description, if a field is not explicitly <strong>REQUIRED</strong> or described with a MUST or SHALL, it can be considered OPTIONAL.</p>
+<section><h3><span id="oasObject">OpenAPI Object</span></h3>
+<p>This is the root document object of the <a href="#oasDocument">OpenAPI document</a>.</p>
+<section><h4>Fixed Fields</h4>
+<table>
+<thead>
+<tr>
+<th>Field Name</th>
+<th style="text-align:center">Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a id="oasVersion"> </a>openapi</td>
+<td style="text-align:center"><code>string</code></td>
+<td><strong>REQUIRED</strong>. This string MUST be the <a href="https://semver.org/spec/v2.0.0.html">semantic version number</a> of the <a href="#versions">OpenAPI Specification version</a> that the OpenAPI document uses. The <code>openapi</code> field SHOULD be used by tooling specifications and clients to interpret the OpenAPI document. This is <em>not</em> related to the API <a href="#infoVersion"><code>info.version</code></a> string.</td>
+</tr>
+<tr>
+<td><a id="oasInfo"> </a>info</td>
+<td style="text-align:center"><a href="#infoObject">Info Object</a></td>
+<td><strong>REQUIRED</strong>. Provides metadata about the API. The metadata MAY be used by tooling as required.</td>
+</tr>
+<tr>
+<td><a id="oasServers"> </a>servers</td>
+<td style="text-align:center">[<a href="#serverObject">Server Object</a>]</td>
+<td>An array of Server Objects, which provide connectivity information to a target server. If the <code>servers</code> property is not provided, or is an empty array, the default value would be a <a href="#serverObject">Server Object</a> with a <a href="#serverUrl">url</a> value of <code>/</code>.</td>
+</tr>
+<tr>
+<td><a id="oasPaths"> </a>paths</td>
+<td style="text-align:center"><a href="#pathsObject">Paths Object</a></td>
+<td><strong>REQUIRED</strong>. The available paths and operations for the API.</td>
+</tr>
+<tr>
+<td><a id="oasComponents"> </a>components</td>
+<td style="text-align:center"><a href="#componentsObject">Components Object</a></td>
+<td>An element to hold various schemas for the specification.</td>
+</tr>
+<tr>
+<td><a id="oasSecurity"> </a>security</td>
+<td style="text-align:center">[<a href="#securityRequirementObject">Security Requirement Object</a>]</td>
+<td>A declaration of which security mechanisms can be used across the API. The list of values includes alternative security requirement objects that can be used. Only one of the security requirement objects need to be satisfied to authorize a request. Individual operations can override this definition. To make security optional, an empty security requirement (<code>{}</code>) can be included in the array.</td>
+</tr>
+<tr>
+<td><a id="oasTags"> </a>tags</td>
+<td style="text-align:center">[<a href="#tagObject">Tag Object</a>]</td>
+<td>A list of tags used by the specification with additional metadata. The order of the tags can be used to reflect on their order by the parsing tools. Not all tags that are used by the <a href="#operationObject">Operation Object</a> must be declared. The tags that are not declared MAY be organized randomly or based on the tools’ logic. Each tag name in the list MUST be unique.</td>
+</tr>
+<tr>
+<td><a id="oasExternalDocs"> </a>externalDocs</td>
+<td style="text-align:center"><a href="#externalDocumentationObject">External Documentation Object</a></td>
+<td>Additional external documentation.</td>
+</tr>
+</tbody>
+</table>
+<p>This object MAY be extended with <a href="#specificationExtensions">Specification Extensions</a>.</p>
+</section></section><section><h3><span id="infoObject">Info Object</span></h3>
+<p>The object provides metadata about the API.
+The metadata MAY be used by the clients if needed, and MAY be presented in editing or documentation generation tools for convenience.</p>
+<section><h4>Fixed Fields</h4>
+<table>
+<thead>
+<tr>
+<th>Field Name</th>
+<th style="text-align:center">Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a id="infoTitle"> </a>title</td>
+<td style="text-align:center"><code>string</code></td>
+<td><strong>REQUIRED</strong>. The title of the API.</td>
+</tr>
+<tr>
+<td><a id="infoDescription"> </a>description</td>
+<td style="text-align:center"><code>string</code></td>
+<td>A short description of the API. <a href="https://spec.commonmark.org/">CommonMark syntax</a> MAY be used for rich text representation.</td>
+</tr>
+<tr>
+<td><a id="infoTermsOfService"> </a>termsOfService</td>
+<td style="text-align:center"><code>string</code></td>
+<td>A URL to the Terms of Service for the API. MUST be in the format of a URL.</td>
+</tr>
+<tr>
+<td><a id="infoContact"> </a>contact</td>
+<td style="text-align:center"><a href="#contactObject">Contact Object</a></td>
+<td>The contact information for the exposed API.</td>
+</tr>
+<tr>
+<td><a id="infoLicense"> </a>license</td>
+<td style="text-align:center"><a href="#licenseObject">License Object</a></td>
+<td>The license information for the exposed API.</td>
+</tr>
+<tr>
+<td><a id="infoVersion"> </a>version</td>
+<td style="text-align:center"><code>string</code></td>
+<td><strong>REQUIRED</strong>. The version of the OpenAPI document (which is distinct from the <a href="#oasVersion">OpenAPI Specification version</a> or the API implementation version).</td>
+</tr>
+</tbody>
+</table>
+<p>This object MAY be extended with <a href="#specificationExtensions">Specification Extensions</a>.</p>
+</section><section><h4>Info Object Example</h4>
+<pre class="nohighlight"><code>
+{
+  <span class="hljs-attr">"title"</span>: <span class="hljs-string">"Sample Pet Store App"</span>,
+  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"This is a sample server for a pet store."</span>,
+  <span class="hljs-attr">"termsOfService"</span>: <span class="hljs-string">"http://example.com/terms/"</span>,
+  <span class="hljs-attr">"contact"</span>: {
+    <span class="hljs-attr">"name"</span>: <span class="hljs-string">"API Support"</span>,
+    <span class="hljs-attr">"url"</span>: <span class="hljs-string">"http://www.example.com/support"</span>,
+    <span class="hljs-attr">"email"</span>: <span class="hljs-string">"support@example.com"</span>
+  },
+  <span class="hljs-attr">"license"</span>: {
+    <span class="hljs-attr">"name"</span>: <span class="hljs-string">"Apache 2.0"</span>,
+    <span class="hljs-attr">"url"</span>: <span class="hljs-string">"https://www.apache.org/licenses/LICENSE-2.0.html"</span>
+  },
+  <span class="hljs-attr">"version"</span>: <span class="hljs-string">"1.0.1"</span>
+}
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">title:</span> <span class="hljs-string">Sample</span> <span class="hljs-string">Pet</span> <span class="hljs-string">Store</span> <span class="hljs-string">App</span>
+<span class="hljs-attr">description:</span> <span class="hljs-string">This</span> <span class="hljs-string">is</span> <span class="hljs-string">a</span> <span class="hljs-string">sample</span> <span class="hljs-string">server</span> <span class="hljs-string">for</span> <span class="hljs-string">a</span> <span class="hljs-string">pet</span> <span class="hljs-string">store.</span>
+<span class="hljs-attr">termsOfService:</span> <span class="hljs-string">http://example.com/terms/</span>
+<span class="hljs-attr">contact:</span>
+  <span class="hljs-attr">name:</span> <span class="hljs-string">API</span> <span class="hljs-string">Support</span>
+  <span class="hljs-attr">url:</span> <span class="hljs-string">http://www.example.com/support</span>
+  <span class="hljs-attr">email:</span> <span class="hljs-string">support@example.com</span>
+<span class="hljs-attr">license:</span>
+  <span class="hljs-attr">name:</span> <span class="hljs-string">Apache</span> <span class="hljs-number">2.0</span>
+  <span class="hljs-attr">url:</span> <span class="hljs-string">https://www.apache.org/licenses/LICENSE-2.0.html</span>
+<span class="hljs-attr">version:</span> <span class="hljs-number">1.0</span><span class="hljs-number">.1</span>
+</code></pre>
+</section></section><section><h3><span id="contactObject">Contact Object</span></h3>
+<p>Contact information for the exposed API.</p>
+<section><h4>Fixed Fields</h4>
+<table>
+<thead>
+<tr>
+<th>Field Name</th>
+<th style="text-align:center">Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a id="contactName"> </a>name</td>
+<td style="text-align:center"><code>string</code></td>
+<td>The identifying name of the contact person/organization.</td>
+</tr>
+<tr>
+<td><a id="contactUrl"> </a>url</td>
+<td style="text-align:center"><code>string</code></td>
+<td>The URL pointing to the contact information. MUST be in the format of a URL.</td>
+</tr>
+<tr>
+<td><a id="contactEmail"> </a>email</td>
+<td style="text-align:center"><code>string</code></td>
+<td>The email address of the contact person/organization. MUST be in the format of an email address.</td>
+</tr>
+</tbody>
+</table>
+<p>This object MAY be extended with <a href="#specificationExtensions">Specification Extensions</a>.</p>
+</section><section><h4>Contact Object Example</h4>
+<pre class="nohighlight"><code>
+{
+  <span class="hljs-attr">"name"</span>: <span class="hljs-string">"API Support"</span>,
+  <span class="hljs-attr">"url"</span>: <span class="hljs-string">"http://www.example.com/support"</span>,
+  <span class="hljs-attr">"email"</span>: <span class="hljs-string">"support@example.com"</span>
+}
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">name:</span> <span class="hljs-string">API</span> <span class="hljs-string">Support</span>
+<span class="hljs-attr">url:</span> <span class="hljs-string">http://www.example.com/support</span>
+<span class="hljs-attr">email:</span> <span class="hljs-string">support@example.com</span>
+</code></pre>
+</section></section><section><h3><span id="licenseObject">License Object</span></h3>
+<p>License information for the exposed API.</p>
+<section><h4>Fixed Fields</h4>
+<table>
+<thead>
+<tr>
+<th>Field Name</th>
+<th style="text-align:center">Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a id="licenseName"> </a>name</td>
+<td style="text-align:center"><code>string</code></td>
+<td><strong>REQUIRED</strong>. The license name used for the API.</td>
+</tr>
+<tr>
+<td><a id="licenseUrl"> </a>url</td>
+<td style="text-align:center"><code>string</code></td>
+<td>A URL to the license used for the API. MUST be in the format of a URL.</td>
+</tr>
+</tbody>
+</table>
+<p>This object MAY be extended with <a href="#specificationExtensions">Specification Extensions</a>.</p>
+</section><section><h4>License Object Example</h4>
+<pre class="nohighlight"><code>
+{
+  <span class="hljs-attr">"name"</span>: <span class="hljs-string">"Apache 2.0"</span>,
+  <span class="hljs-attr">"url"</span>: <span class="hljs-string">"https://www.apache.org/licenses/LICENSE-2.0.html"</span>
+}
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">name:</span> <span class="hljs-string">Apache</span> <span class="hljs-number">2.0</span>
+<span class="hljs-attr">url:</span> <span class="hljs-string">https://www.apache.org/licenses/LICENSE-2.0.html</span>
+</code></pre>
+</section></section><section><h3><span id="serverObject">Server Object</span></h3>
+<p>An object representing a Server.</p>
+<section><h4>Fixed Fields</h4>
+<table>
+<thead>
+<tr>
+<th>Field Name</th>
+<th style="text-align:center">Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a id="serverUrl"> </a>url</td>
+<td style="text-align:center"><code>string</code></td>
+<td><strong>REQUIRED</strong>. A URL to the target host.  This URL supports Server Variables and MAY be relative, to indicate that the host location is relative to the location where the OpenAPI document is being served. Variable substitutions will be made when a variable is named in <code>{</code>brackets<code>}</code>.</td>
+</tr>
+<tr>
+<td><a id="serverDescription"> </a>description</td>
+<td style="text-align:center"><code>string</code></td>
+<td>An optional string describing the host designated by the URL. <a href="https://spec.commonmark.org/">CommonMark syntax</a> MAY be used for rich text representation.</td>
+</tr>
+<tr>
+<td><a id="serverVariables"> </a>variables</td>
+<td style="text-align:center">Map[<code>string</code>, <a href="#serverVariableObject">Server Variable Object</a>]</td>
+<td>A map between a variable name and its value.  The value is used for substitution in the server’s URL template.</td>
+</tr>
+</tbody>
+</table>
+<p>This object MAY be extended with <a href="#specificationExtensions">Specification Extensions</a>.</p>
+</section><section><h4>Server Object Example</h4>
+<p>A single server would be described as:</p>
+<pre class="nohighlight"><code>
+{
+  <span class="hljs-attr">"url"</span>: <span class="hljs-string">"https://development.gigantic-server.com/v1"</span>,
+  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Development server"</span>
+}
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">url:</span> <span class="hljs-string">https://development.gigantic-server.com/v1</span>
+<span class="hljs-attr">description:</span> <span class="hljs-string">Development</span> <span class="hljs-string">server</span>
+</code></pre>
+<p>The following shows how multiple servers can be described, for example, at the OpenAPI Object’s <a href="#oasServers"><code>servers</code></a>:</p>
+<pre class="nohighlight"><code>
+{
+  <span class="hljs-attr">"servers"</span>: [
+    {
+      <span class="hljs-attr">"url"</span>: <span class="hljs-string">"https://development.gigantic-server.com/v1"</span>,
+      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Development server"</span>
+    },
+    {
+      <span class="hljs-attr">"url"</span>: <span class="hljs-string">"https://staging.gigantic-server.com/v1"</span>,
+      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Staging server"</span>
+    },
+    {
+      <span class="hljs-attr">"url"</span>: <span class="hljs-string">"https://api.gigantic-server.com/v1"</span>,
+      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Production server"</span>
+    }
+  ]
+}
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">servers:</span>
+<span class="hljs-bullet">-</span> <span class="hljs-attr">url:</span> <span class="hljs-string">https://development.gigantic-server.com/v1</span>
+  <span class="hljs-attr">description:</span> <span class="hljs-string">Development</span> <span class="hljs-string">server</span>
+<span class="hljs-bullet">-</span> <span class="hljs-attr">url:</span> <span class="hljs-string">https://staging.gigantic-server.com/v1</span>
+  <span class="hljs-attr">description:</span> <span class="hljs-string">Staging</span> <span class="hljs-string">server</span>
+<span class="hljs-bullet">-</span> <span class="hljs-attr">url:</span> <span class="hljs-string">https://api.gigantic-server.com/v1</span>
+  <span class="hljs-attr">description:</span> <span class="hljs-string">Production</span> <span class="hljs-string">server</span>
+</code></pre>
+<p>The following shows how variables can be used for a server configuration:</p>
+<pre class="nohighlight"><code>
+{
+  <span class="hljs-attr">"servers"</span>: [
+    {
+      <span class="hljs-attr">"url"</span>: <span class="hljs-string">"https://{username}.gigantic-server.com:{port}/{basePath}"</span>,
+      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"The production API server"</span>,
+      <span class="hljs-attr">"variables"</span>: {
+        <span class="hljs-attr">"username"</span>: {
+          <span class="hljs-attr">"default"</span>: <span class="hljs-string">"demo"</span>,
+          <span class="hljs-attr">"description"</span>: <span class="hljs-string">"this value is assigned by the service provider, in this example `gigantic-server.com`"</span>
+        },
+        <span class="hljs-attr">"port"</span>: {
+          <span class="hljs-attr">"enum"</span>: [
+            <span class="hljs-string">"8443"</span>,
+            <span class="hljs-string">"443"</span>
+          ],
+          <span class="hljs-attr">"default"</span>: <span class="hljs-string">"8443"</span>
+        },
+        <span class="hljs-attr">"basePath"</span>: {
+          <span class="hljs-attr">"default"</span>: <span class="hljs-string">"v2"</span>
+        }
+      }
+    }
+  ]
+}
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">servers:</span>
+<span class="hljs-bullet">-</span> <span class="hljs-attr">url:</span> <span class="hljs-string">https://{username}.gigantic-server.com:{port}/{basePath}</span>
+  <span class="hljs-attr">description:</span> <span class="hljs-string">The</span> <span class="hljs-string">production</span> <span class="hljs-string">API</span> <span class="hljs-string">server</span>
+  <span class="hljs-attr">variables:</span>
+    <span class="hljs-attr">username:</span>
+      <span class="hljs-comment"># note! no enum here means it is an open value</span>
+      <span class="hljs-attr">default:</span> <span class="hljs-string">demo</span>
+      <span class="hljs-attr">description:</span> <span class="hljs-string">this</span> <span class="hljs-string">value</span> <span class="hljs-string">is</span> <span class="hljs-string">assigned</span> <span class="hljs-string">by</span> <span class="hljs-string">the</span> <span class="hljs-string">service</span> <span class="hljs-string">provider,</span> <span class="hljs-string">in</span> <span class="hljs-string">this</span> <span class="hljs-string">example</span> <span class="hljs-string">`gigantic-server.com`</span>
+    <span class="hljs-attr">port:</span>
+      <span class="hljs-attr">enum:</span>
+        <span class="hljs-bullet">-</span> <span class="hljs-string">'8443'</span>
+        <span class="hljs-bullet">-</span> <span class="hljs-string">'443'</span>
+      <span class="hljs-attr">default:</span> <span class="hljs-string">'8443'</span>
+    <span class="hljs-attr">basePath:</span>
+      <span class="hljs-comment"># open meaning there is the opportunity to use special base paths as assigned by the provider, default is `v2`</span>
+      <span class="hljs-attr">default:</span> <span class="hljs-string">v2</span>
+</code></pre>
+</section></section><section><h3><span id="serverVariableObject">Server Variable Object</span></h3>
+<p>An object representing a Server Variable for server URL template substitution.</p>
+<section><h4>Fixed Fields</h4>
+<table>
+<thead>
+<tr>
+<th>Field Name</th>
+<th style="text-align:center">Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a id="serverVariableEnum"> </a>enum</td>
+<td style="text-align:center">[<code>string</code>]</td>
+<td>An enumeration of string values to be used if the substitution options are from a limited set. The array SHOULD NOT be empty.</td>
+</tr>
+<tr>
+<td><a id="serverVariableDefault"> </a>default</td>
+<td style="text-align:center"><code>string</code></td>
+<td><strong>REQUIRED</strong>. The default value to use for substitution, which SHALL be sent if an alternate value is <em>not</em> supplied. Note this behavior is different than the <a href="#schemaObject">Schema Object’s</a> treatment of default values, because in those cases parameter values are optional. If the <a href="#serverVariableEnum"><code>enum</code></a> is defined, the value SHOULD exist in the enum’s values.</td>
+</tr>
+<tr>
+<td><a id="serverVariableDescription"> </a>description</td>
+<td style="text-align:center"><code>string</code></td>
+<td>An optional description for the server variable. <a href="https://spec.commonmark.org/">CommonMark syntax</a> MAY be used for rich text representation.</td>
+</tr>
+</tbody>
+</table>
+<p>This object MAY be extended with <a href="#specificationExtensions">Specification Extensions</a>.</p>
+</section></section><section><h3><span id="componentsObject">Components Object</span></h3>
+<p>Holds a set of reusable objects for different aspects of the OAS.
+All objects defined within the components object will have no effect on the API unless they are explicitly referenced from properties outside the components object.</p>
+<section><h4>Fixed Fields</h4>
+<table>
+<thead>
+<tr>
+<th>Field Name</th>
+<th style="text-align:left">Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a id="componentsSchemas"> </a> schemas</td>
+<td style="text-align:left">Map[<code>string</code>, <a href="#schemaObject">Schema Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td>An object to hold reusable <a href="#schemaObject">Schema Objects</a>.</td>
+</tr>
+<tr>
+<td><a id="componentsResponses"> </a> responses</td>
+<td style="text-align:left">Map[<code>string</code>, <a href="#responseObject">Response Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td>An object to hold reusable <a href="#responseObject">Response Objects</a>.</td>
+</tr>
+<tr>
+<td><a id="componentsParameters"> </a> parameters</td>
+<td style="text-align:left">Map[<code>string</code>, <a href="#parameterObject">Parameter Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td>An object to hold reusable <a href="#parameterObject">Parameter Objects</a>.</td>
+</tr>
+<tr>
+<td><a id="componentsExamples"> </a> examples</td>
+<td style="text-align:left">Map[<code>string</code>, <a href="#exampleObject">Example Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td>An object to hold reusable <a href="#exampleObject">Example Objects</a>.</td>
+</tr>
+<tr>
+<td><a id="componentsRequestBodies"> </a> requestBodies</td>
+<td style="text-align:left">Map[<code>string</code>, <a href="#requestBodyObject">Request Body Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td>An object to hold reusable <a href="#requestBodyObject">Request Body Objects</a>.</td>
+</tr>
+<tr>
+<td><a id="componentsHeaders"> </a> headers</td>
+<td style="text-align:left">Map[<code>string</code>, <a href="#headerObject">Header Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td>An object to hold reusable <a href="#headerObject">Header Objects</a>.</td>
+</tr>
+<tr>
+<td><a id="componentsSecuritySchemes"> </a> securitySchemes</td>
+<td style="text-align:left">Map[<code>string</code>, <a href="#securitySchemeObject">Security Scheme Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td>An object to hold reusable <a href="#securitySchemeObject">Security Scheme Objects</a>.</td>
+</tr>
+<tr>
+<td><a id="componentsLinks"> </a> links</td>
+<td style="text-align:left">Map[<code>string</code>, <a href="#linkObject">Link Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td>An object to hold reusable <a href="#linkObject">Link Objects</a>.</td>
+</tr>
+<tr>
+<td><a id="componentsCallbacks"> </a> callbacks</td>
+<td style="text-align:left">Map[<code>string</code>, <a href="#callbackObject">Callback Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td>An object to hold reusable <a href="#callbackObject">Callback Objects</a>.</td>
+</tr>
+</tbody>
+</table>
+<p>This object MAY be extended with <a href="#specificationExtensions">Specification Extensions</a>.</p>
+<p>All the fixed fields declared above are objects that MUST use keys that match the regular expression: <code>^[a-zA-Z0-9\.\-_]+$</code>.</p>
+<p>Field Name Examples:</p>
+<pre class="highlight "><code>
+User
+User_1
+User_Name
+user-name
+my.org.User
+</code></pre>
+</section><section><h4>Components Object Example</h4>
+<pre class="nohighlight"><code>
+<span class="hljs-string">"components"</span>: {
+  <span class="hljs-attr">"schemas"</span>: {
+    <span class="hljs-attr">"GeneralError"</span>: {
+      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
+      <span class="hljs-attr">"properties"</span>: {
+        <span class="hljs-attr">"code"</span>: {
+          <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>,
+          <span class="hljs-attr">"format"</span>: <span class="hljs-string">"int32"</span>
+        },
+        <span class="hljs-attr">"message"</span>: {
+          <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+        }
+      }
+    },
+    <span class="hljs-attr">"Category"</span>: {
+      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
+      <span class="hljs-attr">"properties"</span>: {
+        <span class="hljs-attr">"id"</span>: {
+          <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>,
+          <span class="hljs-attr">"format"</span>: <span class="hljs-string">"int64"</span>
+        },
+        <span class="hljs-attr">"name"</span>: {
+          <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+        }
+      }
+    },
+    <span class="hljs-attr">"Tag"</span>: {
+      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
+      <span class="hljs-attr">"properties"</span>: {
+        <span class="hljs-attr">"id"</span>: {
+          <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>,
+          <span class="hljs-attr">"format"</span>: <span class="hljs-string">"int64"</span>
+        },
+        <span class="hljs-attr">"name"</span>: {
+          <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+        }
+      }
+    }
+  },
+  <span class="hljs-attr">"parameters"</span>: {
+    <span class="hljs-attr">"skipParam"</span>: {
+      <span class="hljs-attr">"name"</span>: <span class="hljs-string">"skip"</span>,
+      <span class="hljs-attr">"in"</span>: <span class="hljs-string">"query"</span>,
+      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"number of items to skip"</span>,
+      <span class="hljs-attr">"required"</span>: <span class="hljs-literal">true</span>,
+      <span class="hljs-attr">"schema"</span>: {
+        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>,
+        <span class="hljs-attr">"format"</span>: <span class="hljs-string">"int32"</span>
+      }
+    },
+    <span class="hljs-attr">"limitParam"</span>: {
+      <span class="hljs-attr">"name"</span>: <span class="hljs-string">"limit"</span>,
+      <span class="hljs-attr">"in"</span>: <span class="hljs-string">"query"</span>,
+      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"max records to return"</span>,
+      <span class="hljs-attr">"required"</span>: <span class="hljs-literal">true</span>,
+      <span class="hljs-attr">"schema"</span> : {
+        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>,
+        <span class="hljs-attr">"format"</span>: <span class="hljs-string">"int32"</span>
+      }
+    }
+  },
+  <span class="hljs-attr">"responses"</span>: {
+    <span class="hljs-attr">"NotFound"</span>: {
+      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Entity not found."</span>
+    },
+    <span class="hljs-attr">"IllegalInput"</span>: {
+      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Illegal input for operation."</span>
+    },
+    <span class="hljs-attr">"GeneralError"</span>: {
+      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"General Error"</span>,
+      <span class="hljs-attr">"content"</span>: {
+        <span class="hljs-attr">"application/json"</span>: {
+          <span class="hljs-attr">"schema"</span>: {
+            <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/GeneralError"</span>
+          }
+        }
+      }
+    }
+  },
+  <span class="hljs-attr">"securitySchemes"</span>: {
+    <span class="hljs-attr">"api_key"</span>: {
+      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"apiKey"</span>,
+      <span class="hljs-attr">"name"</span>: <span class="hljs-string">"api_key"</span>,
+      <span class="hljs-attr">"in"</span>: <span class="hljs-string">"header"</span>
+    },
+    <span class="hljs-attr">"petstore_auth"</span>: {
+      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"oauth2"</span>,
+      <span class="hljs-attr">"flows"</span>: {
+        <span class="hljs-attr">"implicit"</span>: {
+          <span class="hljs-attr">"authorizationUrl"</span>: <span class="hljs-string">"http://example.org/api/oauth/dialog"</span>,
+          <span class="hljs-attr">"scopes"</span>: {
+            <span class="hljs-attr">"write:pets"</span>: <span class="hljs-string">"modify pets in your account"</span>,
+            <span class="hljs-attr">"read:pets"</span>: <span class="hljs-string">"read your pets"</span>
+          }
+        }
+      }
+    }
+  }
+}
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">components:</span>
+  <span class="hljs-attr">schemas:</span>
+    <span class="hljs-attr">GeneralError:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+      <span class="hljs-attr">properties:</span>
+        <span class="hljs-attr">code:</span>
+          <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+          <span class="hljs-attr">format:</span> <span class="hljs-string">int32</span>
+        <span class="hljs-attr">message:</span>
+          <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+    <span class="hljs-attr">Category:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+      <span class="hljs-attr">properties:</span>
+        <span class="hljs-attr">id:</span>
+          <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+          <span class="hljs-attr">format:</span> <span class="hljs-string">int64</span>
+        <span class="hljs-attr">name:</span>
+          <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+    <span class="hljs-attr">Tag:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+      <span class="hljs-attr">properties:</span>
+        <span class="hljs-attr">id:</span>
+          <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+          <span class="hljs-attr">format:</span> <span class="hljs-string">int64</span>
+        <span class="hljs-attr">name:</span>
+          <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">parameters:</span>
+    <span class="hljs-attr">skipParam:</span>
+      <span class="hljs-attr">name:</span> <span class="hljs-string">skip</span>
+      <span class="hljs-attr">in:</span> <span class="hljs-string">query</span>
+      <span class="hljs-attr">description:</span> <span class="hljs-string">number</span> <span class="hljs-string">of</span> <span class="hljs-string">items</span> <span class="hljs-string">to</span> <span class="hljs-string">skip</span>
+      <span class="hljs-attr">required:</span> <span class="hljs-literal">true</span>
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+        <span class="hljs-attr">format:</span> <span class="hljs-string">int32</span>
+    <span class="hljs-attr">limitParam:</span>
+      <span class="hljs-attr">name:</span> <span class="hljs-string">limit</span>
+      <span class="hljs-attr">in:</span> <span class="hljs-string">query</span>
+      <span class="hljs-attr">description:</span> <span class="hljs-string">max</span> <span class="hljs-string">records</span> <span class="hljs-string">to</span> <span class="hljs-string">return</span>
+      <span class="hljs-attr">required:</span> <span class="hljs-literal">true</span>
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+        <span class="hljs-attr">format:</span> <span class="hljs-string">int32</span>
+  <span class="hljs-attr">responses:</span>
+    <span class="hljs-attr">NotFound:</span>
+      <span class="hljs-attr">description:</span> <span class="hljs-string">Entity</span> <span class="hljs-string">not</span> <span class="hljs-string">found.</span>
+    <span class="hljs-attr">IllegalInput:</span>
+      <span class="hljs-attr">description:</span> <span class="hljs-string">Illegal</span> <span class="hljs-string">input</span> <span class="hljs-string">for</span> <span class="hljs-string">operation.</span>
+    <span class="hljs-attr">GeneralError:</span>
+      <span class="hljs-attr">description:</span> <span class="hljs-string">General</span> <span class="hljs-string">Error</span>
+      <span class="hljs-attr">content:</span>
+        <span class="hljs-attr">application/json:</span>
+          <span class="hljs-attr">schema:</span>
+            <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/GeneralError'</span>
+  <span class="hljs-attr">securitySchemes:</span>
+    <span class="hljs-attr">api_key:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">apiKey</span>
+      <span class="hljs-attr">name:</span> <span class="hljs-string">api_key</span>
+      <span class="hljs-attr">in:</span> <span class="hljs-string">header</span>
+    <span class="hljs-attr">petstore_auth:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">oauth2</span>
+      <span class="hljs-attr">flows:</span> 
+        <span class="hljs-attr">implicit:</span>
+          <span class="hljs-attr">authorizationUrl:</span> <span class="hljs-string">http://example.org/api/oauth/dialog</span>
+          <span class="hljs-attr">scopes:</span>
+            <span class="hljs-attr">write:pets:</span> <span class="hljs-string">modify</span> <span class="hljs-string">pets</span> <span class="hljs-string">in</span> <span class="hljs-string">your</span> <span class="hljs-string">account</span>
+            <span class="hljs-attr">read:pets:</span> <span class="hljs-string">read</span> <span class="hljs-string">your</span> <span class="hljs-string">pets</span>
+</code></pre>
+</section></section><section><h3><span id="pathsObject">Paths Object</span></h3>
+<p>Holds the relative paths to the individual endpoints and their operations.
+The path is appended to the URL from the <a href="#serverObject"><code>Server Object</code></a> in order to construct the full URL.  The Paths MAY be empty, due to <a href="#securityFiltering">ACL constraints</a>.</p>
+<section><h4>Patterned Fields</h4>
+<table>
+<thead>
+<tr>
+<th>Field Pattern</th>
+<th style="text-align:center">Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a id="pathsPath"> </a>/{path}</td>
+<td style="text-align:center"><a href="#pathItemObject">Path Item Object</a></td>
+<td>A relative path to an individual endpoint. The field name MUST begin with a forward slash (<code>/</code>). The path is <strong>appended</strong> (no relative URL resolution) to the expanded URL from the <a href="#serverObject"><code>Server Object</code></a>'s <code>url</code> field in order to construct the full URL. <a href="#pathTemplating">Path templating</a> is allowed. When matching URLs, concrete (non-templated) paths would be matched before their templated counterparts. Templated paths with the same hierarchy but different templated names MUST NOT exist as they are identical. In case of ambiguous matching, it’s up to the tooling to decide which one to use.</td>
+</tr>
+</tbody>
+</table>
+<p>This object MAY be extended with <a href="#specificationExtensions">Specification Extensions</a>.</p>
+</section><section><h4>Path Templating Matching</h4>
+<p>Assuming the following paths, the concrete definition, <code>/pets/mine</code>, will be matched first if used:</p>
+<pre class="highlight "><code>
+  /pets/{petId}
+  /pets/mine
+</code></pre>
+<p>The following paths are considered identical and invalid:</p>
+<pre class="highlight "><code>
+  /pets/{petId}
+  /pets/{name}
+</code></pre>
+<p>The following may lead to ambiguous resolution:</p>
+<pre class="highlight "><code>
+  /{entity}/me
+  /books/{id}
+</code></pre>
+</section><section><h4>Paths Object Example</h4>
+<pre class="nohighlight"><code>
+{
+  <span class="hljs-attr">"/pets"</span>: {
+    <span class="hljs-attr">"get"</span>: {
+      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Returns all pets from the system that the user has access to"</span>,
+      <span class="hljs-attr">"responses"</span>: {
+        <span class="hljs-attr">"200"</span>: {          
+          <span class="hljs-attr">"description"</span>: <span class="hljs-string">"A list of pets."</span>,
+          <span class="hljs-attr">"content"</span>: {
+            <span class="hljs-attr">"application/json"</span>: {
+              <span class="hljs-attr">"schema"</span>: {
+                <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
+                <span class="hljs-attr">"items"</span>: {
+                  <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/pet"</span>
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-string">/pets:</span>
+  <span class="hljs-attr">get:</span>
+    <span class="hljs-attr">description:</span> <span class="hljs-string">Returns</span> <span class="hljs-string">all</span> <span class="hljs-string">pets</span> <span class="hljs-string">from</span> <span class="hljs-string">the</span> <span class="hljs-string">system</span> <span class="hljs-string">that</span> <span class="hljs-string">the</span> <span class="hljs-string">user</span> <span class="hljs-string">has</span> <span class="hljs-string">access</span> <span class="hljs-string">to</span>
+    <span class="hljs-attr">responses:</span>
+      <span class="hljs-attr">'200':</span>
+        <span class="hljs-attr">description:</span> <span class="hljs-string">A</span> <span class="hljs-string">list</span> <span class="hljs-string">of</span> <span class="hljs-string">pets.</span>
+        <span class="hljs-attr">content:</span>
+          <span class="hljs-attr">application/json:</span>
+            <span class="hljs-attr">schema:</span>
+              <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+              <span class="hljs-attr">items:</span>
+                <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/pet'</span>
+</code></pre>
+</section></section><section><h3><span id="pathItemObject">Path Item Object</span></h3>
+<p>Describes the operations available on a single path.
+A Path Item MAY be empty, due to <a href="#securityFiltering">ACL constraints</a>.
+The path itself is still exposed to the documentation viewer but they will not know which operations and parameters are available.</p>
+<section><h4>Fixed Fields</h4>
+<table>
+<thead>
+<tr>
+<th>Field Name</th>
+<th style="text-align:center">Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a id="pathItemRef"> </a>$ref</td>
+<td style="text-align:center"><code>string</code></td>
+<td>Allows for an external definition of this path item. The referenced structure MUST be in the format of a <a href="#pathItemObject">Path Item Object</a>.  In case a Path Item Object field appears both in the defined object and the referenced object, the behavior is undefined.</td>
+</tr>
+<tr>
+<td><a id="pathItemSummary"> </a>summary</td>
+<td style="text-align:center"><code>string</code></td>
+<td>An optional, string summary, intended to apply to all operations in this path.</td>
+</tr>
+<tr>
+<td><a id="pathItemDescription"> </a>description</td>
+<td style="text-align:center"><code>string</code></td>
+<td>An optional, string description, intended to apply to all operations in this path. <a href="https://spec.commonmark.org/">CommonMark syntax</a> MAY be used for rich text representation.</td>
+</tr>
+<tr>
+<td><a id="pathItemGet"> </a>get</td>
+<td style="text-align:center"><a href="#operationObject">Operation Object</a></td>
+<td>A definition of a GET operation on this path.</td>
+</tr>
+<tr>
+<td><a id="pathItemPut"> </a>put</td>
+<td style="text-align:center"><a href="#operationObject">Operation Object</a></td>
+<td>A definition of a PUT operation on this path.</td>
+</tr>
+<tr>
+<td><a id="pathItemPost"> </a>post</td>
+<td style="text-align:center"><a href="#operationObject">Operation Object</a></td>
+<td>A definition of a POST operation on this path.</td>
+</tr>
+<tr>
+<td><a id="pathItemDelete"> </a>delete</td>
+<td style="text-align:center"><a href="#operationObject">Operation Object</a></td>
+<td>A definition of a DELETE operation on this path.</td>
+</tr>
+<tr>
+<td><a id="pathItemOptions"> </a>options</td>
+<td style="text-align:center"><a href="#operationObject">Operation Object</a></td>
+<td>A definition of a OPTIONS operation on this path.</td>
+</tr>
+<tr>
+<td><a id="pathItemHead"> </a>head</td>
+<td style="text-align:center"><a href="#operationObject">Operation Object</a></td>
+<td>A definition of a HEAD operation on this path.</td>
+</tr>
+<tr>
+<td><a id="pathItemPatch"> </a>patch</td>
+<td style="text-align:center"><a href="#operationObject">Operation Object</a></td>
+<td>A definition of a PATCH operation on this path.</td>
+</tr>
+<tr>
+<td><a id="pathItemTrace"> </a>trace</td>
+<td style="text-align:center"><a href="#operationObject">Operation Object</a></td>
+<td>A definition of a TRACE operation on this path.</td>
+</tr>
+<tr>
+<td><a id="pathItemServers"> </a>servers</td>
+<td style="text-align:center">[<a href="#serverObject">Server Object</a>]</td>
+<td>An alternative <code>server</code> array to service all operations in this path.</td>
+</tr>
+<tr>
+<td><a id="pathItemParameters"> </a>parameters</td>
+<td style="text-align:center">[<a href="#parameterObject">Parameter Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td>A list of parameters that are applicable for all the operations described under this path. These parameters can be overridden at the operation level, but cannot be removed there. The list MUST NOT include duplicated parameters. A unique parameter is defined by a combination of a <a href="#parameterName">name</a> and <a href="#parameterIn">location</a>. The list can use the <a href="#referenceObject">Reference Object</a> to link to parameters that are defined at the <a href="#componentsParameters">OpenAPI Object’s components/parameters</a>.</td>
+</tr>
+</tbody>
+</table>
+<p>This object MAY be extended with <a href="#specificationExtensions">Specification Extensions</a>.</p>
+</section><section><h4>Path Item Object Example</h4>
+<pre class="nohighlight"><code>
+{
+  <span class="hljs-attr">"get"</span>: {
+    <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Returns pets based on ID"</span>,
+    <span class="hljs-attr">"summary"</span>: <span class="hljs-string">"Find pets by ID"</span>,
+    <span class="hljs-attr">"operationId"</span>: <span class="hljs-string">"getPetsById"</span>,
+    <span class="hljs-attr">"responses"</span>: {
+      <span class="hljs-attr">"200"</span>: {
+        <span class="hljs-attr">"description"</span>: <span class="hljs-string">"pet response"</span>,
+        <span class="hljs-attr">"content"</span>: {
+          <span class="hljs-attr">"*/*"</span>: {
+            <span class="hljs-attr">"schema"</span>: {
+              <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
+              <span class="hljs-attr">"items"</span>: {
+                <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/Pet"</span>
+              }
+            }
+          }
+        }
+      },
+      <span class="hljs-attr">"default"</span>: {
+        <span class="hljs-attr">"description"</span>: <span class="hljs-string">"error payload"</span>,
+        <span class="hljs-attr">"content"</span>: {
+          <span class="hljs-attr">"text/html"</span>: {
+            <span class="hljs-attr">"schema"</span>: {
+              <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/ErrorModel"</span>
+            }
+          }
+        }
+      }
+    }
+  },
+  <span class="hljs-attr">"parameters"</span>: [
+    {
+      <span class="hljs-attr">"name"</span>: <span class="hljs-string">"id"</span>,
+      <span class="hljs-attr">"in"</span>: <span class="hljs-string">"path"</span>,
+      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"ID of pet to use"</span>,
+      <span class="hljs-attr">"required"</span>: <span class="hljs-literal">true</span>,
+      <span class="hljs-attr">"schema"</span>: {
+        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
+        <span class="hljs-attr">"items"</span>: {
+          <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+        }
+      },
+      <span class="hljs-attr">"style"</span>: <span class="hljs-string">"simple"</span>
+    }
+  ]
+}
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">get:</span>
+  <span class="hljs-attr">description:</span> <span class="hljs-string">Returns</span> <span class="hljs-string">pets</span> <span class="hljs-string">based</span> <span class="hljs-string">on</span> <span class="hljs-string">ID</span>
+  <span class="hljs-attr">summary:</span> <span class="hljs-string">Find</span> <span class="hljs-string">pets</span> <span class="hljs-string">by</span> <span class="hljs-string">ID</span>
+  <span class="hljs-attr">operationId:</span> <span class="hljs-string">getPetsById</span>
+  <span class="hljs-attr">responses:</span>
+    <span class="hljs-attr">'200':</span>
+      <span class="hljs-attr">description:</span> <span class="hljs-string">pet</span> <span class="hljs-string">response</span>
+      <span class="hljs-attr">content:</span>
+        <span class="hljs-string">'*/*'</span> <span class="hljs-string">:</span>
+          <span class="hljs-attr">schema:</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+            <span class="hljs-attr">items:</span>
+              <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Pet'</span>
+    <span class="hljs-attr">default:</span>
+      <span class="hljs-attr">description:</span> <span class="hljs-string">error</span> <span class="hljs-string">payload</span>
+      <span class="hljs-attr">content:</span>
+        <span class="hljs-attr">'text/html':</span>
+          <span class="hljs-attr">schema:</span>
+            <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/ErrorModel'</span>
+<span class="hljs-attr">parameters:</span>
+<span class="hljs-bullet">-</span> <span class="hljs-attr">name:</span> <span class="hljs-string">id</span>
+  <span class="hljs-attr">in:</span> <span class="hljs-string">path</span>
+  <span class="hljs-attr">description:</span> <span class="hljs-string">ID</span> <span class="hljs-string">of</span> <span class="hljs-string">pet</span> <span class="hljs-string">to</span> <span class="hljs-string">use</span>
+  <span class="hljs-attr">required:</span> <span class="hljs-literal">true</span>
+  <span class="hljs-attr">schema:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+    <span class="hljs-attr">items:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>  
+  <span class="hljs-attr">style:</span> <span class="hljs-string">simple</span>
+</code></pre>
+</section></section><section><h3><span id="operationObject">Operation Object</span></h3>
+<p>Describes a single API operation on a path.</p>
+<section><h4>Fixed Fields</h4>
+<table>
+<thead>
+<tr>
+<th>Field Name</th>
+<th style="text-align:center">Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a id="operationTags"> </a>tags</td>
+<td style="text-align:center">[<code>string</code>]</td>
+<td>A list of tags for API documentation control. Tags can be used for logical grouping of operations by resources or any other qualifier.</td>
+</tr>
+<tr>
+<td><a id="operationSummary"> </a>summary</td>
+<td style="text-align:center"><code>string</code></td>
+<td>A short summary of what the operation does.</td>
+</tr>
+<tr>
+<td><a id="operationDescription"> </a>description</td>
+<td style="text-align:center"><code>string</code></td>
+<td>A verbose explanation of the operation behavior. <a href="https://spec.commonmark.org/">CommonMark syntax</a> MAY be used for rich text representation.</td>
+</tr>
+<tr>
+<td><a id="operationExternalDocs"> </a>externalDocs</td>
+<td style="text-align:center"><a href="#externalDocumentationObject">External Documentation Object</a></td>
+<td>Additional external documentation for this operation.</td>
+</tr>
+<tr>
+<td><a id="operationId"> </a>operationId</td>
+<td style="text-align:center"><code>string</code></td>
+<td>Unique string used to identify the operation. The id MUST be unique among all operations described in the API. The operationId value is <strong>case-sensitive</strong>. Tools and libraries MAY use the operationId to uniquely identify an operation, therefore, it is RECOMMENDED to follow common programming naming conventions.</td>
+</tr>
+<tr>
+<td><a id="operationParameters"> </a>parameters</td>
+<td style="text-align:center">[<a href="#parameterObject">Parameter Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td>A list of parameters that are applicable for this operation. If a parameter is already defined at the <a href="#pathItemParameters">Path Item</a>, the new definition will override it but can never remove it. The list MUST NOT include duplicated parameters. A unique parameter is defined by a combination of a <a href="#parameterName">name</a> and <a href="#parameterIn">location</a>. The list can use the <a href="#referenceObject">Reference Object</a> to link to parameters that are defined at the <a href="#componentsParameters">OpenAPI Object’s components/parameters</a>.</td>
+</tr>
+<tr>
+<td><a id="operationRequestBody"> </a>requestBody</td>
+<td style="text-align:center"><a href="#requestBodyObject">Request Body Object</a> ¦ <a href="#referenceObject">Reference Object</a></td>
+<td>The request body applicable for this operation.  The <code>requestBody</code> is only supported in HTTP methods where the HTTP 1.1 specification [[!RFC7231]] has explicitly defined semantics for request bodies.  In other cases where the HTTP spec is vague, <code>requestBody</code> SHALL be ignored by consumers.</td>
+</tr>
+<tr>
+<td><a id="operationResponses"> </a>responses</td>
+<td style="text-align:center"><a href="#responsesObject">Responses Object</a></td>
+<td><strong>REQUIRED</strong>. The list of possible responses as they are returned from executing this operation.</td>
+</tr>
+<tr>
+<td><a id="operationCallbacks"> </a>callbacks</td>
+<td style="text-align:center">Map[<code>string</code>, <a href="#callbackObject">Callback Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td>A map of possible out-of band callbacks related to the parent operation. The key is a unique identifier for the Callback Object. Each value in the map is a <a href="#callbackObject">Callback Object</a> that describes a request that may be initiated by the API provider and the expected responses.</td>
+</tr>
+<tr>
+<td><a id="operationDeprecated"> </a>deprecated</td>
+<td style="text-align:center"><code>boolean</code></td>
+<td>Declares this operation to be deprecated. Consumers SHOULD refrain from usage of the declared operation. Default value is <code>false</code>.</td>
+</tr>
+<tr>
+<td><a id="operationSecurity"> </a>security</td>
+<td style="text-align:center">[<a href="#securityRequirementObject">Security Requirement Object</a>]</td>
+<td>A declaration of which security mechanisms can be used for this operation. The list of values includes alternative security requirement objects that can be used. Only one of the security requirement objects need to be satisfied to authorize a request. To make security optional, an empty security requirement (<code>{}</code>) can be included in the array. This definition overrides any declared top-level <a href="#oasSecurity"><code>security</code></a>. To remove a top-level security declaration, an empty array can be used.</td>
+</tr>
+<tr>
+<td><a id="operationServers"> </a>servers</td>
+<td style="text-align:center">[<a href="#serverObject">Server Object</a>]</td>
+<td>An alternative <code>server</code> array to service this operation. If an alternative <code>server</code> object is specified at the Path Item Object or Root level, it will be overridden by this value.</td>
+</tr>
+</tbody>
+</table>
+<p>This object MAY be extended with <a href="#specificationExtensions">Specification Extensions</a>.</p>
+</section><section><h4>Operation Object Example</h4>
+<pre class="nohighlight"><code>
+{
+  <span class="hljs-attr">"tags"</span>: [
+    <span class="hljs-string">"pet"</span>
+  ],
+  <span class="hljs-attr">"summary"</span>: <span class="hljs-string">"Updates a pet in the store with form data"</span>,
+  <span class="hljs-attr">"operationId"</span>: <span class="hljs-string">"updatePetWithForm"</span>,
+  <span class="hljs-attr">"parameters"</span>: [
+    {
+      <span class="hljs-attr">"name"</span>: <span class="hljs-string">"petId"</span>,
+      <span class="hljs-attr">"in"</span>: <span class="hljs-string">"path"</span>,
+      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"ID of pet that needs to be updated"</span>,
+      <span class="hljs-attr">"required"</span>: <span class="hljs-literal">true</span>,
+      <span class="hljs-attr">"schema"</span>: {
+        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+      }
+    }
+  ],
+  <span class="hljs-attr">"requestBody"</span>: {
+    <span class="hljs-attr">"content"</span>: {
+      <span class="hljs-attr">"application/x-www-form-urlencoded"</span>: {
+        <span class="hljs-attr">"schema"</span>: {
+          <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
+          <span class="hljs-attr">"properties"</span>: {
+            <span class="hljs-attr">"name"</span>: { 
+              <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Updated name of the pet"</span>,
+              <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+            },
+            <span class="hljs-attr">"status"</span>: {
+              <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Updated status of the pet"</span>,
+              <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+            }
+          },
+          <span class="hljs-attr">"required"</span>: [<span class="hljs-string">"status"</span>] 
+        }
+      }
+    }
+  },
+  <span class="hljs-attr">"responses"</span>: {
+    <span class="hljs-attr">"200"</span>: {
+      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Pet updated."</span>,
+      <span class="hljs-attr">"content"</span>: {
+        <span class="hljs-attr">"application/json"</span>: {},
+        <span class="hljs-attr">"application/xml"</span>: {}
+      }
+    },
+    <span class="hljs-attr">"405"</span>: {
+      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Method Not Allowed"</span>,
+      <span class="hljs-attr">"content"</span>: {
+        <span class="hljs-attr">"application/json"</span>: {},
+        <span class="hljs-attr">"application/xml"</span>: {}
+      }
+    }
+  },
+  <span class="hljs-attr">"security"</span>: [
+    {
+      <span class="hljs-attr">"petstore_auth"</span>: [
+        <span class="hljs-string">"write:pets"</span>,
+        <span class="hljs-string">"read:pets"</span>
+      ]
+    }
+  ]
+}
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">tags:</span>
+<span class="hljs-bullet">-</span> <span class="hljs-string">pet</span>
+<span class="hljs-attr">summary:</span> <span class="hljs-string">Updates</span> <span class="hljs-string">a</span> <span class="hljs-string">pet</span> <span class="hljs-string">in</span> <span class="hljs-string">the</span> <span class="hljs-string">store</span> <span class="hljs-string">with</span> <span class="hljs-string">form</span> <span class="hljs-string">data</span>
+<span class="hljs-attr">operationId:</span> <span class="hljs-string">updatePetWithForm</span>
+<span class="hljs-attr">parameters:</span>
+<span class="hljs-bullet">-</span> <span class="hljs-attr">name:</span> <span class="hljs-string">petId</span>
+  <span class="hljs-attr">in:</span> <span class="hljs-string">path</span>
+  <span class="hljs-attr">description:</span> <span class="hljs-string">ID</span> <span class="hljs-string">of</span> <span class="hljs-string">pet</span> <span class="hljs-string">that</span> <span class="hljs-string">needs</span> <span class="hljs-string">to</span> <span class="hljs-string">be</span> <span class="hljs-string">updated</span>
+  <span class="hljs-attr">required:</span> <span class="hljs-literal">true</span>
+  <span class="hljs-attr">schema:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+<span class="hljs-attr">requestBody:</span>
+  <span class="hljs-attr">content:</span>
+    <span class="hljs-attr">'application/x-www-form-urlencoded':</span>
+      <span class="hljs-attr">schema:</span>
+       <span class="hljs-attr">properties:</span>
+          <span class="hljs-attr">name:</span> 
+            <span class="hljs-attr">description:</span> <span class="hljs-string">Updated</span> <span class="hljs-string">name</span> <span class="hljs-string">of</span> <span class="hljs-string">the</span> <span class="hljs-string">pet</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+          <span class="hljs-attr">status:</span>
+            <span class="hljs-attr">description:</span> <span class="hljs-string">Updated</span> <span class="hljs-string">status</span> <span class="hljs-string">of</span> <span class="hljs-string">the</span> <span class="hljs-string">pet</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+       <span class="hljs-attr">required:</span>
+         <span class="hljs-bullet">-</span> <span class="hljs-string">status</span>
+<span class="hljs-attr">responses:</span>
+  <span class="hljs-attr">'200':</span>
+    <span class="hljs-attr">description:</span> <span class="hljs-string">Pet</span> <span class="hljs-string">updated.</span>
+    <span class="hljs-attr">content:</span> 
+      <span class="hljs-attr">'application/json':</span> <span class="hljs-string">{}</span>
+      <span class="hljs-attr">'application/xml':</span> <span class="hljs-string">{}</span>
+  <span class="hljs-attr">'405':</span>
+    <span class="hljs-attr">description:</span> <span class="hljs-string">Method</span> <span class="hljs-string">Not</span> <span class="hljs-string">Allowed</span>
+    <span class="hljs-attr">content:</span> 
+      <span class="hljs-attr">'application/json':</span> <span class="hljs-string">{}</span>
+      <span class="hljs-attr">'application/xml':</span> <span class="hljs-string">{}</span>
+<span class="hljs-attr">security:</span>
+<span class="hljs-bullet">-</span> <span class="hljs-attr">petstore_auth:</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-string">write:pets</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-string">read:pets</span>
+</code></pre>
+</section></section><section><h3><span id="externalDocumentationObject">External Documentation Object</span></h3>
+<p>Allows referencing an external resource for extended documentation.</p>
+<section><h4>Fixed Fields</h4>
+<table>
+<thead>
+<tr>
+<th>Field Name</th>
+<th style="text-align:center">Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a id="externalDocDescription"> </a>description</td>
+<td style="text-align:center"><code>string</code></td>
+<td>A short description of the target documentation. <a href="https://spec.commonmark.org/">CommonMark syntax</a> MAY be used for rich text representation.</td>
+</tr>
+<tr>
+<td><a id="externalDocUrl"> </a>url</td>
+<td style="text-align:center"><code>string</code></td>
+<td><strong>REQUIRED</strong>. The URL for the target documentation. Value MUST be in the format of a URL.</td>
+</tr>
+</tbody>
+</table>
+<p>This object MAY be extended with <a href="#specificationExtensions">Specification Extensions</a>.</p>
+</section><section><h4>External Documentation Object Example</h4>
+<pre class="nohighlight"><code>
+{
+  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Find more info here"</span>,
+  <span class="hljs-attr">"url"</span>: <span class="hljs-string">"https://example.com"</span>
+}
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">description:</span> <span class="hljs-string">Find</span> <span class="hljs-string">more</span> <span class="hljs-string">info</span> <span class="hljs-string">here</span>
+<span class="hljs-attr">url:</span> <span class="hljs-string">https://example.com</span>
+</code></pre>
+</section></section><section><h3><span id="parameterObject">Parameter Object</span></h3>
+<p>Describes a single operation parameter.</p>
+<p>A unique parameter is defined by a combination of a <a href="#parameterName">name</a> and <a href="#parameterIn">location</a>.</p>
+<section><h4>Parameter Locations</h4>
+<p>There are four possible parameter locations specified by the <code>in</code> field:</p>
+<ul>
+<li>path - Used together with <a href="#pathTemplating">Path Templating</a>, where the parameter value is actually part of the operation’s URL. This does not include the host or base path of the API. For example, in <code>/items/{itemId}</code>, the path parameter is <code>itemId</code>.</li>
+<li>query - Parameters that are appended to the URL. For example, in <code>/items?id=###</code>, the query parameter is <code>id</code>.</li>
+<li>header - Custom headers that are expected as part of the request. Note that [[!RFC7230]] states header names are case insensitive.</li>
+<li>cookie - Used to pass a specific cookie value to the API.</li>
+</ul>
+</section><section><h4>Fixed Fields</h4>
+<table>
+<thead>
+<tr>
+<th>Field Name</th>
+<th style="text-align:center">Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a id="parameterName"> </a>name</td>
+<td style="text-align:center"><code>string</code></td>
+<td><strong>REQUIRED</strong>. The name of the parameter. Parameter names are <em>case sensitive</em>. <ul><li>If <a href="#parameterIn"><code>in</code></a> is <code>&quot;path&quot;</code>, the <code>name</code> field MUST correspond to a template expression occurring within the <a href="#pathsPath">path</a> field in the <a href="#pathsObject">Paths Object</a>. See <a href="#pathTemplating">Path Templating</a> for further information.<li>If <a href="#parameterIn"><code>in</code></a> is <code>&quot;header&quot;</code> and the <code>name</code> field is <code>&quot;Accept&quot;</code>, <code>&quot;Content-Type&quot;</code> or <code>&quot;Authorization&quot;</code>, the parameter definition SHALL be ignored.<li>For all other cases, the <code>name</code> corresponds to the parameter name used by the <a href="#parameterIn"><code>in</code></a> property.</ul></td>
+</tr>
+<tr>
+<td><a id="parameterIn"> </a>in</td>
+<td style="text-align:center"><code>string</code></td>
+<td><strong>REQUIRED</strong>. The location of the parameter. Possible values are <code>&quot;query&quot;</code>, <code>&quot;header&quot;</code>, <code>&quot;path&quot;</code> or <code>&quot;cookie&quot;</code>.</td>
+</tr>
+<tr>
+<td><a id="parameterDescription"> </a>description</td>
+<td style="text-align:center"><code>string</code></td>
+<td>A brief description of the parameter. This could contain examples of use. <a href="https://spec.commonmark.org/">CommonMark syntax</a> MAY be used for rich text representation.</td>
+</tr>
+<tr>
+<td><a id="parameterRequired"> </a>required</td>
+<td style="text-align:center"><code>boolean</code></td>
+<td>Determines whether this parameter is mandatory. If the <a href="#parameterIn">parameter location</a> is <code>&quot;path&quot;</code>, this property is <strong>REQUIRED</strong> and its value MUST be <code>true</code>. Otherwise, the property MAY be included and its default value is <code>false</code>.</td>
+</tr>
+<tr>
+<td><a id="parameterDeprecated"> </a> deprecated</td>
+<td style="text-align:center"><code>boolean</code></td>
+<td>Specifies that a parameter is deprecated and SHOULD be transitioned out of usage. Default value is <code>false</code>.</td>
+</tr>
+<tr>
+<td><a id="parameterAllowEmptyValue"> </a> allowEmptyValue</td>
+<td style="text-align:center"><code>boolean</code></td>
+<td>Sets the ability to pass empty-valued parameters. This is valid only for <code>query</code> parameters and allows sending a parameter with an empty value. Default value is <code>false</code>. If <a href="#parameterStyle"><code>style</code></a> is used, and if behavior is <code>n/a</code> (cannot be serialized), the value of <code>allowEmptyValue</code> SHALL be ignored. Use of this property is NOT RECOMMENDED, as it is likely to be removed in a later revision.</td>
+</tr>
+</tbody>
+</table>
+<p>The rules for serialization of the parameter are specified in one of two ways.
+For simpler scenarios, a <a href="#parameterSchema"><code>schema</code></a> and <a href="#parameterStyle"><code>style</code></a> can describe the structure and syntax of the parameter.</p>
+<table>
+<thead>
+<tr>
+<th>Field Name</th>
+<th style="text-align:center">Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a id="parameterStyle"> </a>style</td>
+<td style="text-align:center"><code>string</code></td>
+<td>Describes how the parameter value will be serialized depending on the type of the parameter value. Default values (based on value of <code>in</code>): for <code>query</code> - <code>form</code>; for <code>path</code> - <code>simple</code>; for <code>header</code> - <code>simple</code>; for <code>cookie</code> - <code>form</code>.</td>
+</tr>
+<tr>
+<td><a id="parameterExplode"> </a>explode</td>
+<td style="text-align:center"><code>boolean</code></td>
+<td>When this is true, parameter values of type <code>array</code> or <code>object</code> generate separate parameters for each value of the array or key-value pair of the map. For other types of parameters this property has no effect. When <a href="#parameterStyle"><code>style</code></a> is <code>form</code>, the default value is <code>true</code>. For all other styles, the default value is <code>false</code>.</td>
+</tr>
+<tr>
+<td><a id="parameterAllowReserved"> </a>allowReserved</td>
+<td style="text-align:center"><code>boolean</code></td>
+<td>Determines whether the parameter value SHOULD allow reserved characters, as defined by [[!RFC3986]] <code>:/?#[]@!$&amp;'()*+,;=</code> to be included without percent-encoding. This property only applies to parameters with an <code>in</code> value of <code>query</code>. The default value is <code>false</code>.</td>
+</tr>
+<tr>
+<td><a id="parameterSchema"> </a>schema</td>
+<td style="text-align:center"><a href="#schemaObject">Schema Object</a> ¦ <a href="#referenceObject">Reference Object</a></td>
+<td>The schema defining the type used for the parameter.</td>
+</tr>
+<tr>
+<td><a id="parameterExample"> </a>example</td>
+<td style="text-align:center">Any</td>
+<td>Example of the parameter’s potential value. The example SHOULD match the specified schema and encoding properties if present. The <code>example</code> field is mutually exclusive of the <code>examples</code> field. Furthermore, if referencing a <code>schema</code> that contains an example, the <code>example</code> value SHALL <em>override</em> the example provided by the schema. To represent examples of media types that cannot naturally be represented in JSON or YAML, a string value can contain the example with escaping where necessary.</td>
+</tr>
+<tr>
+<td><a id="parameterExamples"> </a>examples</td>
+<td style="text-align:center">Map[ <code>string</code>, <a href="#exampleObject">Example Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td>Examples of the parameter’s potential value. Each example SHOULD contain a value in the correct format as specified in the parameter encoding. The <code>examples</code> field is mutually exclusive of the <code>example</code> field. Furthermore, if referencing a <code>schema</code> that contains an example, the <code>examples</code> value SHALL <em>override</em> the example provided by the schema.</td>
+</tr>
+</tbody>
+</table>
+<p>For more complex scenarios, the <a href="#parameterContent"><code>content</code></a> property can define the media type and schema of the parameter.
+A parameter MUST contain either a <code>schema</code> property, or a <code>content</code> property, but not both.
+When <code>example</code> or <code>examples</code> are provided in conjunction with the <code>schema</code> object, the example MUST follow the prescribed serialization strategy for the parameter.</p>
+<table>
+<thead>
+<tr>
+<th>Field Name</th>
+<th style="text-align:center">Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a id="parameterContent"> </a>content</td>
+<td style="text-align:center">Map[<code>string</code>, <a href="#mediaTypeObject">Media Type Object</a>]</td>
+<td>A map containing the representations for the parameter. The key is the media type and the value describes it. The map MUST only contain one entry.</td>
+</tr>
+</tbody>
+</table>
+</section><section><h4>Style Values</h4>
+<p>In order to support common ways of serializing simple parameters, a set of <code>style</code> values are defined.</p>
+<table>
+<thead>
+<tr>
+<th><code>style</code></th>
+<th><a href="#dataTypes"><code>type</code></a></th>
+<th><code>in</code></th>
+<th>Comments</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>matrix</td>
+<td><code>primitive</code>, <code>array</code>, <code>object</code></td>
+<td><code>path</code></td>
+<td>Path-style parameters defined by [[!RFC6570]]</td>
+</tr>
+<tr>
+<td>label</td>
+<td><code>primitive</code>, <code>array</code>, <code>object</code></td>
+<td><code>path</code></td>
+<td>Label style parameters defined by [[!RFC6570]]</td>
+</tr>
+<tr>
+<td>form</td>
+<td><code>primitive</code>, <code>array</code>, <code>object</code></td>
+<td><code>query</code>, <code>cookie</code></td>
+<td>Form style parameters defined by [[!RFC6570]]. This option replaces <code>collectionFormat</code> with a <code>csv</code> (when <code>explode</code> is false) or <code>multi</code> (when <code>explode</code> is true) value from OpenAPI 2.0.</td>
+</tr>
+<tr>
+<td>simple</td>
+<td><code>array</code></td>
+<td><code>path</code>, <code>header</code></td>
+<td>Simple style parameters defined by [[!RFC6570]].  This option replaces <code>collectionFormat</code> with a <code>csv</code> value from OpenAPI 2.0.</td>
+</tr>
+<tr>
+<td>spaceDelimited</td>
+<td><code>array</code></td>
+<td><code>query</code></td>
+<td>Space separated array values. This option replaces <code>collectionFormat</code> equal to <code>ssv</code> from OpenAPI 2.0.</td>
+</tr>
+<tr>
+<td>pipeDelimited</td>
+<td><code>array</code></td>
+<td><code>query</code></td>
+<td>Pipe separated array values. This option replaces <code>collectionFormat</code> equal to <code>pipes</code> from OpenAPI 2.0.</td>
+</tr>
+<tr>
+<td>deepObject</td>
+<td><code>object</code></td>
+<td><code>query</code></td>
+<td>Provides a simple way of rendering nested objects using form parameters.</td>
+</tr>
+</tbody>
+</table>
+</section><section><h4>Style Examples</h4>
+<p>Assume a parameter named <code>color</code> has one of the following values:</p>
+<pre class="highlight "><code>
+   string -&gt; &quot;blue&quot;
+   array -&gt; [&quot;blue&quot;,&quot;black&quot;,&quot;brown&quot;]
+   object -&gt; { &quot;R&quot;: 100, &quot;G&quot;: 200, &quot;B&quot;: 150 }
+</code></pre>
+<p>The following table shows examples of rendering differences for each value.</p>
+<table>
+<thead>
+<tr>
+<th><a href="#dataTypeFormat"><code>style</code></a></th>
+<th><code>explode</code></th>
+<th><code>empty</code></th>
+<th><code>string</code></th>
+<th><code>array</code></th>
+<th><code>object</code></th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>matrix</td>
+<td>false</td>
+<td>;color</td>
+<td>;color=blue</td>
+<td>;color=blue,black,brown</td>
+<td>;color=R,100,G,200,B,150</td>
+</tr>
+<tr>
+<td>matrix</td>
+<td>true</td>
+<td>;color</td>
+<td>;color=blue</td>
+<td>;color=blue;color=black;color=brown</td>
+<td>;R=100;G=200;B=150</td>
+</tr>
+<tr>
+<td>label</td>
+<td>false</td>
+<td>.</td>
+<td>.blue</td>
+<td>.blue.black.brown</td>
+<td>.R.100.G.200.B.150</td>
+</tr>
+<tr>
+<td>label</td>
+<td>true</td>
+<td>.</td>
+<td>.blue</td>
+<td>.blue.black.brown</td>
+<td>.R=100.G=200.B=150</td>
+</tr>
+<tr>
+<td>form</td>
+<td>false</td>
+<td>color=</td>
+<td>color=blue</td>
+<td>color=blue,black,brown</td>
+<td>color=R,100,G,200,B,150</td>
+</tr>
+<tr>
+<td>form</td>
+<td>true</td>
+<td>color=</td>
+<td>color=blue</td>
+<td>color=blue&amp;color=black&amp;color=brown</td>
+<td>R=100&amp;G=200&amp;B=150</td>
+</tr>
+<tr>
+<td>simple</td>
+<td>false</td>
+<td>n/a</td>
+<td>blue</td>
+<td>blue,black,brown</td>
+<td>R,100,G,200,B,150</td>
+</tr>
+<tr>
+<td>simple</td>
+<td>true</td>
+<td>n/a</td>
+<td>blue</td>
+<td>blue,black,brown</td>
+<td>R=100,G=200,B=150</td>
+</tr>
+<tr>
+<td>spaceDelimited</td>
+<td>false</td>
+<td>n/a</td>
+<td>n/a</td>
+<td>blue%20black%20brown</td>
+<td>R%20100%20G%20200%20B%20150</td>
+</tr>
+<tr>
+<td>pipeDelimited</td>
+<td>false</td>
+<td>n/a</td>
+<td>n/a</td>
+<td>blue¦black¦brown</td>
+<td>R¦100¦G¦200¦B¦150</td>
+</tr>
+<tr>
+<td>deepObject</td>
+<td>true</td>
+<td>n/a</td>
+<td>n/a</td>
+<td>n/a</td>
+<td>color\R=100&amp;color\G=200&amp;color\B=150</td>
+</tr>
+</tbody>
+</table>
+<p>This object MAY be extended with <a href="#specificationExtensions">Specification Extensions</a>.</p>
+</section><section><h4>Parameter Object Examples</h4>
+<p>A header parameter with an array of 64 bit integer numbers:</p>
+<pre class="nohighlight"><code>
+{
+  <span class="hljs-attr">"name"</span>: <span class="hljs-string">"token"</span>,
+  <span class="hljs-attr">"in"</span>: <span class="hljs-string">"header"</span>,
+  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"token to be passed as a header"</span>,
+  <span class="hljs-attr">"required"</span>: <span class="hljs-literal">true</span>,
+  <span class="hljs-attr">"schema"</span>: {
+    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
+    <span class="hljs-attr">"items"</span>: {
+      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>,
+      <span class="hljs-attr">"format"</span>: <span class="hljs-string">"int64"</span>
+    }
+  },
+  <span class="hljs-attr">"style"</span>: <span class="hljs-string">"simple"</span>
+}
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">name:</span> <span class="hljs-string">token</span>
+<span class="hljs-attr">in:</span> <span class="hljs-string">header</span>
+<span class="hljs-attr">description:</span> <span class="hljs-string">token</span> <span class="hljs-string">to</span> <span class="hljs-string">be</span> <span class="hljs-string">passed</span> <span class="hljs-string">as</span> <span class="hljs-string">a</span> <span class="hljs-string">header</span>
+<span class="hljs-attr">required:</span> <span class="hljs-literal">true</span>
+<span class="hljs-attr">schema:</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+  <span class="hljs-attr">items:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+    <span class="hljs-attr">format:</span> <span class="hljs-string">int64</span>
+<span class="hljs-attr">style:</span> <span class="hljs-string">simple</span>
+</code></pre>
+<p>A path parameter of a string value:</p>
+<pre class="nohighlight"><code>
+{
+  <span class="hljs-attr">"name"</span>: <span class="hljs-string">"username"</span>,
+  <span class="hljs-attr">"in"</span>: <span class="hljs-string">"path"</span>,
+  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"username to fetch"</span>,
+  <span class="hljs-attr">"required"</span>: <span class="hljs-literal">true</span>,
+  <span class="hljs-attr">"schema"</span>: {
+    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+  }
+}
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">name:</span> <span class="hljs-string">username</span>
+<span class="hljs-attr">in:</span> <span class="hljs-string">path</span>
+<span class="hljs-attr">description:</span> <span class="hljs-string">username</span> <span class="hljs-string">to</span> <span class="hljs-string">fetch</span>
+<span class="hljs-attr">required:</span> <span class="hljs-literal">true</span>
+<span class="hljs-attr">schema:</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+</code></pre>
+<p>An optional query parameter of a string value, allowing multiple values by repeating the query parameter:</p>
+<pre class="nohighlight"><code>
+{
+  <span class="hljs-attr">"name"</span>: <span class="hljs-string">"id"</span>,
+  <span class="hljs-attr">"in"</span>: <span class="hljs-string">"query"</span>,
+  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"ID of the object to fetch"</span>,
+  <span class="hljs-attr">"required"</span>: <span class="hljs-literal">false</span>,
+  <span class="hljs-attr">"schema"</span>: {
+    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
+    <span class="hljs-attr">"items"</span>: {
+      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+    }
+  },
+  <span class="hljs-attr">"style"</span>: <span class="hljs-string">"form"</span>,
+  <span class="hljs-attr">"explode"</span>: <span class="hljs-literal">true</span>
+}
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">name:</span> <span class="hljs-string">id</span>
+<span class="hljs-attr">in:</span> <span class="hljs-string">query</span>
+<span class="hljs-attr">description:</span> <span class="hljs-string">ID</span> <span class="hljs-string">of</span> <span class="hljs-string">the</span> <span class="hljs-string">object</span> <span class="hljs-string">to</span> <span class="hljs-string">fetch</span>
+<span class="hljs-attr">required:</span> <span class="hljs-literal">false</span>
+<span class="hljs-attr">schema:</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+  <span class="hljs-attr">items:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+<span class="hljs-attr">style:</span> <span class="hljs-string">form</span>
+<span class="hljs-attr">explode:</span> <span class="hljs-literal">true</span>
+</code></pre>
+<p>A free-form query parameter, allowing undefined parameters of a specific type:</p>
+<pre class="nohighlight"><code>
+{
+  <span class="hljs-attr">"in"</span>: <span class="hljs-string">"query"</span>,
+  <span class="hljs-attr">"name"</span>: <span class="hljs-string">"freeForm"</span>,
+  <span class="hljs-attr">"schema"</span>: {
+    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
+    <span class="hljs-attr">"additionalProperties"</span>: {
+      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>
+    },
+  },
+  <span class="hljs-attr">"style"</span>: <span class="hljs-string">"form"</span>
+}
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">in:</span> <span class="hljs-string">query</span>
+<span class="hljs-attr">name:</span> <span class="hljs-string">freeForm</span>
+<span class="hljs-attr">schema:</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+  <span class="hljs-attr">additionalProperties:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+<span class="hljs-attr">style:</span> <span class="hljs-string">form</span>
+</code></pre>
+<p>A complex parameter using <code>content</code> to define serialization:</p>
+<pre class="nohighlight"><code>
+{
+  <span class="hljs-attr">"in"</span>: <span class="hljs-string">"query"</span>,
+  <span class="hljs-attr">"name"</span>: <span class="hljs-string">"coordinates"</span>,
+  <span class="hljs-attr">"content"</span>: {
+    <span class="hljs-attr">"application/json"</span>: {
+      <span class="hljs-attr">"schema"</span>: {
+        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
+        <span class="hljs-attr">"required"</span>: [
+          <span class="hljs-string">"lat"</span>,
+          <span class="hljs-string">"long"</span>
+        ],
+        <span class="hljs-attr">"properties"</span>: {
+          <span class="hljs-attr">"lat"</span>: {
+            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"number"</span>
+          },
+          <span class="hljs-attr">"long"</span>: {
+            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"number"</span>
+          }
+        }
+      }
+    }
+  }
+}
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">in:</span> <span class="hljs-string">query</span>
+<span class="hljs-attr">name:</span> <span class="hljs-string">coordinates</span>
+<span class="hljs-attr">content:</span>
+  <span class="hljs-attr">application/json:</span>
+    <span class="hljs-attr">schema:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+      <span class="hljs-attr">required:</span>
+        <span class="hljs-bullet">-</span> <span class="hljs-string">lat</span>
+        <span class="hljs-bullet">-</span> <span class="hljs-string">long</span>
+      <span class="hljs-attr">properties:</span>
+        <span class="hljs-attr">lat:</span>
+          <span class="hljs-attr">type:</span> <span class="hljs-string">number</span>
+        <span class="hljs-attr">long:</span>
+          <span class="hljs-attr">type:</span> <span class="hljs-string">number</span>
+</code></pre>
+</section></section><section><h3><span id="requestBodyObject">Request Body Object</span></h3>
+<p>Describes a single request body.</p>
+<section><h4>Fixed Fields</h4>
+<table>
+<thead>
+<tr>
+<th>Field Name</th>
+<th style="text-align:center">Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a id="requestBodyDescription"> </a>description</td>
+<td style="text-align:center"><code>string</code></td>
+<td>A brief description of the request body. This could contain examples of use.  <a href="https://spec.commonmark.org/">CommonMark syntax</a> MAY be used for rich text representation.</td>
+</tr>
+<tr>
+<td><a id="requestBodyContent"> </a>content</td>
+<td style="text-align:center">Map[<code>string</code>, <a href="#mediaTypeObject">Media Type Object</a>]</td>
+<td><strong>REQUIRED</strong>. The content of the request body. The key is a media type or [media type range]appendix-D) and the value describes it.  For requests that match multiple keys, only the most specific key is applicable. e.g. text/plain overrides text/*</td>
+</tr>
+<tr>
+<td><a id="requestBodyRequired"> </a>required</td>
+<td style="text-align:center"><code>boolean</code></td>
+<td>Determines if the request body is required in the request. Defaults to <code>false</code>.</td>
+</tr>
+</tbody>
+</table>
+<p>This object MAY be extended with <a href="#specificationExtensions">Specification Extensions</a>.</p>
+</section><section><h4>Request Body Examples</h4>
+<p>A request body with a referenced model definition.</p>
+<pre class="nohighlight"><code>
+{
+  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"user to add to the system"</span>,
+  <span class="hljs-attr">"content"</span>: {
+    <span class="hljs-attr">"application/json"</span>: {
+      <span class="hljs-attr">"schema"</span>: {
+        <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/User"</span>
+      },
+      <span class="hljs-attr">"examples"</span>: {
+          <span class="hljs-attr">"user"</span> : {
+            <span class="hljs-attr">"summary"</span>: <span class="hljs-string">"User Example"</span>, 
+            <span class="hljs-attr">"externalValue"</span>: <span class="hljs-string">"http://foo.bar/examples/user-example.json"</span>
+          } 
+        }
+    },
+    <span class="hljs-attr">"application/xml"</span>: {
+      <span class="hljs-attr">"schema"</span>: {
+        <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/User"</span>
+      },
+      <span class="hljs-attr">"examples"</span>: {
+          <span class="hljs-attr">"user"</span> : {
+            <span class="hljs-attr">"summary"</span>: <span class="hljs-string">"User example in XML"</span>,
+            <span class="hljs-attr">"externalValue"</span>: <span class="hljs-string">"http://foo.bar/examples/user-example.xml"</span>
+          }
+        }
+    },
+    <span class="hljs-attr">"text/plain"</span>: {
+      <span class="hljs-attr">"examples"</span>: {
+        <span class="hljs-attr">"user"</span> : {
+            <span class="hljs-attr">"summary"</span>: <span class="hljs-string">"User example in Plain text"</span>,
+            <span class="hljs-attr">"externalValue"</span>: <span class="hljs-string">"http://foo.bar/examples/user-example.txt"</span> 
+        }
+      } 
+    },
+    <span class="hljs-attr">"*/*"</span>: {
+      <span class="hljs-attr">"examples"</span>: {
+        <span class="hljs-attr">"user"</span> : {
+            <span class="hljs-attr">"summary"</span>: <span class="hljs-string">"User example in other format"</span>,
+            <span class="hljs-attr">"externalValue"</span>: <span class="hljs-string">"http://foo.bar/examples/user-example.whatever"</span>
+        }
+      }
+    }
+  }
+}
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">description:</span> <span class="hljs-string">user</span> <span class="hljs-string">to</span> <span class="hljs-string">add</span> <span class="hljs-string">to</span> <span class="hljs-string">the</span> <span class="hljs-string">system</span>
+<span class="hljs-attr">content:</span> 
+  <span class="hljs-attr">'application/json':</span>
+    <span class="hljs-attr">schema:</span>
+      <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/User'</span>
+    <span class="hljs-attr">examples:</span>
+      <span class="hljs-attr">user:</span>
+        <span class="hljs-attr">summary:</span> <span class="hljs-string">User</span> <span class="hljs-string">Example</span>
+        <span class="hljs-attr">externalValue:</span> <span class="hljs-string">'http://foo.bar/examples/user-example.json'</span>
+  <span class="hljs-attr">'application/xml':</span>
+    <span class="hljs-attr">schema:</span>
+      <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/User'</span>
+    <span class="hljs-attr">examples:</span>
+      <span class="hljs-attr">user:</span>
+        <span class="hljs-attr">summary:</span> <span class="hljs-string">User</span> <span class="hljs-string">Example</span> <span class="hljs-string">in</span> <span class="hljs-string">XML</span>
+        <span class="hljs-attr">externalValue:</span> <span class="hljs-string">'http://foo.bar/examples/user-example.xml'</span>
+  <span class="hljs-attr">'text/plain':</span>
+    <span class="hljs-attr">examples:</span>
+      <span class="hljs-attr">user:</span>
+        <span class="hljs-attr">summary:</span> <span class="hljs-string">User</span> <span class="hljs-string">example</span> <span class="hljs-string">in</span> <span class="hljs-string">text</span> <span class="hljs-string">plain</span> <span class="hljs-string">format</span>
+        <span class="hljs-attr">externalValue:</span> <span class="hljs-string">'http://foo.bar/examples/user-example.txt'</span>
+  <span class="hljs-string">'*/*'</span><span class="hljs-string">:</span>
+    <span class="hljs-attr">examples:</span>
+      <span class="hljs-attr">user:</span> 
+        <span class="hljs-attr">summary:</span> <span class="hljs-string">User</span> <span class="hljs-string">example</span> <span class="hljs-string">in</span> <span class="hljs-string">other</span> <span class="hljs-string">format</span>
+        <span class="hljs-attr">externalValue:</span> <span class="hljs-string">'http://foo.bar/examples/user-example.whatever'</span>
+</code></pre>
+<p>A body parameter that is an array of string values:</p>
+<pre class="nohighlight"><code>
+{
+  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"user to add to the system"</span>,
+  <span class="hljs-attr">"content"</span>: {
+    <span class="hljs-attr">"text/plain"</span>: {
+      <span class="hljs-attr">"schema"</span>: {
+        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
+        <span class="hljs-attr">"items"</span>: {
+          <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+        }
+      }
+    }
+  }
+}
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">description:</span> <span class="hljs-string">user</span> <span class="hljs-string">to</span> <span class="hljs-string">add</span> <span class="hljs-string">to</span> <span class="hljs-string">the</span> <span class="hljs-string">system</span>
+<span class="hljs-attr">required:</span> <span class="hljs-literal">true</span>
+<span class="hljs-attr">content:</span>
+  <span class="hljs-attr">text/plain:</span>
+    <span class="hljs-attr">schema:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+      <span class="hljs-attr">items:</span>
+        <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+</code></pre>
+</section></section><section><h3><span id="mediaTypeObject">Media Type Object</span></h3>
+<p>Each Media Type Object provides schema and examples for the media type identified by its key.</p>
+<section><h4>Fixed Fields</h4>
+<table>
+<thead>
+<tr>
+<th>Field Name</th>
+<th style="text-align:center">Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a id="mediaTypeSchema"> </a>schema</td>
+<td style="text-align:center"><a href="#schemaObject">Schema Object</a> ¦ <a href="#referenceObject">Reference Object</a></td>
+<td>The schema defining the content of the request, response, or parameter.</td>
+</tr>
+<tr>
+<td><a id="mediaTypeExample"> </a>example</td>
+<td style="text-align:center">Any</td>
+<td>Example of the media type.  The example object SHOULD be in the correct format as specified by the media type.  The <code>example</code> field is mutually exclusive of the <code>examples</code> field.  Furthermore, if referencing a <code>schema</code> which contains an example, the <code>example</code> value SHALL <em>override</em> the example provided by the schema.</td>
+</tr>
+<tr>
+<td><a id="mediaTypeExamples"> </a>examples</td>
+<td style="text-align:center">Map[ <code>string</code>, <a href="#exampleObject">Example Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td>Examples of the media type.  Each example object SHOULD  match the media type and specified schema if present.  The <code>examples</code> field is mutually exclusive of the <code>example</code> field.  Furthermore, if referencing a <code>schema</code> which contains an example, the <code>examples</code> value SHALL <em>override</em> the example provided by the schema.</td>
+</tr>
+<tr>
+<td><a id="mediaTypeEncoding"> </a>encoding</td>
+<td style="text-align:center">Map[<code>string</code>, <a href="#encodingObject">Encoding Object</a>]</td>
+<td>A map between a property name and its encoding information. The key, being the property name, MUST exist in the schema as a property. The encoding object SHALL only apply to <code>requestBody</code> objects when the media type is <code>multipart</code> or <code>application/x-www-form-urlencoded</code>.</td>
+</tr>
+</tbody>
+</table>
+<p>This object MAY be extended with <a href="#specificationExtensions">Specification Extensions</a>.</p>
+</section><section><h4>Media Type Examples</h4>
+<pre class="nohighlight"><code>
+{
+  <span class="hljs-attr">"application/json"</span>: {
+    <span class="hljs-attr">"schema"</span>: {
+         <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/Pet"</span>
+    },
+    <span class="hljs-attr">"examples"</span>: {
+      <span class="hljs-attr">"cat"</span> : {
+        <span class="hljs-attr">"summary"</span>: <span class="hljs-string">"An example of a cat"</span>,
+        <span class="hljs-attr">"value"</span>: 
+          {
+            <span class="hljs-attr">"name"</span>: <span class="hljs-string">"Fluffy"</span>,
+            <span class="hljs-attr">"petType"</span>: <span class="hljs-string">"Cat"</span>,
+            <span class="hljs-attr">"color"</span>: <span class="hljs-string">"White"</span>,
+            <span class="hljs-attr">"gender"</span>: <span class="hljs-string">"male"</span>,
+            <span class="hljs-attr">"breed"</span>: <span class="hljs-string">"Persian"</span>
+          }
+      },
+      <span class="hljs-attr">"dog"</span>: {
+        <span class="hljs-attr">"summary"</span>: <span class="hljs-string">"An example of a dog with a cat's name"</span>,
+        <span class="hljs-attr">"value"</span> :  { 
+          <span class="hljs-attr">"name"</span>: <span class="hljs-string">"Puma"</span>,
+          <span class="hljs-attr">"petType"</span>: <span class="hljs-string">"Dog"</span>,
+          <span class="hljs-attr">"color"</span>: <span class="hljs-string">"Black"</span>,
+          <span class="hljs-attr">"gender"</span>: <span class="hljs-string">"Female"</span>,
+          <span class="hljs-attr">"breed"</span>: <span class="hljs-string">"Mixed"</span>
+        },
+      <span class="hljs-attr">"frog"</span>: {
+          <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/examples/frog-example"</span>
+        }
+      }
+    }
+  }
+}
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">application/json:</span> 
+  <span class="hljs-attr">schema:</span>
+    <span class="hljs-string">$ref:</span> <span class="hljs-string">"#/components/schemas/Pet"</span>
+  <span class="hljs-attr">examples:</span>
+    <span class="hljs-attr">cat:</span>
+      <span class="hljs-attr">summary:</span> <span class="hljs-string">An</span> <span class="hljs-string">example</span> <span class="hljs-string">of</span> <span class="hljs-string">a</span> <span class="hljs-string">cat</span>
+      <span class="hljs-attr">value:</span>
+        <span class="hljs-attr">name:</span> <span class="hljs-string">Fluffy</span>
+        <span class="hljs-attr">petType:</span> <span class="hljs-string">Cat</span>
+        <span class="hljs-attr">color:</span> <span class="hljs-string">White</span>
+        <span class="hljs-attr">gender:</span> <span class="hljs-string">male</span>
+        <span class="hljs-attr">breed:</span> <span class="hljs-string">Persian</span>
+    <span class="hljs-attr">dog:</span>
+      <span class="hljs-attr">summary:</span> <span class="hljs-string">An</span> <span class="hljs-string">example</span> <span class="hljs-string">of</span> <span class="hljs-string">a</span> <span class="hljs-string">dog</span> <span class="hljs-string">with</span> <span class="hljs-string">a</span> <span class="hljs-string">cat's</span> <span class="hljs-string">name</span>
+      <span class="hljs-attr">value:</span>
+        <span class="hljs-attr">name:</span> <span class="hljs-string">Puma</span>
+        <span class="hljs-attr">petType:</span> <span class="hljs-string">Dog</span>
+        <span class="hljs-attr">color:</span> <span class="hljs-string">Black</span>
+        <span class="hljs-attr">gender:</span> <span class="hljs-string">Female</span>
+        <span class="hljs-attr">breed:</span> <span class="hljs-string">Mixed</span>
+    <span class="hljs-attr">frog:</span>
+      <span class="hljs-string">$ref:</span> <span class="hljs-string">"#/components/examples/frog-example"</span>
+</code></pre>
+</section><section><h4>Considerations for File Uploads</h4>
+<p>In contrast with the 2.0 specification, <code>file</code> input/output content in OpenAPI is described with the same semantics as any other schema type. Specifically:</p>
+<pre class="nohighlight"><code>
+<span class="hljs-comment"># content transferred with base64 encoding</span>
+<span class="hljs-attr">schema:</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">format:</span> <span class="hljs-string">base64</span>
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-comment"># content transferred in binary (octet-stream):</span>
+<span class="hljs-attr">schema:</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">format:</span> <span class="hljs-string">binary</span>
+</code></pre>
+<p>These examples apply to either input payloads of file uploads or response payloads.</p>
+<p>A <code>requestBody</code> for submitting a file in a <code>POST</code> operation may look like the following example:</p>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">requestBody:</span>
+  <span class="hljs-attr">content:</span>
+    <span class="hljs-attr">application/octet-stream:</span>
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-comment"># a binary file of any type</span>
+        <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+        <span class="hljs-attr">format:</span> <span class="hljs-string">binary</span>
+</code></pre>
+<p>In addition, specific media types MAY be specified:</p>
+<pre class="nohighlight"><code>
+<span class="hljs-comment"># multiple, specific media types may be specified:</span>
+<span class="hljs-attr">requestBody:</span>
+  <span class="hljs-attr">content:</span>
+      <span class="hljs-comment"># a binary file of type png or jpeg</span>
+    <span class="hljs-attr">'image/jpeg':</span>
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+        <span class="hljs-attr">format:</span> <span class="hljs-string">binary</span>
+    <span class="hljs-attr">'image/png':</span>
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+        <span class="hljs-attr">format:</span> <span class="hljs-string">binary</span>        
+</code></pre>
+<p>To upload multiple files, a <code>multipart</code> media type MUST be used:</p>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">requestBody:</span>
+  <span class="hljs-attr">content:</span>
+    <span class="hljs-attr">multipart/form-data:</span>
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-attr">properties:</span>
+          <span class="hljs-comment"># The property name 'file' will be used for all files.</span>
+          <span class="hljs-attr">file:</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+            <span class="hljs-attr">items:</span>
+              <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+              <span class="hljs-attr">format:</span> <span class="hljs-string">binary</span>
+
+</code></pre>
+</section><section><h4>Support for x-www-form-urlencoded Request Bodies</h4>
+<p>To submit content using form url encoding via [[!RFC1866]], the following
+definition may be used:</p>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">requestBody:</span>
+  <span class="hljs-attr">content:</span>
+    <span class="hljs-attr">application/x-www-form-urlencoded:</span>
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+        <span class="hljs-attr">properties:</span>
+          <span class="hljs-attr">id:</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+            <span class="hljs-attr">format:</span> <span class="hljs-string">uuid</span>
+          <span class="hljs-attr">address:</span>
+            <span class="hljs-comment"># complex types are stringified to support RFC 1866</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+            <span class="hljs-attr">properties:</span> <span class="hljs-string">{}</span>
+</code></pre>
+<p>In this example, the contents in the <code>requestBody</code> MUST be stringified per [[!RFC1866]] when passed to the server.  In addition, the <code>address</code> field complex object will be stringified.</p>
+<p>When passing complex objects in the <code>application/x-www-form-urlencoded</code> content type, the default serialization strategy of such properties is described in the <a href="#encodingObject"><code>Encoding Object</code></a>'s <a href="#encodingStyle"><code>style</code></a> property as <code>form</code>.</p>
+</section><section><h4>Special Considerations for <code>multipart</code> Content</h4>
+<p>It is common to use <code>multipart/form-data</code> as a <code>Content-Type</code> when transferring request bodies to operations.  In contrast to 2.0, a <code>schema</code> is REQUIRED to define the input parameters to the operation when using <code>multipart</code> content.  This supports complex structures as well as supporting mechanisms for multiple file uploads.</p>
+<p>When passing in <code>multipart</code> types, boundaries MAY be used to separate sections of the content being transferred — thus, the following default <code>Content-Type</code>s are defined for <code>multipart</code>:</p>
+<ul>
+<li>If the property is a primitive, or an array of primitive values, the default Content-Type is <code>text/plain</code></li>
+<li>If the property is complex, or an array of complex values, the default Content-Type is <code>application/json</code></li>
+<li>If the property is a <code>type: string</code> with <code>format: binary</code> or <code>format: base64</code> (aka a file object), the default Content-Type is <code>application/octet-stream</code></li>
+</ul>
+<p>Examples:</p>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">requestBody:</span>
+  <span class="hljs-attr">content:</span>
+    <span class="hljs-attr">multipart/form-data:</span>
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+        <span class="hljs-attr">properties:</span>
+          <span class="hljs-attr">id:</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+            <span class="hljs-attr">format:</span> <span class="hljs-string">uuid</span>
+          <span class="hljs-attr">address:</span>
+            <span class="hljs-comment"># default Content-Type for objects is `application/json`</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+            <span class="hljs-attr">properties:</span> <span class="hljs-string">{}</span>
+          <span class="hljs-attr">profileImage:</span>
+            <span class="hljs-comment"># default Content-Type for string/binary is `application/octet-stream`</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+            <span class="hljs-attr">format:</span> <span class="hljs-string">binary</span>
+          <span class="hljs-attr">children:</span>
+            <span class="hljs-comment"># default Content-Type for arrays is based on the `inner` type (text/plain here)</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+            <span class="hljs-attr">items:</span>
+              <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+          <span class="hljs-attr">addresses:</span>
+            <span class="hljs-comment"># default Content-Type for arrays is based on the `inner` type (object shown, so `application/json` in this example)</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+            <span class="hljs-attr">items:</span>
+              <span class="hljs-attr">type:</span> <span class="hljs-string">'#/components/schemas/Address'</span>
+</code></pre>
+<p>An <code>encoding</code> attribute is introduced to give you control over the serialization of parts of <code>multipart</code> request bodies.  This attribute is <em>only</em> applicable to <code>multipart</code> and <code>application/x-www-form-urlencoded</code> request bodies.</p>
+</section></section><section><h3><span id="encodingObject">Encoding Object</span></h3>
+<p>A single encoding definition applied to a single schema property.</p>
+<section><h4>Fixed Fields</h4>
+<table>
+<thead>
+<tr>
+<th>Field Name</th>
+<th style="text-align:center">Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a id="encodingContentType"> </a>contentType</td>
+<td style="text-align:center"><code>string</code></td>
+<td>The Content-Type for encoding a specific property. Default value depends on the property type: for <code>string</code> with <code>format</code> being <code>binary</code> – <code>application/octet-stream</code>; for other primitive types – <code>text/plain</code>; for <code>object</code> - <code>application/json</code>; for <code>array</code> – the default is defined based on the inner type. The value can be a specific media type (e.g. <code>application/json</code>), a wildcard media type (e.g. <code>image/*</code>), or a comma-separated list of the two types.</td>
+</tr>
+<tr>
+<td><a id="encodingHeaders"> </a>headers</td>
+<td style="text-align:center">Map[<code>string</code>, <a href="#headerObject">Header Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td>A map allowing additional information to be provided as headers, for example <code>Content-Disposition</code>.  <code>Content-Type</code> is described separately and SHALL be ignored in this section. This property SHALL be ignored if the request body media type is not a <code>multipart</code>.</td>
+</tr>
+<tr>
+<td><a id="encodingStyle"> </a>style</td>
+<td style="text-align:center"><code>string</code></td>
+<td>Describes how a specific property value will be serialized depending on its type.  See <a href="#parameterObject">Parameter Object</a> for details on the <a href="#parameterStyle"><code>style</code></a> property. The behavior follows the same values as <code>query</code> parameters, including default values. This property SHALL be ignored if the request body media type is not <code>application/x-www-form-urlencoded</code>.</td>
+</tr>
+<tr>
+<td><a id="encodingExplode"> </a>explode</td>
+<td style="text-align:center"><code>boolean</code></td>
+<td>When this is true, property values of type <code>array</code> or <code>object</code> generate separate parameters for each value of the array, or key-value-pair of the map.  For other types of properties this property has no effect. When <a href="#encodingStyle"><code>style</code></a> is <code>form</code>, the default value is <code>true</code>. For all other styles, the default value is <code>false</code>. This property SHALL be ignored if the request body media type is not <code>application/x-www-form-urlencoded</code>.</td>
+</tr>
+<tr>
+<td><a id="encodingAllowReserved"> </a>allowReserved</td>
+<td style="text-align:center"><code>boolean</code></td>
+<td>Determines whether the parameter value SHOULD allow reserved characters, as defined by [[!RFC3986]] <code>:/?#[]@!$&amp;'()*+,;=</code> to be included without percent-encoding. The default value is <code>false</code>. This property SHALL be ignored if the request body media type is not <code>application/x-www-form-urlencoded</code>.</td>
+</tr>
+</tbody>
+</table>
+<p>This object MAY be extended with <a href="#specificationExtensions">Specification Extensions</a>.</p>
+</section><section><h4>Encoding Object Example</h4>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">requestBody:</span>
+  <span class="hljs-attr">content:</span>
+    <span class="hljs-attr">multipart/mixed:</span>
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+        <span class="hljs-attr">properties:</span>
+          <span class="hljs-attr">id:</span>
+            <span class="hljs-comment"># default is text/plain</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+            <span class="hljs-attr">format:</span> <span class="hljs-string">uuid</span>
+          <span class="hljs-attr">address:</span>
+            <span class="hljs-comment"># default is application/json</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+            <span class="hljs-attr">properties:</span> <span class="hljs-string">{}</span>
+          <span class="hljs-attr">historyMetadata:</span>
+            <span class="hljs-comment"># need to declare XML format!</span>
+            <span class="hljs-attr">description:</span> <span class="hljs-string">metadata</span> <span class="hljs-string">in</span> <span class="hljs-string">XML</span> <span class="hljs-string">format</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+            <span class="hljs-attr">properties:</span> <span class="hljs-string">{}</span>
+          <span class="hljs-attr">profileImage:</span>
+            <span class="hljs-comment"># default is application/octet-stream, need to declare an image type only!</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+            <span class="hljs-attr">format:</span> <span class="hljs-string">binary</span>
+      <span class="hljs-attr">encoding:</span>
+        <span class="hljs-attr">historyMetadata:</span>
+          <span class="hljs-comment"># require XML Content-Type in utf-8 encoding</span>
+          <span class="hljs-attr">contentType:</span> <span class="hljs-string">application/xml;</span> <span class="hljs-string">charset=utf-8</span>
+        <span class="hljs-attr">profileImage:</span>
+          <span class="hljs-comment"># only accept png/jpeg</span>
+          <span class="hljs-attr">contentType:</span> <span class="hljs-string">image/png,</span> <span class="hljs-string">image/jpeg</span>
+          <span class="hljs-attr">headers:</span>
+            <span class="hljs-attr">X-Rate-Limit-Limit:</span>
+              <span class="hljs-attr">description:</span> <span class="hljs-string">The</span> <span class="hljs-string">number</span> <span class="hljs-string">of</span> <span class="hljs-string">allowed</span> <span class="hljs-string">requests</span> <span class="hljs-string">in</span> <span class="hljs-string">the</span> <span class="hljs-string">current</span> <span class="hljs-string">period</span>
+              <span class="hljs-attr">schema:</span>
+                <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+</code></pre>
+</section></section><section><h3><span id="responsesObject">Responses Object</span></h3>
+<p>A container for the expected responses of an operation.
+The container maps a HTTP response code to the expected response.</p>
+<p>The documentation is not necessarily expected to cover all possible HTTP response codes because they may not be known in advance.
+However, documentation is expected to cover a successful operation response and any known errors.</p>
+<p>The <code>default</code> MAY be used as a default response object for all HTTP codes
+that are not covered individually by the specification.</p>
+<p>The <code>Responses Object</code> MUST contain at least one response code, and it
+SHOULD be the response for a successful operation call.</p>
+<section><h4>Fixed Fields</h4>
+<table>
+<thead>
+<tr>
+<th>Field Name</th>
+<th style="text-align:center">Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a id="responsesDefault"> </a>default</td>
+<td style="text-align:center"><a href="#responseObject">Response Object</a> ¦ <a href="#referenceObject">Reference Object</a></td>
+<td>The documentation of responses other than the ones declared for specific HTTP response codes. Use this field to cover undeclared responses. A <a href="#referenceObject">Reference Object</a> can link to a response that the <a href="#componentsResponses">OpenAPI Object’s components/responses</a> section defines.</td>
+</tr>
+</tbody>
+</table>
+</section><section><h4>Patterned Fields</h4>
+<table>
+<thead>
+<tr>
+<th>Field Pattern</th>
+<th style="text-align:center">Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a id="responsesCode"> </a><a href="#httpCodes">HTTP Status Code</a></td>
+<td style="text-align:center"><a href="#responseObject">Response Object</a> ¦ <a href="#referenceObject">Reference Object</a></td>
+<td>Any <a href="#httpCodes">HTTP status code</a> can be used as the property name, but only one property per code, to describe the expected response for that HTTP status code.  A <a href="#referenceObject">Reference Object</a> can link to a response that is defined in the <a href="#componentsResponses">OpenAPI Object’s components/responses</a> section. This field MUST be enclosed in quotation marks (for example, “200”) for compatibility between JSON and YAML. To define a range of response codes, this field MAY contain the uppercase wildcard character <code>X</code>. For example, <code>2XX</code> represents all response codes between <code>[200-299]</code>. Only the following range definitions are allowed: <code>1XX</code>, <code>2XX</code>, <code>3XX</code>, <code>4XX</code>, and <code>5XX</code>. If a response is defined using an explicit code, the explicit code definition takes precedence over the range definition for that code.</td>
+</tr>
+</tbody>
+</table>
+<p>This object MAY be extended with <a href="#specificationExtensions">Specification Extensions</a>.</p>
+</section><section><h4>Responses Object Example</h4>
+<p>A 200 response for a successful operation and a default response for others (implying an error):</p>
+<pre class="nohighlight"><code>
+{
+  <span class="hljs-attr">"200"</span>: {
+    <span class="hljs-attr">"description"</span>: <span class="hljs-string">"a pet to be returned"</span>,
+    <span class="hljs-attr">"content"</span>: {
+      <span class="hljs-attr">"application/json"</span>: {
+        <span class="hljs-attr">"schema"</span>: {
+          <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/Pet"</span>
+        }
+      }
+    }
+  },
+  <span class="hljs-attr">"default"</span>: {
+    <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Unexpected error"</span>,
+    <span class="hljs-attr">"content"</span>: {
+      <span class="hljs-attr">"application/json"</span>: {
+        <span class="hljs-attr">"schema"</span>: {
+          <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/ErrorModel"</span>
+        }
+      }
+    }
+  }
+}
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">'200':</span>
+  <span class="hljs-attr">description:</span> <span class="hljs-string">a</span> <span class="hljs-string">pet</span> <span class="hljs-string">to</span> <span class="hljs-string">be</span> <span class="hljs-string">returned</span>
+  <span class="hljs-attr">content:</span> 
+    <span class="hljs-attr">application/json:</span>
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Pet'</span>
+<span class="hljs-attr">default:</span>
+  <span class="hljs-attr">description:</span> <span class="hljs-string">Unexpected</span> <span class="hljs-string">error</span>
+  <span class="hljs-attr">content:</span>
+    <span class="hljs-attr">application/json:</span>
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/ErrorModel'</span>
+</code></pre>
+</section></section><section><h3><span id="responseObject">Response Object</span></h3>
+<p>Describes a single response from an API Operation, including design-time, static
+<code>links</code> to operations based on the response.</p>
+<section><h4>Fixed Fields</h4>
+<table>
+<thead>
+<tr>
+<th>Field Name</th>
+<th style="text-align:center">Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a id="responseDescription"> </a>description</td>
+<td style="text-align:center"><code>string</code></td>
+<td><strong>REQUIRED</strong>. A short description of the response. <a href="https://spec.commonmark.org/">CommonMark syntax</a> MAY be used for rich text representation.</td>
+</tr>
+<tr>
+<td><a id="responseHeaders"> </a>headers</td>
+<td style="text-align:center">Map[<code>string</code>, <a href="#headerObject">Header Object</a>  ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td>Maps a header name to its definition. [[!RFC7230]] states header names are case insensitive. If a response header is defined with the name <code>&quot;Content-Type&quot;</code>, it SHALL be ignored.</td>
+</tr>
+<tr>
+<td><a id="responseContent"> </a>content</td>
+<td style="text-align:center">Map[<code>string</code>, <a href="#mediaTypeObject">Media Type Object</a>]</td>
+<td>A map containing descriptions of potential response payloads. The key is a media type or [media type range]appendix-D) and the value describes it.  For responses that match multiple keys, only the most specific key is applicable. e.g. text/plain overrides text/*</td>
+</tr>
+<tr>
+<td><a id="responseLinks"> </a>links</td>
+<td style="text-align:center">Map[<code>string</code>, <a href="#linkObject">Link Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td>A map of operations links that can be followed from the response. The key of the map is a short name for the link, following the naming constraints of the names for <a href="#componentsObject">Component Objects</a>.</td>
+</tr>
+</tbody>
+</table>
+<p>This object MAY be extended with <a href="#specificationExtensions">Specification Extensions</a>.</p>
+</section><section><h4>Response Object Examples</h4>
+<p>Response of an array of a complex type:</p>
+<pre class="nohighlight"><code>
+{
+  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"A complex object array response"</span>,
+  <span class="hljs-attr">"content"</span>: {
+    <span class="hljs-attr">"application/json"</span>: {
+      <span class="hljs-attr">"schema"</span>: {
+        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
+        <span class="hljs-attr">"items"</span>: {
+          <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/VeryComplexType"</span>
+        }
+      }
+    }
+  }
+}
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">description:</span> <span class="hljs-string">A</span> <span class="hljs-string">complex</span> <span class="hljs-string">object</span> <span class="hljs-string">array</span> <span class="hljs-string">response</span>
+<span class="hljs-attr">content:</span> 
+  <span class="hljs-attr">application/json:</span>
+    <span class="hljs-attr">schema:</span> 
+      <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+      <span class="hljs-attr">items:</span>
+        <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/VeryComplexType'</span>
+</code></pre>
+<p>Response with a string type:</p>
+<pre class="nohighlight"><code>
+{
+  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"A simple string response"</span>,
+  <span class="hljs-attr">"content"</span>: {
+    <span class="hljs-attr">"text/plain"</span>: {
+      <span class="hljs-attr">"schema"</span>: {
+        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+      }
+    }
+  }
+
+}
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">description:</span> <span class="hljs-string">A</span> <span class="hljs-string">simple</span> <span class="hljs-string">string</span> <span class="hljs-string">response</span>
+<span class="hljs-attr">content:</span>
+  <span class="hljs-attr">text/plain:</span>
+    <span class="hljs-attr">schema:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+</code></pre>
+<p>Plain text response with headers:</p>
+<pre class="nohighlight"><code>
+{
+  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"A simple string response"</span>,
+  <span class="hljs-attr">"content"</span>: {
+    <span class="hljs-attr">"text/plain"</span>: {
+      <span class="hljs-attr">"schema"</span>: {
+        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
+        <span class="hljs-attr">"example"</span>: <span class="hljs-string">"whoa!"</span>
+      }
+    }
+  },
+  <span class="hljs-attr">"headers"</span>: {
+    <span class="hljs-attr">"X-Rate-Limit-Limit"</span>: {
+      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"The number of allowed requests in the current period"</span>,
+      <span class="hljs-attr">"schema"</span>: {
+        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>
+      }
+    },
+    <span class="hljs-attr">"X-Rate-Limit-Remaining"</span>: {
+      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"The number of remaining requests in the current period"</span>,
+      <span class="hljs-attr">"schema"</span>: {
+        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>
+      }
+    },
+    <span class="hljs-attr">"X-Rate-Limit-Reset"</span>: {
+      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"The number of seconds left in the current period"</span>,
+      <span class="hljs-attr">"schema"</span>: {
+        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>
+      }
+    }
+  }
+}
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">description:</span> <span class="hljs-string">A</span> <span class="hljs-string">simple</span> <span class="hljs-string">string</span> <span class="hljs-string">response</span>
+<span class="hljs-attr">content:</span>
+  <span class="hljs-attr">text/plain:</span>
+    <span class="hljs-attr">schema:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+    <span class="hljs-attr">example:</span> <span class="hljs-string">'whoa!'</span>
+<span class="hljs-attr">headers:</span>
+  <span class="hljs-attr">X-Rate-Limit-Limit:</span>
+    <span class="hljs-attr">description:</span> <span class="hljs-string">The</span> <span class="hljs-string">number</span> <span class="hljs-string">of</span> <span class="hljs-string">allowed</span> <span class="hljs-string">requests</span> <span class="hljs-string">in</span> <span class="hljs-string">the</span> <span class="hljs-string">current</span> <span class="hljs-string">period</span>
+    <span class="hljs-attr">schema:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+  <span class="hljs-attr">X-Rate-Limit-Remaining:</span>
+    <span class="hljs-attr">description:</span> <span class="hljs-string">The</span> <span class="hljs-string">number</span> <span class="hljs-string">of</span> <span class="hljs-string">remaining</span> <span class="hljs-string">requests</span> <span class="hljs-string">in</span> <span class="hljs-string">the</span> <span class="hljs-string">current</span> <span class="hljs-string">period</span>
+    <span class="hljs-attr">schema:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+  <span class="hljs-attr">X-Rate-Limit-Reset:</span>
+    <span class="hljs-attr">description:</span> <span class="hljs-string">The</span> <span class="hljs-string">number</span> <span class="hljs-string">of</span> <span class="hljs-string">seconds</span> <span class="hljs-string">left</span> <span class="hljs-string">in</span> <span class="hljs-string">the</span> <span class="hljs-string">current</span> <span class="hljs-string">period</span>
+    <span class="hljs-attr">schema:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+</code></pre>
+<p>Response with no return value:</p>
+<pre class="nohighlight"><code>
+{
+  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"object created"</span>
+}
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">description:</span> <span class="hljs-string">object</span> <span class="hljs-string">created</span>
+</code></pre>
+</section></section><section><h3><span id="callbackObject">Callback Object</span></h3>
+<p>A map of possible out-of band callbacks related to the parent operation.
+Each value in the map is a <a href="#pathItemObject">Path Item Object</a> that describes a set of requests that may be initiated by the API provider and the expected responses.
+The key value used to identify the path item object is an expression, evaluated at runtime, that identifies a URL to use for the callback operation.</p>
+<section><h4>Patterned Fields</h4>
+<table>
+<thead>
+<tr>
+<th>Field Pattern</th>
+<th style="text-align:center">Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a id="callbackExpression"> </a>{expression}</td>
+<td style="text-align:center"><a href="#pathItemObject">Path Item Object</a></td>
+<td>A Path Item Object used to define a callback request and expected responses.  A <a href="https://github.com/OAI/OpenAPI-Specification/tree/master/examples/v3.0/callback-example.yaml">complete example</a> is available.</td>
+</tr>
+</tbody>
+</table>
+<p>This object MAY be extended with <a href="#specificationExtensions">Specification Extensions</a>.</p>
+</section><section><h4>Key Expression</h4>
+<p>The key that identifies the <a href="#pathItemObject">Path Item Object</a> is a <a href="#runtimeExpression">runtime expression</a> that can be evaluated in the context of a runtime HTTP request/response to identify the URL to be used for the callback request.
+A simple example might be <code>$request.body#/url</code>.
+However, using a <a href="#runtimeExpression">runtime expression</a> the complete HTTP message can be accessed.
+This includes accessing any part of a body that a JSON Pointer [[!RFC6901]] can reference.</p>
+<p>For example, given the following HTTP request:</p>
+<pre class="nohighlight"><code>
+<span class="hljs-keyword">POST</span> <span class="hljs-string">/subscribe/myevent?queryUrl=http://clientdomain.com/stillrunning</span> HTTP/1.1
+<span class="hljs-attribute">Host</span>: example.org
+<span class="hljs-attribute">Content-Type</span>: application/json
+<span class="hljs-attribute">Content-Length</span>: 187
+
+<span class="groovy">{
+  <span class="hljs-string">"failedUrl"</span> : <span class="hljs-string">"http://clientdomain.com/failed"</span>,
+  <span class="hljs-string">"successUrls"</span> : [
+    <span class="hljs-string">"http://clientdomain.com/fast"</span>,
+    <span class="hljs-string">"http://clientdomain.com/medium"</span>,
+    <span class="hljs-string">"http://clientdomain.com/slow"</span>
+  ] 
+}
+
+<span class="hljs-number">201</span> Created
+<span class="hljs-string">Location:</span> <span class="hljs-string">http:</span><span class="hljs-comment">//example.org/subscription/1</span>
+</span></code></pre>
+<p>The following examples show how the various expressions evaluate, assuming the callback operation has a path parameter named <code>eventType</code> and a query parameter named <code>queryUrl</code>.</p>
+<table>
+<thead>
+<tr>
+<th>Expression</th>
+<th style="text-align:left">Value</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>$url</td>
+<td style="text-align:left"><a href="http://example.org/subscribe/myevent?queryUrl=http://clientdomain.com/stillrunning">http://example.org/subscribe/myevent?queryUrl=http://clientdomain.com/stillrunning</a></td>
+</tr>
+<tr>
+<td>$method</td>
+<td style="text-align:left">POST</td>
+</tr>
+<tr>
+<td>$request.path.eventType</td>
+<td style="text-align:left">myevent</td>
+</tr>
+<tr>
+<td>$request.query.queryUrl</td>
+<td style="text-align:left"><a href="http://clientdomain.com/stillrunning">http://clientdomain.com/stillrunning</a></td>
+</tr>
+<tr>
+<td>$request.header.content-Type</td>
+<td style="text-align:left">application/json</td>
+</tr>
+<tr>
+<td>$request.body#/failedUrl</td>
+<td style="text-align:left"><a href="http://clientdomain.com/failed">http://clientdomain.com/failed</a></td>
+</tr>
+<tr>
+<td>$request.body#/successUrls/2</td>
+<td style="text-align:left"><a href="http://clientdomain.com/medium">http://clientdomain.com/medium</a></td>
+</tr>
+<tr>
+<td>$response.header.Location</td>
+<td style="text-align:left"><a href="http://example.org/subscription/1">http://example.org/subscription/1</a></td>
+</tr>
+</tbody>
+</table>
+</section><section><h4>Callback Object Examples</h4>
+<p>The following example uses the user provided <code>queryUrl</code> query string parameter to define the callback URL.  This is an example of how to use a callback object to describe a WebHook callback that goes with the subscription operation to enable registering for the WebHook.</p>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">myCallback:</span>
+  <span class="hljs-string">'{$request.query.queryUrl}'</span><span class="hljs-string">:</span>
+    <span class="hljs-attr">post:</span>
+      <span class="hljs-attr">requestBody:</span>
+        <span class="hljs-attr">description:</span> <span class="hljs-string">Callback</span> <span class="hljs-string">payload</span>
+        <span class="hljs-attr">content:</span> 
+          <span class="hljs-attr">'application/json':</span>
+            <span class="hljs-attr">schema:</span>
+              <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/SomePayload'</span>
+      <span class="hljs-attr">responses:</span>
+        <span class="hljs-attr">'200':</span>
+          <span class="hljs-attr">description:</span> <span class="hljs-string">callback</span> <span class="hljs-string">successfully</span> <span class="hljs-string">processed</span>
+</code></pre>
+<p>The following example shows a callback where the server is hard-coded, but the query string parameters are populated from the <code>id</code> and <code>email</code> property in the request body.</p>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">transactionCallback:</span>
+  <span class="hljs-string">'http://notificationServer.com?transactionId={$request.body#/id}&amp;email={$request.body#/email}'</span><span class="hljs-string">:</span>
+    <span class="hljs-attr">post:</span>
+      <span class="hljs-attr">requestBody:</span>
+        <span class="hljs-attr">description:</span> <span class="hljs-string">Callback</span> <span class="hljs-string">payload</span>
+        <span class="hljs-attr">content:</span> 
+          <span class="hljs-attr">'application/json':</span>
+            <span class="hljs-attr">schema:</span>
+              <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/SomePayload'</span>
+      <span class="hljs-attr">responses:</span>
+        <span class="hljs-attr">'200':</span>
+          <span class="hljs-attr">description:</span> <span class="hljs-string">callback</span> <span class="hljs-string">successfully</span> <span class="hljs-string">processed</span>
+</code></pre>
+</section></section><section><h3><span id="exampleObject">Example Object</span></h3>
+<section><h4>Fixed Fields</h4>
+<table>
+<thead>
+<tr>
+<th>Field Name</th>
+<th style="text-align:center">Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a id="exampleSummary"> </a>summary</td>
+<td style="text-align:center"><code>string</code></td>
+<td>Short description for the example.</td>
+</tr>
+<tr>
+<td><a id="exampleDescription"> </a>description</td>
+<td style="text-align:center"><code>string</code></td>
+<td>Long description for the example. <a href="https://spec.commonmark.org/">CommonMark syntax</a> MAY be used for rich text representation.</td>
+</tr>
+<tr>
+<td><a id="exampleValue"> </a>value</td>
+<td style="text-align:center">Any</td>
+<td>Embedded literal example. The <code>value</code> field and <code>externalValue</code> field are mutually exclusive. To represent examples of media types that cannot naturally represented in JSON or YAML, use a string value to contain the example, escaping where necessary.</td>
+</tr>
+<tr>
+<td><a id="exampleExternalValue"> </a>externalValue</td>
+<td style="text-align:center"><code>string</code></td>
+<td>A URL that points to the literal example. This provides the capability to reference examples that cannot easily be included in JSON or YAML documents.  The <code>value</code> field and <code>externalValue</code> field are mutually exclusive.</td>
+</tr>
+</tbody>
+</table>
+<p>This object MAY be extended with <a href="#specificationExtensions">Specification Extensions</a>.</p>
+<p>In all cases, the example value is expected to be compatible with the type schema
+of its associated value.  Tooling implementations MAY choose to
+validate compatibility automatically, and reject the example value(s) if incompatible.</p>
+</section><section><h4>Example Object Examples</h4>
+<p>In a request body:</p>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">requestBody:</span>
+  <span class="hljs-attr">content:</span>
+    <span class="hljs-attr">'application/json':</span>
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Address'</span>
+      <span class="hljs-attr">examples:</span> 
+        <span class="hljs-attr">foo:</span>
+          <span class="hljs-attr">summary:</span> <span class="hljs-string">A</span> <span class="hljs-string">foo</span> <span class="hljs-string">example</span>
+          <span class="hljs-attr">value:</span> <span class="hljs-string">{"foo":</span> <span class="hljs-string">"bar"</span><span class="hljs-string">}</span>
+        <span class="hljs-attr">bar:</span>
+          <span class="hljs-attr">summary:</span> <span class="hljs-string">A</span> <span class="hljs-string">bar</span> <span class="hljs-string">example</span>
+          <span class="hljs-attr">value:</span> <span class="hljs-string">{"bar":</span> <span class="hljs-string">"baz"</span><span class="hljs-string">}</span>
+    <span class="hljs-attr">'application/xml':</span>
+      <span class="hljs-attr">examples:</span> 
+        <span class="hljs-attr">xmlExample:</span>
+          <span class="hljs-attr">summary:</span> <span class="hljs-string">This</span> <span class="hljs-string">is</span> <span class="hljs-string">an</span> <span class="hljs-string">example</span> <span class="hljs-string">in</span> <span class="hljs-string">XML</span>
+          <span class="hljs-attr">externalValue:</span> <span class="hljs-string">'http://example.org/examples/address-example.xml'</span>
+    <span class="hljs-attr">'text/plain':</span>
+      <span class="hljs-attr">examples:</span>
+        <span class="hljs-attr">textExample:</span> 
+          <span class="hljs-attr">summary:</span> <span class="hljs-string">This</span> <span class="hljs-string">is</span> <span class="hljs-string">a</span> <span class="hljs-string">text</span> <span class="hljs-string">example</span>
+          <span class="hljs-attr">externalValue:</span> <span class="hljs-string">'http://foo.bar/examples/address-example.txt'</span>
+</code></pre>
+<p>In a parameter:</p>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">parameters:</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-attr">name:</span> <span class="hljs-string">'zipCode'</span>
+    <span class="hljs-attr">in:</span> <span class="hljs-string">'query'</span>
+    <span class="hljs-attr">schema:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">'string'</span>
+      <span class="hljs-attr">format:</span> <span class="hljs-string">'zip-code'</span>
+    <span class="hljs-attr">examples:</span>
+      <span class="hljs-attr">zip-example:</span> 
+        <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/examples/zip-example'</span>
+</code></pre>
+<p>In a response:</p>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">responses:</span>
+  <span class="hljs-attr">'200':</span>
+    <span class="hljs-attr">description:</span> <span class="hljs-string">your</span> <span class="hljs-string">car</span> <span class="hljs-string">appointment</span> <span class="hljs-string">has</span> <span class="hljs-string">been</span> <span class="hljs-string">booked</span>
+    <span class="hljs-attr">content:</span> 
+      <span class="hljs-attr">application/json:</span>
+        <span class="hljs-attr">schema:</span>
+          <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/SuccessResponse'</span>
+        <span class="hljs-attr">examples:</span>
+          <span class="hljs-attr">confirmation-success:</span>
+            <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/examples/confirmation-success'</span>
+</code></pre>
+</section></section><section><h3><span id="linkObject">Link Object</span></h3>
+<p>The <code>Link object</code> represents a possible design-time link for a response.
+The presence of a link does not guarantee the caller’s ability to successfully invoke it, rather it provides a known relationship and traversal mechanism between responses and other operations.</p>
+<p>Unlike <em>dynamic</em> links (i.e. links provided <strong>in</strong> the response payload), the OAS linking mechanism does not require link information in the runtime response.</p>
+<p>For computing links, and providing instructions to execute them, a <a href="#runtimeExpression">runtime expression</a> is used for accessing values in an operation and using them as parameters while invoking the linked operation.</p>
+<section><h4>Fixed Fields</h4>
+<table>
+<thead>
+<tr>
+<th>Field Name</th>
+<th style="text-align:center">Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a id="linkOperationRef"> </a>operationRef</td>
+<td style="text-align:center"><code>string</code></td>
+<td>A relative or absolute URI reference to an OAS operation. This field is mutually exclusive of the <code>operationId</code> field, and MUST point to an <a href="#operationObject">Operation Object</a>. Relative <code>operationRef</code> values MAY be used to locate an existing <a href="#operationObject">Operation Object</a> in the OpenAPI definition.</td>
+</tr>
+<tr>
+<td><a id="linkOperationId"> </a>operationId</td>
+<td style="text-align:center"><code>string</code></td>
+<td>The name of an <em>existing</em>, resolvable OAS operation, as defined with a unique <code>operationId</code>.  This field is mutually exclusive of the <code>operationRef</code> field.</td>
+</tr>
+<tr>
+<td><a id="linkParameters"> </a>parameters</td>
+<td style="text-align:center">Map[<code>string</code>, Any ¦ <a href="#runtimeExpression">{expression}</a>]</td>
+<td>A map representing parameters to pass to an operation as specified with <code>operationId</code> or identified via <code>operationRef</code>. The key is the parameter name to be used, whereas the value can be a constant or an expression to be evaluated and passed to the linked operation.  The parameter name can be qualified using the <a href="#parameterIn">parameter location</a> <code>[{in}.]{name}</code> for operations that use the same parameter name in different locations (e.g. <a href="http://path.id">path.id</a>).</td>
+</tr>
+<tr>
+<td><a id="linkRequestBody"> </a>requestBody</td>
+<td style="text-align:center">Any ¦ <a href="#runtimeExpression">{expression}</a></td>
+<td>A literal value or <a href="#runtimeExpression">{expression}</a> to use as a request body when calling the target operation.</td>
+</tr>
+<tr>
+<td><a id="linkDescription"> </a>description</td>
+<td style="text-align:center"><code>string</code></td>
+<td>A description of the link. <a href="https://spec.commonmark.org/">CommonMark syntax</a> MAY be used for rich text representation.</td>
+</tr>
+<tr>
+<td><a id="linkServer"> </a>server</td>
+<td style="text-align:center"><a href="#serverObject">Server Object</a></td>
+<td>A server object to be used by the target operation.</td>
+</tr>
+</tbody>
+</table>
+<p>This object MAY be extended with <a href="#specificationExtensions">Specification Extensions</a>.</p>
+<p>A linked operation MUST be identified using either an <code>operationRef</code> or <code>operationId</code>.
+In the case of an <code>operationId</code>, it MUST be unique and resolved in the scope of the OAS document.
+Because of the potential for name clashes, the <code>operationRef</code> syntax is preferred
+for specifications with external references.</p>
+</section><section><h4>Examples</h4>
+<p>Computing a link from a request operation where the <code>$request.path.id</code> is used to pass a request parameter to the linked operation.</p>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">paths:</span>
+  <span class="hljs-string">/users/{id}:</span>
+    <span class="hljs-attr">parameters:</span>
+    <span class="hljs-bullet">-</span> <span class="hljs-attr">name:</span> <span class="hljs-string">id</span>
+      <span class="hljs-attr">in:</span> <span class="hljs-string">path</span>
+      <span class="hljs-attr">required:</span> <span class="hljs-literal">true</span>
+      <span class="hljs-attr">description:</span> <span class="hljs-string">the</span> <span class="hljs-string">user</span> <span class="hljs-string">identifier,</span> <span class="hljs-string">as</span> <span class="hljs-string">userId</span> 
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+    <span class="hljs-attr">get:</span>
+      <span class="hljs-attr">responses:</span>
+        <span class="hljs-attr">'200':</span>
+          <span class="hljs-attr">description:</span> <span class="hljs-string">the</span> <span class="hljs-string">user</span> <span class="hljs-string">being</span> <span class="hljs-string">returned</span>
+          <span class="hljs-attr">content:</span>
+            <span class="hljs-attr">application/json:</span>
+              <span class="hljs-attr">schema:</span>
+                <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+                <span class="hljs-attr">properties:</span>
+                  <span class="hljs-attr">uuid:</span> <span class="hljs-comment"># the unique user id</span>
+                    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+                    <span class="hljs-attr">format:</span> <span class="hljs-string">uuid</span>
+          <span class="hljs-attr">links:</span>
+            <span class="hljs-attr">address:</span>
+              <span class="hljs-comment"># the target link operationId</span>
+              <span class="hljs-attr">operationId:</span> <span class="hljs-string">getUserAddress</span>
+              <span class="hljs-attr">parameters:</span>
+                <span class="hljs-comment"># get the `id` field from the request path parameter named `id`</span>
+                <span class="hljs-attr">userId:</span> <span class="hljs-string">$request.path.id</span>
+  <span class="hljs-comment"># the path item of the linked operation</span>
+  <span class="hljs-string">/users/{userid}/address:</span>
+    <span class="hljs-attr">parameters:</span>
+    <span class="hljs-bullet">-</span> <span class="hljs-attr">name:</span> <span class="hljs-string">userid</span>
+      <span class="hljs-attr">in:</span> <span class="hljs-string">path</span>
+      <span class="hljs-attr">required:</span> <span class="hljs-literal">true</span>
+      <span class="hljs-attr">description:</span> <span class="hljs-string">the</span> <span class="hljs-string">user</span> <span class="hljs-string">identifier,</span> <span class="hljs-string">as</span> <span class="hljs-string">userId</span> 
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+    <span class="hljs-comment"># linked operation</span>
+    <span class="hljs-attr">get:</span>
+      <span class="hljs-attr">operationId:</span> <span class="hljs-string">getUserAddress</span>
+      <span class="hljs-attr">responses:</span>
+        <span class="hljs-attr">'200':</span>
+          <span class="hljs-attr">description:</span> <span class="hljs-string">the</span> <span class="hljs-string">user's</span> <span class="hljs-string">address</span>
+</code></pre>
+<p>When a runtime expression fails to evaluate, no parameter value is passed to the target operation.</p>
+<p>Values from the response body can be used to drive a linked operation.</p>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">links:</span>
+  <span class="hljs-attr">address:</span>
+    <span class="hljs-attr">operationId:</span> <span class="hljs-string">getUserAddressByUUID</span>
+    <span class="hljs-attr">parameters:</span>
+      <span class="hljs-comment"># get the `uuid` field from the `uuid` field in the response body</span>
+      <span class="hljs-attr">userUuid:</span> <span class="hljs-string">$response.body#/uuid</span>
+</code></pre>
+<p>Clients follow all links at their discretion.
+Neither permissions, nor the capability to make a successful call to that link, is guaranteed
+solely by the existence of a relationship.</p>
+</section><section><h4>OperationRef Examples</h4>
+<p>As references to <code>operationId</code> MAY NOT be possible (the <code>operationId</code> is an optional
+field in an <a href="#operationObject">Operation Object</a>), references MAY also be made through a relative <code>operationRef</code>:</p>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">links:</span>
+  <span class="hljs-attr">UserRepositories:</span>
+    <span class="hljs-comment"># returns array of '#/components/schemas/repository'</span>
+    <span class="hljs-attr">operationRef:</span> <span class="hljs-string">'#/paths/~12.0~1repositories~1{username}/get'</span>
+    <span class="hljs-attr">parameters:</span>
+      <span class="hljs-attr">username:</span> <span class="hljs-string">$response.body#/username</span>
+</code></pre>
+<p>or an absolute <code>operationRef</code>:</p>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">links:</span>
+  <span class="hljs-attr">UserRepositories:</span>
+    <span class="hljs-comment"># returns array of '#/components/schemas/repository'</span>
+    <span class="hljs-attr">operationRef:</span> <span class="hljs-string">'https://na2.gigantic-server.com/#/paths/~12.0~1repositories~1{username}/get'</span>
+    <span class="hljs-attr">parameters:</span>
+      <span class="hljs-attr">username:</span> <span class="hljs-string">$response.body#/username</span>
+</code></pre>
+<p>Note that in the use of <code>operationRef</code>, the <em>escaped forward-slash</em> is necessary when
+using JSON references.</p>
+</section><section><h4><span id="runtimeExpression">Runtime Expressions</span></h4>
+<p>Runtime expressions allow defining values based on information that will only be available within the HTTP message in an actual API call.
+This mechanism is used by <a href="#linkObject">Link Objects</a> and <a href="#callbackObject">Callback Objects</a>.</p>
+<p>The runtime expression is defined by the following [ABNF] syntax</p>
+<pre class="nohighlight"><code>
+      expression = ( <span class="hljs-string">"$url"</span> / <span class="hljs-string">"$method"</span> / <span class="hljs-string">"$statusCode"</span> / <span class="hljs-string">"$request."</span> source / <span class="hljs-string">"$response."</span> source )
+      source = ( header-reference / query-reference / path-reference / body-reference )
+      header-reference = <span class="hljs-string">"header."</span> token
+      query-reference = <span class="hljs-string">"query."</span> name  
+      path-reference = <span class="hljs-string">"path."</span> name
+      body-reference = <span class="hljs-string">"body"</span> [<span class="hljs-string">"#"</span> json-pointer ]
+      json-pointer    = *( <span class="hljs-string">"/"</span> reference-token )
+      reference-token = *( unescaped / escaped )
+      unescaped       = <span class="hljs-symbol">%x00-2E</span> / <span class="hljs-symbol">%x30-7D</span> / <span class="hljs-symbol">%x7F-10FFFF</span>
+         <span class="hljs-comment">; %x2F ('/') and %x7E ('~') are excluded from 'unescaped'</span>
+      escaped         = <span class="hljs-string">"~"</span> ( <span class="hljs-string">"0"</span> / <span class="hljs-string">"1"</span> )
+        <span class="hljs-comment">; representing '~' and '/', respectively</span>
+      name = *( <span class="hljs-keyword">CHAR</span> )
+      token = <span class="hljs-number">1</span>*tchar
+      tchar = <span class="hljs-string">"!"</span> / <span class="hljs-string">"#"</span> / <span class="hljs-string">"$"</span> / <span class="hljs-string">"%"</span> / <span class="hljs-string">"&amp;"</span> / <span class="hljs-string">"'"</span> / <span class="hljs-string">"*"</span> / <span class="hljs-string">"+"</span> / <span class="hljs-string">"-"</span> / <span class="hljs-string">"."</span> /
+        <span class="hljs-string">"^"</span> / <span class="hljs-string">"_"</span> / <span class="hljs-string">"`"</span> / <span class="hljs-string">"|"</span> / <span class="hljs-string">"~"</span> / <span class="hljs-keyword">DIGIT</span> / <span class="hljs-keyword">ALPHA</span>
+</code></pre>
+<p>Here, <code>json-pointer</code> is taken from [[!RFC6901]], <code>char</code> from [[!RFC7159]] and <code>token</code> from [[!RFC7230]].</p>
+<p>The <code>name</code> identifier is case-sensitive, whereas <code>token</code> is not.</p>
+<p>The table below provides examples of runtime expressions and examples of their use in a value:</p>
+</section><section><h4><span id="runtimeExpressionExamples">Examples</span></h4>
+<table>
+<thead>
+<tr>
+<th>Source Location</th>
+<th style="text-align:left">example expression</th>
+<th style="text-align:left">notes</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>HTTP Method</td>
+<td style="text-align:left"><code>$method</code></td>
+<td style="text-align:left">The allowable values for the <code>$method</code> will be those for the HTTP operation.</td>
+</tr>
+<tr>
+<td>Requested media type</td>
+<td style="text-align:left"><code>$request.header.accept</code></td>
+<td style="text-align:left"></td>
+</tr>
+<tr>
+<td>Request parameter</td>
+<td style="text-align:left"><code>$request.path.id</code></td>
+<td style="text-align:left">Request parameters MUST be declared in the <code>parameters</code> section of the parent operation or they cannot be evaluated. This includes request headers.</td>
+</tr>
+<tr>
+<td>Request body property</td>
+<td style="text-align:left"><code>$request.body#/user/uuid</code></td>
+<td style="text-align:left">In operations which accept payloads, references may be made to portions of the <code>requestBody</code> or the entire body.</td>
+</tr>
+<tr>
+<td>Request URL</td>
+<td style="text-align:left"><code>$url</code></td>
+<td style="text-align:left"></td>
+</tr>
+<tr>
+<td>Response value</td>
+<td style="text-align:left"><code>$response.body#/status</code></td>
+<td style="text-align:left">In operations which return payloads, references may be made to portions of the response body or the entire body.</td>
+</tr>
+<tr>
+<td>Response header</td>
+<td style="text-align:left"><code>$response.header.Server</code></td>
+<td style="text-align:left">Single header values only are available</td>
+</tr>
+</tbody>
+</table>
+<p>Runtime expressions preserve the type of the referenced value.
+Expressions can be embedded into string values by surrounding the expression with <code>{}</code> curly braces.</p>
+</section></section><section><h3><span id="headerObject">Header Object</span></h3>
+<p>The Header Object follows the structure of the <a href="#parameterObject">Parameter Object</a> with the following changes:</p>
+<ol>
+<li><code>name</code> MUST NOT be specified, it is given in the corresponding <code>headers</code> map.</li>
+<li><code>in</code> MUST NOT be specified, it is implicitly in <code>header</code>.</li>
+<li>All traits that are affected by the location MUST be applicable to a location of <code>header</code> (for example, <a href="#parameterStyle"><code>style</code></a>).</li>
+</ol>
+<section><h4>Header Object Example</h4>
+<p>A simple header of type <code>integer</code>:</p>
+<pre class="nohighlight"><code>
+{
+  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"The number of allowed requests in the current period"</span>,
+  <span class="hljs-attr">"schema"</span>: {
+    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>
+  }
+}
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">description:</span> <span class="hljs-string">The</span> <span class="hljs-string">number</span> <span class="hljs-string">of</span> <span class="hljs-string">allowed</span> <span class="hljs-string">requests</span> <span class="hljs-string">in</span> <span class="hljs-string">the</span> <span class="hljs-string">current</span> <span class="hljs-string">period</span>
+<span class="hljs-attr">schema:</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+</code></pre>
+</section></section><section><h3><span id="tagObject">Tag Object</span></h3>
+<p>Adds metadata to a single tag that is used by the <a href="#operationObject">Operation Object</a>.
+It is not mandatory to have a Tag Object per tag defined in the Operation Object instances.</p>
+<section><h4>Fixed Fields</h4>
+<table>
+<thead>
+<tr>
+<th>Field Name</th>
+<th style="text-align:center">Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a id="tagName"> </a>name</td>
+<td style="text-align:center"><code>string</code></td>
+<td><strong>REQUIRED</strong>. The name of the tag.</td>
+</tr>
+<tr>
+<td><a id="tagDescription"> </a>description</td>
+<td style="text-align:center"><code>string</code></td>
+<td>A short description for the tag. <a href="https://spec.commonmark.org/">CommonMark syntax</a> MAY be used for rich text representation.</td>
+</tr>
+<tr>
+<td><a id="tagExternalDocs"> </a>externalDocs</td>
+<td style="text-align:center"><a href="#externalDocumentationObject">External Documentation Object</a></td>
+<td>Additional external documentation for this tag.</td>
+</tr>
+</tbody>
+</table>
+<p>This object MAY be extended with <a href="#specificationExtensions">Specification Extensions</a>.</p>
+</section><section><h4>Tag Object Example</h4>
+<pre class="nohighlight"><code>
+{
+	<span class="hljs-attr">"name"</span>: <span class="hljs-string">"pet"</span>,
+	<span class="hljs-attr">"description"</span>: <span class="hljs-string">"Pets operations"</span>
+}
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">name:</span> <span class="hljs-string">pet</span>
+<span class="hljs-attr">description:</span> <span class="hljs-string">Pets</span> <span class="hljs-string">operations</span>
+</code></pre>
+</section></section><section><h3><span id="referenceObject">Reference Object</span></h3>
+<p>A simple object to allow referencing other components in the specification, internally and externally.</p>
+<p>The Reference Object is defined by <a href="https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03">JSON Reference</a> and follows the same structure, behavior and rules.</p>
+<p>For this specification, reference resolution is accomplished as defined by the JSON Reference specification and not by the JSON Schema specification.</p>
+<section><h4>Fixed Fields</h4>
+<table>
+<thead>
+<tr>
+<th>Field Name</th>
+<th style="text-align:center">Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a id="referenceRef"> </a>$ref</td>
+<td style="text-align:center"><code>string</code></td>
+<td><strong>REQUIRED</strong>. The reference string.</td>
+</tr>
+</tbody>
+</table>
+<p>This object cannot be extended with additional properties and any properties added SHALL be ignored.</p>
+</section><section><h4>Reference Object Example</h4>
+<pre class="nohighlight"><code>
+{
+	<span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/Pet"</span>
+}
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Pet'</span>
+</code></pre>
+</section><section><h4>Relative Schema Document Example</h4>
+<pre class="nohighlight"><code>
+{
+  <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"Pet.json"</span>
+}
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-string">$ref:</span> <span class="hljs-string">Pet.yaml</span>
+</code></pre>
+</section><section><h4>Relative Documents With Embedded Schema Example</h4>
+<pre class="nohighlight"><code>
+{
+  <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"definitions.json#/Pet"</span>
+}
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-string">$ref:</span> <span class="hljs-string">definitions.yaml#/Pet</span>
+</code></pre>
+</section></section><section><h3><span id="schemaObject">Schema Object</span></h3>
+<p>The Schema Object allows the definition of input and output data types.
+These types can be objects, but also primitives and arrays.
+This object is an extended subset of the <a href="https://json-schema.org/">JSON Schema Specification Wright Draft 00</a>.</p>
+<p>For more information about the properties, see <a href="https://tools.ietf.org/html/draft-wright-json-schema-00">JSON Schema Core</a> and <a href="https://tools.ietf.org/html/draft-wright-json-schema-validation-00">JSON Schema Validation</a>.
+Unless stated otherwise, the property definitions follow the JSON Schema.</p>
+<section><h4>Properties</h4>
+<p>The following properties are taken directly from the JSON Schema definition and follow the same specifications:</p>
+<ul>
+<li>title</li>
+<li>multipleOf</li>
+<li>maximum</li>
+<li>exclusiveMaximum</li>
+<li>minimum</li>
+<li>exclusiveMinimum</li>
+<li>maxLength</li>
+<li>minLength</li>
+<li>pattern (This string SHOULD be a valid regular expression, according to the <a href="https://www.ecma-international.org/ecma-262/5.1/#sec-15.10.1">Ecma-262 Edition 5.1 regular expression</a> dialect)</li>
+<li>maxItems</li>
+<li>minItems</li>
+<li>uniqueItems</li>
+<li>maxProperties</li>
+<li>minProperties</li>
+<li>required</li>
+<li>enum</li>
+</ul>
+<p>The following properties are taken from the JSON Schema definition but their definitions were adjusted to the OpenAPI Specification.</p>
+<ul>
+<li>type - Value MUST be a string. Multiple types via an array are not supported.</li>
+<li>allOf - Inline or referenced schema MUST be of a <a href="#schemaObject">Schema Object</a> and not a standard JSON Schema.</li>
+<li>oneOf - Inline or referenced schema MUST be of a <a href="#schemaObject">Schema Object</a> and not a standard JSON Schema.</li>
+<li>anyOf - Inline or referenced schema MUST be of a <a href="#schemaObject">Schema Object</a> and not a standard JSON Schema.</li>
+<li>not - Inline or referenced schema MUST be of a <a href="#schemaObject">Schema Object</a> and not a standard JSON Schema.</li>
+<li>items - Value MUST be an object and not an array. Inline or referenced schema MUST be of a <a href="#schemaObject">Schema Object</a> and not a standard JSON Schema. <code>items</code> MUST be present if the <code>type</code> is <code>array</code>.</li>
+<li>properties - Property definitions MUST be a <a href="#schemaObject">Schema Object</a> and not a standard JSON Schema (inline or referenced).</li>
+<li>additionalProperties - Value can be boolean or object. Inline or referenced schema MUST be of a <a href="#schemaObject">Schema Object</a> and not a standard JSON Schema. Consistent with JSON Schema, <code>additionalProperties</code> defaults to <code>true</code>.</li>
+<li>description - <a href="https://spec.commonmark.org/">CommonMark syntax</a> MAY be used for rich text representation.</li>
+<li>format - See <a href="#dataTypeFormat">Data Type Formats</a> for further details. While relying on JSON Schema’s defined formats, the OAS offers a few additional predefined formats.</li>
+<li>default - The default value represents what would be assumed by the consumer of the input as the value of the schema if one is not provided. Unlike JSON Schema, the value MUST conform to the defined type for the Schema Object defined at the same level. For example, if <code>type</code> is <code>string</code>, then <code>default</code> can be <code>&quot;foo&quot;</code> but cannot be <code>1</code>.</li>
+</ul>
+<p>Alternatively, any time a Schema Object can be used, a <a href="#referenceObject">Reference Object</a> can be used in its place. This allows referencing definitions instead of defining them inline.</p>
+<p>Additional properties defined by the JSON Schema specification that are not mentioned here are strictly unsupported.</p>
+<p>Other than the JSON Schema subset fields, the following fields MAY be used for further schema documentation:</p>
+</section><section><h4>Fixed Fields</h4>
+<table>
+<thead>
+<tr>
+<th>Field Name</th>
+<th style="text-align:center">Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a id="schemaNullable"> </a>nullable</td>
+<td style="text-align:center"><code>boolean</code></td>
+<td>A <code>true</code> value adds <code>&quot;null&quot;</code> to the allowed type specified by the <code>type</code> keyword, only if <code>type</code> is explicitly defined within the same Schema Object. Other Schema Object constraints retain their defined behavior, and therefore may disallow the use of <code>null</code> as a value. A <code>false</code> value leaves the specified or default <code>type</code> unmodified. The default value is <code>false</code>.</td>
+</tr>
+<tr>
+<td><a id="schemaDiscriminator"> </a>discriminator</td>
+<td style="text-align:center"><a href="#discriminatorObject">Discriminator Object</a></td>
+<td>Adds support for polymorphism. The discriminator is an object name that is used to differentiate between other schemas which may satisfy the payload description. See <a href="#schemaComposition">Composition and Inheritance</a> for more details.</td>
+</tr>
+<tr>
+<td><a id="schemaReadOnly"> </a>readOnly</td>
+<td style="text-align:center"><code>boolean</code></td>
+<td>Relevant only for Schema <code>&quot;properties&quot;</code> definitions. Declares the property as “read only”. This means that it MAY be sent as part of a response but SHOULD NOT be sent as part of the request. If the property is marked as <code>readOnly</code> being <code>true</code> and is in the <code>required</code> list, the <code>required</code> will take effect on the response only. A property MUST NOT be marked as both <code>readOnly</code> and <code>writeOnly</code> being <code>true</code>. Default value is <code>false</code>.</td>
+</tr>
+<tr>
+<td><a id="schemaWriteOnly"> </a>writeOnly</td>
+<td style="text-align:center"><code>boolean</code></td>
+<td>Relevant only for Schema <code>&quot;properties&quot;</code> definitions. Declares the property as “write only”. Therefore, it MAY be sent as part of a request but SHOULD NOT be sent as part of the response. If the property is marked as <code>writeOnly</code> being <code>true</code> and is in the <code>required</code> list, the <code>required</code> will take effect on the request only. A property MUST NOT be marked as both <code>readOnly</code> and <code>writeOnly</code> being <code>true</code>. Default value is <code>false</code>.</td>
+</tr>
+<tr>
+<td><a id="schemaXml"> </a>xml</td>
+<td style="text-align:center"><a href="#xmlObject">XML Object</a></td>
+<td>This MAY be used only on properties schemas. It has no effect on root schemas. Adds additional metadata to describe the XML representation of this property.</td>
+</tr>
+<tr>
+<td><a id="schemaExternalDocs"> </a>externalDocs</td>
+<td style="text-align:center"><a href="#externalDocumentationObject">External Documentation Object</a></td>
+<td>Additional external documentation for this schema.</td>
+</tr>
+<tr>
+<td><a id="schemaExample"> </a>example</td>
+<td style="text-align:center">Any</td>
+<td>A free-form property to include an example of an instance for this schema. To represent examples that cannot be naturally represented in JSON or YAML, a string value can be used to contain the example with escaping where necessary.</td>
+</tr>
+<tr>
+<td><a id="schemaDeprecated"> </a> deprecated</td>
+<td style="text-align:center"><code>boolean</code></td>
+<td>Specifies that a schema is deprecated and SHOULD be transitioned out of usage. Default value is <code>false</code>.</td>
+</tr>
+</tbody>
+</table>
+<p>This object MAY be extended with <a href="#specificationExtensions">Specification Extensions</a>.</p>
+<section><h5><span id="schemaComposition">Composition and Inheritance (Polymorphism)</span></h5>
+<p>The OpenAPI Specification allows combining and extending model definitions using the <code>allOf</code> property of JSON Schema, in effect offering model composition.
+<code>allOf</code> takes an array of object definitions that are validated <em>independently</em> but together compose a single object.</p>
+<p>While composition offers model extensibility, it does not imply a hierarchy between the models.
+To support polymorphism, the OpenAPI Specification adds the <code>discriminator</code> field.
+When used, the <code>discriminator</code> will be the name of the property that decides which schema definition validates the structure of the model.
+As such, the <code>discriminator</code> field MUST be a required field.
+There are two ways to define the value of a discriminator for an inheriting instance.</p>
+<ul>
+<li>Use the schema name.</li>
+<li>Override the schema name by overriding the property with a new value. If a new value exists, this takes precedence over the schema name.
+As such, inline schema definitions, which do not have a given id, <em>cannot</em> be used in polymorphism.</li>
+</ul>
+</section><section><h5>XML Modeling</h5>
+<p>The <a href="#schemaXml">xml</a> property allows extra definitions when translating the JSON definition to XML.
+The <a href="#xmlObject">XML Object</a> contains additional information about the available options.</p>
+</section></section><section><h4>Schema Object Examples</h4>
+<section><h5>Primitive Sample</h5>
+<pre class="nohighlight"><code>
+{
+  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
+  <span class="hljs-attr">"format"</span>: <span class="hljs-string">"email"</span>
+}
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+<span class="hljs-attr">format:</span> <span class="hljs-string">email</span>
+</code></pre>
+</section><section><h5>Simple Model</h5>
+<pre class="nohighlight"><code>
+{
+  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
+  <span class="hljs-attr">"required"</span>: [
+    <span class="hljs-string">"name"</span>
+  ],
+  <span class="hljs-attr">"properties"</span>: {
+    <span class="hljs-attr">"name"</span>: {
+      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+    },
+    <span class="hljs-attr">"address"</span>: {
+      <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/Address"</span>
+    },
+    <span class="hljs-attr">"age"</span>: {
+      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>,
+      <span class="hljs-attr">"format"</span>: <span class="hljs-string">"int32"</span>,
+      <span class="hljs-attr">"minimum"</span>: <span class="hljs-number">0</span>
+    }
+  }
+}
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+<span class="hljs-attr">required:</span>
+<span class="hljs-bullet">-</span> <span class="hljs-string">name</span>
+<span class="hljs-attr">properties:</span>
+  <span class="hljs-attr">name:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">address:</span>
+    <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Address'</span>
+  <span class="hljs-attr">age:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+    <span class="hljs-attr">format:</span> <span class="hljs-string">int32</span>
+    <span class="hljs-attr">minimum:</span> <span class="hljs-number">0</span>
+</code></pre>
+</section><section><h5>Model with Map/Dictionary Properties</h5>
+<p>For a simple string to string mapping:</p>
+<pre class="nohighlight"><code>
+{
+  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
+  <span class="hljs-attr">"additionalProperties"</span>: {
+    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+  }
+}
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+<span class="hljs-attr">additionalProperties:</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+</code></pre>
+<p>For a string to model mapping:</p>
+<pre class="nohighlight"><code>
+{
+  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
+  <span class="hljs-attr">"additionalProperties"</span>: {
+    <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/ComplexModel"</span>
+  }
+}
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+<span class="hljs-attr">additionalProperties:</span>
+  <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/ComplexModel'</span>
+</code></pre>
+</section><section><h5>Model with Example</h5>
+<pre class="nohighlight"><code>
+{
+  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
+  <span class="hljs-attr">"properties"</span>: {
+    <span class="hljs-attr">"id"</span>: {
+      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>,
+      <span class="hljs-attr">"format"</span>: <span class="hljs-string">"int64"</span>
+    },
+    <span class="hljs-attr">"name"</span>: {
+      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+    }
+  },
+  <span class="hljs-attr">"required"</span>: [
+    <span class="hljs-string">"name"</span>
+  ],
+  <span class="hljs-attr">"example"</span>: {
+    <span class="hljs-attr">"name"</span>: <span class="hljs-string">"Puma"</span>,
+    <span class="hljs-attr">"id"</span>: <span class="hljs-number">1</span>
+  }
+}
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+<span class="hljs-attr">properties:</span>
+  <span class="hljs-attr">id:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+    <span class="hljs-attr">format:</span> <span class="hljs-string">int64</span>
+  <span class="hljs-attr">name:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+<span class="hljs-attr">required:</span>
+<span class="hljs-bullet">-</span> <span class="hljs-string">name</span>
+<span class="hljs-attr">example:</span>
+  <span class="hljs-attr">name:</span> <span class="hljs-string">Puma</span>
+  <span class="hljs-attr">id:</span> <span class="hljs-number">1</span>
+</code></pre>
+</section><section><h5>Models with Composition</h5>
+<pre class="nohighlight"><code>
+{
+  <span class="hljs-attr">"components"</span>: {
+    <span class="hljs-attr">"schemas"</span>: {
+      <span class="hljs-attr">"ErrorModel"</span>: {
+        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
+        <span class="hljs-attr">"required"</span>: [
+          <span class="hljs-string">"message"</span>,
+          <span class="hljs-string">"code"</span>
+        ],
+        <span class="hljs-attr">"properties"</span>: {
+          <span class="hljs-attr">"message"</span>: {
+            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+          },
+          <span class="hljs-attr">"code"</span>: {
+            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>,
+            <span class="hljs-attr">"minimum"</span>: <span class="hljs-number">100</span>,
+            <span class="hljs-attr">"maximum"</span>: <span class="hljs-number">600</span>
+          }
+        }
+      },
+      <span class="hljs-attr">"ExtendedErrorModel"</span>: {
+        <span class="hljs-attr">"allOf"</span>: [
+          {
+            <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/ErrorModel"</span>
+          },
+          {
+            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
+            <span class="hljs-attr">"required"</span>: [
+              <span class="hljs-string">"rootCause"</span>
+            ],
+            <span class="hljs-attr">"properties"</span>: {
+              <span class="hljs-attr">"rootCause"</span>: {
+                <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">components:</span>
+  <span class="hljs-attr">schemas:</span>
+    <span class="hljs-attr">ErrorModel:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+      <span class="hljs-attr">required:</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-string">message</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-string">code</span>
+      <span class="hljs-attr">properties:</span>
+        <span class="hljs-attr">message:</span>
+          <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+        <span class="hljs-attr">code:</span>
+          <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+          <span class="hljs-attr">minimum:</span> <span class="hljs-number">100</span>
+          <span class="hljs-attr">maximum:</span> <span class="hljs-number">600</span>
+    <span class="hljs-attr">ExtendedErrorModel:</span>
+      <span class="hljs-attr">allOf:</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/ErrorModel'</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+        <span class="hljs-attr">required:</span>
+        <span class="hljs-bullet">-</span> <span class="hljs-string">rootCause</span>
+        <span class="hljs-attr">properties:</span>
+          <span class="hljs-attr">rootCause:</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+</code></pre>
+</section><section><h5>Models with Polymorphism Support</h5>
+<pre class="nohighlight"><code>
+{
+  <span class="hljs-attr">"components"</span>: {
+    <span class="hljs-attr">"schemas"</span>: {
+      <span class="hljs-attr">"Pet"</span>: {
+        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
+        <span class="hljs-attr">"discriminator"</span>: {
+          <span class="hljs-attr">"propertyName"</span>: <span class="hljs-string">"petType"</span>
+        },
+        <span class="hljs-attr">"properties"</span>: {
+          <span class="hljs-attr">"name"</span>: {
+            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+          },
+          <span class="hljs-attr">"petType"</span>: {
+            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+          }
+        },
+        <span class="hljs-attr">"required"</span>: [
+          <span class="hljs-string">"name"</span>,
+          <span class="hljs-string">"petType"</span>
+        ]
+      },
+      <span class="hljs-attr">"Cat"</span>: {
+        <span class="hljs-attr">"description"</span>: <span class="hljs-string">"A representation of a cat. Note that `Cat` will be used as the discriminator value."</span>,
+        <span class="hljs-attr">"allOf"</span>: [
+          {
+            <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/Pet"</span>
+          },
+          {
+            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
+            <span class="hljs-attr">"properties"</span>: {
+              <span class="hljs-attr">"huntingSkill"</span>: {
+                <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
+                <span class="hljs-attr">"description"</span>: <span class="hljs-string">"The measured skill for hunting"</span>,
+                <span class="hljs-attr">"default"</span>: <span class="hljs-string">"lazy"</span>,
+                <span class="hljs-attr">"enum"</span>: [
+                  <span class="hljs-string">"clueless"</span>,
+                  <span class="hljs-string">"lazy"</span>,
+                  <span class="hljs-string">"adventurous"</span>,
+                  <span class="hljs-string">"aggressive"</span>
+                ]
+              }
+            },
+            <span class="hljs-attr">"required"</span>: [
+              <span class="hljs-string">"huntingSkill"</span>
+            ]
+          }
+        ]
+      },
+      <span class="hljs-attr">"Dog"</span>: {
+        <span class="hljs-attr">"description"</span>: <span class="hljs-string">"A representation of a dog. Note that `Dog` will be used as the discriminator value."</span>,
+        <span class="hljs-attr">"allOf"</span>: [
+          {
+            <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/Pet"</span>
+          },
+          {
+            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
+            <span class="hljs-attr">"properties"</span>: {
+              <span class="hljs-attr">"packSize"</span>: {
+                <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>,
+                <span class="hljs-attr">"format"</span>: <span class="hljs-string">"int32"</span>,
+                <span class="hljs-attr">"description"</span>: <span class="hljs-string">"the size of the pack the dog is from"</span>,
+                <span class="hljs-attr">"default"</span>: <span class="hljs-number">0</span>,
+                <span class="hljs-attr">"minimum"</span>: <span class="hljs-number">0</span>
+              }
+            },
+            <span class="hljs-attr">"required"</span>: [
+              <span class="hljs-string">"packSize"</span>
+            ]
+          }
+        ]
+      }
+    }
+  }
+}
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">components:</span>
+  <span class="hljs-attr">schemas:</span>
+    <span class="hljs-attr">Pet:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+      <span class="hljs-attr">discriminator:</span>
+        <span class="hljs-attr">propertyName:</span> <span class="hljs-string">petType</span>
+      <span class="hljs-attr">properties:</span>
+        <span class="hljs-attr">name:</span>
+          <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+        <span class="hljs-attr">petType:</span>
+          <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+      <span class="hljs-attr">required:</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-string">name</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-string">petType</span>
+    <span class="hljs-attr">Cat:</span>  <span class="hljs-comment">## "Cat" will be used as the discriminator value</span>
+      <span class="hljs-attr">description:</span> <span class="hljs-string">A</span> <span class="hljs-string">representation</span> <span class="hljs-string">of</span> <span class="hljs-string">a</span> <span class="hljs-string">cat</span>
+      <span class="hljs-attr">allOf:</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Pet'</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+        <span class="hljs-attr">properties:</span>
+          <span class="hljs-attr">huntingSkill:</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+            <span class="hljs-attr">description:</span> <span class="hljs-string">The</span> <span class="hljs-string">measured</span> <span class="hljs-string">skill</span> <span class="hljs-string">for</span> <span class="hljs-string">hunting</span>
+            <span class="hljs-attr">enum:</span>
+            <span class="hljs-bullet">-</span> <span class="hljs-string">clueless</span>
+            <span class="hljs-bullet">-</span> <span class="hljs-string">lazy</span>
+            <span class="hljs-bullet">-</span> <span class="hljs-string">adventurous</span>
+            <span class="hljs-bullet">-</span> <span class="hljs-string">aggressive</span>
+        <span class="hljs-attr">required:</span>
+        <span class="hljs-bullet">-</span> <span class="hljs-string">huntingSkill</span>
+    <span class="hljs-attr">Dog:</span>  <span class="hljs-comment">## "Dog" will be used as the discriminator value</span>
+      <span class="hljs-attr">description:</span> <span class="hljs-string">A</span> <span class="hljs-string">representation</span> <span class="hljs-string">of</span> <span class="hljs-string">a</span> <span class="hljs-string">dog</span>
+      <span class="hljs-attr">allOf:</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Pet'</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+        <span class="hljs-attr">properties:</span>
+          <span class="hljs-attr">packSize:</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+            <span class="hljs-attr">format:</span> <span class="hljs-string">int32</span>
+            <span class="hljs-attr">description:</span> <span class="hljs-string">the</span> <span class="hljs-string">size</span> <span class="hljs-string">of</span> <span class="hljs-string">the</span> <span class="hljs-string">pack</span> <span class="hljs-string">the</span> <span class="hljs-string">dog</span> <span class="hljs-string">is</span> <span class="hljs-string">from</span>
+            <span class="hljs-attr">default:</span> <span class="hljs-number">0</span>
+            <span class="hljs-attr">minimum:</span> <span class="hljs-number">0</span>
+        <span class="hljs-attr">required:</span>
+        <span class="hljs-bullet">-</span> <span class="hljs-string">packSize</span>
+</code></pre>
+</section></section></section><section><h3><span id="discriminatorObject">Discriminator Object</span></h3>
+<p>When request bodies or response payloads may be one of a number of different schemas, a <code>discriminator</code> object can be used to aid in serialization, deserialization, and validation.  The discriminator is a specific object in a schema which is used to inform the consumer of the specification of an alternative schema based on the value associated with it.</p>
+<p>When using the discriminator, <em>inline</em> schemas will not be considered.</p>
+<section><h4>Fixed Fields</h4>
+<table>
+<thead>
+<tr>
+<th>Field Name</th>
+<th style="text-align:center">Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a id="propertyName"> </a>propertyName</td>
+<td style="text-align:center"><code>string</code></td>
+<td><strong>REQUIRED</strong>. The name of the property in the payload that will hold the discriminator value.</td>
+</tr>
+<tr>
+<td><a id="discriminatorMapping"> </a> mapping</td>
+<td style="text-align:center">Map[<code>string</code>, <code>string</code>]</td>
+<td>An object to hold mappings between payload values and schema names or references.</td>
+</tr>
+</tbody>
+</table>
+<p>The discriminator object is legal only when using one of the composite keywords <code>oneOf</code>, <code>anyOf</code>, <code>allOf</code>.</p>
+<p>In OAS 3.0, a response payload MAY be described to be exactly one of any number of types:</p>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">MyResponseType:</span>
+  <span class="hljs-attr">oneOf:</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Cat'</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Dog'</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Lizard'</span>
+</code></pre>
+<p>which means the payload <em>MUST</em>, by validation, match exactly one of the schemas described by <code>Cat</code>, <code>Dog</code>, or <code>Lizard</code>.  In this case, a discriminator MAY act as a “hint” to shortcut validation and selection of the matching schema which may be a costly operation, depending on the complexity of the schema. We can then describe exactly which field tells us which schema to use:</p>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">MyResponseType:</span>
+  <span class="hljs-attr">oneOf:</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Cat'</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Dog'</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Lizard'</span>
+  <span class="hljs-attr">discriminator:</span>
+    <span class="hljs-attr">propertyName:</span> <span class="hljs-string">petType</span>
+</code></pre>
+<p>The expectation now is that a property with name <code>petType</code> <em>MUST</em> be present in the response payload, and the value will correspond to the name of a schema defined in the OAS document.  Thus the response payload:</p>
+<pre class="nohighlight"><code>
+{
+  <span class="hljs-attr">"id"</span>: <span class="hljs-number">12345</span>,
+  <span class="hljs-attr">"petType"</span>: <span class="hljs-string">"Cat"</span>
+}
+</code></pre>
+<p>Will indicate that the <code>Cat</code> schema be used in conjunction with this payload.</p>
+<p>In scenarios where the value of the discriminator field does not match the schema name or implicit mapping is not possible, an optional <code>mapping</code> definition MAY be used:</p>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">MyResponseType:</span>
+  <span class="hljs-attr">oneOf:</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Cat'</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Dog'</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Lizard'</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'https://gigantic-server.com/schemas/Monster/schema.json'</span>
+  <span class="hljs-attr">discriminator:</span>
+    <span class="hljs-attr">propertyName:</span> <span class="hljs-string">petType</span>
+    <span class="hljs-attr">mapping:</span>
+      <span class="hljs-attr">dog:</span> <span class="hljs-string">'#/components/schemas/Dog'</span>
+      <span class="hljs-attr">monster:</span> <span class="hljs-string">'https://gigantic-server.com/schemas/Monster/schema.json'</span>
+</code></pre>
+<p>Here the discriminator <em>value</em> of <code>dog</code> will map to the schema <code>#/components/schemas/Dog</code>, rather than the default (implicit) value of <code>Dog</code>.  If the discriminator <em>value</em> does not match an implicit or explicit mapping, no schema can be determined and validation SHOULD fail. Mapping keys MUST be string values, but tooling MAY convert response values to strings for comparison.</p>
+<p>When used in conjunction with the <code>anyOf</code> construct, the use of the discriminator can avoid ambiguity where multiple schemas may satisfy a single payload.</p>
+<p>In both the <code>oneOf</code> and <code>anyOf</code> use cases, all possible schemas MUST be listed explicitly.  To avoid redundancy, the discriminator MAY be added to a parent schema definition, and all schemas comprising the parent schema in an <code>allOf</code> construct may be used as an alternate schema.</p>
+<p>For example:</p>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">components:</span>
+  <span class="hljs-attr">schemas:</span>
+    <span class="hljs-attr">Pet:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+      <span class="hljs-attr">required:</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-string">petType</span>
+      <span class="hljs-attr">properties:</span>
+        <span class="hljs-attr">petType:</span>
+          <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+      <span class="hljs-attr">discriminator:</span>
+        <span class="hljs-attr">propertyName:</span> <span class="hljs-string">petType</span>
+        <span class="hljs-attr">mapping:</span>
+          <span class="hljs-attr">dog:</span> <span class="hljs-string">Dog</span>
+    <span class="hljs-attr">Cat:</span>
+      <span class="hljs-attr">allOf:</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Pet'</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+        <span class="hljs-comment"># all other properties specific to a `Cat`</span>
+        <span class="hljs-attr">properties:</span>
+          <span class="hljs-attr">name:</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+    <span class="hljs-attr">Dog:</span>
+      <span class="hljs-attr">allOf:</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Pet'</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+        <span class="hljs-comment"># all other properties specific to a `Dog`</span>
+        <span class="hljs-attr">properties:</span>
+          <span class="hljs-attr">bark:</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+    <span class="hljs-attr">Lizard:</span>
+      <span class="hljs-attr">allOf:</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Pet'</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+        <span class="hljs-comment"># all other properties specific to a `Lizard`</span>
+        <span class="hljs-attr">properties:</span>
+          <span class="hljs-attr">lovesRocks:</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">boolean</span>
+</code></pre>
+<p>a payload like this:</p>
+<pre class="nohighlight"><code>
+{
+  <span class="hljs-attr">"petType"</span>: <span class="hljs-string">"Cat"</span>,
+  <span class="hljs-attr">"name"</span>: <span class="hljs-string">"misty"</span>
+}
+</code></pre>
+<p>will indicate that the <code>Cat</code> schema be used.  Likewise this schema:</p>
+<pre class="nohighlight"><code>
+{
+  <span class="hljs-attr">"petType"</span>: <span class="hljs-string">"dog"</span>,
+  <span class="hljs-attr">"bark"</span>: <span class="hljs-string">"soft"</span>
+}
+</code></pre>
+<p>will map to <code>Dog</code> because of the definition in the <code>mappings</code> element.</p>
+</section></section><section><h3><span id="xmlObject">XML Object</span></h3>
+<p>A metadata object that allows for more fine-tuned XML model definitions.</p>
+<p>When using arrays, XML element names are <em>not</em> inferred (for singular/plural forms) and the <code>name</code> property SHOULD be used to add that information.
+See examples for expected behavior.</p>
+<section><h4>Fixed Fields</h4>
+<table>
+<thead>
+<tr>
+<th>Field Name</th>
+<th style="text-align:center">Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a id="xmlName"> </a>name</td>
+<td style="text-align:center"><code>string</code></td>
+<td>Replaces the name of the element/attribute used for the described schema property. When defined within <code>items</code>, it will affect the name of the individual XML elements within the list. When defined alongside <code>type</code> being <code>array</code> (outside the <code>items</code>), it will affect the wrapping element and only if <code>wrapped</code> is <code>true</code>. If <code>wrapped</code> is <code>false</code>, it will be ignored.</td>
+</tr>
+<tr>
+<td><a id="xmlNamespace"> </a>namespace</td>
+<td style="text-align:center"><code>string</code></td>
+<td>The URI of the namespace definition. Value MUST be in the form of an absolute URI.</td>
+</tr>
+<tr>
+<td><a id="xmlPrefix"> </a>prefix</td>
+<td style="text-align:center"><code>string</code></td>
+<td>The prefix to be used for the <a href="#xmlName">name</a>.</td>
+</tr>
+<tr>
+<td><a id="xmlAttribute"> </a>attribute</td>
+<td style="text-align:center"><code>boolean</code></td>
+<td>Declares whether the property definition translates to an attribute instead of an element. Default value is <code>false</code>.</td>
+</tr>
+<tr>
+<td><a id="xmlWrapped"> </a>wrapped</td>
+<td style="text-align:center"><code>boolean</code></td>
+<td>MAY be used only for an array definition. Signifies whether the array is wrapped (for example, <code>&lt;books&gt;&lt;book/&gt;&lt;book/&gt;&lt;/books&gt;</code>) or unwrapped (<code>&lt;book/&gt;&lt;book/&gt;</code>). Default value is <code>false</code>. The definition takes effect only when defined alongside <code>type</code> being <code>array</code> (outside the <code>items</code>).</td>
+</tr>
+</tbody>
+</table>
+<p>This object MAY be extended with <a href="#specificationExtensions">Specification Extensions</a>.</p>
+</section><section><h4>XML Object Examples</h4>
+<p>The examples of the XML object definitions are included inside a property definition of a <a href="#schemaObject">Schema Object</a> with a sample of the XML representation of it.</p>
+<section><h5>No XML Element</h5>
+<p>Basic string property:</p>
+<pre class="nohighlight"><code>
+{
+    <span class="hljs-attr">"animals"</span>: {
+        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+    }
+}
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">animals:</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-tag">&lt;<span class="hljs-name">animals</span>&gt;</span>...<span class="hljs-tag">&lt;/<span class="hljs-name">animals</span>&gt;</span>
+</code></pre>
+<p>Basic string array property (<a href="#xmlWrapped"><code>wrapped</code></a> is <code>false</code> by default):</p>
+<pre class="nohighlight"><code>
+{
+    <span class="hljs-attr">"animals"</span>: {
+        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
+        <span class="hljs-attr">"items"</span>: {
+            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+        }
+    }
+}
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">animals:</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+  <span class="hljs-attr">items:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-tag">&lt;<span class="hljs-name">animals</span>&gt;</span>...<span class="hljs-tag">&lt;/<span class="hljs-name">animals</span>&gt;</span>
+<span class="hljs-tag">&lt;<span class="hljs-name">animals</span>&gt;</span>...<span class="hljs-tag">&lt;/<span class="hljs-name">animals</span>&gt;</span>
+<span class="hljs-tag">&lt;<span class="hljs-name">animals</span>&gt;</span>...<span class="hljs-tag">&lt;/<span class="hljs-name">animals</span>&gt;</span>
+</code></pre>
+</section><section><h5>XML Name Replacement</h5>
+<pre class="nohighlight"><code>
+{
+  <span class="hljs-attr">"animals"</span>: {
+    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
+    <span class="hljs-attr">"xml"</span>: {
+      <span class="hljs-attr">"name"</span>: <span class="hljs-string">"animal"</span>
+    }
+  }
+}
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">animals:</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">xml:</span>
+    <span class="hljs-attr">name:</span> <span class="hljs-string">animal</span>
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-tag">&lt;<span class="hljs-name">animal</span>&gt;</span>...<span class="hljs-tag">&lt;/<span class="hljs-name">animal</span>&gt;</span>
+</code></pre>
+</section><section><h5>XML Attribute, Prefix and Namespace</h5>
+<p>In this example, a full model definition is shown.</p>
+<pre class="nohighlight"><code>
+{
+  <span class="hljs-attr">"Person"</span>: {
+    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
+    <span class="hljs-attr">"properties"</span>: {
+      <span class="hljs-attr">"id"</span>: {
+        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>,
+        <span class="hljs-attr">"format"</span>: <span class="hljs-string">"int32"</span>,
+        <span class="hljs-attr">"xml"</span>: {
+          <span class="hljs-attr">"attribute"</span>: <span class="hljs-literal">true</span>
+        }
+      },
+      <span class="hljs-attr">"name"</span>: {
+        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
+        <span class="hljs-attr">"xml"</span>: {
+          <span class="hljs-attr">"namespace"</span>: <span class="hljs-string">"http://example.com/schema/sample"</span>,
+          <span class="hljs-attr">"prefix"</span>: <span class="hljs-string">"sample"</span>
+        }
+      }
+    }
+  }
+}
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">Person:</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+  <span class="hljs-attr">properties:</span>
+    <span class="hljs-attr">id:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+      <span class="hljs-attr">format:</span> <span class="hljs-string">int32</span>
+      <span class="hljs-attr">xml:</span>
+        <span class="hljs-attr">attribute:</span> <span class="hljs-literal">true</span>
+    <span class="hljs-attr">name:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+      <span class="hljs-attr">xml:</span>
+        <span class="hljs-attr">namespace:</span> <span class="hljs-string">http://example.com/schema/sample</span>
+        <span class="hljs-attr">prefix:</span> <span class="hljs-string">sample</span>
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-tag">&lt;<span class="hljs-name">Person</span> <span class="hljs-attr">id</span>=<span class="hljs-string">"123"</span>&gt;</span>
+    <span class="hljs-tag">&lt;<span class="hljs-name">sample:name</span> <span class="hljs-attr">xmlns:sample</span>=<span class="hljs-string">"http://example.com/schema/sample"</span>&gt;</span>example<span class="hljs-tag">&lt;/<span class="hljs-name">sample:name</span>&gt;</span>
+<span class="hljs-tag">&lt;/<span class="hljs-name">Person</span>&gt;</span>
+</code></pre>
+</section><section><h5>XML Arrays</h5>
+<p>Changing the element names:</p>
+<pre class="nohighlight"><code>
+{
+  <span class="hljs-attr">"animals"</span>: {
+    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
+    <span class="hljs-attr">"items"</span>: {
+      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
+      <span class="hljs-attr">"xml"</span>: {
+        <span class="hljs-attr">"name"</span>: <span class="hljs-string">"animal"</span>
+      }
+    }
+  }
+}
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">animals:</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+  <span class="hljs-attr">items:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+    <span class="hljs-attr">xml:</span>
+      <span class="hljs-attr">name:</span> <span class="hljs-string">animal</span>
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-tag">&lt;<span class="hljs-name">animal</span>&gt;</span>value<span class="hljs-tag">&lt;/<span class="hljs-name">animal</span>&gt;</span>
+<span class="hljs-tag">&lt;<span class="hljs-name">animal</span>&gt;</span>value<span class="hljs-tag">&lt;/<span class="hljs-name">animal</span>&gt;</span>
+</code></pre>
+<p>The external <code>name</code> property has no effect on the XML:</p>
+<pre class="nohighlight"><code>
+{
+  <span class="hljs-attr">"animals"</span>: {
+    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
+    <span class="hljs-attr">"items"</span>: {
+      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
+      <span class="hljs-attr">"xml"</span>: {
+        <span class="hljs-attr">"name"</span>: <span class="hljs-string">"animal"</span>
+      }
+    },
+    <span class="hljs-attr">"xml"</span>: {
+      <span class="hljs-attr">"name"</span>: <span class="hljs-string">"aliens"</span>
+    }
+  }
+}
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">animals:</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+  <span class="hljs-attr">items:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+    <span class="hljs-attr">xml:</span>
+      <span class="hljs-attr">name:</span> <span class="hljs-string">animal</span>
+  <span class="hljs-attr">xml:</span>
+    <span class="hljs-attr">name:</span> <span class="hljs-string">aliens</span>
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-tag">&lt;<span class="hljs-name">animal</span>&gt;</span>value<span class="hljs-tag">&lt;/<span class="hljs-name">animal</span>&gt;</span>
+<span class="hljs-tag">&lt;<span class="hljs-name">animal</span>&gt;</span>value<span class="hljs-tag">&lt;/<span class="hljs-name">animal</span>&gt;</span>
+</code></pre>
+<p>Even when the array is wrapped, if a name is not explicitly defined, the same name will be used both internally and externally:</p>
+<pre class="nohighlight"><code>
+{
+  <span class="hljs-attr">"animals"</span>: {
+    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
+    <span class="hljs-attr">"items"</span>: {
+      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+    },
+    <span class="hljs-attr">"xml"</span>: {
+      <span class="hljs-attr">"wrapped"</span>: <span class="hljs-literal">true</span>
+    }
+  }
+}
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">animals:</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+  <span class="hljs-attr">items:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">xml:</span>
+    <span class="hljs-attr">wrapped:</span> <span class="hljs-literal">true</span>
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-tag">&lt;<span class="hljs-name">animals</span>&gt;</span>
+  <span class="hljs-tag">&lt;<span class="hljs-name">animals</span>&gt;</span>value<span class="hljs-tag">&lt;/<span class="hljs-name">animals</span>&gt;</span>
+  <span class="hljs-tag">&lt;<span class="hljs-name">animals</span>&gt;</span>value<span class="hljs-tag">&lt;/<span class="hljs-name">animals</span>&gt;</span>
+<span class="hljs-tag">&lt;/<span class="hljs-name">animals</span>&gt;</span>
+</code></pre>
+<p>To overcome the naming problem in the example above, the following definition can be used:</p>
+<pre class="nohighlight"><code>
+{
+  <span class="hljs-attr">"animals"</span>: {
+    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
+    <span class="hljs-attr">"items"</span>: {
+      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
+      <span class="hljs-attr">"xml"</span>: {
+        <span class="hljs-attr">"name"</span>: <span class="hljs-string">"animal"</span>
+      }
+    },
+    <span class="hljs-attr">"xml"</span>: {
+      <span class="hljs-attr">"wrapped"</span>: <span class="hljs-literal">true</span>
+    }
+  }
+}
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">animals:</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+  <span class="hljs-attr">items:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+    <span class="hljs-attr">xml:</span>
+      <span class="hljs-attr">name:</span> <span class="hljs-string">animal</span>
+  <span class="hljs-attr">xml:</span>
+    <span class="hljs-attr">wrapped:</span> <span class="hljs-literal">true</span>
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-tag">&lt;<span class="hljs-name">animals</span>&gt;</span>
+  <span class="hljs-tag">&lt;<span class="hljs-name">animal</span>&gt;</span>value<span class="hljs-tag">&lt;/<span class="hljs-name">animal</span>&gt;</span>
+  <span class="hljs-tag">&lt;<span class="hljs-name">animal</span>&gt;</span>value<span class="hljs-tag">&lt;/<span class="hljs-name">animal</span>&gt;</span>
+<span class="hljs-tag">&lt;/<span class="hljs-name">animals</span>&gt;</span>
+</code></pre>
+<p>Affecting both internal and external names:</p>
+<pre class="nohighlight"><code>
+{
+  <span class="hljs-attr">"animals"</span>: {
+    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
+    <span class="hljs-attr">"items"</span>: {
+      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
+      <span class="hljs-attr">"xml"</span>: {
+        <span class="hljs-attr">"name"</span>: <span class="hljs-string">"animal"</span>
+      }
+    },
+    <span class="hljs-attr">"xml"</span>: {
+      <span class="hljs-attr">"name"</span>: <span class="hljs-string">"aliens"</span>,
+      <span class="hljs-attr">"wrapped"</span>: <span class="hljs-literal">true</span>
+    }
+  }
+}
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">animals:</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+  <span class="hljs-attr">items:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+    <span class="hljs-attr">xml:</span>
+      <span class="hljs-attr">name:</span> <span class="hljs-string">animal</span>
+  <span class="hljs-attr">xml:</span>
+    <span class="hljs-attr">name:</span> <span class="hljs-string">aliens</span>
+    <span class="hljs-attr">wrapped:</span> <span class="hljs-literal">true</span>
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-tag">&lt;<span class="hljs-name">aliens</span>&gt;</span>
+  <span class="hljs-tag">&lt;<span class="hljs-name">animal</span>&gt;</span>value<span class="hljs-tag">&lt;/<span class="hljs-name">animal</span>&gt;</span>
+  <span class="hljs-tag">&lt;<span class="hljs-name">animal</span>&gt;</span>value<span class="hljs-tag">&lt;/<span class="hljs-name">animal</span>&gt;</span>
+<span class="hljs-tag">&lt;/<span class="hljs-name">aliens</span>&gt;</span>
+</code></pre>
+<p>If we change the external element but not the internal ones:</p>
+<pre class="nohighlight"><code>
+{
+  <span class="hljs-attr">"animals"</span>: {
+    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
+    <span class="hljs-attr">"items"</span>: {
+      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+    },
+    <span class="hljs-attr">"xml"</span>: {
+      <span class="hljs-attr">"name"</span>: <span class="hljs-string">"aliens"</span>,
+      <span class="hljs-attr">"wrapped"</span>: <span class="hljs-literal">true</span>
+    }
+  }
+}
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">animals:</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+  <span class="hljs-attr">items:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">xml:</span>
+    <span class="hljs-attr">name:</span> <span class="hljs-string">aliens</span>
+    <span class="hljs-attr">wrapped:</span> <span class="hljs-literal">true</span>
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-tag">&lt;<span class="hljs-name">aliens</span>&gt;</span>
+  <span class="hljs-tag">&lt;<span class="hljs-name">aliens</span>&gt;</span>value<span class="hljs-tag">&lt;/<span class="hljs-name">aliens</span>&gt;</span>
+  <span class="hljs-tag">&lt;<span class="hljs-name">aliens</span>&gt;</span>value<span class="hljs-tag">&lt;/<span class="hljs-name">aliens</span>&gt;</span>
+<span class="hljs-tag">&lt;/<span class="hljs-name">aliens</span>&gt;</span>
+</code></pre>
+</section></section></section><section><h3><span id="securitySchemeObject">Security Scheme Object</span></h3>
+<p>Defines a security scheme that can be used by the operations.
+Supported schemes are HTTP authentication, an API key (either as a header, a cookie parameter or as a query parameter), OAuth2’s common flows (implicit, password, client credentials and authorization code) as defined in [[!RFC6749]], and <a href="https://tools.ietf.org/html/draft-ietf-oauth-discovery-06">OpenID Connect Discovery</a>.</p>
+<section><h4>Fixed Fields</h4>
+<table>
+<thead>
+<tr>
+<th>Field Name</th>
+<th style="text-align:center">Type</th>
+<th>Applies To</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a id="securitySchemeType"> </a>type</td>
+<td style="text-align:center"><code>string</code></td>
+<td>Any</td>
+<td><strong>REQUIRED</strong>. The type of the security scheme. Valid values are <code>&quot;apiKey&quot;</code>, <code>&quot;http&quot;</code>, <code>&quot;oauth2&quot;</code>, <code>&quot;openIdConnect&quot;</code>.</td>
+</tr>
+<tr>
+<td><a id="securitySchemeDescription"> </a>description</td>
+<td style="text-align:center"><code>string</code></td>
+<td>Any</td>
+<td>A short description for security scheme. <a href="https://spec.commonmark.org/">CommonMark syntax</a> MAY be used for rich text representation.</td>
+</tr>
+<tr>
+<td><a id="securitySchemeName"> </a>name</td>
+<td style="text-align:center"><code>string</code></td>
+<td><code>apiKey</code></td>
+<td><strong>REQUIRED</strong>. The name of the header, query or cookie parameter to be used.</td>
+</tr>
+<tr>
+<td><a id="securitySchemeIn"> </a>in</td>
+<td style="text-align:center"><code>string</code></td>
+<td><code>apiKey</code></td>
+<td><strong>REQUIRED</strong>. The location of the API key. Valid values are <code>&quot;query&quot;</code>, <code>&quot;header&quot;</code> or <code>&quot;cookie&quot;</code>.</td>
+</tr>
+<tr>
+<td><a id="securitySchemeScheme"> </a>scheme</td>
+<td style="text-align:center"><code>string</code></td>
+<td><code>http</code></td>
+<td><strong>REQUIRED</strong>. The name of the HTTP Authorization scheme to be used in the Authorization header as defined in [[!RFC7235]].  The values used SHOULD be registered in the <a href="https://www.iana.org/assignments/http-authschemes/http-authschemes.xhtml">IANA Authentication Scheme registry</a>.</td>
+</tr>
+<tr>
+<td><a id="securitySchemeBearerFormat"> </a>bearerFormat</td>
+<td style="text-align:center"><code>string</code></td>
+<td><code>http</code> (<code>&quot;bearer&quot;</code>)</td>
+<td>A hint to the client to identify how the bearer token is formatted.  Bearer tokens are usually generated by an authorization server, so this information is primarily for documentation purposes.</td>
+</tr>
+<tr>
+<td><a id="securitySchemeFlows"> </a>flows</td>
+<td style="text-align:center"><a href="#oauthFlowsObject">OAuth Flows Object</a></td>
+<td><code>oauth2</code></td>
+<td><strong>REQUIRED</strong>. An object containing configuration information for the flow types supported.</td>
+</tr>
+<tr>
+<td><a id="securitySchemeOpenIdConnectUrl"> </a>openIdConnectUrl</td>
+<td style="text-align:center"><code>string</code></td>
+<td><code>openIdConnect</code></td>
+<td><strong>REQUIRED</strong>. OpenId Connect URL to discover OAuth2 configuration values. This MUST be in the form of a URL.</td>
+</tr>
+</tbody>
+</table>
+<p>This object MAY be extended with <a href="#specificationExtensions">Specification Extensions</a>.</p>
+</section><section><h4>Security Scheme Object Example</h4>
+<section><h5>Basic Authentication Sample</h5>
+<pre class="nohighlight"><code>
+{
+  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"http"</span>,
+  <span class="hljs-attr">"scheme"</span>: <span class="hljs-string">"basic"</span>
+}
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">type:</span> <span class="hljs-string">http</span>
+<span class="hljs-attr">scheme:</span> <span class="hljs-string">basic</span>
+</code></pre>
+</section><section><h5>API Key Sample</h5>
+<pre class="nohighlight"><code>
+{
+  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"apiKey"</span>,
+  <span class="hljs-attr">"name"</span>: <span class="hljs-string">"api_key"</span>,
+  <span class="hljs-attr">"in"</span>: <span class="hljs-string">"header"</span>
+}
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">type:</span> <span class="hljs-string">apiKey</span>
+<span class="hljs-attr">name:</span> <span class="hljs-string">api_key</span>
+<span class="hljs-attr">in:</span> <span class="hljs-string">header</span>
+</code></pre>
+</section><section><h5>JWT Bearer Sample</h5>
+<pre class="nohighlight"><code>
+{
+  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"http"</span>,
+  <span class="hljs-attr">"scheme"</span>: <span class="hljs-string">"bearer"</span>,
+  <span class="hljs-attr">"bearerFormat"</span>: <span class="hljs-string">"JWT"</span>,
+}
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">type:</span> <span class="hljs-string">http</span>
+<span class="hljs-attr">scheme:</span> <span class="hljs-string">bearer</span>
+<span class="hljs-attr">bearerFormat:</span> <span class="hljs-string">JWT</span>
+</code></pre>
+</section><section><h5>Implicit OAuth2 Sample</h5>
+<pre class="nohighlight"><code>
+{
+  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"oauth2"</span>,
+  <span class="hljs-attr">"flows"</span>: {
+    <span class="hljs-attr">"implicit"</span>: {
+      <span class="hljs-attr">"authorizationUrl"</span>: <span class="hljs-string">"https://example.com/api/oauth/dialog"</span>,
+      <span class="hljs-attr">"scopes"</span>: {
+        <span class="hljs-attr">"write:pets"</span>: <span class="hljs-string">"modify pets in your account"</span>,
+        <span class="hljs-attr">"read:pets"</span>: <span class="hljs-string">"read your pets"</span>
+      }
+    }
+  }
+}
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">type:</span> <span class="hljs-string">oauth2</span>
+<span class="hljs-attr">flows:</span> 
+  <span class="hljs-attr">implicit:</span>
+    <span class="hljs-attr">authorizationUrl:</span> <span class="hljs-string">https://example.com/api/oauth/dialog</span>
+    <span class="hljs-attr">scopes:</span>
+      <span class="hljs-attr">write:pets:</span> <span class="hljs-string">modify</span> <span class="hljs-string">pets</span> <span class="hljs-string">in</span> <span class="hljs-string">your</span> <span class="hljs-string">account</span>
+      <span class="hljs-attr">read:pets:</span> <span class="hljs-string">read</span> <span class="hljs-string">your</span> <span class="hljs-string">pets</span>
+</code></pre>
+</section></section></section><section><h3><span id="oauthFlowsObject">OAuth Flows Object</span></h3>
+<p>Allows configuration of the supported OAuth Flows.</p>
+<section><h4>Fixed Fields</h4>
+<table>
+<thead>
+<tr>
+<th>Field Name</th>
+<th style="text-align:center">Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a id="oauthFlowsImplicit"> </a>implicit</td>
+<td style="text-align:center"><a href="#oauthFlowObject">OAuth Flow Object</a></td>
+<td>Configuration for the OAuth Implicit flow</td>
+</tr>
+<tr>
+<td><a id="oauthFlowsPassword"> </a>password</td>
+<td style="text-align:center"><a href="#oauthFlowObject">OAuth Flow Object</a></td>
+<td>Configuration for the OAuth Resource Owner Password flow</td>
+</tr>
+<tr>
+<td><a id="oauthFlowsClientCredentials"> </a>clientCredentials</td>
+<td style="text-align:center"><a href="#oauthFlowObject">OAuth Flow Object</a></td>
+<td>Configuration for the OAuth Client Credentials flow.  Previously called <code>application</code> in OpenAPI 2.0.</td>
+</tr>
+<tr>
+<td><a id="oauthFlowsAuthorizationCode"> </a>authorizationCode</td>
+<td style="text-align:center"><a href="#oauthFlowObject">OAuth Flow Object</a></td>
+<td>Configuration for the OAuth Authorization Code flow.  Previously called <code>accessCode</code> in OpenAPI 2.0.</td>
+</tr>
+</tbody>
+</table>
+<p>This object MAY be extended with <a href="#specificationExtensions">Specification Extensions</a>.</p>
+</section></section><section><h3><span id="oauthFlowObject">OAuth Flow Object</span></h3>
+<p>Configuration details for a supported OAuth Flow</p>
+<section><h4>Fixed Fields</h4>
+<table>
+<thead>
+<tr>
+<th>Field Name</th>
+<th style="text-align:center">Type</th>
+<th>Applies To</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a id="oauthFlowAuthorizationUrl"> </a>authorizationUrl</td>
+<td style="text-align:center"><code>string</code></td>
+<td><code>oauth2</code> (<code>&quot;implicit&quot;</code>, <code>&quot;authorizationCode&quot;</code>)</td>
+<td><strong>REQUIRED</strong>. The authorization URL to be used for this flow. This MUST be in the form of a URL.</td>
+</tr>
+<tr>
+<td><a id="oauthFlowTokenUrl"> </a>tokenUrl</td>
+<td style="text-align:center"><code>string</code></td>
+<td><code>oauth2</code> (<code>&quot;password&quot;</code>, <code>&quot;clientCredentials&quot;</code>, <code>&quot;authorizationCode&quot;</code>)</td>
+<td><strong>REQUIRED</strong>. The token URL to be used for this flow. This MUST be in the form of a URL.</td>
+</tr>
+<tr>
+<td><a id="oauthFlowRefreshUrl"> </a>refreshUrl</td>
+<td style="text-align:center"><code>string</code></td>
+<td><code>oauth2</code></td>
+<td>The URL to be used for obtaining refresh tokens. This MUST be in the form of a URL.</td>
+</tr>
+<tr>
+<td><a id="oauthFlowScopes"> </a>scopes</td>
+<td style="text-align:center">Map[<code>string</code>, <code>string</code>]</td>
+<td><code>oauth2</code></td>
+<td><strong>REQUIRED</strong>. The available scopes for the OAuth2 security scheme. A map between the scope name and a short description for it. The map MAY be empty.</td>
+</tr>
+</tbody>
+</table>
+<p>This object MAY be extended with <a href="#specificationExtensions">Specification Extensions</a>.</p>
+</section><section><h4>OAuth Flow Object Examples</h4>
+<pre class="nohighlight"><code>
+{
+  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"oauth2"</span>,
+  <span class="hljs-attr">"flows"</span>: {
+    <span class="hljs-attr">"implicit"</span>: {
+      <span class="hljs-attr">"authorizationUrl"</span>: <span class="hljs-string">"https://example.com/api/oauth/dialog"</span>,
+      <span class="hljs-attr">"scopes"</span>: {
+        <span class="hljs-attr">"write:pets"</span>: <span class="hljs-string">"modify pets in your account"</span>,
+        <span class="hljs-attr">"read:pets"</span>: <span class="hljs-string">"read your pets"</span>
+      }
+    },
+    <span class="hljs-attr">"authorizationCode"</span>: {
+      <span class="hljs-attr">"authorizationUrl"</span>: <span class="hljs-string">"https://example.com/api/oauth/dialog"</span>,
+      <span class="hljs-attr">"tokenUrl"</span>: <span class="hljs-string">"https://example.com/api/oauth/token"</span>,
+      <span class="hljs-attr">"scopes"</span>: {
+        <span class="hljs-attr">"write:pets"</span>: <span class="hljs-string">"modify pets in your account"</span>,
+        <span class="hljs-attr">"read:pets"</span>: <span class="hljs-string">"read your pets"</span>
+      }
+    }
+  }
+}
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">type:</span> <span class="hljs-string">oauth2</span>
+<span class="hljs-attr">flows:</span> 
+  <span class="hljs-attr">implicit:</span>
+    <span class="hljs-attr">authorizationUrl:</span> <span class="hljs-string">https://example.com/api/oauth/dialog</span>
+    <span class="hljs-attr">scopes:</span>
+      <span class="hljs-attr">write:pets:</span> <span class="hljs-string">modify</span> <span class="hljs-string">pets</span> <span class="hljs-string">in</span> <span class="hljs-string">your</span> <span class="hljs-string">account</span>
+      <span class="hljs-attr">read:pets:</span> <span class="hljs-string">read</span> <span class="hljs-string">your</span> <span class="hljs-string">pets</span>
+  <span class="hljs-attr">authorizationCode:</span>
+    <span class="hljs-attr">authorizationUrl:</span> <span class="hljs-string">https://example.com/api/oauth/dialog</span>
+    <span class="hljs-attr">tokenUrl:</span> <span class="hljs-string">https://example.com/api/oauth/token</span>
+    <span class="hljs-attr">scopes:</span>
+      <span class="hljs-attr">write:pets:</span> <span class="hljs-string">modify</span> <span class="hljs-string">pets</span> <span class="hljs-string">in</span> <span class="hljs-string">your</span> <span class="hljs-string">account</span>
+      <span class="hljs-attr">read:pets:</span> <span class="hljs-string">read</span> <span class="hljs-string">your</span> <span class="hljs-string">pets</span> 
+</code></pre>
+</section></section><section><h3><span id="securityRequirementObject">Security Requirement Object</span></h3>
+<p>Lists the required security schemes to execute this operation.
+The name used for each property MUST correspond to a security scheme declared in the <a href="#componentsSecuritySchemes">Security Schemes</a> under the <a href="#componentsObject">Components Object</a>.</p>
+<p>Security Requirement Objects that contain multiple schemes require that all schemes MUST be satisfied for a request to be authorized.
+This enables support for scenarios where multiple query parameters or HTTP headers are required to convey security information.</p>
+<p>When a list of Security Requirement Objects is defined on the <a href="#oasObject">OpenAPI Object</a> or <a href="#operationObject">Operation Object</a>, only one of the Security Requirement Objects in the list needs to be satisfied to authorize the request.</p>
+<section><h4>Patterned Fields</h4>
+<table>
+<thead>
+<tr>
+<th>Field Pattern</th>
+<th style="text-align:center">Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a id="securityRequirementsName"> </a>{name}</td>
+<td style="text-align:center">[<code>string</code>]</td>
+<td>Each name MUST correspond to a security scheme which is declared in the <a href="#componentsSecuritySchemes">Security Schemes</a> under the <a href="#componentsObject">Components Object</a>. If the security scheme is of type <code>&quot;oauth2&quot;</code> or <code>&quot;openIdConnect&quot;</code>, then the value is a list of scope names required for the execution, and the list MAY be empty if authorization does not require a specified scope. For other security scheme types, the array MUST be empty.</td>
+</tr>
+</tbody>
+</table>
+</section><section><h4>Security Requirement Object Examples</h4>
+<section><h5>Non-OAuth2 Security Requirement</h5>
+<pre class="nohighlight"><code>
+{
+  <span class="hljs-attr">"api_key"</span>: []
+}
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">api_key:</span> <span class="hljs-string">[]</span>
+</code></pre>
+</section><section><h5>OAuth2 Security Requirement</h5>
+<pre class="nohighlight"><code>
+{
+  <span class="hljs-attr">"petstore_auth"</span>: [
+    <span class="hljs-string">"write:pets"</span>,
+    <span class="hljs-string">"read:pets"</span>
+  ]
+}
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">petstore_auth:</span>
+<span class="hljs-bullet">-</span> <span class="hljs-string">write:pets</span>
+<span class="hljs-bullet">-</span> <span class="hljs-string">read:pets</span>
+</code></pre>
+</section><section><h5>Optional OAuth2 Security</h5>
+<p>Optional OAuth2 security as would be defined in an <a href="#openapi-object">OpenAPI Object</a> or an <a href="#operation-object">Operation Object</a>:</p>
+<pre class="nohighlight"><code>
+{
+  <span class="hljs-attr">"security"</span>: [
+    {},
+    {
+      <span class="hljs-attr">"petstore_auth"</span>: [
+        <span class="hljs-string">"write:pets"</span>,
+        <span class="hljs-string">"read:pets"</span>
+      ]
+    }
+  ]
+}
+</code></pre>
+<pre class="nohighlight"><code>
+<span class="hljs-attr">security:</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-string">{}</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-attr">petstore_auth:</span>
+    <span class="hljs-bullet">-</span> <span class="hljs-string">write:pets</span>
+    <span class="hljs-bullet">-</span> <span class="hljs-string">read:pets</span>
+</code></pre>
+</section></section></section></section><section><h2><span id="specificationExtensions">Specification Extensions</span></h2>
+<p>While the OpenAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.</p>
+<p>The extensions properties are implemented as patterned fields that are always prefixed by <code>&quot;x-&quot;</code>.</p>
+<table>
+<thead>
+<tr>
+<th>Field Pattern</th>
+<th style="text-align:center">Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a id="infoExtensions"> </a>^x-</td>
+<td style="text-align:center">Any</td>
+<td>Allows extensions to the OpenAPI Schema. The field name MUST begin with <code>x-</code>, for example, <code>x-internal-id</code>. The value can be <code>null</code>, a primitive, an array or an object. Can have any valid JSON format value.</td>
+</tr>
+</tbody>
+</table>
+<p>The extensions may or may not be supported by the available tooling, but those may be extended as well to add requested support (if tools are internal or open-sourced).</p>
+</section><section><h2><span id="securityFiltering">Security Filtering</span></h2>
+<p>Some objects in the OpenAPI Specification MAY be declared and remain empty, or be completely removed, even though they are inherently the core of the API documentation.</p>
+<p>The reasoning is to allow an additional layer of access control over the documentation.
+While not part of the specification itself, certain libraries MAY choose to allow access to parts of the documentation based on some form of authentication/authorization.</p>
+<p>Two examples of this:</p>
+<ol>
+<li>The <a href="#pathsObject">Paths Object</a> MAY be empty. It may be counterintuitive, but this may tell the viewer that they got to the right place, but can’t access any documentation. They’d still have access to the <a href="#infoObject">Info Object</a> which may contain additional information regarding authentication.</li>
+<li>The <a href="#pathItemObject">Path Item Object</a> MAY be empty. In this case, the viewer will be aware that the path exists, but will not be able to see any of its operations or parameters. This is different from hiding the path itself from the <a href="#pathsObject">Paths Object</a>, because the user will be aware of its existence. This allows the documentation provider to finely control what the viewer can see.</li>
+</ol>
+</section></section><section><h1><span id="revisionHistory">Appendix A: Revision History</span></h1>
+<table>
+<thead>
+<tr>
+<th>Version</th>
+<th>Date</th>
+<th>Notes</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>3.0.3</td>
+<td>2020-02-20</td>
+<td>Patch release of the OpenAPI Specification 3.0.3</td>
+</tr>
+<tr>
+<td>3.0.2</td>
+<td>2018-10-08</td>
+<td>Patch release of the OpenAPI Specification 3.0.2</td>
+</tr>
+<tr>
+<td>3.0.1</td>
+<td>2017-12-06</td>
+<td>Patch release of the OpenAPI Specification 3.0.1</td>
+</tr>
+<tr>
+<td>3.0.0</td>
+<td>2017-07-26</td>
+<td>Release of the OpenAPI Specification 3.0.0</td>
+</tr>
+<tr>
+<td>3.0.0-rc2</td>
+<td>2017-06-16</td>
+<td>rc2 of the 3.0 specification</td>
+</tr>
+<tr>
+<td>3.0.0-rc1</td>
+<td>2017-04-27</td>
+<td>rc1 of the 3.0 specification</td>
+</tr>
+<tr>
+<td>3.0.0-rc0</td>
+<td>2017-02-28</td>
+<td>Implementer’s Draft of the 3.0 specification</td>
+</tr>
+<tr>
+<td>2.0</td>
+<td>2015-12-31</td>
+<td>Donation of Swagger 2.0 to the OpenAPI Initiative</td>
+</tr>
+<tr>
+<td>2.0</td>
+<td>2014-09-08</td>
+<td>Release of Swagger 2.0</td>
+</tr>
+<tr>
+<td>1.2</td>
+<td>2014-03-14</td>
+<td>Initial release of the formal document.</td>
+</tr>
+<tr>
+<td>1.1</td>
+<td>2012-08-22</td>
+<td>Release of Swagger 1.1</td>
+</tr>
+<tr>
+<td>1.0</td>
+<td>2011-08-10</td>
+<td>First release of the Swagger Specification</td>
+</tr>
+</tbody>
+</table>
+


### PR DESCRIPTION
This PR (to the **`gh-pages`** branch) adds the ReSpec html version of the v3.0.3 release. It also corrects the index /landing page (which is not really designed to be found) where the link did not do what it was supposed to.