### PR TITLE
Update build badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The OpenAPI Specification
 
-[![Build Status](https://travis-ci.org/OAI/OpenAPI-Specification.svg?branch=master)](https://travis-ci.org/OAI/OpenAPI-Specification)
+![Build Status](https://github.com/OAI/OpenAPI-Specification/workflows/validate-markdown/badge.svg)
 
 ![](https://avatars3.githubusercontent.com/u/16343502?v=3&s=200)
 


### PR DESCRIPTION
This replaces the old Travis CI build badge with a GitHub Actions one.

We could have a badge for the other actions too (validate schemas, validate examples etc) but as the schemas and examples are non-normative I thought best to leave it at just the markdown validation ('build') one.