### PR TITLE
Improve wording about summary and description fields in Reference Object

### DIFF
--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -2241,8 +2241,8 @@ A simple object to allow referencing other components in the OpenAPI document, i
 Field Name | Type | Description
 ---|:---:|---
 <a name="referenceRef"></a>$ref | `string` | **REQUIRED**. The reference string.
-<a name="referenceSummary"></a>summary | `string` | A short summary which by default SHOULD override that of the referenced component. If the referenced object-type does not define a `summary` field, then this field has no effect.
-<a name="referenceDescription"></a>description | `string` | A description which by default SHOULD override that of the referenced component. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation. If the referenced object-type does not define a `description` field, then this field has no effect.
+<a name="referenceSummary"></a>summary | `string` | A short summary which by default SHOULD override that of the referenced component. If the referenced object-type does not allow a `summary` field, then this field has no effect.
+<a name="referenceDescription"></a>description | `string` | A description which by default SHOULD override that of the referenced component. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation. If the referenced object-type does not allow a `description` field, then this field has no effect.
 
 This object cannot be extended with additional properties and any properties added SHALL be ignored.
 


### PR DESCRIPTION
Word "define" is used in two meanings in software development: ~"declare" and ~"assign". In this particular case I would like to avoid possible confusion of a reader caused by understanding it as the former case: "if 'description' field is not set in Reference Object, it will be ignored". Some more details here: https://github.com/OAI/OpenAPI-Specification/issues/1514#issuecomment-720141763

If you can suggest a better wording in English, I would appreciate that.