### PR TITLE
Allow summary and description as $ref siblings outside schema objects

### DIFF
--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -2251,6 +2251,8 @@ A simple object to allow referencing other components in the OpenAPI document, i
 Field Name | Type | Description
 ---|:---:|---
 <a name="referenceRef"></a>$ref | `string` | **REQUIRED**. The reference string.
+<a name="referenceSummary"></a>summary | `string` | A short summary which by default SHOULD override that of the referenced component. If the referenced object-type does not define a `summary` field, then this field has no effect.
+<a name="referenceDescription"></a>description | `string` | A description which by default SHOULD override that of the referenced component. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation. If the referenced object-type does not define a `description` field, then this field has no effect.
 
 This object cannot be extended with additional properties and any properties added SHALL be ignored.
 


### PR DESCRIPTION
As discussed re: 3.1-RC0

* I'm not wedded to either the "SHOULD by default" override wording or the "has no effect" behaviour (i.e. we could outlaw it instead) but at least they are placeholder answers to questions we should address.
* By "object-type" I was trying to clearly indicate the target OAS object, and whether it defines a summary/description field as distinct from whether the referenced component has a summary/description property in the OAS document instance. 