### PR TITLE
Improve "Discriminator object" section of the OAS specification.

### DIFF
--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -2698,6 +2698,7 @@ A payload MAY be described to be exactly one of any number of types:
 ```yaml
 MyType:
   oneOf:
+  - type: 'null'
   - $ref: '#/components/schemas/Cat'
   - $ref: '#/components/schemas/Dog'
   - $ref: '#/components/schemas/Lizard'
@@ -2709,6 +2710,7 @@ which means the payload _MUST_, by validation, match exactly one of the schemas 
 ```yaml
 MyType:
   oneOf:
+  - type: 'null'
   - $ref: '#/components/schemas/Cat'
   - $ref: '#/components/schemas/Dog'
   - $ref: '#/components/schemas/Lizard'

--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -2677,7 +2677,9 @@ components:
 When request bodies or response payloads may be one of a number of different schemas, a `discriminator` object can be used to aid in serialization, deserialization, and validation.  The discriminator is a specific object in a schema which is used to inform the consumer of the document of an alternative schema based on the value associated with it.
 
 The discriminator object is legal only when using one of the composite keywords `oneOf`, `anyOf`, `allOf`. Both _inline_ and references are valid child schemas.
-When a child schema is a reference, the discriminator property _MUST_ be present in the payload. A discriminator MAY act as a "hint" to shortcut validation and selection of the matching schema which may be a costly operation, depending on the complexity of the schema. Even when the discriminator is used as shortcut hint, the payload MUST still be validated against the JSON schema.
+When a child schema is a reference, the discriminator property _MUST_ be present in the payload.
+A discriminator MAY act as a "hint" to shortcut validation and selection of the matching schema which may be a costly operation, depending on the complexity of the schema.
+Even when the discriminator is used as shortcut hint, the payload MUST still be validated against the JSON schema.
 When a child schema is specified _inline_, the discriminator property is not required in the payload. Validation is applied to determine if the payload matches the child JSON schema.
 
 The discriminator `propertyName` field MUST be a required field in the schema object. However, as shown below, the discriminator is not required to be present in the payload for _inline_ schemas.

--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -2674,7 +2674,7 @@ components:
 
 #### <a name="discriminatorObject"></a>Discriminator Object
 
-When request bodies or response payloads may be one of a number of different schemas, a `discriminator` object can be used to aid in serialization, deserialization, and validation. The discriminator is a specific object in a schema which is used to inform the consumer of the document of an alternative schema based on the value associated with it.
+When request bodies or response payloads may be one of a number of different schemas, a `discriminator` object can be used to aid in serialization, deserialization, and validation.  The discriminator is a specific object in a schema which is used to inform the consumer of the document of an alternative schema based on the value associated with it.
 
 A discriminator MAY act as a "hint" to shortcut validation and selection of the matching schema which may be a costly operation, depending on the complexity of the schema.
 The discriminator `propertyName` field MUST be a required field in the schema object. However, as shown below, the discriminator is not required to be present in the payload for _inline_ schemas.

--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -2674,9 +2674,14 @@ components:
 
 #### <a name="discriminatorObject"></a>Discriminator Object
 
-When request bodies or response payloads may be one of a number of different schemas, a `discriminator` object can be used to aid in serialization, deserialization, and validation.  The discriminator is a specific object in a schema which is used to inform the consumer of the document of an alternative schema based on the value associated with it.
+When request bodies or response payloads may be one of a number of different schemas, a `discriminator` object can be used to aid in serialization, deserialization, and validation. The discriminator is a specific object in a schema which is used to inform the consumer of the document of an alternative schema based on the value associated with it.
 
-When using the discriminator, _inline_ schemas will not be considered.
+A discriminator MAY act as a "hint" to shortcut validation and selection of the matching schema which may be a costly operation, depending on the complexity of the schema.
+The discriminator `propertyName` field MUST be a required field in the schema object. However, as shown below, the discriminator is not required to be present in the payload for _inline_ schemas.
+
+The discriminator object is legal only when using one of the composite keywords `oneOf`, `anyOf`, `allOf`. The child schemas MAY be a mix of _inline_ or references schemas.
+When a child schema is specified as a reference, the discriminator property _MUST_ be present in the payload.
+When a child schema is specified _inline_, the discriminator property is not required in the payload. Validation is applied to determine if the payload matches the child JSON schema.
 
 ##### Fixed Fields
 Field Name | Type | Description
@@ -2685,9 +2690,6 @@ Field Name | Type | Description
 <a name="discriminatorMapping"></a> mapping | Map[`string`, `string`] | An object to hold mappings between payload values and schema names or references.
 
 This object MAY be extended with [Specification Extensions](#specificationExtensions).
-
-The discriminator `propertyName` field MUST be a required field in the schema object.
-The discriminator object is legal only when using one of the composite keywords `oneOf`, `anyOf`, `allOf`.
 
 A payload MAY be described to be exactly one of any number of types:
 
@@ -2699,7 +2701,7 @@ MyType:
   - $ref: '#/components/schemas/Lizard'
 ```
 
-which means the payload _MUST_, by validation, match exactly one of the schemas described by `Cat`, `Dog`, or `Lizard`.  In this case, a discriminator MAY act as a "hint" to shortcut validation and selection of the matching schema which may be a costly operation, depending on the complexity of the schema. We can then describe exactly which field tells us which schema to use:
+which means the payload _MUST_, by validation, match exactly one of the schemas described by `Cat`, `Dog`, or `Lizard`. We can then describe exactly which field tells us which schema to use:
 
 
 ```yaml
@@ -2712,7 +2714,7 @@ MyType:
     propertyName: petType
 ```
 
-The expectation now is that a property with name `petType` _MUST_ be present in the payload, and the value will correspond to the name of a schema defined in the OAS document.  Thus the payload:
+The expectation now is that a property with name `petType` _MUST_ be present in the payload, and the value will correspond to the name of a schema defined in the OAS document. Thus the payload:
 
 ```json
 {

--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -2691,6 +2691,8 @@ Field Name | Type | Description
 
 This object MAY be extended with [Specification Extensions](#specificationExtensions).
 
+##### Discriminator Object Example
+
 A payload MAY be described to be exactly one of any number of types:
 
 ```yaml

--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -2676,7 +2676,7 @@ components:
 
 When request bodies or response payloads may be one of a number of different schemas, a `discriminator` object can be used to aid in serialization, deserialization, and validation.  The discriminator is a specific object in a schema which is used to inform the consumer of the document of an alternative schema based on the value associated with it.
 
-The discriminator object is legal only when using one of the composite keywords `oneOf`, `anyOf`, `allOf`. Both _inline_ and references are valid child schemas.
+The discriminator object is legal only when using a schema that has one or more of the composite keywords `oneOf`, `anyOf`, `allOf`. Both _inline_ and references can be used as composite child schemas.
 When a child schema is a reference, the discriminator property _MUST_ be present in the payload.
 A discriminator MAY act as a "hint" to shortcut validation and selection of the matching schema which may be a costly operation, depending on the complexity of the schema.
 Even when the discriminator is used as shortcut hint, the payload MUST still be validated against the JSON schema.

--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -2689,10 +2689,10 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
 
 The discriminator object is legal only when using one of the composite keywords `oneOf`, `anyOf`, `allOf`.
 
-In OAS 3.0, a response payload MAY be described to be exactly one of any number of types:
+A payload MAY be described to be exactly one of any number of types:
 
 ```yaml
-MyResponseType:
+MyType:
   oneOf:
   - $ref: '#/components/schemas/Cat'
   - $ref: '#/components/schemas/Dog'
@@ -2703,7 +2703,7 @@ which means the payload _MUST_, by validation, match exactly one of the schemas 
 
 
 ```yaml
-MyResponseType:
+MyType:
   oneOf:
   - $ref: '#/components/schemas/Cat'
   - $ref: '#/components/schemas/Dog'
@@ -2712,7 +2712,7 @@ MyResponseType:
     propertyName: petType
 ```
 
-The expectation now is that a property with name `petType` _MUST_ be present in the response payload, and the value will correspond to the name of a schema defined in the OAS document.  Thus the response payload:
+The expectation now is that a property with name `petType` _MUST_ be present in the payload, and the value will correspond to the name of a schema defined in the OAS document.  Thus the payload:
 
 ```json
 {
@@ -2726,7 +2726,7 @@ Will indicate that the `Cat` schema be used in conjunction with this payload.
 In scenarios where the value of the discriminator field does not match the schema name or implicit mapping is not possible, an optional `mapping` definition MAY be used:
 
 ```yaml
-MyResponseType:
+MyType:
   oneOf:
   - $ref: '#/components/schemas/Cat'
   - $ref: '#/components/schemas/Dog'

--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -2676,12 +2676,12 @@ components:
 
 When request bodies or response payloads may be one of a number of different schemas, a `discriminator` object can be used to aid in serialization, deserialization, and validation.  The discriminator is a specific object in a schema which is used to inform the consumer of the document of an alternative schema based on the value associated with it.
 
-A discriminator MAY act as a "hint" to shortcut validation and selection of the matching schema which may be a costly operation, depending on the complexity of the schema.
+The discriminator object is legal only when using one of the composite keywords `oneOf`, `anyOf`, `allOf`. Both _inline_ and references are valid child schemas.
+When a child schema is a reference, the discriminator property _MUST_ be present in the payload. A discriminator MAY act as a "hint" to shortcut validation and selection of the matching schema which may be a costly operation, depending on the complexity of the schema. Even when the discriminator is used as shortcut hint, the payload MUST still be validated against the JSON schema.
+When a child schema is specified _inline_, the discriminator property is not required in the payload. Validation is applied to determine if the payload matches the child JSON schema.
+
 The discriminator `propertyName` field MUST be a required field in the schema object. However, as shown below, the discriminator is not required to be present in the payload for _inline_ schemas.
 
-The discriminator object is legal only when using one of the composite keywords `oneOf`, `anyOf`, `allOf`. The child schemas MAY be a mix of _inline_ or references schemas.
-When a child schema is specified as a reference, the discriminator property _MUST_ be present in the payload.
-When a child schema is specified _inline_, the discriminator property is not required in the payload. Validation is applied to determine if the payload matches the child JSON schema.
 
 ##### Fixed Fields
 Field Name | Type | Description

--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -2334,7 +2334,6 @@ The OpenAPI Specification allows combining and extending model definitions using
 While composition offers model extensibility, it does not imply a hierarchy between the models.
 To support polymorphism, the OpenAPI Specification adds the `discriminator` field.
 When used, the `discriminator` will be the name of the property that decides which schema definition validates the structure of the model.
-As such, the `discriminator` field MUST be a required field.
 There are two ways to define the value of a discriminator for an inheriting instance.
 - Use the schema name.
 - Override the schema name by overriding the property with a new value. If a new value exists, this takes precedence over the schema name.
@@ -2687,6 +2686,7 @@ Field Name | Type | Description
 
 This object MAY be extended with [Specification Extensions](#specificationExtensions).
 
+The discriminator `propertyName` field MUST be a required field in the schema object.
 The discriminator object is legal only when using one of the composite keywords `oneOf`, `anyOf`, `allOf`.
 
 A payload MAY be described to be exactly one of any number of types:

--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -2680,7 +2680,7 @@ The discriminator object is legal only when using one of the composite keywords 
 When a child schema is a reference, the discriminator property _MUST_ be present in the payload.
 A discriminator MAY act as a "hint" to shortcut validation and selection of the matching schema which may be a costly operation, depending on the complexity of the schema.
 Even when the discriminator is used as shortcut hint, the payload MUST still be validated against the JSON schema.
-When a child schema is specified _inline_, the discriminator property is not required in the payload. Validation is applied to determine if the payload matches the child JSON schema.
+When a child schema is specified _inline_, the discriminator property is not required to be present in the payload. Validation is applied to determine if the payload matches the child JSON schema.
 
 The discriminator `propertyName` field MUST be a required field in the schema object. However, as shown below, the discriminator is not required to be present in the payload for _inline_ schemas.
 


### PR DESCRIPTION
This PR attempts to clarify the **Discriminator Object** section of OAS 3.1. Discriminators seem to cause a number of questions, confusion and interoperability issues. I think some of these questions could be addressed by formulating the normative statements more precisely. I am aware of #2143 but a goal of deprecating the discriminator object is not in conflict with improving the existing specification.