### PR TITLE
Add securitySchemes examples. Related to #1829

### DIFF
--- a/examples/v3.1/securitySchemes.yaml
+++ b/examples/v3.1/securitySchemes.yaml
@@ -1,0 +1,73 @@
+openapi: 3.1.0
+info:
+  title: Security Schemes example
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      security:
+        # Either a `read/write` ClientCertificate ...
+        - ClientCertificate:
+            - read
+            - write
+        # ... or a `read/write` OAuth2
+        - OAuth2:
+            - read
+            - write
+      summary: List all pets
+      operationId: listPets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: A paged array of pets
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pets"
+components:
+  securitySchemes:
+    OAuth2:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: https://example.com/oauth/authorize
+          tokenUrl: https://example.com/oauth/token
+          scopes:
+            read: Grants read access
+            write: Grants write access
+            admin: Grants access to admin operations
+    ClientCertificate:
+      type: mutualTLS
+      description: |-
+        To autenticate you must provide a trusted client certificate.
+        OAS does not mandate a trust model.
+
+        You can use scopes too, though this is might not be
+        supported in tooling:
+        - read: Grants read access
+        - write: Grants write access
+        - admin: Grants access to admin operations
+  schemas:
+    Pet:
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+    Pets:
+      type: array
+      items:
+        $ref: "#/components/schemas/Pet"


### PR DESCRIPTION
## This PR

Adds some examples for securitySchemes:

- `mutualTLS` usage
- `mutualTLS` with scope #1829 
- `OAuth2` sourced from https://swagger.io/docs/specification/authentication/

## It is done

Adding file in [examples](examples/)