### PR TITLE
Update JSON Schema Draft to 2020-12 and make $ref resolution rules explicit

### DIFF
--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -2247,7 +2247,7 @@ The `$ref` string value contains a URI [RFC3986](https://tools.ietf.org/html/rfc
 
 Resolution of a Reference Object SHOULD yield the referenced value. Implementations MAY choose to replace the reference with the referenced value.
 
-If the URI contained in the `$ref` value is a relative URI, then the Base URI resolution MUST be calculated according to [RFC3986](https://tools.ietf.org/html/rfc3986#section-5.2). Resolution is performed relative to the referring document.
+If the URI contained in the `$ref` value is a [Relative Reference](https://tools.ietf.org/html/rfc3986#section-4.2), then the Base URI resolution MUST be calculated according to [RFC3986](https://tools.ietf.org/html/rfc3986#section-5.2). Resolution is performed relative to the referring document.
 
 If a URI contains a fragment identifier, then the fragment should be resolved per the fragment resolution mechanism of the referrant document.  If the representation of the referrant document is JSON or YAML, then the fragment identifier SHOULD be interpreted as a JSON-Pointer as per [RFC6901](https://tools.ietf.org/html/rfc6901).
 

--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -1535,7 +1535,7 @@ When passing complex objects in the `application/x-www-form-urlencoded` content 
 
 It is common to use `multipart/form-data` as a `Content-Type` when transferring request bodies to operations.  In contrast to 2.0, a `schema` is REQUIRED to define the input parameters to the operation when using `multipart` content.  This supports complex structures as well as supporting mechanisms for multiple file uploads.
 
-In a `multipart/form-data` request body, each schema property, or each element of a schema array property, takes a section in the payload with an internal header as defined by [RFC 7578](https://tools.ietf.org/html/rfc7578). The serialization strategy for each property of a `multipart/form-data` request body can be specified in an associated [`Encoding Object`](#encodingObject).
+In a `multipart/form-data` request body, each schema property, or each element of a schema array property, takes a section in the payload with an internal header as defined by [RFC7578](https://tools.ietf.org/html/rfc7578). The serialization strategy for each property of a `multipart/form-data` request body can be specified in an associated [`Encoding Object`](#encodingObject).
 
 When passing in `multipart` types, boundaries MAY be used to separate sections of the content being transferred — thus, the following default `Content-Type`s are defined for `multipart`:
 
@@ -2162,7 +2162,7 @@ The runtime expression is defined by the following [ABNF](https://tools.ietf.org
         "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA
 ```
 
-Here, `json-pointer` is taken from [RFC 6901](https://tools.ietf.org/html/rfc6901), `char` from [RFC 7159](https://tools.ietf.org/html/rfc7159#section-7) and `token` from [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2.6).
+Here, `json-pointer` is taken from [RFC6901](https://tools.ietf.org/html/rfc6901), `char` from [RFC7159](https://tools.ietf.org/html/rfc7159#section-7) and `token` from [RFC7230](https://tools.ietf.org/html/rfc7230#section-3.2.6).
 
 The `name` identifier is case-sensitive, whereas `token` is not. 
 

--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -2245,8 +2245,6 @@ A simple object to allow referencing other components in the OpenAPI document, i
 
 The `$ref` string value contains a URI [RFC3986](https://tools.ietf.org/html/rfc3986), which identifies the location of the value being referenced.
 
-Resolution of a Reference Object SHOULD yield the referenced value. Implementations MAY choose to replace the reference with the referenced value.
-
 If the URI contained in the `$ref` value is a [Relative Reference](https://tools.ietf.org/html/rfc3986#section-4.2), then the Base URI resolution MUST be calculated according to [RFC3986](https://tools.ietf.org/html/rfc3986#section-5.2). Resolution is performed relative to the referring document.
 
 If a URI contains a fragment identifier, then the fragment should be resolved per the fragment resolution mechanism of the referrant document.  If the representation of the referrant document is JSON or YAML, then the fragment identifier SHOULD be interpreted as a JSON-Pointer as per [RFC6901](https://tools.ietf.org/html/rfc6901).

--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -2304,7 +2304,7 @@ The OpenAPI Schema Object dialect for this version of the specification is ident
 
 The following properties are taken from the JSON Schema specification but their definitions have been extended by the OAS:
 
-- description - [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
+- description - [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
 - format - See [Data Type Formats](#dataTypeFormat) for further details. While relying on JSON Schema's defined formats, the OAS offers a few additional predefined formats.
 
 In addition to the JSON Schema properties comprising the OAS dialect, the Schema Object supports keywords from any other vocabularies, or entirely arbitrary properties.

--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -185,7 +185,7 @@ Field Name | Type | Description
 ---|:---:|---
 <a name="oasVersion"></a>openapi | `string` | **REQUIRED**. This string MUST be the [version number](#versions) of the OpenAPI Specification that the OpenAPI document uses. The `openapi` field SHOULD be used by tooling to interpret the OpenAPI document. This is *not* related to the API [`info.version`](#infoVersion) string.
 <a name="oasInfo"></a>info | [Info Object](#infoObject) | **REQUIRED**. Provides metadata about the API. The metadata MAY be used by tooling as required.
-<a name="oasJsonSchemaDialect"></a> jsonSchemaDialect | `string` | The default value for the `$schema` keyword within [Schema Objects](#schemaObject) contained within this OAS document. MUST be in the form of a URI.
+<a name="oasJsonSchemaDialect"></a> jsonSchemaDialect | `string` | The default value for the `$schema` keyword within [Schema Objects](#schemaObject) contained within this OAS document. This MUST be in the form of a URI.
 <a name="oasServers"></a>servers | [[Server Object](#serverObject)] | An array of Server Objects, which provide connectivity information to a target server. If the `servers` property is not provided, or is an empty array, the default value would be a [Server Object](#serverObject) with a [url](#serverUrl) value of `/`.
 <a name="oasPaths"></a>paths | [Paths Object](#pathsObject) | The available paths and operations for the API.
 <a name="oasWebhooks"></a>webhooks | Map[`string`, [Path Item Object](#pathItemObject) \| [Reference Object](#referenceObject)] ] | The incoming webhooks that MAY be received as part of this API and that the API consumer MAY choose to implement. Closely related to the `callbacks` feature, this section describes requests initiated other than by an API call, for example by an out of band registration. The key name is a unique string to refer to each webhook, while the (optionally referenced) Path Item Object describes a request that may be initiated by the API provider and the expected responses. An [example](../examples/v3.1/webhook-example.yaml) is available.
@@ -209,7 +209,7 @@ Field Name | Type | Description
 <a name="infoTitle"></a>title | `string` | **REQUIRED**. The title of the API.
 <a name="infoSummary"></a>summary | `string` | A short summary of the API.
 <a name="infoDescription"></a>description | `string` | A description of the API. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="infoTermsOfService"></a>termsOfService | `string` | A URL to the Terms of Service for the API. MUST be in the format of a URL.
+<a name="infoTermsOfService"></a>termsOfService | `string` | A URL to the Terms of Service for the API. This MUST be in the form of a URL.
 <a name="infoContact"></a>contact | [Contact Object](#contactObject) | The contact information for the exposed API.
 <a name="infoLicense"></a>license | [License Object](#licenseObject) | The license information for the exposed API.
 <a name="infoVersion"></a>version | `string` | **REQUIRED**. The version of the OpenAPI document (which is distinct from the [OpenAPI Specification version](#oasVersion) or the API implementation version).
@@ -262,8 +262,8 @@ Contact information for the exposed API.
 Field Name | Type | Description
 ---|:---:|---
 <a name="contactName"></a>name | `string` | The identifying name of the contact person/organization.
-<a name="contactUrl"></a>url | `string` | The URL pointing to the contact information. MUST be in the format of a URL.
-<a name="contactEmail"></a>email | `string` | The email address of the contact person/organization. MUST be in the format of an email address.
+<a name="contactUrl"></a>url | `string` | The URL pointing to the contact information. This MUST be in the form of a URL.
+<a name="contactEmail"></a>email | `string` | The email address of the contact person/organization. This MUST be in the form of an email address.
 
 This object MAY be extended with [Specification Extensions](#specificationExtensions).
 
@@ -293,7 +293,7 @@ Field Name | Type | Description
 ---|:---:|---
 <a name="licenseName"></a>name | `string` | **REQUIRED**. The license name used for the API.
 <a name="licenseIdentifier"></a>identifier | `string` | An [SPDX](https://spdx.org/spdx-specification-21-web-version#h.jxpfx0ykyb60) license expression for the API. The `identifier` field is mutually exclusive of the `url` field.
-<a name="licenseUrl"></a>url | `string` | A URL to the license used for the API. MUST be in the format of a URL. The `url` field is mutually exclusive of the `identifier` field.
+<a name="licenseUrl"></a>url | `string` | A URL to the license used for the API. This MUST be in the form of a URL. The `url` field is mutually exclusive of the `identifier` field.
 
 This object MAY be extended with [Specification Extensions](#specificationExtensions).
 
@@ -977,7 +977,7 @@ Allows referencing an external resource for extended documentation.
 Field Name | Type | Description
 ---|:---:|---
 <a name="externalDocDescription"></a>description | `string` | A description of the target documentation. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="externalDocUrl"></a>url | `string` | **REQUIRED**. The URL for the target documentation. Value MUST be in the format of a URL.
+<a name="externalDocUrl"></a>url | `string` | **REQUIRED**. The URL for the target documentation. This MUST be in the form of a URL.
 
 This object MAY be extended with [Specification Extensions](#specificationExtensions).
 
@@ -2835,7 +2835,7 @@ See examples for expected behavior.
 Field Name | Type | Description
 ---|:---:|---
 <a name="xmlName"></a>name | `string` | Replaces the name of the element/attribute used for the described schema property. When defined within `items`, it will affect the name of the individual XML elements within the list. When defined alongside `type` being `array` (outside the `items`), it will affect the wrapping element and only if `wrapped` is `true`. If `wrapped` is `false`, it will be ignored.
-<a name="xmlNamespace"></a>namespace | `string` | The URI of the namespace definition. Value MUST be in the form of an absolute URI.
+<a name="xmlNamespace"></a>namespace | `string` | The URI of the namespace definition. This MUST be in the form of an absolute URI.
 <a name="xmlPrefix"></a>prefix | `string` | The prefix to be used for the [name](#xmlName).
 <a name="xmlAttribute"></a>attribute | `boolean` | Declares whether the property definition translates to an attribute instead of an element. Default value is `false`.
 <a name="xmlWrapped"></a>wrapped | `boolean` | MAY be used only for an array definition. Signifies whether the array is wrapped (for example, `<books><book/><book/></books>`) or unwrapped (`<book/><book/>`). Default value is `false`. The definition takes effect only when defined alongside `type` being `array` (outside the `items`).

--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -1945,7 +1945,7 @@ Field Name | Type | Description
 <a name="exampleSummary"></a>summary | `string` | Short description for the example.
 <a name="exampleDescription"></a>description | `string` | Long description for the example. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
 <a name="exampleValue"></a>value | Any | Embedded literal example. The `value` field and `externalValue` field are mutually exclusive. To represent examples of media types that cannot naturally represented in JSON or YAML, use a string value to contain the example, escaping where necessary.
-<a name="exampleExternalValue"></a>externalValue | `string` | A URL that points to the literal example. This provides the capability to reference examples that cannot easily be included in JSON or YAML documents.  The `value` field and `externalValue` field are mutually exclusive. 
+<a name="exampleExternalValue"></a>externalValue | `string` | A URI that points to the literal example. This provides the capability to reference examples that cannot easily be included in JSON or YAML documents.  The `value` field and `externalValue` field are mutually exclusive.
 
 This object MAY be extended with [Specification Extensions](#specificationExtensions).
 

--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -26,7 +26,8 @@ An OpenAPI definition can then be used by documentation generation tools to disp
 	- [Document Structure](#documentStructure)
 	- [Data Types](#dataTypes)
 	- [Rich Text Formatting](#richText)
-	- [Relative References In URIs](#relativeReferences)
+	- [Relative References In URIs](#relativeReferencesURI)
+	- [Relative References In URLs](#relativeReferencesURL)
 	- [Schema](#schema)
 		- [OpenAPI Object](#oasObject)
 		- [Info Object](#infoObject)
@@ -162,16 +163,20 @@ The formats defined by the OAS are:
 Throughout the specification `description` fields are noted as supporting CommonMark markdown formatting.
 Where OpenAPI tooling renders rich text it MUST support, at a minimum, markdown syntax as described by [CommonMark 0.27](https://spec.commonmark.org/0.27/). Tooling MAY choose to ignore some CommonMark features to address security concerns. 
 
-### <a name="relativeReferences"></a>Relative References in URIs
+### <a name="relativeReferencesURI"></a>Relative References in URIs
 
 Unless specified otherwise, all properties that are URIs MAY be relative references as defined by [RFC3986](https://tools.ietf.org/html/rfc3986#section-4.2).
-Unless specified otherwise, relative references are resolved using the URLs defined in the [`Server Object`](#serverObject) as a Base URI.
 
-Relative references in [`Reference Objects`](#referenceObject), [`PathItem Object`](#pathItemObject) `$ref` fields, [`Link Object`](#linkObject) `operationRef` fields and [`Example Object`](#exampleObject) `externalValue` fields are resolved using the referring document as the Base URI according to [RFC3986](https://tools.ietf.org/html/rfc3986#section-5.2).
+Relative references, including those in [`Reference Objects`](#referenceObject), [`PathItem Object`](#pathItemObject) `$ref` fields, [`Link Object`](#linkObject) `operationRef` fields and [`Example Object`](#exampleObject) `externalValue` fields, are resolved using the referring document as the Base URI according to [RFC3986](https://tools.ietf.org/html/rfc3986#section-5.2).
 
 If a URI contains a fragment identifier, then the fragment should be resolved per the fragment resolution mechanism of the referenced document.  If the representation of the referenced document is JSON or YAML, then the fragment identifier SHOULD be interpreted as a JSON-Pointer as per [RFC6901](https://tools.ietf.org/html/rfc6901).
 
 Relative references in [`Schema Objects`](#schemaObject), including any that appear as `$id` values, use the nearest parent `$id` as a Base URI, as described by [JSON Schema Specification Draft 2020-12](https://tools.ietf.org/html/draft-bhutton-json-schema-00#section-8.2).  If no parent schema contains an `$id`, then the Base URI MUST be determined according to [RFC3986](https://tools.ietf.org/html/rfc3986#section-5.1).
+
+### <a name="relativeReferencesURL"></a>Relative References in URLs
+
+Unless specified otherwise, all properties that are URLs MAY be relative references as defined by [RFC3986](https://tools.ietf.org/html/rfc3986#section-4.2).
+Unless specified otherwise, relative references are resolved using the URLs defined in the [`Server Object`](#serverObject) as a Base URL. Note that these themselves MAY be relative to the referring document.
 
 ### Schema
 
@@ -735,7 +740,7 @@ The path itself is still exposed to the documentation viewer but they will not k
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="pathItemRef"></a>$ref | `string` | Allows for a referenced definition of this path item. The referenced structure MUST be in the form of a [Path Item Object](#pathItemObject).  In case a Path Item Object field appears both in the defined object and the referenced object, the behavior is undefined. See the rules for resolving [Relative References](#relativeReferences).
+<a name="pathItemRef"></a>$ref | `string` | Allows for a referenced definition of this path item. The referenced structure MUST be in the form of a [Path Item Object](#pathItemObject).  In case a Path Item Object field appears both in the defined object and the referenced object, the behavior is undefined. See the rules for resolving [Relative References](#relativeReferencesURI).
 <a name="pathItemSummary"></a>summary| `string` | An optional, string summary, intended to apply to all operations in this path.
 <a name="pathItemDescription"></a>description | `string` | An optional, string description, intended to apply to all operations in this path. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
 <a name="pathItemGet"></a>get | [Operation Object](#operationObject) | A definition of a GET operation on this path.
@@ -1947,7 +1952,7 @@ Field Name | Type | Description
 <a name="exampleSummary"></a>summary | `string` | Short description for the example.
 <a name="exampleDescription"></a>description | `string` | Long description for the example. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
 <a name="exampleValue"></a>value | Any | Embedded literal example. The `value` field and `externalValue` field are mutually exclusive. To represent examples of media types that cannot naturally represented in JSON or YAML, use a string value to contain the example, escaping where necessary.
-<a name="exampleExternalValue"></a>externalValue | `string` | A URI that points to the literal example. This provides the capability to reference examples that cannot easily be included in JSON or YAML documents.  The `value` field and `externalValue` field are mutually exclusive. See the rules for resolving [Relative References](#relativeReferences).
+<a name="exampleExternalValue"></a>externalValue | `string` | A URI that points to the literal example. This provides the capability to reference examples that cannot easily be included in JSON or YAML documents.  The `value` field and `externalValue` field are mutually exclusive. See the rules for resolving [Relative References](#relativeReferencesURI).
 
 This object MAY be extended with [Specification Extensions](#specificationExtensions).
 
@@ -2027,7 +2032,7 @@ For computing links, and providing instructions to execute them, a [runtime expr
 
 Field Name  |  Type  | Description
 ---|:---:|---
-<a name="linkOperationRef"></a>operationRef | `string` | A relative or absolute URI reference to an OAS operation. This field is mutually exclusive of the `operationId` field, and MUST point to an [Operation Object](#operationObject). Relative `operationRef` values MAY be used to locate an existing [Operation Object](#operationObject) in the OpenAPI definition. See the rules for resolving [Relative References](#relativeReferences).
+<a name="linkOperationRef"></a>operationRef | `string` | A relative or absolute URI reference to an OAS operation. This field is mutually exclusive of the `operationId` field, and MUST point to an [Operation Object](#operationObject). Relative `operationRef` values MAY be used to locate an existing [Operation Object](#operationObject) in the OpenAPI definition. See the rules for resolving [Relative References](#relativeReferencesURI).
 <a name="linkOperationId"></a>operationId  | `string` | The name of an _existing_, resolvable OAS operation, as defined with a unique `operationId`.  This field is mutually exclusive of the `operationRef` field.  
 <a name="linkParameters"></a>parameters   | Map[`string`, Any \| [{expression}](#runtimeExpression)] | A map representing parameters to pass to an operation as specified with `operationId` or identified via `operationRef`. The key is the parameter name to be used, whereas the value can be a constant or an expression to be evaluated and passed to the linked operation.  The parameter name can be qualified using the [parameter location](#parameterIn) `[{in}.]{name}` for operations that use the same parameter name in different locations (e.g. path.id).
 <a name="linkRequestBody"></a>requestBody | Any \| [{expression}](#runtimeExpression) | A literal value or [{expression}](#runtimeExpression) to use as a request body when calling the target operation.
@@ -2247,7 +2252,7 @@ A simple object to allow referencing other components in the OpenAPI document, i
 
 The `$ref` string value contains a URI [RFC3986](https://tools.ietf.org/html/rfc3986), which identifies the location of the value being referenced.
 
-See the rules for resolving [Relative References](#relativeReferences).
+See the rules for resolving [Relative References](#relativeReferencesURI).
 
 ##### Fixed Fields
 Field Name | Type | Description

--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -2298,7 +2298,7 @@ Where JSON Schema indicates that behavior is defined by the application (e.g. fo
 
 ##### Properties
 
-The OpenAPI Schema Object [dialect](https://json-schema.org/draft/2019-09/json-schema-core.html#rfc.section.4.3.3) is defined as requiring the [OAS base vocabulary](#baseVocabulary), in addition to the vocabularies as specified in the JSON Schema draft 2019-09 [general purpose meta-schema](http://json-schema.org/draft/2019-09/json-schema-core.html#rfc.section.8).
+The OpenAPI Schema Object [dialect](https://json-schema.org/draft/2019-09/json-schema-core.html#rfc.section.4.3.3) is defined as requiring the [OAS base vocabulary](#baseVocabulary), in addition to the vocabularies as specified in the JSON Schema draft 2019-09 [general purpose meta-schema](https://json-schema.org/draft/2019-09/json-schema-core.html#rfc.section.8).
 
 The OpenAPI Schema Object dialect for this version of the specification is identified by the URI `https://spec.openapis.org/oas/3.1/dialect/base` (the <a name="dialectSchemaId"></a>"OAS dialect schema id").
 

--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -167,7 +167,7 @@ Where OpenAPI tooling renders rich text it MUST support, at a minimum, markdown 
 Unless specified otherwise, all properties that are URIs MAY be relative references as defined by [RFC3986](https://tools.ietf.org/html/rfc3986#section-4.2).
 Unless specified otherwise, relative references are resolved using the URLs defined in the [`Server Object`](#serverObject) as a Base URI.
 
-Relative references in [`Reference Objects`](#referenceObject) are resolved using the referring document as the Base URI.
+Relative references in [`Reference Objects`](#referenceObject), [`PathItem Object`](#pathItemObject) `$ref` fields and [`Example Object`](#exampleObject) `externalValue` fields are resolved using the referring document as the Base URI.
 
 Relative references in [`Schema Objects`](#schemaObject), including any that appear as `$id` values, use the nearest parent `$id` as a Base URI, as described by [JSON Schema Specification Draft 2020-12](https://tools.ietf.org/html/draft-bhutton-json-schema-00#section-8.2).  If no parent schema contains an `$id`, then the Base URI is that of the referring document.
 

--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -169,7 +169,7 @@ Unless specified otherwise, relative references are resolved using the URLs defi
 
 Relative references in [`Reference Objects`](#referenceObject), [`PathItem Object`](#pathItemObject) `$ref` fields and [`Example Object`](#exampleObject) `externalValue` fields are resolved using the referring document as the Base URI.
 
-Relative references in [`Schema Objects`](#schemaObject), including any that appear as `$id` values, use the nearest parent `$id` as a Base URI, as described by [JSON Schema Specification Draft 2020-12](https://tools.ietf.org/html/draft-bhutton-json-schema-00#section-8.2).  If no parent schema contains an `$id`, then the Base URI is that of the referring resource.
+Relative references in [`Schema Objects`](#schemaObject), including any that appear as `$id` values, use the nearest parent `$id` as a Base URI, as described by [JSON Schema Specification Draft 2020-12](https://tools.ietf.org/html/draft-bhutton-json-schema-00#section-8.2).  If no parent schema contains an `$id`, then the Base URI MUST be determined according to [RFC3986](https://tools.ietf.org/html/rfc3986#section-5.1).
 
 ### Schema
 

--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -2247,7 +2247,7 @@ The `$ref` string value contains a URI [RFC3986](https://tools.ietf.org/html/rfc
 
 If the URI contained in the `$ref` value is a [Relative Reference](https://tools.ietf.org/html/rfc3986#section-4.2), then the Base URI resolution MUST be calculated according to [RFC3986](https://tools.ietf.org/html/rfc3986#section-5.2). Resolution is performed relative to the referring document.
 
-If a URI contains a fragment identifier, then the fragment should be resolved per the fragment resolution mechanism of the referrant document.  If the representation of the referrant document is JSON or YAML, then the fragment identifier SHOULD be interpreted as a JSON-Pointer as per [RFC6901](https://tools.ietf.org/html/rfc6901).
+If a URI contains a fragment identifier, then the fragment should be resolved per the fragment resolution mechanism of the referenced document.  If the representation of the referenced document is JSON or YAML, then the fragment identifier SHOULD be interpreted as a JSON-Pointer as per [RFC6901](https://tools.ietf.org/html/rfc6901).
 
 ##### Fixed Fields
 Field Name | Type | Description

--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -141,11 +141,11 @@ It is RECOMMENDED that the root OpenAPI document be named: `openapi.json` or `op
 
 ### <a name="dataTypes"></a>Data Types
 
-Data types in the OAS are based on the types supported by the [JSON Schema Specification Draft 2019-09](https://json-schema.org/draft/2019-09/json-schema-core.html#rfc.section.4.2).
+Data types in the OAS are based on the types supported by the [JSON Schema Specification Draft 2020-12](https://tools.ietf.org/html/draft-bhutton-json-schema-00#section-4.2.1).
 Note that `integer` as a type is also supported and is defined as a JSON number without a fraction or exponent part. 
-Models are defined using the [Schema Object](#schemaObject), which is a superset of JSON Schema Specification Draft 2019-09.
+Models are defined using the [Schema Object](#schemaObject), which is a superset of JSON Schema Specification Draft 2020-12.
 
-<a name="dataTypeFormat"></a>As defined by the [JSON Schema Validation vocabulary](https://json-schema.org/draft/2019-09/json-schema-validation.html#rfc.section.7.3), data types can have an optional modifier property: `format`.
+<a name="dataTypeFormat"></a>As defined by the [JSON Schema Validation vocabulary](https://tools.ietf.org/html/draft-bhutton-json-schema-validation-00#section-7.3), data types can have an optional modifier property: `format`.
 OAS defines additional formats to provide fine detail for primitive data types.
 
 The formats defined by the OAS are:
@@ -169,7 +169,7 @@ Unless specified otherwise, relative references are resolved using the URLs defi
 
 Relative references in [`Reference Objects`](#referenceObject), [`PathItem Object`](#pathItemObject) `$ref` fields and [`Example Object`](#exampleObject) `externalValue` fields are resolved using the referring document as the Base URI.
 
-Relative references in [`Schema Objects`](#schemaObject), including any that appear as `$id` values, use the nearest parent `$id` as a Base URI, as described by [JSON Schema Specification Draft 2020-12](https://tools.ietf.org/html/draft-bhutton-json-schema-00#section-8.2).  If no parent schema contains an `$id`, then the Base URI is that of the referring document.
+Relative references in [`Schema Objects`](#schemaObject), including any that appear as `$id` values, use the nearest parent `$id` as a Base URI, as described by [JSON Schema Specification Draft 2020-12](https://tools.ietf.org/html/draft-bhutton-json-schema-00#section-8.2).  If no parent schema contains an `$id`, then the Base URI is that of the referring resource.
 
 ### Schema
 
@@ -2299,16 +2299,16 @@ $ref: definitions.yaml#/Pet
 #### <a name="schemaObject"></a>Schema Object
 
 The Schema Object allows the definition of input and output data types.
-These types can be objects, but also primitives and arrays. This object is a superset of the [JSON Schema Specification Draft 2019-09](https://json-schema.org/specification-links.html#2019-09-formerly-known-as-draft-8).
+These types can be objects, but also primitives and arrays. This object is a superset of the [JSON Schema Specification Draft 2020-12](https://tools.ietf.org/html/draft-bhutton-json-schema-00).
 
-For more information about the properties, see [JSON Schema Core](https://json-schema.org/draft/2019-09/json-schema-core.html) and [JSON Schema Validation](https://json-schema.org/draft/2019-09/json-schema-validation.html).
+For more information about the properties, see [JSON Schema Core](https://tools.ietf.org/html/draft-bhutton-json-schema-00) and [JSON Schema Validation](https://tools.ietf.org/html/draft-bhutton-json-schema-validation-00).
 
 Unless stated otherwise, the property definitions follow those of JSON Schema and do not add any additional semantics.
 Where JSON Schema indicates that behavior is defined by the application (e.g. for annotations), OAS also defers the definition of semantics to the application consuming the OpenAPI document.
 
 ##### Properties
 
-The OpenAPI Schema Object [dialect](https://json-schema.org/draft/2019-09/json-schema-core.html#rfc.section.4.3.3) is defined as requiring the [OAS base vocabulary](#baseVocabulary), in addition to the vocabularies as specified in the JSON Schema draft 2019-09 [general purpose meta-schema](https://json-schema.org/draft/2019-09/json-schema-core.html#rfc.section.8).
+The OpenAPI Schema Object [dialect](https://tools.ietf.org/html/draft-bhutton-json-schema-00#section-4.3.3) is defined as requiring the [OAS base vocabulary](#baseVocabulary), in addition to the vocabularies as specified in the JSON Schema draft 2020-12 [general purpose meta-schema](https://tools.ietf.org/html/draft-bhutton-json-schema-00#section-8).
 
 The OpenAPI Schema Object dialect for this version of the specification is identified by the URI `https://spec.openapis.org/oas/3.1/dialect/base` (the <a name="dialectSchemaId"></a>"OAS dialect schema id").
 
@@ -2355,11 +2355,11 @@ The [XML Object](#xmlObject) contains additional information about the available
 
 It is important for tooling to be able to determine which dialect or meta-schema any given resource wishes to be processed with: JSON Schema Core, JSON Schema Validation, OpenAPI Schema dialect, or some custom meta-schema.
 
-The `$schema` keyword MAY be present in any root Schema Object, and if present MUST be used to determine which dialect should be used when processing the schema. This allows use of Schema Objects which comply with other drafts of JSON Schema than the default Draft 2019-09 support. Tooling MUST support the <a href="#dialectSchemaId">OAS dialect schema id</a>, and MAY support additional values of `$schema`.
+The `$schema` keyword MAY be present in any root Schema Object, and if present MUST be used to determine which dialect should be used when processing the schema. This allows use of Schema Objects which comply with other drafts of JSON Schema than the default Draft 2020-12 support. Tooling MUST support the <a href="#dialectSchemaId">OAS dialect schema id</a>, and MAY support additional values of `$schema`.
 
 To allow use of a different default `$schema` value for all Schema Objects contained within an OAS document, a `jsonSchemaDialect` value may be set within the <a href="#oasObject">OpenAPI Object</a>. If this default is not set, then the OAS dialact schema id MUST be used for these Schema Objects. The value of `$schema` within a Schema Object always overrides any default.
 
-When a Schema Object is referenced from an external resource which is not an OAS document (e.g. a bare JSON Schema resource), then the value of the `$schema` keyword for schemas within that resource MUST follow [JSON Schema rules](https://json-schema.org/draft/2019-09/json-schema-core.html#rfc.section.8.1.1).
+When a Schema Object is referenced from an external resource which is not an OAS document (e.g. a bare JSON Schema resource), then the value of the `$schema` keyword for schemas within that resource MUST follow [JSON Schema rules](https://tools.ietf.org/html/draft-bhutton-json-schema-00#section-8.1.1).
 
 ##### Schema Object Examples
 

--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -135,7 +135,7 @@ In order to preserve the ability to round-trip between YAML and JSON formats, YA
 
 ### <a name="documentStructure"></a>Document Structure
 
-An OpenAPI document MAY be made up of a single document or be divided into multiple, connected parts at the discretion of the user. In the latter case, `$ref` fields MUST be used in the OAS document to reference those parts as follows from the [JSON Schema](https://json-schema.org/draft/2019-09/json-schema-core.html#references) definitions.
+An OpenAPI document MAY be made up of a single document or be divided into multiple, connected parts at the discretion of the user. In the latter case, [`Reference Objects`](#referenceObject) and [`Schema Object`](#schemaObject) `$ref` keywords are used.
 
 It is RECOMMENDED that the root OpenAPI document be named: `openapi.json` or `openapi.yaml`.
 
@@ -165,9 +165,11 @@ Where OpenAPI tooling renders rich text it MUST support, at a minimum, markdown 
 ### <a name="relativeReferences"></a>Relative References in URIs
 
 Unless specified otherwise, all properties that are URIs MAY be relative references as defined by [RFC3986](https://tools.ietf.org/html/rfc3986#section-4.2).
-Relative references are resolved using the URLs defined in the [`Server Object`](#serverObject) as a Base URI.  This includes relative references in [`Reference Objects`](#referenceObject), outside of any [`Schema Object`](#schemaObject).
+Unless specified otherwise, relative references are resolved using the URLs defined in the [`Server Object`](#serverObject) as a Base URI.
 
-Relative references in [`Schema Objects`](#schemaObject), including any that appear as `$id` values, use the nearest parent `$id` as a Base URI, as described by [JSON Schema Specification Draft 2019-09](https://json-schema.org/draft/2019-09/json-schema-core.html).  If no parent schema contains an `$id`, then the Base URI is determined as in the previous paragraph.
+Relative references in [`Reference Objects`](#referenceObject) are resolved using the referring document as the Base URI.
+
+Relative references in [`Schema Objects`](#schemaObject), including any that appear as `$id` values, use the nearest parent `$id` as a Base URI, as described by [JSON Schema Specification Draft 2020-12](https://tools.ietf.org/html/draft-bhutton-json-schema-00#section-8.2).  If no parent schema contains an `$id`, then the Base URI is that of the referring document.
 
 ### Schema
 
@@ -2241,10 +2243,18 @@ description: Pets operations
 
 A simple object to allow referencing other components in the OpenAPI document, internally and externally.
 
+The `$ref` string value contains a URI [RFC3986](https://tools.ietf.org/html/rfc3986), which identifies the location of the value being referenced.
+
+Resolution of a Reference Object SHOULD yield the referenced value. Implementations MAY choose to replace the reference with the referenced value.
+
+If the URI contained in the `$ref` value is a relative URI, then the Base URI resolution MUST be calculated according to [RFC3986](https://tools.ietf.org/html/rfc3986#section-5.2). Resolution is performed relative to the referring document.
+
+If a URI contains a fragment identifier, then the fragment should be resolved per the fragment resolution mechanism of the referrant document.  If the representation of the referrant document is JSON or YAML, then the fragment identifier SHOULD be interpreted as a JSON-Pointer as per [RFC6901](https://tools.ietf.org/html/rfc6901).
+
 ##### Fixed Fields
 Field Name | Type | Description
 ---|:---:|---
-<a name="referenceRef"></a>$ref | `string` | **REQUIRED**. The reference string.
+<a name="referenceRef"></a>$ref | `string` | **REQUIRED**. The reference identifier. This MUST be in the form of a URI.
 <a name="referenceSummary"></a>summary | `string` | A short summary which by default SHOULD override that of the referenced component. If the referenced object-type does not allow a `summary` field, then this field has no effect.
 <a name="referenceDescription"></a>description | `string` | A description which by default SHOULD override that of the referenced component. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation. If the referenced object-type does not allow a `description` field, then this field has no effect.
 

--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -167,7 +167,9 @@ Where OpenAPI tooling renders rich text it MUST support, at a minimum, markdown 
 Unless specified otherwise, all properties that are URIs MAY be relative references as defined by [RFC3986](https://tools.ietf.org/html/rfc3986#section-4.2).
 Unless specified otherwise, relative references are resolved using the URLs defined in the [`Server Object`](#serverObject) as a Base URI.
 
-Relative references in [`Reference Objects`](#referenceObject), [`PathItem Object`](#pathItemObject) `$ref` fields and [`Example Object`](#exampleObject) `externalValue` fields are resolved using the referring document as the Base URI.
+Relative references in [`Reference Objects`](#referenceObject), [`PathItem Object`](#pathItemObject) `$ref` fields, [`Link Object`](#linkObject) `operationRef` fields and [`Example Object`](#exampleObject) `externalValue` fields are resolved using the referring document as the Base URI according to [RFC3986](https://tools.ietf.org/html/rfc3986#section-5.2).
+
+If a URI contains a fragment identifier, then the fragment should be resolved per the fragment resolution mechanism of the referenced document.  If the representation of the referenced document is JSON or YAML, then the fragment identifier SHOULD be interpreted as a JSON-Pointer as per [RFC6901](https://tools.ietf.org/html/rfc6901).
 
 Relative references in [`Schema Objects`](#schemaObject), including any that appear as `$id` values, use the nearest parent `$id` as a Base URI, as described by [JSON Schema Specification Draft 2020-12](https://tools.ietf.org/html/draft-bhutton-json-schema-00#section-8.2).  If no parent schema contains an `$id`, then the Base URI MUST be determined according to [RFC3986](https://tools.ietf.org/html/rfc3986#section-5.1).
 
@@ -733,7 +735,7 @@ The path itself is still exposed to the documentation viewer but they will not k
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="pathItemRef"></a>$ref | `string` | Allows for a referenced definition of this path item. The referenced structure MUST be in the form of a [Path Item Object](#pathItemObject).  In case a Path Item Object field appears both in the defined object and the referenced object, the behavior is undefined.
+<a name="pathItemRef"></a>$ref | `string` | Allows for a referenced definition of this path item. The referenced structure MUST be in the form of a [Path Item Object](#pathItemObject).  In case a Path Item Object field appears both in the defined object and the referenced object, the behavior is undefined. See the rules for resolving [Relative References](#relativeReferences).
 <a name="pathItemSummary"></a>summary| `string` | An optional, string summary, intended to apply to all operations in this path.
 <a name="pathItemDescription"></a>description | `string` | An optional, string description, intended to apply to all operations in this path. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
 <a name="pathItemGet"></a>get | [Operation Object](#operationObject) | A definition of a GET operation on this path.
@@ -1945,7 +1947,7 @@ Field Name | Type | Description
 <a name="exampleSummary"></a>summary | `string` | Short description for the example.
 <a name="exampleDescription"></a>description | `string` | Long description for the example. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
 <a name="exampleValue"></a>value | Any | Embedded literal example. The `value` field and `externalValue` field are mutually exclusive. To represent examples of media types that cannot naturally represented in JSON or YAML, use a string value to contain the example, escaping where necessary.
-<a name="exampleExternalValue"></a>externalValue | `string` | A URI that points to the literal example. This provides the capability to reference examples that cannot easily be included in JSON or YAML documents.  The `value` field and `externalValue` field are mutually exclusive.
+<a name="exampleExternalValue"></a>externalValue | `string` | A URI that points to the literal example. This provides the capability to reference examples that cannot easily be included in JSON or YAML documents.  The `value` field and `externalValue` field are mutually exclusive. See the rules for resolving [Relative References](#relativeReferences).
 
 This object MAY be extended with [Specification Extensions](#specificationExtensions).
 
@@ -2025,7 +2027,7 @@ For computing links, and providing instructions to execute them, a [runtime expr
 
 Field Name  |  Type  | Description
 ---|:---:|---
-<a name="linkOperationRef"></a>operationRef | `string` | A relative or absolute URI reference to an OAS operation. This field is mutually exclusive of the `operationId` field, and MUST point to an [Operation Object](#operationObject). Relative `operationRef` values MAY be used to locate an existing [Operation Object](#operationObject) in the OpenAPI definition.
+<a name="linkOperationRef"></a>operationRef | `string` | A relative or absolute URI reference to an OAS operation. This field is mutually exclusive of the `operationId` field, and MUST point to an [Operation Object](#operationObject). Relative `operationRef` values MAY be used to locate an existing [Operation Object](#operationObject) in the OpenAPI definition. See the rules for resolving [Relative References](#relativeReferences).
 <a name="linkOperationId"></a>operationId  | `string` | The name of an _existing_, resolvable OAS operation, as defined with a unique `operationId`.  This field is mutually exclusive of the `operationRef` field.  
 <a name="linkParameters"></a>parameters   | Map[`string`, Any \| [{expression}](#runtimeExpression)] | A map representing parameters to pass to an operation as specified with `operationId` or identified via `operationRef`. The key is the parameter name to be used, whereas the value can be a constant or an expression to be evaluated and passed to the linked operation.  The parameter name can be qualified using the [parameter location](#parameterIn) `[{in}.]{name}` for operations that use the same parameter name in different locations (e.g. path.id).
 <a name="linkRequestBody"></a>requestBody | Any \| [{expression}](#runtimeExpression) | A literal value or [{expression}](#runtimeExpression) to use as a request body when calling the target operation.
@@ -2245,9 +2247,7 @@ A simple object to allow referencing other components in the OpenAPI document, i
 
 The `$ref` string value contains a URI [RFC3986](https://tools.ietf.org/html/rfc3986), which identifies the location of the value being referenced.
 
-If the URI contained in the `$ref` value is a [Relative Reference](https://tools.ietf.org/html/rfc3986#section-4.2), then the Base URI resolution MUST be calculated according to [RFC3986](https://tools.ietf.org/html/rfc3986#section-5.2). Resolution is performed relative to the referring document.
-
-If a URI contains a fragment identifier, then the fragment should be resolved per the fragment resolution mechanism of the referenced document.  If the representation of the referenced document is JSON or YAML, then the fragment identifier SHOULD be interpreted as a JSON-Pointer as per [RFC6901](https://tools.ietf.org/html/rfc6901).
+See the rules for resolving [Relative References](#relativeReferences).
 
 ##### Fixed Fields
 Field Name | Type | Description

--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -733,7 +733,7 @@ The path itself is still exposed to the documentation viewer but they will not k
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="pathItemRef"></a>$ref | `string` | Allows for an external definition of this path item. The referenced structure MUST be in the format of a [Path Item Object](#pathItemObject).  In case a Path Item Object field appears both in the defined object and the referenced object, the behavior is undefined.
+<a name="pathItemRef"></a>$ref | `string` | Allows for a referenced definition of this path item. The referenced structure MUST be in the form of a [Path Item Object](#pathItemObject).  In case a Path Item Object field appears both in the defined object and the referenced object, the behavior is undefined.
 <a name="pathItemSummary"></a>summary| `string` | An optional, string summary, intended to apply to all operations in this path.
 <a name="pathItemDescription"></a>description | `string` | An optional, string description, intended to apply to all operations in this path. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
 <a name="pathItemGet"></a>get | [Operation Object](#operationObject) | A definition of a GET operation on this path.


### PR DESCRIPTION
Firstly, apologies that this PR does more than one thing, I didn't have time to create multiple branches and keep switching between them when authoring the commits (which sometimes overlap). It may be helpful to review the individual commits first and then the changes as a whole.

This PR:

* Updates the JSON Schema Draft links to Draft 2020-12 using the canonical IETF links
* Makes explicit the relative `$ref` resolution rules (using wording taken from the expired [JSON Reference spec](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03)
* Makes Reference Objects, pathItem `$ref`s and Example Object `externalValue` fields always relative to the referring document, not the servers array. This makes a distinction between OAS document *authoring* and API *operation* (for example oAuth endpoints).
* Allows Example Object `externalValue` to be a URI and not just a URL - for consistency with other `$ref`-like fields
* Makes it clear pathItem `$ref`s don't now need to be external
* Makes consistent wording around "This MUST be in the **form** of a ..."
* Makes RFC link display text consistent with regard to spacing
* Fixes one stray `http:` link to `spec.commonmark.org` to be `https:` for consistency