### PR TITLE
v3.1.0: rephrase data-type section because `format` keyword can be used for any data type.

### DIFF
--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -139,11 +139,11 @@ It is RECOMMENDED that the root OpenAPI document be named: `openapi.json` or `op
 
 ### <a name="dataTypes"></a>Data Types
 
-Primitive data types in the OAS are based on the types supported by the [JSON Schema Specification Draft 2019-09](http://json-schema.org/draft/2019-09/json-schema-core.html#rfc.section.4.2). 
+Data types in the OAS are based on the types supported by the [JSON Schema Specification Draft 2019-09](http://json-schema.org/draft/2019-09/json-schema-core.html#rfc.section.4.2). 
 Note that `integer` as a type is also supported and is defined as a JSON number without a fraction or exponent part. 
 Models are defined using the [Schema Object](#schemaObject), which is a superset of JSON Schema Specification Draft 2019-09.
 
-<a name="dataTypeFormat"></a>Primitives have an optional modifier property: `format`, which is defined by JSON Schema.
+<a name="dataTypeFormat"></a>Data types can have an optional modifier property: `format`, which is defined by JSON Schema.
 OAS uses several known additional formats to define in fine detail the data type being used.
 However, to support documentation needs, the `format` property is an open `string`-valued property, and can have any value.
 Additional formats MAY be used even though undefined by either JSON Schema or this specification.

--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -143,13 +143,8 @@ Data types in the OAS are based on the types supported by the [JSON Schema Speci
 Note that `integer` as a type is also supported and is defined as a JSON number without a fraction or exponent part. 
 Models are defined using the [Schema Object](#schemaObject), which is a superset of JSON Schema Specification Draft 2019-09.
 
-<a name="dataTypeFormat"></a>Data types can have an optional modifier property: `format`, which is defined by JSON Schema.
-OAS uses several known additional formats to define in fine detail the data type being used.
-However, to support documentation needs, the `format` property is an open `string`-valued property, and can have any value.
-Additional formats MAY be used even though undefined by either JSON Schema or this specification.
-Types that are not accompanied by a `format` property follow the type definition in the JSON Schema. Tools that do not recognize a specific `format` MAY default back to the `type` alone, as if the `format` is not specified.
-
-Note that by default, JSON Schema validators will not attempt to validate the `format` keyword.  https://json-schema.org/draft/2019-09/release-notes.html#format-vocabulary
+<a name="dataTypeFormat"></a>As defined by JSON Schema, data types can have an optional modifier property: `format`.
+OAS defines additional formats to provide fine detail for primitive data types.
 
 The formats defined by the OAS are:
 


### PR DESCRIPTION
Fix #2301 