### PR TITLE
fix typo in release history table

### DIFF
--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -3424,7 +3424,7 @@ Two examples of this:
 
 Version   | Date       | Notes
 ---       | ---        | ---
-3.1.0-rc0 | 2020-10-08 | rc1 of the 3.1 specification
+3.1.0-rc1 | 2020-10-08 | rc1 of the 3.1 specification
 3.1.0-rc0 | 2020-06-18 | rc0 of the 3.1 specification
 3.0.3     | 2020-02-20 | Patch release of the OpenAPI Specification 3.0.3
 3.0.2     | 2018-10-08 | Patch release of the OpenAPI Specification 3.0.2


### PR DESCRIPTION
If wanted we could cherry-pick this to `master` too, but it's probably not needed.