### PR TITLE
Add links and spell out acronyms

### DIFF
--- a/TOB.md
+++ b/TOB.md
@@ -1,7 +1,7 @@
 # Technical Oversight Board ("TOB")
 
 ## Description: 
-> The TOB is responsible for managing conflicts, violations of procedures or guidelines or other issues that cannot be resolved in the TSC for the OAS. For further details please consult the OpenAPI Project Charter.
+> The TOB is responsible for managing conflicts, violations of procedures or guidelines, or other issues that cannot be resolved in the [Technical Steering Committee](https://github.com/OAI/OpenAPI-Specification/blob/master/MAINTAINERS.md) (TSC) for the OAS. For further details please consult the [OpenAPI Project Charter](https://www.openapis.org/participate/how-to-contribute/governance).
 
 ## TSC Elected - terms through May 2021
 Isabelle Mauny @isamauny
@@ -12,7 +12,7 @@ Marsh Gardiner @earth2marsh
 
 Ron Ratovsky @webron
 
-## BGB Elected - terms through May 2020
+## Business Governance Board Elected - terms through May 2020
 
 Darrel Miller @darrelmiller
 


### PR DESCRIPTION
Add links for easy navigation to references. To adhere to the style guide, spell out acronyms on first use. Also add a serial comma to make the first sentence easier to parse.