### PR TITLE
Editorial: Use problem+json fields

### DIFF
--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -486,11 +486,11 @@ my.org.User
     "GeneralError": {
       "type": "object",
       "properties": {
-        "code": {
+        "status": {
           "type": "integer",
           "format": "int32"
         },
-        "message": {
+        "title": {
           "type": "string"
         }
       }
@@ -588,10 +588,10 @@ components:
     GeneralError:
       type: object
       properties:
-        code:
+        status:
           type: integer
           format: int32
-        message:
+        title:
           type: string
     Category:
       type: object
@@ -2507,15 +2507,15 @@ example:
       "ErrorModel": {
         "type": "object",
         "required": [
-          "message",
-          "code"
+          "title",
+          "status"
         ],
         "properties": {
-          "message": {
+          "title": {
             "type": "string"
           },
           "code": {
-            "type": "integer",
+            "status": "integer",
             "minimum": 100,
             "maximum": 600
           }


### PR DESCRIPTION
## This PR

- Use status and title fields from RFC7807 instead of non-standard fields message and code.
- This change is non-normative.