### PR TITLE
Remove Schema Object `example` and Media Type `example`

### DIFF
--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -1029,11 +1029,11 @@ Field Name | Type | Description
 <a name="parameterAllowReserved"></a>allowReserved | `boolean` | Determines whether the parameter value SHOULD allow reserved characters, as defined by [RFC3986](https://tools.ietf.org/html/rfc3986#section-2.2) `:/?#[]@!$&'()*+,;=` to be included without percent-encoding. This property only applies to parameters with an `in` value of `query`. The default value is `false`.
 <a name="parameterSchema"></a>schema | [Schema Object](#schemaObject) | The schema defining the type used for the parameter.
 <a name="parameterExample"></a>example | Any | Example of the parameter's potential value. The example SHOULD match the specified schema and encoding properties if present. The `example` field is mutually exclusive of the `examples` field. Furthermore, if referencing a `schema` that contains an example, the `example` value SHALL _override_ the example provided by the schema. To represent examples of media types that cannot naturally be represented in JSON or YAML, a string value can contain the example with escaping where necessary.
-<a name="parameterExamples"></a>examples | Map[ `string`, [Example Object](#exampleObject) \| [Reference Object](#referenceObject)] | Examples of the parameter's potential value. Each example SHOULD contain a value in the correct format as specified in the parameter encoding. The `examples` field is mutually exclusive of the `example` field. Furthermore, if referencing a `schema` that contains an example, the `examples` value SHALL _override_ the example provided by the schema.
+<a name="parameterExamples"></a>examples | Map[`string`, [Example Object](#exampleObject) \| [Reference Object](#referenceObject)] | Examples of the parameter's potential value. Each example SHOULD contain a value in the correct format as specified in the parameter encoding. If referencing a `schema` that contains an example, the `examples` value SHALL _override_ the example provided by the schema.
 
 For more complex scenarios, the [`content`](#parameterContent) property can define the media type and schema of the parameter.
 A parameter MUST contain either a `schema` property, or a `content` property, but not both.
-When `example` or `examples` are provided in conjunction with the `schema` object, the example MUST follow the prescribed serialization strategy for the parameter.
+When `examples` are provided in conjunction with the `schema` object, the examples MUST follow the prescribed serialization strategy for the parameter.
 
 
 Field Name | Type | Description
@@ -1367,8 +1367,7 @@ Each Media Type Object provides schema and examples for the media type identifie
 Field Name | Type | Description
 ---|:---:|---
 <a name="mediaTypeSchema"></a>schema | [Schema Object](#schemaObject) | The schema defining the content of the request, response, or parameter.
-<a name="mediaTypeExample"></a>example | Any | Example of the media type.  The example object SHOULD be in the correct format as specified by the media type.  The `example` field is mutually exclusive of the `examples` field.  Furthermore, if referencing a `schema` which contains an example, the `example` value SHALL _override_ the example provided by the schema.
-<a name="mediaTypeExamples"></a>examples | Map[ `string`, [Example Object](#exampleObject) \| [Reference Object](#referenceObject)] | Examples of the media type.  Each example object SHOULD  match the media type and specified schema if present.  The `examples` field is mutually exclusive of the `example` field.  Furthermore, if referencing a `schema` which contains an example, the `examples` value SHALL _override_ the example provided by the schema.
+<a name="mediaTypeExamples"></a>examples | Map[`string`, [Example Object](#exampleObject) \| [Reference Object](#referenceObject)] | Examples of the media type.  Each example object SHOULD  match the media type and specified schema if present.  If referencing a `schema` which contains an example, the `examples` value SHALL _override_ the example provided by the schema.
 <a name="mediaTypeEncoding"></a>encoding | Map[`string`, [Encoding Object](#encodingObject)] | A map between a property name and its encoding information. The key, being the property name, MUST exist in the schema as a property. The encoding object SHALL only apply to `requestBody` objects when the media type is `multipart` or `application/x-www-form-urlencoded`.
 
 This object MAY be extended with [Specification Extensions](#specificationExtensions).
@@ -1782,7 +1781,7 @@ Plain text response with headers:
     "text/plain": {
       "schema": {
         "type": "string",
-        "example": "whoa!"
+        "examples": ["whoa!"]
       }
     }
   },
@@ -1815,7 +1814,7 @@ content:
   text/plain:
     schema:
       type: string
-    example: 'whoa!'
+      examples: ['whoa!']
 headers:
   X-Rate-Limit-Limit:
     description: The number of allowed requests in the current period
@@ -1964,19 +1963,23 @@ requestBody:
         $ref: '#/components/schemas/Address'
       examples: 
         foo:
+          # Example Object
           summary: A foo example
           value: {"foo": "bar"}
         bar:
+          # Example Object
           summary: A bar example
           value: {"bar": "baz"}
     'application/xml':
       examples: 
         xmlExample:
+          # Example Object
           summary: This is an example in XML
           externalValue: 'https://example.org/examples/address-example.xml'
     'text/plain':
       examples:
         textExample: 
+          # Example Object
           summary: This is a text example
           externalValue: 'https://foo.bar/examples/address-example.txt'
 ```
@@ -2313,7 +2316,6 @@ Field Name | Type | Description
 <a name="schemaDiscriminator"></a>discriminator | [Discriminator Object](#discriminatorObject) | Adds support for polymorphism. The discriminator is an object name that is used to differentiate between other schemas which may satisfy the payload description. See [Composition and Inheritance](#schemaComposition) for more details.
 <a name="schemaXml"></a>xml | [XML Object](#xmlObject) | This MAY be used only on properties schemas. It has no effect on root schemas. Adds additional metadata to describe the XML representation of this property.
 <a name="schemaExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation for this schema.
-<a name="schemaExample"></a>example | Any | A free-form property to include an example of an instance for this schema. To represent examples that cannot be naturally represented in JSON or YAML, a string value can be used to contain the example with escaping where necessary.<br><br>**Deprecated:** The `example` property has been deprecated in favor of the JSON Schema `examples` keyword. Use of `example` is discouraged, and later versions of this specification may remove it.
 
 This object MAY be extended with [Specification Extensions](#specificationExtensions). 
 
@@ -2452,10 +2454,12 @@ additionalProperties:
   "required": [
     "name"
   ],
-  "example": {
-    "name": "Puma",
-    "id": 1
-  }
+  "examples": [
+    {
+      "name": "Puma",
+      "id": 1
+    }
+  ]
 }
 ```
 
@@ -2469,8 +2473,8 @@ properties:
     type: string
 required:
 - name
-example:
-  name: Puma
+examples:
+- name: Puma
   id: 1
 ```
 


### PR DESCRIPTION
There are too many types of examples currently in OpenAPI, v3.1 is going to see another one come in as part of JSON Schema 2019-09.

In OpenAPI v3.1, here are all the places you could put examples just for a response:

```yaml
/infinite-examples:
  get:
    operationId: infinite-examples
    responses:
      "200":
        description: OK
        content:
          application/json:
            schema:
              properties:
                name:
                  type: string
                  # OpenAPI Schema Object Example
                  example: stowford
                coordinates:
                  description: We couldn't pick a format for coordinates so we support
                  pretty much all of them.
                  # JSON Schema Examples from 2019-09
                  examples:
                  - "52.377956, 4.897070"
                  - [52.377956, 4.897070]
                  - { lat: 52.377956, lon: 4.897070 }
              required:
                - name
                - coordinates
              
              # OpenAPI Schema Object Example (but for an object)
              example:
                name: freddy
                coordinates: "52.377956, 4.897070"

            # OpenAPI Media Type Example
            example:
              name: finn
              coordinates: "52.377956, 4.897070"

            # OpenAPI Media Type Examples
            examples:
              arbitrary example name:
                value:
                  name: finns evil twin
                  coordinates: "52.377956, 4.897070"   
```

Thankfully "OpenAPI Media Type Example" and "OpenAPI Media Type Examples" are a xor so its always going to be one or the other, but this is still really complex for tool maintainers to support. Over at Stoplight it's caused untold confusion, and we're still not quite supporting all of them correctly despite various attempts to get it right, and with v3.1 adding more it's just going to make our tooling and our user interfaces more complicated.

We can cope with being confused, but I think it's generally bad for the ecosystem: tooling vendors and end users alike, to have umpteen different ways to do the same thing. 

So, I propose getting rid of 2/5 types of example: 

1. `example` in the Schema Object 
2. `example` in the Media Type / Parameters

1 seems easy. Yes, it's a little more typing to write:

```
examples: 
- stowford
# or 
examples: [stowford]
```

instead of 

```
example: stowford
```

but we're already deprecating it, and just like nullable, let's kill it instead of dragging it out. 

> ~**Deprecated:** The `example` property has been deprecated in favor of the JSON Schema `examples` keyword.~ 👋

As for media type `example` and `parameter` example, that's an easy one too, because again folks can use `examples` in the OpenAPI form: `Map[string, [Example Object](#exampleObject) \| [Reference Object](#referenceObject)]`, or they can do example stuff inside the schema (using `examples` in the JSON Schema-ish way).

Whatever we do, taking an axe to some of these 5 approaches will be helpful for end users and tooling vendors who are just tying to figure out how to show examples, in docs, mocks, etc.

For more insight into the plethora of examples we currently have, I done a giant blog post. You'll laugh. You'll cry. You'll have questions. https://phil.tech/2020/openapi-examples/