### PR TITLE
Add meta-schema for 3.1 base vocab and dialect

### DIFF
--- a/schemas/v3.1/dialect/base.schema.json
+++ b/schemas/v3.1/dialect/base.schema.json
@@ -1,0 +1,27 @@
+{
+    "$id": "https://spec.openapis.org/oas/3.1/dialect/base",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$vocabulary": {
+        "https://json-schema.org/draft/2020-12/vocab/core": true,
+        "https://json-schema.org/draft/2020-12/vocab/applicator": true,
+        "https://json-schema.org/draft/2020-12/vocab/unevaluated": true,
+        "https://json-schema.org/draft/2020-12/vocab/validation": true,
+        "https://json-schema.org/draft/2020-12/vocab/meta-data": true,
+        "https://json-schema.org/draft/2020-12/vocab/format-annotation": true,
+        "https://json-schema.org/draft/2020-12/vocab/content": true,
+        "https://spec.openapis.org/oas/3.1/vocab/base": false
+    },
+    "$dynamicAnchor": "meta",
+
+    "title": "OpenAPI 3.1 Schema Object Dialect",
+    "allOf": [
+        { "$ref": "https://json-schema.org/draft/2020-12/meta/core" },
+        { "$ref": "https://json-schema.org/draft/2020-12/meta/applicator" },
+        { "$ref": "https://json-schema.org/draft/2020-12/meta/unevaluated" },
+        { "$ref": "https://json-schema.org/draft/2020-12/meta/validation" },
+        { "$ref": "https://json-schema.org/draft/2020-12/meta/meta-data" },
+        { "$ref": "https://json-schema.org/draft/2020-12/meta/format-annotation" },
+        { "$ref": "https://json-schema.org/draft/2020-12/meta/content" },
+        { "$ref": "https://spec.openapis.org/oas/3.1/meta/base" }
+    ]
+}

--- a/schemas/v3.1/meta/base.schema.json
+++ b/schemas/v3.1/meta/base.schema.json
@@ -1,0 +1,79 @@
+{
+    "$id": "https://spec.openapis.org/oas/3.1/meta/base",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$vocabulary": {
+        "https://spec.openapis.org/oas/3.1/vocab/base": true
+    },
+    "$dynamicAnchor": "meta",
+    "title": "OAS Base vocabulary",
+
+    "type": ["object", "boolean"],
+    "properties": {
+        "example": true,
+        "discriminator": { "$ref": "#/$defs/Discriminator" },
+        "externalDocs": { "$ref": "#/$defs/ExternalDocs" },
+        "xml": { "$ref": "#/$defs/Xml" }
+    },
+    "$defs": {
+        "Discriminator": {
+            "type": "object",
+            "properties": {
+                "propertyName": {
+                    "type": "string"
+                },
+                "mapping": {
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                }
+            },
+            "patternProperties": {
+                "^x-": true
+            },
+            "required": ["propertyName"],
+            "additionalProperties": false
+        },
+        "ExternalDocs": {
+            "type": "object",
+            "properties": {
+                "url": {
+                    "type": "string",
+                    "format": "uri-reference"
+                },
+                "description": {
+                    "type": "string"
+                }
+            },
+            "patternProperties": {
+                "^x-": true
+            },
+            "required": ["url"],
+            "additionalProperties": false
+        },
+        "Xml": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "namespace": {
+                    "type": "string",
+                    "format": "uri"
+                },
+                "prefix": {
+                    "type": "string"
+                },
+                "attribute": {
+                    "type": "boolean"
+                },
+                "wrapped": {
+                    "type": "boolean"
+                }
+            },
+            "patternProperties": {
+                "^x-": true
+            },
+            "additionalProperties": false
+        }
+    }
+}

--- a/schemas/v3.1/meta/base.schema.json
+++ b/schemas/v3.1/meta/base.schema.json
@@ -15,7 +15,13 @@
         "xml": { "$ref": "#/$defs/Xml" }
     },
     "$defs": {
+        "Extensible": {
+            "patternProperties": {
+                "^x-": true
+            }
+        },
         "Discriminator": {
+            "$ref": "#/$defs/Extensible",
             "type": "object",
             "properties": {
                 "propertyName": {
@@ -27,13 +33,11 @@
                     }
                 }
             },
-            "patternProperties": {
-                "^x-": true
-            },
             "required": ["propertyName"],
-            "additionalProperties": false
+            "unevaluatedProperties": false
         },
         "ExternalDocs": {
+            "$ref": "#/$defs/Extensible",
             "type": "object",
             "properties": {
                 "url": {
@@ -44,13 +48,11 @@
                     "type": "string"
                 }
             },
-            "patternProperties": {
-                "^x-": true
-            },
             "required": ["url"],
-            "additionalProperties": false
+            "unevaluatedProperties": false
         },
         "Xml": {
+            "$ref": "#/$defs/Extensible",
             "type": "object",
             "properties": {
                 "name": {
@@ -70,10 +72,7 @@
                     "type": "boolean"
                 }
             },
-            "patternProperties": {
-                "^x-": true
-            },
-            "additionalProperties": false
+            "unevaluatedProperties": false
         }
     }
 }

--- a/schemas/v3.1/meta/base.schema.json
+++ b/schemas/v3.1/meta/base.schema.json
@@ -28,6 +28,7 @@
                     "type": "string"
                 },
                 "mapping": {
+                    "type": "object",
                     "additionalProperties": {
                         "type": "string"
                     }


### PR DESCRIPTION
Here's a candidate for the OAS 3.1 Base Schema vocabulary and dialect meta-schemas.

I wasn't quite sure what to names things. The directory and file names are intended to match the `$id`s. Both the dialect and the vocabulary are called "base", which is awkward, but it seemed the most accurate based on the language in the spec. Let me know if you prefer different names or flatter structure.

The "base" vocabulary is set to `false` in the dialect schema. This allows validators to validate instances against this meta-schema even if it doesn't know about the OpenAPI extensions. This is no concern for most of the extensions because they are just annotations and don't affect validation. The exception is `discriminator`. In that case, the `discriminator` keyword will be quietly skipped by a validator. If you prefer users get an error in this case, let me know and I'll switch that to `true`.

In JSON Schema, `format` is an annotation-only by default. I wasn't sure if OpenAPI 3.1 expects format to be annotation-only or for it to validate against the format. Currently, it's set to annotation-only. Let me know if you rather it validate.

I didn't explicitly add the additional `format` values that OpenAPI 3.1 adds because JSON Schema Draft 2020-10 already allows any value, so there was nothing to do.

If you want to run this through its paces, head over to https://json-schema.hyperjump.io. Add two additional schema tabs using the [+] button next to the "Schema" tab. Add one of the schemas in this PR to each tab. In the original tab, change the value of the `$schema` keyword to `https://spec.openapis.org/oas/3.1/dialect/base`. That schema will then meta-validate using these meta-schemas. For example, you can add a `discriminator` and see that you get an error if the `propertyName` field is missing. You can also modify the meta-schemas if you want to try to modify anything. You can leave the "Instance" tab(s) empty, validating an instance works, but it's not relevant to the meta-schemas.