### PR TITLE
Added wording to clarify scope of references

### DIFF
--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -2235,7 +2235,7 @@ description: Pets operations
 
 #### <a name="referenceObject"></a>Reference Object
 
-A simple object to allow referencing other objects in the OpenAPI document, internally and externally. The target of the reference must match the type required by the context of the reference. Targets of a reference do not need to be contained in a components section and for external references, targets do not need to exist within a valid OpenAPI description. The validity of the target MUST be based on the context of the reference object.
+A simple object to allow referencing other objects in the OpenAPI document, internally and externally. Targets of a reference do not need to be contained in a components section and for external references, targets MAY exist within any compatible resource. Referenced objects are subject to the same constraints as inline objects.
 
 ##### Fixed Fields
 Field Name | Type | Description

--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -2235,7 +2235,7 @@ description: Pets operations
 
 #### <a name="referenceObject"></a>Reference Object
 
-A simple object to allow referencing other components in the OpenAPI document, internally and externally.
+A simple object to allow referencing other objects in the OpenAPI document, internally and externally. The target of the reference must match the type required by the context of the reference. Targets of a reference do not need to be contained in a components section and for external references, targets do not need to exist within a valid OpenAPI description. The validity of the target MUST be based on the context of the reference object.
 
 ##### Fixed Fields
 Field Name | Type | Description

--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -2235,7 +2235,7 @@ description: Pets operations
 
 #### <a name="referenceObject"></a>Reference Object
 
-A simple object to allow referencing other objects in the OpenAPI document, internally and externally. Targets of a reference do not need to be contained in a components section and for external references, targets MAY exist within any compatible resource. Referenced objects are subject to the same constraints as inline objects.
+A simple object to allow referencing other objects in the OpenAPI document, internally and externally. Targets of a reference do not need to be contained in a components section and for external references, targets MAY exist within any compatible resource. Targets are subject to the same constraints as inline objects.
 
 ##### Fixed Fields
 Field Name | Type | Description


### PR DESCRIPTION
Previous wording was ambiguous as to what a $ref could point to.  This PR adds text to be more precise.