### PR TITLE
Remove boolean compatibility for exclusive*

### DIFF
--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -2307,8 +2307,6 @@ The OpenAPI Schema Object is a JSON Schema vocabulary which extends JSON Schema 
 The following properties are taken from the JSON Schema definition but their definitions were adjusted to the OpenAPI Specification.
 
 - type - Used to restrict the allowed types as specified in JSON Schema, but may be modified by the [`nullable`](#schemaNullable) keyword.
-- exclusiveMinimum - Value can be a numeric value just like JSON Schema, or for backwards compatibility with older drafts it can accept a boolean to act as a modifier to the `minimum` keyword. The numeric value usage is recommended.
-- exclusiveMaximum - Value can be a numeric value just like JSON Schema, or for backwards compatibility with older drafts it can accept a boolean to act as a modifier to the `minimum` keyword. The numeric value usage is recommended.
 - description - [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
 - format - See [Data Type Formats](#dataTypeFormat) for further details. While relying on JSON Schema's defined formats, the OAS offers a few additional predefined formats.
 


### PR DESCRIPTION
This brings exclusiveMinimum, exclusiveMaximum, minimum, and
maximum, into full modern JSON Schema compatibility.

There are no edits directly mentioning minimum and maximum,
but removing the boolean form simplifies their processing
by making it context-independent.