### PR TITLE
Unescaped Slashes Aint Welcome Around 'Ere

### DIFF
--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -75,7 +75,7 @@ Path templating refers to the usage of template expressions, delimited by curly 
 
 Each template expression in the path MUST correspond to a path parameter that is included in the [Path Item](#path-item-object) itself and/or in each of the Path Item's [Operations](#operation-object).
 
-The value for these path parameters MUST NOT contain unescaped forward slashes (`/`).
+The value for these path parameters MUST NOT contain any unescaped "generic syntax" characters described by [RFC3986](https://tools.ietf.org/html/rfc3986#section-3): forward slashes (`/`), question marks (`?`), or hashes (`#`).
 
 ##### <a name="mediaTypes"></a>Media Types
 Media type definitions are spread across several resources.
@@ -660,7 +660,7 @@ components:
 #### <a name="pathsObject"></a>Paths Object
 
 Holds the relative paths to the individual endpoints and their operations.
-The path is appended to the URL from the [`Server Object`](#serverObject) in order to construct the full URL. The Paths MAY be empty, due to [Access Control List (ACL) constraints](#securityFiltering). Paths MAY be omitted in some classes of OAS documents, including referenced sub-documents and overlays.
+The path is appended to the URL from the [`Server Object`](#serverObject) in order to construct the full URL.  The Paths MAY be empty, due to [Access Control List (ACL) constraints](#securityFiltering). Paths MAY be omitted in some classes of OAS documents, including referenced sub-documents and overlays.
 
 ##### Patterned Fields
 

--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -75,6 +75,8 @@ Path templating refers to the usage of template expressions, delimited by curly 
 
 Each template expression in the path MUST correspond to a path parameter that is included in the [Path Item](#path-item-object) itself and/or in each of the Path Item's [Operations](#operation-object).
 
+The value for these path parameters MUST NOT contain unescaped forward slashes (`/`).
+
 ##### <a name="mediaTypes"></a>Media Types
 Media type definitions are spread across several resources.
 The media type definitions SHOULD be in compliance with [RFC6838](https://tools.ietf.org/html/rfc6838).
@@ -658,7 +660,7 @@ components:
 #### <a name="pathsObject"></a>Paths Object
 
 Holds the relative paths to the individual endpoints and their operations.
-The path is appended to the URL from the [`Server Object`](#serverObject) in order to construct the full URL.  The Paths MAY be empty, due to [Access Control List (ACL) constraints](#securityFiltering). Paths MAY be omitted in some classes of OAS documents, including referenced sub-documents and overlays.
+The path is appended to the URL from the [`Server Object`](#serverObject) in order to construct the full URL. The Paths MAY be empty, due to [Access Control List (ACL) constraints](#securityFiltering). Paths MAY be omitted in some classes of OAS documents, including referenced sub-documents and overlays.
 
 ##### Patterned Fields
 


### PR DESCRIPTION
Seeing as unespcaped slashes are not allowed, and various tools will escape them or just not know what to do with one due to the behavior being undefined, we should probably define it.

Closes https://github.com/OAI/OpenAPI-Specification/issues/2204

Might close https://github.com/OAI/OpenAPI-Specification/issues/892

