### PR TITLE
3.1.0 release prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,28 +15,24 @@ The OpenAPI Specification does not require rewriting existing APIs. It does not 
 
 This GitHub project is the starting point for OpenAPI. Here you will find the information you need about the OpenAPI Specification, simple examples of what it looks like, and some general information regarding the project.
 
-## Current Version - 3.0.3
+## Current Version - 3.1.0
 
-The current version of the OpenAPI specification is [OpenAPI Specification 3.0.3](versions/3.0.3.md).
-
-## Current Release Candidate Version - 3.1.0-RC1
-
-We invite the community to review and provide feedback for the current release candidate ([OpenAPI Specification 3.1.0-RC1](versions/3.1.0.md). Changes related to the upcoming 3.1.0 release should be submitted at [the development branch](https://github.com/OAI/OpenAPI-Specification/tree/v3.1.0-dev).
+The current version of the OpenAPI specification is [OpenAPI Specification 3.1.0](versions/3.1.0.md).
 
 ### Previous Versions
 
-This repository also contains the [OpenAPI Specification 2.0](versions/2.0.md), which is identical to the Swagger 2.0 specification before it was renamed to "OpenAPI Specification", as well as the Swagger 1.2 and Swagger 2.0 specifications.
+This repository also contains all [previous versions](versions).
 
 Each folder in this repository, such as [examples](examples) and [schemas](schemas), should contain folders pertaining to the current and previous versions of the specification.
 
 ## See It in Action
 
-If you just want to see it work, check out the [list of current examples](examples/v3.0).
+If you just want to see it work, check out the [list of current examples](examples).
 
 ## Tools and Libraries
 
 Looking to see how you can create your own OpenAPI definition, present it, or otherwise use it? Check out the growing
-[list of 3.0 implementations](IMPLEMENTATIONS.md).
+[list of implementations](IMPLEMENTATIONS.md).
 
 ## Participation
 
@@ -48,7 +44,7 @@ The TSC holds weekly web conferences to review open pull requests and discuss op
 
 The OpenAPI Initiative encourages participation from individuals and companies alike. If you want to participate in the evolution of the OpenAPI Specification, consider taking the following actions:
 
-* Review the [current specification](versions/3.0.3.md). The human-readable markdown file _is the source of truth_ for the specification.
+* Review the [current specification](versions/3.1.0.md). The human-readable markdown file _is the source of truth_ for the specification.
 * Review the [development](DEVELOPMENT.md) process so you understand how the spec is evolving.
 * Check the [issues](https://github.com/OAI/OpenAPI-Specification/issues) and [pull requests](https://github.com/OAI/OpenAPI-Specification/pulls) to see if someone has already documented your idea or feedback on the specification. You can follow an existing conversation by subscribing to the existing issue or PR.
 * Create an issue to describe a new concern. If possible, propose a solution.

--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -1,6 +1,6 @@
 # OpenAPI Specification
 
-#### Version 3.1.0-rc1
+#### Version 3.1.0
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [BCP 14](https://tools.ietf.org/html/bcp14) [RFC2119](https://tools.ietf.org/html/rfc2119) [RFC8174](https://tools.ietf.org/html/rfc8174) when, and only when, they appear in all capitals, as shown here.
 
@@ -3451,6 +3451,7 @@ Two examples of this:
 
 Version   | Date       | Notes
 ---       | ---        | ---
+3.1.0     | 2021-02-15 | Release of the OpenAPI Specification 3.1.0 
 3.1.0-rc1 | 2020-10-08 | rc1 of the 3.1 specification
 3.1.0-rc0 | 2020-06-18 | rc0 of the 3.1 specification
 3.0.3     | 2020-02-20 | Patch release of the OpenAPI Specification 3.0.3


### PR DESCRIPTION
- Updated change history and version number in main spec file.
- Updated README to reflect the new version.