### PR TITLE
Update wording that referred to the year 2019 as the current year

### DIFF
--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -3162,7 +3162,7 @@ animals:
 Defines a security scheme that can be used by the operations.
 
 Supported schemes are HTTP authentication, an API key (either as a header, a cookie parameter or as a query parameter), mutual TLS (use of a client certificate), OAuth2's common flows (implicit, password, client credentials and authorization code) as defined in [RFC6749](https://tools.ietf.org/html/rfc6749), and [OpenID Connect Discovery](https://tools.ietf.org/html/draft-ietf-oauth-discovery-06).
- Please note that currently (2019) the implicit flow is about to be deprecated [OAuth 2.0 Security Best Current Practice](https://tools.ietf.org/id/draft-ietf-oauth-security-topics). Recommended for most use case is Authorization Code Grant flow with PKCE.
+Please note that as of 2020, the implicit flow is about to be deprecated by [OAuth 2.0 Security Best Current Practice](https://tools.ietf.org/html/draft-ietf-oauth-security-topics). Recommended for most use case is Authorization Code Grant flow with PKCE.
 
 ##### Fixed Fields
 Field Name | Type | Applies To | Description


### PR DESCRIPTION
A minor edit that replaces "currently (2019)" with "as of 2020" to avoid referring to any particular year as the _current_ year. This way the text will still look fine next year.

Also replaced the link to the IEFT draft with HTML version for consistency with other such links in the text.