### PR TITLE
Require the presence of value or externalValue in Example Objects

### DIFF
--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -1956,6 +1956,7 @@ Field Name | Type | Description
 
 This object MAY be extended with [Specification Extensions](#specificationExtensions).
 
+An Example Object MUST contain either a `value` property or an `externalValue` property.
 In all cases, the example value is expected to be compatible with the type schema 
 of its associated value.  Tooling implementations MAY choose to 
 validate compatibility automatically, and reject the example value(s) if incompatible.


### PR DESCRIPTION
This PR adds wording to require Example Objects to actually contain `value` or `externalValue`.

**Rationale**

The [Example Object](https://github.com/OAI/OpenAPI-Specification/blob/v3.1.0-dev/versions/3.1.0.md#exampleObject) currently doesn't require the presence of `value` or `externalValue` - it only says that these fields are mutually exclusive. This means, for instance, that summary-only examples are syntactically valid, which isn't really useful.

```yaml
examples:
  '0':
    summary: No value
  '1':
    summary: Also no value
```

This seems to be an oversight. If we look at the definitions of [Parameter Object](https://github.com/OAI/OpenAPI-Specification/blob/v3.1.0-dev/versions/3.1.0.md#parameterObject) and [Link Object](https://github.com/OAI/OpenAPI-Specification/blob/v3.1.0-dev/versions/3.1.0.md#linkObject), which also have mutually exclusive properties, they include wording to require one of those properties:

> A parameter MUST contain either a `schema` property, or a `content` property, but not both.

> A linked operation MUST be identified using either an `operationRef` or `operationId`.

This PR adds a similar requirement to the Example Object.