### PR TITLE
actions: convert-examples-to-json (js version)

### DIFF
--- a/.github/workflows/convert-examples-to-json.yaml
+++ b/.github/workflows/convert-examples-to-json.yaml
@@ -1,0 +1,50 @@
+name: convert-examples-to-json
+
+# author: @MikeRalphson / @cebe
+# issue: https://github.com/OAI/OpenAPI-Specification/issues/1385
+
+#
+# This workflow updates the *.json files in the examples/v3.x directories,
+# when the corresponding *.yaml files change.
+# JSON example files are automatically generated from the YAML example files.
+# Only the YAML files should be adjusted manually.
+#
+
+# run this on push to master
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  yaml2json:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1 # checkout repo content
+
+    - name: Install dependencies
+      run: npm i
+
+    - name: convert YAML examples to JSON
+      run: find examples/v3* -type f -name "*.yaml" | xargs node scripts/yaml2json/yaml2json.js
+
+    - name: git diff
+      run: |
+        git add examples/**/*.json
+        git --no-pager -c color.diff=always diff --staged
+
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        branch-suffix: none
+        branch: update-json-examples
+        title: Update JSON example files
+        commit-message: Update JSON example files
+        body: |
+          This pull request is automatically triggered by GitHub action `convert-examples-to-json`.
+
+          The examples/v3.* YAML files have changed, so the JSON files are automatically being recreated.
+

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@
 target
 atlassian-ide-plugin.xml
 node_modules/
+package-lock.json
 Gemfile.lock

--- a/package.json
+++ b/package.json
@@ -18,7 +18,10 @@
     "schemas/*"
   ],
   "dependencies": {},
-  "devDependencies": {},
+  "devDependencies": {
+    "mdv": "^1.0.7",
+    "yaml": "^1.8.3"
+  },
   "keywords": [
     "OpenAPI",
     "OAS",

--- a/scripts/yaml2json/yaml2json.js
+++ b/scripts/yaml2json/yaml2json.js
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const fs = require('fs');
+const yaml = require('yaml');
+
+function convert(filename) {
+    console.log(filename);
+    const s = fs.readFileSync(filename,'utf8');
+    let obj;
+    try {
+        obj = yaml.parse(s, {prettyErrors: true});
+        fs.writeFileSync(filename.replace('.yaml','.json'),JSON.stringify(obj,null,2),'utf8');
+    }
+    catch (ex) {
+        console.warn('  ',ex.message);
+        process.exitCode = 1;
+    }
+}
+
+if (process.argv.length<3) {
+    console.warn('Usage: yaml2json {infiles}');
+}
+else {
+    for (let i=2;i<process.argv.length;i++) {
+        convert(process.argv[i]);
+    }
+}
+


### PR DESCRIPTION
This PR builds on (but replaces) the excellent work done in #2068 by @cebe 

It uses a YAML-test-suite-compliant YAML library to avoid issues seen with `php/symphony` and includes the YAML to JSON script in the repo for visibility. The script is in JavaScript, which I believe we have more TSC experience in for future maintenance.