### PR TITLE
Change base64 to byte in examples

### DIFF
--- a/versions/3.0.3.md
+++ b/versions/3.0.3.md
@@ -1446,7 +1446,7 @@ In contrast with the 2.0 specification, `file` input/output content in OpenAPI i
 # content transferred with base64 encoding
 schema:
   type: string
-  format: base64
+  format: byte
 ```
 
 ```yaml
@@ -1537,7 +1537,7 @@ When passing in `multipart` types, boundaries MAY be used to separate sections o
 
 * If the property is a primitive, or an array of primitive values, the default Content-Type is `text/plain`
 * If the property is complex, or an array of complex values, the default Content-Type is `application/json`
-* If the property is a `type: string` with `format: binary` or `format: base64` (aka a file object), the default Content-Type is `application/octet-stream`
+* If the property is a `type: string` with `format: binary` or `format: byte` (aka a file object), the default Content-Type is `application/octet-stream`
 
 
 Examples:


### PR DESCRIPTION
format is 'byte' not 'base64'.