### PR TITLE
Missing updates

### DIFF
--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -26,7 +26,7 @@ An OpenAPI definition can then be used by documentation generation tools to disp
 	- [Document Structure](#documentStructure)
 	- [Data Types](#dataTypes)
 	- [Rich Text Formatting](#richText)
-	- [Relative References In URLs](#relativeReferences)
+	- [Relative References In URIs](#relativeReferences)
 	- [Schema](#schema)
 		- [OpenAPI Object](#oasObject)
 		- [Info Object](#infoObject)
@@ -658,7 +658,7 @@ components:
 #### <a name="pathsObject"></a>Paths Object
 
 Holds the relative paths to the individual endpoints and their operations.
-The path is appended to the URL from the [`Server Object`](#serverObject) in order to construct the full URL.  The Paths MAY be empty, due to [Access Control List (ACL) constraints](#securityFiltering). Paths MAY be omitted in some classes of OAS documents, including referenced sub-documents and overlays.
+The path is appended to the URL from the [`Server Object`](#serverObject) in order to construct the full URL.  The Paths MAY be empty, due to [Access Control List (ACL) constraints](#securityFiltering).
 
 ##### Patterned Fields
 


### PR DESCRIPTION
While going over the changes for the release notes, found two issues:
- The TOC entry for `Relative references in URIs` was not modified to match the change in the spec.
- The `Paths Object` had an extra sentence that should have not been there (referencing sub-documents and overlays).