### PR TITLE
fix link to style values in serialization table

### DIFF
--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -1035,7 +1035,7 @@ Field Name | Type | Description
 ---|:---:|---
 <a name="parameterContent"></a>content | Map[`string`, [Media Type Object](#mediaTypeObject)] | A map containing the representations for the parameter. The key is the media type and the value describes it. The map MUST only contain one entry.
 
-##### Style Values
+##### <a name="styleValues"></a>Style Values
 
 In order to support common ways of serializing simple parameters, a set of `style` values are defined.
 
@@ -1061,7 +1061,7 @@ Assume a parameter named `color` has one of the following values:
 ```
 The following table shows examples of rendering differences for each value.
 
-[`style`](#dataTypeFormat) | `explode` | `empty` | `string` | `array` | `object`
+[`style`](#styleValues) | `explode` | `empty` | `string` | `array` | `object`
 ----------- | ------ | -------- | -------- | -------- | -------
 matrix | false | ;color | ;color=blue | ;color=blue,black,brown | ;color=R,100,G,200,B,150
 matrix | true | ;color | ;color=blue | ;color=blue;color=black;color=brown | ;R=100;G=200;B=150


### PR DESCRIPTION
The `style` column header link went to `#dataTypeFormat` (the table of additional `format` values), this seems incorrect, so a new anchor has been created for the table containing all of the available `style` values.