### PR TITLE
Add a note about model-refs in places where they don't work to the 1.2 documentation

### DIFF
--- a/versions/1.2.md
+++ b/versions/1.2.md
@@ -838,6 +838,8 @@ The Parameter Object describes a single parameter to be sent in an operation and
 
 This object includes the [Data Type Fields](#433-data-type-fields) in order to describe the type of this parameter. The [`type`](#dataTypeType) field MUST be used to link to other models.
 
+If [`$ref`](#dataTypeRef) is used or [`type`](#dataTypeType) is a model's [`id`](#modelId), the [`paramType`](#parameterParamType) field MUST be `"body"` or `"form"`.
+
 If [`type`](#dataTypeType) is [`File`](#434-file), the [`consumes`](#operationConsumes) field MUST be `"multipart/form-data"`, and the [`paramType`](#parameterParamType) MUST be `"form"`.
 
 Field Name | Type | Description


### PR DESCRIPTION
I have no idea if "I'm allowed to do this", but it's currently 3AM and this could've saved me more hours than I want to admit.

In case you're wondering: why is this dude struggeling with a 4 year old spec, I'm trying to use [openapi-generator](https://github.com/OpenAPITools/openapi-generator) on an API that is described with Swagger 1.2 for some reason. This specification incorrectly declares certain query parameters as "model types", even though they should refer to the **ID *field*** of the model. Throwing this at openapi-generator gave me the following (very unhelpful) error:

```
[main] WARN  o.o.codegen.DefaultCodegen - Unknown type found in the schema: ref
[main] WARN  o.o.c.l.AbstractCSharpCodegen - ref (reserved word) cannot be used as model name. Renamed to ModelRef
```

I might have noticed this problem earlier if this little note was present in the documentation. The only reason I'm sending a PR for a 4 year old spec is to perhaps some day save a fellow community member from my pain.

I have no idea if the wording is correct and all, I tried to stay close to the rest of the document, but I just really want to go to bed. In case this gets rejected for being "too old", I hope this PR will at least show up if somebody Googles this error in the future.