### PR TITLE
reframing `user` as `author`

### DIFF
--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -136,7 +136,7 @@ In order to preserve the ability to round-trip between YAML and JSON formats, YA
 
 ### <a name="documentStructure"></a>Document Structure
 
-An OpenAPI document MAY be made up of a single document or be divided into multiple, connected parts at the discretion of the user. In the latter case, [`Reference Objects`](#referenceObject) and [`Schema Object`](#schemaObject) `$ref` keywords are used.
+An OpenAPI document MAY be made up of a single document or be divided into multiple, connected parts at the discretion of the author. In the latter case, [`Reference Objects`](#referenceObject) and [`Schema Object`](#schemaObject) `$ref` keywords are used.
 
 It is RECOMMENDED that the root OpenAPI document be named: `openapi.json` or `openapi.yaml`.
 


### PR DESCRIPTION
Per comment in review, authors determine whether a spec is a single or multipart document. Those who consume the spec care more about the information itself and less (or not at all directly) about how it was assembled.