### PR TITLE
Fix misspelling of a keyword in text

### DIFF
--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -2801,7 +2801,7 @@ will indicate that the `Cat` schema be used.  Likewise this schema:
 }
 ```
 
-will map to `Dog` because of the definition in the `mappings` element.
+will map to `Dog` because of the definition in the `mapping` element.
 
 
 #### <a name="xmlObject"></a>XML Object


### PR DESCRIPTION
The text in the "Discriminator Object" section mentions the `mappings` keyword, but the keyword name is actually [`mapping`](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md#user-content-discriminatormapping) (i.e. singular form).