### PR TITLE
workflows: yaml2json - update used actions

### DIFF
--- a/.github/workflows/convert-examples-to-json.yaml
+++ b/.github/workflows/convert-examples-to-json.yaml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1 # checkout repo content
+    - uses: actions/checkout@v2 # checkout repo content
 
     - name: Install dependencies
       run: npm i
@@ -36,10 +36,9 @@ jobs:
         git --no-pager -c color.diff=always diff --staged
 
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v1
+      uses: peter-evans/create-pull-request@v3
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        branch-suffix: none
         branch: update-json-examples
         title: Update JSON example files
         commit-message: Update JSON example files


### PR DESCRIPTION
The version of `peter-evans/create-pull-request` we were using is no-longer supported. Updated to `v3`. This meant updating to `checkout@v2` and removing a deprecated option.