### PR TITLE
Fix indentation of a YAML comment

### DIFF
--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -1480,7 +1480,7 @@ In addition, specific media types MAY be specified:
 # multiple, specific media types may be specified:
 requestBody:
   content:
-      # a binary file of type png or jpeg
+    # a binary file of type png or jpeg
     image/jpeg: {}
     image/png: {}
 ```


### PR DESCRIPTION
This PR fixes over-indentation of a comment in one of the YAML examples. That extra indentation resulted in a YAML syntax error.