### PR TITLE
Added link to JSON Schema Validation docs explain which formats are included in JSON Schema

### DIFF
--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -143,7 +143,7 @@ Data types in the OAS are based on the types supported by the [JSON Schema Speci
 Note that `integer` as a type is also supported and is defined as a JSON number without a fraction or exponent part. 
 Models are defined using the [Schema Object](#schemaObject), which is a superset of JSON Schema Specification Draft 2019-09.
 
-<a name="dataTypeFormat"></a>As defined by JSON Schema, data types can have an optional modifier property: `format`.
+<a name="dataTypeFormat"></a>As defined by [JSON Schema Validation](https://json-schema.org/draft/2019-09/json-schema-validation.html#rfc.section.7.3), data types can have an optional modifier property: `format`.
 OAS defines additional formats to provide fine detail for primitive data types.
 
 The formats defined by the OAS are:

--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -143,7 +143,7 @@ Data types in the OAS are based on the types supported by the [JSON Schema Speci
 Note that `integer` as a type is also supported and is defined as a JSON number without a fraction or exponent part. 
 Models are defined using the [Schema Object](#schemaObject), which is a superset of JSON Schema Specification Draft 2019-09.
 
-<a name="dataTypeFormat"></a>As defined by [JSON Schema Validation](https://json-schema.org/draft/2019-09/json-schema-validation.html#rfc.section.7.3), data types can have an optional modifier property: `format`.
+<a name="dataTypeFormat"></a>As defined by the [JSON Schema Validation vocabulary](https://json-schema.org/draft/2019-09/json-schema-validation.html#rfc.section.7.3), data types can have an optional modifier property: `format`.
 OAS defines additional formats to provide fine detail for primitive data types.
 
 The formats defined by the OAS are:


### PR DESCRIPTION
In the `dataTypes` section it is explained that JSON Schema provides support for a number of *format* modifiers, but I feel like it would be helpful to have a link to the JSON Schema Validation documentation which explains which format modifiers are included.