### PR TITLE
OASv3.1 Schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,10 @@
     "README.md",
     "schemas/*"
   ],
-  "dependencies": {},
+  "dependencies": {
+    "@hyperjump/json-schema": "^0.17.0",
+    "@hyperjump/json-schema-core": "^0.20.0"
+  },
   "devDependencies": {
     "mdv": "^1.0.7",
     "yaml": "^1.8.3"

--- a/schemas/v3.1/README.md
+++ b/schemas/v3.1/README.md
@@ -1,0 +1,16 @@
+OpenAPI 3.1.X JSON Schema
+---
+
+Here you can find the JSON Schema for validating OpenAPI definitions of versions 3.1.X.
+
+As a reminder, the JSON Schema is not the source of truth for the Specification. In cases of conflicts between the Specification itself and the JSON Schema, the Specification wins. Also, some Specification constraints cannot be represented with the JSON Schema so it's highly recommended to employ other methods to ensure compliance.
+
+The iteration version of the JSON Schema can be found in the `$id` field. For example, the value of `$id: https://spec.openapis.org/oas/3.1/schema/2021-02-18` means this iteration was created on February 18th, 2021.
+
+To submit improvements to the schema, modify the schema.yaml file only.
+
+The TSC will then:
+- Run tests on the updated schema
+- Update the iteration version
+- Convert the schema.yaml to schema.json
+- Publish the new version

--- a/schemas/v3.1/schema.json
+++ b/schemas/v3.1/schema.json
@@ -1,12 +1,12 @@
 {
   "$id": "https://spec.openapis.org/oas/3.1/schema/2021-02-18",
-  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
   "required": [
     "openapi",
     "info"
   ],
-  "oneOf": [
+  "anyOf": [
     {
       "required": [
         "components"
@@ -37,7 +37,7 @@
       "type": "string"
     },
     "info": {
-      "$ref": "#/$defs/Info"
+      "$ref": "#Info"
     },
     "externalDocs": {
       "$ref": "#ExternalDocumentation"
@@ -62,6 +62,9 @@
     },
     "paths": {
       "$ref": "#Paths"
+    },
+    "webhooks": {
+      "$comment": "TODO: Implement meta-schema for webhooks"
     },
     "components": {
       "$ref": "#Components"
@@ -212,17 +215,17 @@
         "WithExplodeReservedAndEmpty": {
           "allOf": [
             {
-              "$refs": "#/$defs/Mixins/$defs/WithExplodeAndReserved"
+              "$ref": "#/$defs/Mixins/$defs/WithExplodeAndReserved"
             },
             {
-              "$refs": "#/$defs/Mixins/$defs/WithEmpty"
+              "$ref": "#/$defs/Mixins/$defs/WithEmpty"
             }
           ]
         },
         "StyledSimple": {
           "allOf": [
             {
-              "$refs": "#/$defs/Mixins/$defs/WithExplodeReservedAndEmpty"
+              "$ref": "#/$defs/Mixins/$defs/WithExplodeReservedAndEmpty"
             }
           ],
           "properties": {
@@ -249,7 +252,7 @@
         "StyledFormOnly": {
           "allOf": [
             {
-              "$refs": "#/$defs/Mixins/$defs/WithExplodeReservedAndEmpty"
+              "$ref": "#/$defs/Mixins/$defs/WithExplodeReservedAndEmpty"
             }
           ],
           "properties": {
@@ -263,7 +266,7 @@
         "StyledFormComplexNoDefaultOrEmpty": {
           "allOf": [
             {
-              "$refs": "#/$defs/Mixins/$defs/WithExplodeAndReserved"
+              "$ref": "#/$defs/Mixins/$defs/WithExplodeAndReserved"
             }
           ],
           "properties": {
@@ -281,10 +284,10 @@
         "StyledFormComplex": {
           "allOf": [
             {
-              "$refs": "#/$defs/Mixins/$defs/StyledFormComplexNoDefaultOrEmpty"
+              "$ref": "#/$defs/Mixins/$defs/StyledFormComplexNoDefaultOrEmpty"
             },
             {
-              "$refs": "#/$defs/Mixins/$defs/WithExplodeReservedAndEmpty"
+              "$ref": "#/$defs/Mixins/$defs/WithExplodeReservedAndEmpty"
             }
           ],
           "properties": {
@@ -298,7 +301,7 @@
     "Objects": {
       "$defs": {
         "Reference": {
-          "$id": "Reference",
+          "$anchor": "Reference",
           "type": "object",
           "required": [
             "$ref"
@@ -311,6 +314,7 @@
           }
         },
         "Info": {
+          "$anchor": "Info",
           "type": "object",
           "required": [
             "title",
@@ -344,7 +348,7 @@
           },
           "$defs": {
             "Contact": {
-              "$id": "Contact",
+              "$anchor": "Contact",
               "type": "object",
               "allOf": [
                 {
@@ -367,7 +371,7 @@
               "unevaluatedProperties": false
             },
             "License": {
-              "$id": "License",
+              "$anchor": "License",
               "type": "object",
               "required": [
                 "name"
@@ -394,7 +398,7 @@
           }
         },
         "Server": {
-          "$id": "Server",
+          "$anchor": "Server",
           "type": "object",
           "required": [
             "url"
@@ -431,7 +435,8 @@
                     "type": "array",
                     "items": {
                       "type": "string"
-                    }
+                    },
+                    "minItems": 1
                   },
                   "default": {
                     "type": "string"
@@ -444,7 +449,7 @@
           "unevaluatedProperties": false
         },
         "Response": {
-          "$id": "Response",
+          "$anchor": "Response",
           "oneOf": [
             {
               "$ref": "#Reference"
@@ -487,7 +492,7 @@
           ]
         },
         "MediaType": {
-          "$id": "MediaType",
+          "$anchor": "MediaType",
           "type": "object",
           "allOf": [
             {
@@ -518,7 +523,7 @@
           "unevaluatedProperties": false
         },
         "Example": {
-          "$id": "Example",
+          "$anchor": "Example",
           "oneOf": [
             {
               "$ref": "#Reference"
@@ -548,7 +553,7 @@
           ]
         },
         "Header": {
-          "$id": "Header",
+          "$anchor": "Header",
           "oneOf": [
             {
               "$ref": "#Reference"
@@ -593,7 +598,7 @@
           ]
         },
         "Paths": {
-          "$id": "Paths",
+          "$anchor": "Paths",
           "type": "object",
           "allOf": [
             {
@@ -616,7 +621,7 @@
           "unevaluatedProperties": false
         },
         "PathItem": {
-          "$id": "PathItem",
+          "$anchor": "PathItem",
           "type": "object",
           "allOf": [
             {
@@ -653,7 +658,7 @@
           }
         },
         "Operation": {
-          "$id": "Operation",
+          "$anchor": "Operation",
           "type": "object",
           "required": [
             "responses"
@@ -716,7 +721,7 @@
           "unevaluatedProperties": false
         },
         "Responses": {
-          "$id": "Responses",
+          "$anchor": "Responses",
           "type": "object",
           "allOf": [
             {
@@ -737,7 +742,7 @@
           "unevaluatedProperties": false
         },
         "SecurityRequirement": {
-          "$id": "SecurityRequirement",
+          "$anchor": "SecurityRequirement",
           "type": "object",
           "additionalProperties": {
             "type": "array",
@@ -747,7 +752,7 @@
           }
         },
         "Tag": {
-          "$id": "Tag",
+          "$anchor": "Tag",
           "type": "object",
           "required": [
             "name"
@@ -770,8 +775,29 @@
           },
           "unevaluatedProperties": false
         },
+        "ExternalDocumentation": {
+          "$anchor": "ExternalDocumentation",
+          "allOf": [
+            {
+              "$ref": "#/$defs/Mixins/$defs/Extensible"
+            }
+          ],
+          "type": "object",
+          "required": [
+            "url"
+          ],
+          "properties": {
+            "description": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri-reference"
+            }
+          }
+        },
         "Parameter": {
-          "$id": "Parameter",
+          "$anchor": "Parameter",
           "oneOf": [
             {
               "$ref": "#Reference"
@@ -860,10 +886,10 @@
                         {
                           "allOf": [
                             {
-                              "$refs": "#QueryParam"
+                              "$ref": "#QueryParam"
                             },
                             {
-                              "$refs": "#/$defs/Mixins/$defs/StyledFormComplex"
+                              "$ref": "#/$defs/Mixins/$defs/StyledFormComplex"
                             }
                           ]
                         },
@@ -883,7 +909,7 @@
                               "$ref": "#CookieParam"
                             },
                             {
-                              "$refs": "#/$defs/Mixins/$defs/StyledFormOnly"
+                              "$ref": "#/$defs/Mixins/$defs/StyledFormOnly"
                             }
                           ]
                         }
@@ -912,7 +938,7 @@
           ],
           "$defs": {
             "PathParam": {
-              "$id": "PathParam",
+              "$anchor": "PathParam",
               "properties": {
                 "in": {
                   "const": "path"
@@ -920,7 +946,7 @@
               }
             },
             "QueryParam": {
-              "$id": "QueryParam",
+              "$anchor": "QueryParam",
               "properties": {
                 "in": {
                   "const": "query"
@@ -928,7 +954,7 @@
               }
             },
             "HeaderParam": {
-              "$id": "HeaderParam",
+              "$anchor": "HeaderParam",
               "properties": {
                 "in": {
                   "const": "header"
@@ -936,7 +962,7 @@
               }
             },
             "CookieParam": {
-              "$id": "CookieParam",
+              "$anchor": "CookieParam",
               "properties": {
                 "in": {
                   "const": "cookie"
@@ -946,7 +972,7 @@
           }
         },
         "RequestBody": {
-          "$id": "RequestBody",
+          "$anchor": "RequestBody",
           "required": [
             "content"
           ],
@@ -972,7 +998,7 @@
           "unevaluatedProperties": false
         },
         "SecurityScheme": {
-          "$id": "SecurityScheme",
+          "$anchor": "SecurityScheme",
           "oneOf": [
             {
               "$ref": "#Reference"
@@ -1025,7 +1051,7 @@
           ],
           "$defs": {
             "APIKey": {
-              "$id": "APIKey",
+              "$anchor": "APIKey",
               "properties": {
                 "type": {
                   "const": "apiKey"
@@ -1041,7 +1067,7 @@
               }
             },
             "HTTP": {
-              "$id": "HTTP",
+              "$anchor": "HTTP",
               "required": [
                 "scheme"
               ],
@@ -1071,7 +1097,7 @@
               ]
             },
             "MutalTLS": {
-              "$id": "MutalTLS",
+              "$anchor": "MutualTLS",
               "properties": {
                 "type": {
                   "const": "mutalTLS"
@@ -1079,7 +1105,7 @@
               }
             },
             "OAuth2": {
-              "$id": "OAuth2",
+              "$anchor": "OAuth2",
               "required": [
                 "flows"
               ],
@@ -1093,7 +1119,7 @@
               }
             },
             "OpenIdConnect": {
-              "$id": "OpenIdConnect",
+              "$anchor": "OpenIdConnect",
               "required": [
                 "openIdConnectUrl"
               ],
@@ -1110,7 +1136,7 @@
           }
         },
         "OAuthFlows": {
-          "$id": "OAuthFlows",
+          "$anchor": "OAuthFlows",
           "type": "object",
           "allOf": [
             {
@@ -1186,7 +1212,7 @@
           "unevaluatedProperties": false,
           "$defs": {
             "Common": {
-              "$id": "CommonFlow",
+              "$anchor": "CommonFlow",
               "properties": {
                 "refreshUrl": {
                   "type": "string",
@@ -1201,7 +1227,7 @@
               }
             },
             "Token": {
-              "$id": "TokenFlow",
+              "$anchor": "TokenFlow",
               "required": [
                 "tokenUrl"
               ],
@@ -1213,7 +1239,7 @@
               }
             },
             "Authorization": {
-              "$id": "AuthorizationFlow",
+              "$anchor": "AuthorizationFlow",
               "required": [
                 "authorizationUrl"
               ],
@@ -1227,7 +1253,7 @@
           }
         },
         "Link": {
-          "$id": "Link",
+          "$anchor": "Link",
           "oneOf": [
             {
               "$ref": "#Reference"
@@ -1276,7 +1302,7 @@
           ]
         },
         "Callback": {
-          "$id": "Callback",
+          "$anchor": "Callback",
           "oneOf": [
             {
               "$ref": "#Reference"
@@ -1293,7 +1319,7 @@
           ]
         },
         "Schema": {
-          "$id": "Schema",
+          "$anchor": "Schema",
           "oneOf": [
             {
               "$ref": "#Reference"
@@ -1302,13 +1328,13 @@
               "type": "object",
               "allOf": [
                 {
-                  "$ref": "https://json-schema.org/draft/2020-02/schema#"
+                  "$ref": "https://json-schema.org/draft/2020-12/schema"
                 },
                 {
                   "$ref": "#SchemaExtensions"
                 },
                 {
-                  "$ref": "#/$defs/Mixins/$def/Extensible"
+                  "$ref": "#/$defs/Mixins/$defs/Extensible"
                 }
               ],
               "unevaluatedProperties": false
@@ -1316,7 +1342,7 @@
           ],
           "$defs": {
             "Extensions": {
-              "$id": "SchemaExtensions",
+              "$anchor": "SchemaExtensions",
               "properties": {
                 "discriminator": {
                   "$ref": "#Discriminator"
@@ -1330,7 +1356,7 @@
               }
             },
             "Discriminator": {
-              "$id": "Discriminator",
+              "$anchor": "Discriminator",
               "type": "object",
               "required": [
                 "propertyName"
@@ -1348,7 +1374,7 @@
               }
             },
             "XML": {
-              "$id": "XML",
+              "$anchor": "XML",
               "allOf": [
                 {
                   "$ref": "#/$defs/Mixins/$defs/Extensible"
@@ -1382,7 +1408,7 @@
           }
         },
         "Components": {
-          "$id": "Components",
+          "$anchor": "Components",
           "type": "object",
           "allOf": [
             {

--- a/schemas/v3.1/schema.json
+++ b/schemas/v3.1/schema.json
@@ -23,15 +23,11 @@
       ]
     }
   ],
-  "allOf": [
-    {
-      "$ref": "#/$defs/Mixins/$defs/Extensible"
-    }
-  ],
+  "$ref": "#/$defs/Mixins/$defs/Extensible",
   "properties": {
     "openapi": {
       "type": "string",
-      "pattern": "^3\\.1\\.\\d(-.+)?$"
+      "pattern": "^3\\.1\\.\\d+(-.+)?$"
     },
     "jsonSchemaDialect": {
       "type": "string",
@@ -59,7 +55,8 @@
       "type": "array",
       "items": {
         "$ref": "#Tag"
-      }
+      },
+      "uniqueItems": true
     },
     "paths": {
       "$ref": "#Paths"
@@ -483,7 +480,7 @@
                 },
                 "links": {
                   "type": "object",
-                  "additionalProperteis": {
+                  "additionalProperties": {
                     "$ref": "#Link"
                   }
                 }
@@ -645,14 +642,7 @@
             "parameters": {
               "type": "array",
               "items": {
-                "oneOf": [
-                  {
-                    "$ref": "#Parameter"
-                  },
-                  {
-                    "$ref": "#Reference"
-                  }
-                ]
+                "$ref": "#Parameter"
               },
               "uniqueItems": true
             }
@@ -692,7 +682,8 @@
               "type": "array",
               "items": {
                 "$ref": "#Parameter"
-              }
+              },
+              "uniqueItems": true
             },
             "requestBody": {
               "$ref": "#RequestBody"
@@ -732,7 +723,7 @@
             }
           },
           "patternProperties": {
-            "[1-5](?:\\d{2}|XX)": {
+            "^[1-5](?:\\d{2}|XX)$": {
               "$ref": "#Response"
             }
           },
@@ -778,6 +769,9 @@
           "allOf": [
             {
               "$ref": "#/$defs/Mixins/$defs/Extensible"
+            },
+            {
+              "$ref": "#/$defs/Mixins/$defs/Describable"
             }
           ],
           "type": "object",
@@ -785,9 +779,6 @@
             "url"
           ],
           "properties": {
-            "description": {
-              "type": "string"
-            },
             "url": {
               "type": "string",
               "format": "uri-reference"
@@ -1016,7 +1007,7 @@
               ],
               "properties": {
                 "type": {
-                  "string": null,
+                  "type": "string",
                   "enum": [
                     "apiKey",
                     "http",
@@ -1024,26 +1015,26 @@
                     "mutualTLS",
                     "oauth2",
                     "openIdConnect"
-                  ],
-                  "oneOf": [
-                    {
-                      "$ref": "#APIKey"
-                    },
-                    {
-                      "$ref": "#HTTP"
-                    },
-                    {
-                      "$ref": "#MutualTLS"
-                    },
-                    {
-                      "$ref": "#OAuth2"
-                    },
-                    {
-                      "$ref": "#OpenIdConnect"
-                    }
                   ]
                 }
               },
+              "oneOf": [
+                {
+                  "$ref": "#APIKey"
+                },
+                {
+                  "$ref": "#HTTP"
+                },
+                {
+                  "$ref": "#MutualTLS"
+                },
+                {
+                  "$ref": "#OAuth2"
+                },
+                {
+                  "$ref": "#OpenIdConnect"
+                }
+              ],
               "unevaluatedProperties": false
             }
           ],
@@ -1401,7 +1392,7 @@
                   }
                 }
               ],
-              "additionalProperties": false
+              "unevaluatedProperties": false
             }
           }
         },
@@ -1430,7 +1421,7 @@
             },
             "responses": {
               "additionalProperties": {
-                "$ref": "#Responses"
+                "$ref": "#Response"
               }
             },
             "parameters": {

--- a/schemas/v3.1/schema.json
+++ b/schemas/v3.1/schema.json
@@ -1,6 +1,6 @@
 {
   "id": "https://spec.openapis.org/oas/3.1/schema/2021-02-18",
-  "$schema": "https://json-schema.org/draft/2020-02/schema#",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "type": "object",
   "required": [
     "openapi",
@@ -298,7 +298,7 @@
     "Objects": {
       "$defs": {
         "Reference": {
-          "$id": "#Reference",
+          "$id": "Reference",
           "type": "object",
           "required": [
             "$ref"
@@ -344,7 +344,7 @@
           },
           "$defs": {
             "Contact": {
-              "$id": "#Contact",
+              "$id": "Contact",
               "type": "object",
               "allOf": [
                 {
@@ -367,7 +367,7 @@
               "unevaluatedProperties": false
             },
             "License": {
-              "$id": "#License",
+              "$id": "License",
               "type": "object",
               "required": [
                 "name"
@@ -394,7 +394,7 @@
           }
         },
         "Server": {
-          "$id": "#Server",
+          "$id": "Server",
           "type": "object",
           "required": [
             "url"
@@ -444,7 +444,7 @@
           "unevaluatedProperties": false
         },
         "Response": {
-          "$id": "#Response",
+          "$id": "Response",
           "oneOf": [
             {
               "$ref": "#Reference"
@@ -487,7 +487,7 @@
           ]
         },
         "MediaType": {
-          "$id": "#MediaType",
+          "$id": "MediaType",
           "type": "object",
           "allOf": [
             {
@@ -518,7 +518,7 @@
           "unevaluatedProperties": false
         },
         "Example": {
-          "$id": "#Example",
+          "$id": "Example",
           "oneOf": [
             {
               "$ref": "#Reference"
@@ -548,7 +548,7 @@
           ]
         },
         "Header": {
-          "$id": "#Header",
+          "$id": "Header",
           "oneOf": [
             {
               "$ref": "#Reference"
@@ -593,7 +593,7 @@
           ]
         },
         "Paths": {
-          "$id": "#Paths",
+          "$id": "Paths",
           "type": "object",
           "allOf": [
             {
@@ -618,7 +618,7 @@
           "unevaluatedProperties": false
         },
         "PathItem": {
-          "$id": "#PathItem",
+          "$id": "PathItem",
           "type": "object",
           "allOf": [
             {
@@ -655,7 +655,7 @@
           }
         },
         "Operation": {
-          "$id": "#Operation",
+          "$id": "Operation",
           "type": "object",
           "required": [
             "responses"
@@ -718,7 +718,7 @@
           "unevaluatedProperties": false
         },
         "Responses": {
-          "$id": "#Responses",
+          "$id": "Responses",
           "type": "object",
           "allOf": [
             {
@@ -739,7 +739,7 @@
           "unevaluatedProperties": false
         },
         "SecurityRequirement": {
-          "$id": "#SecurityRequirement",
+          "$id": "SecurityRequirement",
           "type": "object",
           "additionalProperties": {
             "type": "array",
@@ -749,7 +749,7 @@
           }
         },
         "Tag": {
-          "$id": "#Tag",
+          "$id": "Tag",
           "type": "object",
           "required": [
             "name"
@@ -773,7 +773,7 @@
           "unevaluatedProperties": false
         },
         "Parameter": {
-          "$id": "#Parameter",
+          "$id": "Parameter",
           "oneOf": [
             {
               "$ref": "#Reference"
@@ -914,7 +914,7 @@
           ],
           "$defs": {
             "PathParam": {
-              "$id": "#PathParam",
+              "$id": "PathParam",
               "properties": {
                 "in": {
                   "const": "path"
@@ -922,7 +922,7 @@
               }
             },
             "QueryParam": {
-              "$id": "#QueryParam",
+              "$id": "QueryParam",
               "properties": {
                 "in": {
                   "const": "query"
@@ -930,7 +930,7 @@
               }
             },
             "HeaderParam": {
-              "$id": "#HeaderParam",
+              "$id": "HeaderParam",
               "properties": {
                 "in": {
                   "const": "header"
@@ -938,7 +938,7 @@
               }
             },
             "CookieParam": {
-              "$id": "#CookieParam",
+              "$id": "CookieParam",
               "properties": {
                 "in": {
                   "const": "cookie"
@@ -948,7 +948,7 @@
           }
         },
         "RequestBody": {
-          "$id": "#RequestBody",
+          "$id": "RequestBody",
           "required": [
             "content"
           ],
@@ -974,7 +974,7 @@
           "unevaluatedProperties": false
         },
         "SecurityScheme": {
-          "$id": "#SecurityScheme",
+          "$id": "SecurityScheme",
           "oneOf": [
             {
               "$ref": "#Reference"
@@ -1025,7 +1025,7 @@
           ],
           "$defs": {
             "APIKey": {
-              "$id": "#APIKey",
+              "$id": "APIKey",
               "properties": {
                 "type": {
                   "const": "apiKey"
@@ -1041,7 +1041,7 @@
               }
             },
             "HTTP": {
-              "$id": "#HTTP",
+              "$id": "HTTP",
               "required": [
                 "scheme"
               ],
@@ -1071,7 +1071,7 @@
               ]
             },
             "MutalTLS": {
-              "$id": "#MutalTLS",
+              "$id": "MutalTLS",
               "properties": {
                 "type": {
                   "const": "mutalTLS"
@@ -1079,7 +1079,7 @@
               }
             },
             "OAuth2": {
-              "$id": "#OAuth2",
+              "$id": "OAuth2",
               "required": [
                 "flows"
               ],
@@ -1093,7 +1093,7 @@
               }
             },
             "OpenIdConnect": {
-              "$id": "#OpenIdConnect",
+              "$id": "OpenIdConnect",
               "required": [
                 "openIdConnectUrl"
               ],
@@ -1110,7 +1110,7 @@
           }
         },
         "OAuthFlows": {
-          "$id": "#OAuthFlows",
+          "$id": "OAuthFlows",
           "type": "object",
           "allOf": [
             {
@@ -1186,7 +1186,7 @@
           "unevaluatedProperties": false,
           "$defs": {
             "Common": {
-              "$id": "#CommonFlow",
+              "$id": "CommonFlow",
               "properties": {
                 "refreshUrl": {
                   "type": "string",
@@ -1201,7 +1201,7 @@
               }
             },
             "Token": {
-              "$id": "#TokenFlow",
+              "$id": "TokenFlow",
               "required": [
                 "tokenUrl"
               ],
@@ -1213,7 +1213,7 @@
               }
             },
             "Authorization": {
-              "$id": "#AuthorizationFlow",
+              "$id": "AuthorizationFlow",
               "required": [
                 "authorizationUrl"
               ],
@@ -1227,7 +1227,7 @@
           }
         },
         "Link": {
-          "$id": "#Link",
+          "$id": "Link",
           "oneOf": [
             {
               "$ref": "#Reference"
@@ -1276,7 +1276,7 @@
           ]
         },
         "Callback": {
-          "$id": "#Callback",
+          "$id": "Callback",
           "oneOf": [
             {
               "$ref": "#Reference"
@@ -1293,7 +1293,7 @@
           ]
         },
         "Schema": {
-          "$id": "#Schema",
+          "$id": "Schema",
           "oneOf": [
             {
               "$ref": "#Reference"
@@ -1316,7 +1316,7 @@
           ],
           "$defs": {
             "Extensions": {
-              "$id": "#SchemaExtensions",
+              "$id": "SchemaExtensions",
               "properties": {
                 "discriminator": {
                   "$ref": "#Discriminator"
@@ -1330,7 +1330,7 @@
               }
             },
             "Discriminator": {
-              "$id": "#Discriminator",
+              "$id": "Discriminator",
               "type": "object",
               "required": [
                 "propertyName"
@@ -1348,7 +1348,7 @@
               }
             },
             "XML": {
-              "$id": "#XML",
+              "$id": "XML",
               "allOf": [
                 {
                   "$ref": "#/$defs/Mixins/$defs/Extensible"
@@ -1382,7 +1382,7 @@
           }
         },
         "Components": {
-          "$id": "#Components",
+          "$id": "Components",
           "type": "object",
           "allOf": [
             {

--- a/schemas/v3.1/schema.json
+++ b/schemas/v3.1/schema.json
@@ -4,8 +4,24 @@
   "type": "object",
   "required": [
     "openapi",
-    "info",
-    "paths"
+    "info"
+  ],
+  "oneOf": [
+    {
+      "required": [
+        "components"
+      ]
+    },
+    {
+      "required": [
+        "paths"
+      ]
+    },
+    {
+      "required": [
+        "webhooks"
+      ]
+    }
   ],
   "allOf": [
     {
@@ -16,6 +32,9 @@
     "openapi": {
       "type": "string",
       "pattern": "^3\\.1\\.\\d(-.+)?$"
+    },
+    "jsonSchemaDialect": {
+      "type": "string"
     },
     "info": {
       "$ref": "#Info"
@@ -309,6 +328,9 @@
             "title": {
               "type": "string"
             },
+            "summary": {
+              "type": "string"
+            },
             "termsOfService": {
               "type": "string",
               "format": "uri-reference"
@@ -362,6 +384,9 @@
                 "url": {
                   "type": "string",
                   "format": "uri-reference"
+                },
+                "identifier": {
+                  "type": "string"
                 }
               },
               "unevaluatedProperties": false
@@ -578,26 +603,56 @@
           "patternProperties": {
             "^\\/": {
               "type": "object",
-              "patternProperties": {
-                "^(get|put|post|delete|options|head|patch|trace)$": {
-                  "$ref": "#Operation"
-                }
-              },
               "properties": {
-                "servers": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "Server"
+                "oneOf": [
+                  {
+                    "$ref": "#Reference"
+                  },
+                  {
+                    "type": "#PathItem"
                   }
-                },
-                "parameters": {
-                  "type": "array",
-                  "items": "$"
-                }
+                ]
               }
             }
           },
           "unevaluatedProperties": false
+        },
+        "PathItem": {
+          "$id": "#PathItem",
+          "type": "object",
+          "allOf": [
+            {
+              "$ref": "#/$defs/Mixins/$defs/Describable"
+            },
+            {
+              "$ref": "#/$defs/Mixins/$defs/Extensible"
+            }
+          ],
+          "properties": {
+            "summary": {
+              "type": "string"
+            },
+            "servers": {
+              "type": "array",
+              "items": {
+                "$ref": "#Server"
+              }
+            },
+            "parameters": {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "$ref": "#Parameter"
+                  },
+                  {
+                    "$ref": "#Reference"
+                  }
+                ]
+              },
+              "uniqueItems": true
+            }
+          }
         },
         "Operation": {
           "$id": "#Operation",
@@ -942,6 +997,7 @@
                     "apiKey",
                     "http",
                     "bearer",
+                    "mutualTLS",
                     "oauth2",
                     "openIdConnect"
                   ],
@@ -951,6 +1007,9 @@
                     },
                     {
                       "$ref": "#HTTP"
+                    },
+                    {
+                      "$ref": "#MutualTLS"
                     },
                     {
                       "$ref": "#OAuth2"
@@ -1010,6 +1069,14 @@
                   }
                 }
               ]
+            },
+            "MutalTLS": {
+              "$id": "#MutalTLS",
+              "properties": {
+                "type": {
+                  "const": "mutalTLS"
+                }
+              }
             },
             "OAuth2": {
               "$id": "#OAuth2",
@@ -1235,10 +1302,7 @@
               "type": "object",
               "allOf": [
                 {
-                  "$ref": "http://json-schema.org/draft-04/schema#"
-                },
-                {
-                  "$ref": "#SchemaRestrictions"
+                  "$ref": "https://json-schema.org/draft/2020-02/schema#"
                 },
                 {
                   "$ref": "#SchemaExtensions"
@@ -1251,58 +1315,6 @@
             }
           ],
           "$defs": {
-            "Restrictions": {
-              "$id": "#SchemaRestrictions",
-              "properties": {
-                "type": {
-                  "not": {
-                    "const": "null"
-                  }
-                },
-                "not": {
-                  "$ref": "#/$defs/Schema"
-                },
-                "allOf": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/$defs/Schema"
-                  }
-                },
-                "oneOf": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/$defs/Schema"
-                  }
-                },
-                "anyOf": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/$defs/Schema"
-                  }
-                },
-                "items": {
-                  "$ref": "#/$defs/Schema"
-                },
-                "properties": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "$ref": "#/$defs/Schema"
-                  }
-                },
-                "additionalProperties": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/$defs/Schema"
-                    },
-                    {
-                      "type": "boolean"
-                    }
-                  ],
-                  "default": true
-                },
-                "patternProperties": false
-              }
-            },
             "Extensions": {
               "$id": "#SchemaExtensions",
               "properties": {
@@ -1337,30 +1349,34 @@
             },
             "XML": {
               "$id": "#XML",
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string"
+              "allOf": [
+                {
+                  "$ref": "#/$defs/Mixins/$defs/Extensible"
                 },
-                "namespace": {
-                  "type": "string",
-                  "format": "url"
-                },
-                "prefix": {
-                  "type": "string"
-                },
-                "attribute": {
-                  "type": "boolean",
-                  "default": false
-                },
-                "wrapped": {
-                  "type": "boolean",
-                  "default": false
+                {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "type": "string",
+                      "format": "url"
+                    },
+                    "prefix": {
+                      "type": "string"
+                    },
+                    "attribute": {
+                      "type": "boolean",
+                      "default": false
+                    },
+                    "wrapped": {
+                      "type": "boolean",
+                      "default": false
+                    }
+                  }
                 }
-              },
-              "patternProperties": {
-                "^x-": true
-              },
+              ],
               "additionalProperties": false
             }
           }
@@ -1396,6 +1412,11 @@
             "parameters": {
               "additionalProperties": {
                 "$ref": "#Parameter"
+              }
+            },
+            "pathItems": {
+              "additionalProperties": {
+                "$ref": "#PathItem"
               }
             },
             "examples": {

--- a/schemas/v3.1/schema.json
+++ b/schemas/v3.1/schema.json
@@ -34,7 +34,8 @@
       "pattern": "^3\\.1\\.\\d(-.+)?$"
     },
     "jsonSchemaDialect": {
-      "type": "string"
+      "type": "string",
+      "format": "uri"
     },
     "info": {
       "$ref": "#Info"
@@ -606,7 +607,7 @@
             }
           ],
           "patternProperties": {
-            "^\\/": {
+            "^/": {
               "type": "object",
               "oneOf": [
                 {
@@ -660,9 +661,6 @@
         "Operation": {
           "$anchor": "Operation",
           "type": "object",
-          "required": [
-            "responses"
-          ],
           "allOf": [
             {
               "$ref": "#/$defs/Mixins/$defs/Describable"
@@ -1100,7 +1098,7 @@
               "$anchor": "MutualTLS",
               "properties": {
                 "type": {
-                  "const": "mutalTLS"
+                  "const": "mutualTLS"
                 }
               }
             },
@@ -1471,7 +1469,7 @@
               }
             }
           },
-          "unevaluatedProperties": true
+          "unevaluatedProperties": false
         }
       }
     }

--- a/schemas/v3.1/schema.json
+++ b/schemas/v3.1/schema.json
@@ -1,0 +1,1432 @@
+{
+  "id": "https://spec.openapis.org/oas/3.1/schema/2021-02-18",
+  "$schema": "https://json-schema.org/draft/2020-02/schema#",
+  "type": "object",
+  "required": [
+    "openapi",
+    "info",
+    "paths"
+  ],
+  "allOf": [
+    {
+      "$ref": "#/$defs/Mixins/$defs/Extensible"
+    }
+  ],
+  "properties": {
+    "openapi": {
+      "type": "string",
+      "pattern": "^3\\.1\\.\\d(-.+)?$"
+    },
+    "info": {
+      "$ref": "#Info"
+    },
+    "externalDocs": {
+      "$ref": "#ExternalDocumentation"
+    },
+    "servers": {
+      "type": "array",
+      "items": {
+        "$ref": "#Server"
+      }
+    },
+    "security": {
+      "type": "array",
+      "items": {
+        "$ref": "#SecurityRequirement"
+      }
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "$ref": "#Tag"
+      }
+    },
+    "paths": {
+      "$ref": "#Paths"
+    },
+    "components": {
+      "$ref": "#Components"
+    }
+  },
+  "unevaluatedProperties": false,
+  "$defs": {
+    "Mixins": {
+      "$defs": {
+        "Describable": {
+          "properties": {
+            "description": {
+              "type": "string"
+            }
+          }
+        },
+        "Requireable": {
+          "properties": {
+            "required": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        },
+        "Deprecatable": {
+          "properties": {
+            "deprecated": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        },
+        "DescReqDep": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Mixins/$defs/Describable"
+            },
+            {
+              "$ref": "#/$defs/Mixins/$defs/Requireable"
+            },
+            {
+              "$ref": "#/$defs/Mixins/$defs/Deprecatable"
+            }
+          ]
+        },
+        "Extensible": {
+          "patternProperties": {
+            "^x-": true
+          }
+        },
+        "WithSingleExample": {
+          "properties": {
+            "example": true,
+            "examples": false
+          }
+        },
+        "WithExampleObjects": {
+          "properties": {
+            "example": false,
+            "examples": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#Example"
+              }
+            }
+          }
+        },
+        "WithExamples": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/Mixins/$defs/WithSingleExample"
+            },
+            {
+              "$ref": "#/$defs/Mixins/$defs/WithExampleObjects"
+            }
+          ]
+        },
+        "WithSchema": {
+          "properties": {
+            "schema": {
+              "$ref": "#Schema"
+            },
+            "content": false
+          }
+        },
+        "WithSchemaAndExamples": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Mixins/$defs/WithSchema"
+            },
+            {
+              "$ref": "#/$defs/Mixins/$defs/WithExamples"
+            }
+          ]
+        },
+        "WithContent": {
+          "properties": {
+            "schema": false,
+            "content": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#MediaType"
+              },
+              "minProperties": 1,
+              "maxProperties": 1
+            }
+          }
+        },
+        "WithNameAndLocation": {
+          "required": [
+            "name",
+            "in"
+          ],
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "in": {
+              "type": "string",
+              "enum": [
+                "path",
+                "query",
+                "header",
+                "cookie"
+              ]
+            }
+          }
+        },
+        "WithExplodeAndReserved": {
+          "properties": {
+            "explode": {
+              "type": "boolean"
+            },
+            "allowReserved": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        },
+        "WithEmpty": {
+          "properties": {
+            "allowEmptyValue": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        },
+        "WithExplodeReservedAndEmpty": {
+          "allOf": [
+            {
+              "$refs": "#/$defs/Mixins/$defs/WithExplodeAndReserved"
+            },
+            {
+              "$refs": "#/$defs/Mixins/$defs/WithEmpty"
+            }
+          ]
+        },
+        "StyledSimple": {
+          "allOf": [
+            {
+              "$refs": "#/$defs/Mixins/$defs/WithExplodeReservedAndEmpty"
+            }
+          ],
+          "properties": {
+            "style": {
+              "type": "string",
+              "const": "simple",
+              "default": "simple"
+            }
+          }
+        },
+        "StyledMatrix": {
+          "properties": {
+            "style": {
+              "type": "string",
+              "enum": [
+                "matrix",
+                "label",
+                "simple"
+              ],
+              "default": "simple"
+            }
+          }
+        },
+        "StyledFormOnly": {
+          "allOf": [
+            {
+              "$refs": "#/$defs/Mixins/$defs/WithExplodeReservedAndEmpty"
+            }
+          ],
+          "properties": {
+            "style": {
+              "type": "string",
+              "const": "form",
+              "default": "form"
+            }
+          }
+        },
+        "StyledFormComplexNoDefaultOrEmpty": {
+          "allOf": [
+            {
+              "$refs": "#/$defs/Mixins/$defs/WithExplodeAndReserved"
+            }
+          ],
+          "properties": {
+            "style": {
+              "type": "string",
+              "enum": [
+                "form",
+                "spaceDelimited",
+                "pipeDelimited",
+                "deepObject"
+              ]
+            }
+          }
+        },
+        "StyledFormComplex": {
+          "allOf": [
+            {
+              "$refs": "#/$defs/Mixins/$defs/StyledFormComplexNoDefaultOrEmpty"
+            },
+            {
+              "$refs": "#/$defs/Mixins/$defs/WithExplodeReservedAndEmpty"
+            }
+          ],
+          "properties": {
+            "style": {
+              "default": "form"
+            }
+          }
+        }
+      }
+    },
+    "Objects": {
+      "$defs": {
+        "Reference": {
+          "$id": "#Reference",
+          "type": "object",
+          "required": [
+            "$ref"
+          ],
+          "properties": {
+            "$ref": {
+              "type": "string",
+              "format": "uri-reference"
+            }
+          }
+        },
+        "Info": {
+          "type": "object",
+          "required": [
+            "title",
+            "version"
+          ],
+          "allOf": [
+            {
+              "$ref": "#/$defs/Mixins/$defs/Describable"
+            },
+            {
+              "$ref": "#/$defs/Mixins/$defs/Extensible"
+            }
+          ],
+          "properties": {
+            "title": {
+              "type": "string"
+            },
+            "termsOfService": {
+              "type": "string",
+              "format": "uri-reference"
+            },
+            "contact": {
+              "$ref": "#Contact"
+            },
+            "license": {
+              "$ref": "#License"
+            }
+          },
+          "$defs": {
+            "Contact": {
+              "$id": "#Contact",
+              "type": "object",
+              "allOf": [
+                {
+                  "$ref": "#/$defs/Mixins/$defs/Extensible"
+                }
+              ],
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string",
+                  "format": "uri-reference"
+                },
+                "email": {
+                  "type": "string",
+                  "format": "email"
+                }
+              },
+              "unevaluatedProperties": false
+            },
+            "License": {
+              "$id": "#License",
+              "type": "object",
+              "required": [
+                "name"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/$defs/Mixins/$defs/Extensible"
+                }
+              ],
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string",
+                  "format": "uri-reference"
+                }
+              },
+              "unevaluatedProperties": false
+            }
+          }
+        },
+        "Server": {
+          "$id": "#Server",
+          "type": "object",
+          "required": [
+            "url"
+          ],
+          "allOf": [
+            {
+              "$ref": "#/$defs/Mixins/$defs/Describable"
+            },
+            {
+              "$ref": "#/$defs/Mixins/$defs/Extensible"
+            }
+          ],
+          "properties": {
+            "url": {
+              "type": "string"
+            },
+            "variables": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "object",
+                "required": [
+                  "default"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/$defs/Mixins/$defs/Describable"
+                  },
+                  {
+                    "$ref": "#/$defs/Mixins/$defs/Extensible"
+                  }
+                ],
+                "properties": {
+                  "enum": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "default": {
+                    "type": "string"
+                  }
+                },
+                "unevaluatedProperties": false
+              }
+            }
+          },
+          "unevaluatedProperties": false
+        },
+        "Response": {
+          "$id": "#Response",
+          "oneOf": [
+            {
+              "$ref": "#Reference"
+            },
+            {
+              "type": "object",
+              "required": [
+                "description"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/$defs/Mixins/$defs/Describable"
+                },
+                {
+                  "$ref": "#/$defs/Mixins/$defs/Extensible"
+                }
+              ],
+              "properties": {
+                "headers": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "$ref": "#Header"
+                  }
+                },
+                "content": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "$ref": "#MediaType"
+                  }
+                },
+                "links": {
+                  "type": "object",
+                  "additionalProperteis": {
+                    "$ref": "#Link"
+                  }
+                }
+              },
+              "unevaluatedProperties": false
+            }
+          ]
+        },
+        "MediaType": {
+          "$id": "#MediaType",
+          "type": "object",
+          "allOf": [
+            {
+              "$ref": "#/$defs/Mixins/$defs/WithSchemaAndExamples"
+            }
+          ],
+          "properties": {
+            "encoding": {
+              "type": "object",
+              "allOf": [
+                {
+                  "$ref": "#/$defs/Mixins/$defs/StyledFormComplexNoDefaultOrEmpty"
+                }
+              ],
+              "properties": {
+                "contentType": {
+                  "type": "string"
+                },
+                "headers": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "$ref": "#Header"
+                  }
+                }
+              }
+            }
+          },
+          "unevaluatedProperties": false
+        },
+        "Example": {
+          "$id": "#Example",
+          "oneOf": [
+            {
+              "$ref": "#Reference"
+            },
+            {
+              "type": "object",
+              "allOf": [
+                {
+                  "$ref": "#/$defs/Mixins/$defs/Describable"
+                },
+                {
+                  "$ref": "#/$defs/Mixins/$defs/Extensible"
+                }
+              ],
+              "properties": {
+                "summary": {
+                  "type": "string"
+                },
+                "value": true,
+                "externalValue": {
+                  "type": "string",
+                  "format": "uri-reference"
+                }
+              },
+              "unevaluatedProperties": false
+            }
+          ]
+        },
+        "Header": {
+          "$id": "#Header",
+          "oneOf": [
+            {
+              "$ref": "#Reference"
+            },
+            {
+              "type": "object",
+              "required": [
+                "schema"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/$defs/Mixins/$defs/DescReqDep"
+                },
+                {
+                  "$ref": "#/$defs/Mixins/$defs/Extensible"
+                }
+              ],
+              "oneOf": [
+                {
+                  "allOf": [
+                    {
+                      "$ref": "#/$defs/Mixins/$defs/WithSchemaAndExamples"
+                    },
+                    {
+                      "$ref": "#/$defs/Mixins/$defs/StyledSimple"
+                    }
+                  ]
+                },
+                {
+                  "allOf": [
+                    {
+                      "$ref": "#/$defs/Mixins/$defs/WithContent"
+                    },
+                    {
+                      "$ref": "#/$defs/Mixins/$defs/WithEmpty"
+                    }
+                  ]
+                }
+              ],
+              "unevaluatedProperties": false
+            }
+          ]
+        },
+        "Paths": {
+          "$id": "#Paths",
+          "type": "object",
+          "allOf": [
+            {
+              "$ref": "#/$defs/Mixins/$defs/Extensible"
+            }
+          ],
+          "patternProperties": {
+            "^\\/": {
+              "type": "object",
+              "patternProperties": {
+                "^(get|put|post|delete|options|head|patch|trace)$": {
+                  "$ref": "#Operation"
+                }
+              },
+              "properties": {
+                "servers": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "Server"
+                  }
+                },
+                "parameters": {
+                  "type": "array",
+                  "items": "$"
+                }
+              }
+            }
+          },
+          "unevaluatedProperties": false
+        },
+        "Operation": {
+          "$id": "#Operation",
+          "type": "object",
+          "required": [
+            "responses"
+          ],
+          "allOf": [
+            {
+              "$ref": "#/$defs/Mixins/$defs/Describable"
+            },
+            {
+              "$ref": "#/$defs/Mixins/$defs/Deprecatable"
+            },
+            {
+              "$ref": "#/$defs/Mixins/$defs/Extensible"
+            }
+          ],
+          "properties": {
+            "tags": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "summary": {
+              "type": "string"
+            },
+            "externalDocs": {
+              "$ref": "#ExternalDocumentation"
+            },
+            "operationId": {
+              "type": "string"
+            },
+            "parameters": {
+              "type": "array",
+              "items": {
+                "$ref": "#Parameter"
+              }
+            },
+            "requestBody": {
+              "$ref": "#RequestBody"
+            },
+            "responses": {
+              "$ref": "#Responses"
+            },
+            "callback": {
+              "$ref": "#Callback"
+            },
+            "security": {
+              "type": "array",
+              "items": {
+                "$ref": "#SecurityRequirement"
+              }
+            },
+            "servers": {
+              "type": "array",
+              "items": {
+                "$ref": "#Server"
+              }
+            }
+          },
+          "unevaluatedProperties": false
+        },
+        "Responses": {
+          "$id": "#Responses",
+          "type": "object",
+          "allOf": [
+            {
+              "$ref": "#/$defs/Mixins/$defs/Extensible"
+            }
+          ],
+          "properties": {
+            "default": {
+              "$ref": "#Response"
+            }
+          },
+          "patternProperties": {
+            "[1-5](?:\\d{2}|XX)": {
+              "$ref": "#Response"
+            }
+          },
+          "minProperties": 1,
+          "unevaluatedProperties": false
+        },
+        "SecurityRequirement": {
+          "$id": "#SecurityRequirement",
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "Tag": {
+          "$id": "#Tag",
+          "type": "object",
+          "required": [
+            "name"
+          ],
+          "allOf": [
+            {
+              "$ref": "#/$defs/Mixins/$defs/Describable"
+            },
+            {
+              "$ref": "#/$defs/Mixins/$defs/Extensible"
+            }
+          ],
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "externalDocs": {
+              "$ref": "#ExternalDocumentation"
+            }
+          },
+          "unevaluatedProperties": false
+        },
+        "Parameter": {
+          "$id": "#Parameter",
+          "oneOf": [
+            {
+              "$ref": "#Reference"
+            },
+            {
+              "type": "object",
+              "allOf": [
+                {
+                  "$ref": "#/$defs/Mixins/$defs/WithNameAndLocation"
+                },
+                {
+                  "$ref": "#/$defs/Mixins/$defs/Extensible"
+                },
+                {
+                  "oneOf": [
+                    {
+                      "allOf": [
+                        {
+                          "$ref": "#PathParam"
+                        },
+                        {
+                          "$ref": "#/$defs/Mixins/$defs/Describable"
+                        },
+                        {
+                          "$ref": "#/$defs/Mixins/$defs/Deprecatable"
+                        },
+                        {
+                          "required": [
+                            "required"
+                          ],
+                          "properties": {
+                            "required": {
+                              "const": true,
+                              "default": true
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "allOf": [
+                        {
+                          "anyOf": [
+                            {
+                              "$ref": "#QueryParam"
+                            },
+                            {
+                              "$ref": "#HeaderParam"
+                            },
+                            {
+                              "$ref": "#CookieParam"
+                            }
+                          ]
+                        },
+                        {
+                          "$ref": "#/$defs/Mixins/$defs/DescReqDep"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "oneOf": [
+                {
+                  "allOf": [
+                    {
+                      "required": [
+                        "schema"
+                      ]
+                    },
+                    {
+                      "$ref": "#/$defs/Mixins/$defs/WithSchemaAndExamples"
+                    },
+                    {
+                      "oneOf": [
+                        {
+                          "allOf": [
+                            {
+                              "$ref": "#PathParam"
+                            },
+                            {
+                              "$ref": "#/$defs/Mixins/$defs/StyledMatrix"
+                            }
+                          ]
+                        },
+                        {
+                          "allOf": [
+                            {
+                              "$refs": "#QueryParam"
+                            },
+                            {
+                              "$refs": "#/$defs/Mixins/$defs/StyledFormComplex"
+                            }
+                          ]
+                        },
+                        {
+                          "allOf": [
+                            {
+                              "$ref": "#HeaderParam"
+                            },
+                            {
+                              "$ref": "#/$defs/Mixins/$defs/StyledSimple"
+                            }
+                          ]
+                        },
+                        {
+                          "allOf": [
+                            {
+                              "$ref": "#CookieParam"
+                            },
+                            {
+                              "$refs": "#/$defs/Mixins/$defs/StyledFormOnly"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "allOf": [
+                    {
+                      "required": [
+                        "content"
+                      ]
+                    },
+                    {
+                      "$ref": "#/$defs/Mixins/$defs/WithContent"
+                    },
+                    {
+                      "$ref": "#/$defs/Mixins/$defs/WithEmpty"
+                    }
+                  ]
+                }
+              ],
+              "unevaluatedProperties": false
+            }
+          ],
+          "$defs": {
+            "PathParam": {
+              "$id": "#PathParam",
+              "properties": {
+                "in": {
+                  "const": "path"
+                }
+              }
+            },
+            "QueryParam": {
+              "$id": "#QueryParam",
+              "properties": {
+                "in": {
+                  "const": "query"
+                }
+              }
+            },
+            "HeaderParam": {
+              "$id": "#HeaderParam",
+              "properties": {
+                "in": {
+                  "const": "header"
+                }
+              }
+            },
+            "CookieParam": {
+              "$id": "#CookieParam",
+              "properties": {
+                "in": {
+                  "const": "cookie"
+                }
+              }
+            }
+          }
+        },
+        "RequestBody": {
+          "$id": "#RequestBody",
+          "required": [
+            "content"
+          ],
+          "allOf": [
+            {
+              "$ref": "#/$defs/Mixins/$defs/Describable"
+            },
+            {
+              "$ref": "#/$defs/Mixins/$defs/Requireable"
+            },
+            {
+              "$ref": "#/$defs/Mixins/$defs/Extensible"
+            }
+          ],
+          "properties": {
+            "content": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#MediaType"
+              }
+            }
+          },
+          "unevaluatedProperties": false
+        },
+        "SecurityScheme": {
+          "$id": "#SecurityScheme",
+          "oneOf": [
+            {
+              "$ref": "#Reference"
+            },
+            {
+              "type": "object",
+              "required": "-type",
+              "allOf": [
+                {
+                  "$ref": "#/$defs/Mixins/$defs/Describable"
+                },
+                {
+                  "$ref": "#/$defs/Mixins/$defs/Extensible"
+                }
+              ],
+              "properties": {
+                "type": {
+                  "string": null,
+                  "enum": [
+                    "apiKey",
+                    "http",
+                    "bearer",
+                    "oauth2",
+                    "openIdConnect"
+                  ],
+                  "oneOf": [
+                    {
+                      "$ref": "#APIKey"
+                    },
+                    {
+                      "$ref": "#HTTP"
+                    },
+                    {
+                      "$ref": "#OAuth2"
+                    },
+                    {
+                      "$ref": "#OpenIdConnect"
+                    }
+                  ]
+                }
+              },
+              "unevaluatedProperties": false
+            }
+          ],
+          "$defs": {
+            "APIKey": {
+              "$id": "#APIKey",
+              "properties": {
+                "type": {
+                  "const": "apiKey"
+                }
+              },
+              "allOf": [
+                {
+                  "$ref": "#/$defs/Mixins/$defs/WithNameAndLocation"
+                }
+              ],
+              "not": {
+                "$ref": "#PathParam"
+              }
+            },
+            "HTTP": {
+              "$id": "#HTTP",
+              "required": [
+                "scheme"
+              ],
+              "properties": {
+                "scheme": {
+                  "type": "string"
+                }
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "type": {
+                      "const": "http"
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "type": {
+                      "const": "bearer"
+                    },
+                    "bearerFormat": {
+                      "type": "string"
+                    }
+                  }
+                }
+              ]
+            },
+            "OAuth2": {
+              "$id": "#OAuth2",
+              "required": [
+                "flows"
+              ],
+              "properties": {
+                "type": {
+                  "const": "oauth2"
+                },
+                "flows": {
+                  "$ref": "#OAuthFlows"
+                }
+              }
+            },
+            "OpenIdConnect": {
+              "$id": "#OpenIdConnect",
+              "required": [
+                "openIdConnectUrl"
+              ],
+              "properties": {
+                "type": {
+                  "const": "openIdConnect"
+                },
+                "openIdConnectUrl": {
+                  "type": "string",
+                  "format": "uri"
+                }
+              }
+            }
+          }
+        },
+        "OAuthFlows": {
+          "$id": "#OAuthFlows",
+          "type": "object",
+          "allOf": [
+            {
+              "$ref": "#/$defs/Mixins/$defs/Extensible"
+            }
+          ],
+          "properties": {
+            "implicit": {
+              "allOf": [
+                {
+                  "required": [
+                    "scopes"
+                  ]
+                },
+                {
+                  "$ref": "#CommonFlow"
+                },
+                {
+                  "$ref": "#AuthorizationFlow"
+                },
+                {
+                  "$ref": "#/$defs/Mixins/$defs/Extensible"
+                }
+              ],
+              "unevaluatedProperties": false
+            },
+            "password": {
+              "allOf": [
+                {
+                  "$ref": "#CommonFlow"
+                },
+                {
+                  "$ref": "#TokenFlow"
+                },
+                {
+                  "$ref": "#/$defs/Mixins/$defs/Extensible"
+                }
+              ],
+              "unevaluatedProperties": false
+            },
+            "clientCredentials": {
+              "allOf": [
+                {
+                  "$ref": "#CommonFlow"
+                },
+                {
+                  "$ref": "#TokenFlow"
+                },
+                {
+                  "$ref": "#/$defs/Mixins/$defs/Extensible"
+                }
+              ],
+              "unevaluatedProperties": false
+            },
+            "authorizationCode": {
+              "allOf": [
+                {
+                  "$ref": "#CommonFlow"
+                },
+                {
+                  "$ref": "#TokenFlow"
+                },
+                {
+                  "$ref": "#AuthorizationFlow"
+                },
+                {
+                  "$ref": "#/$defs/Mixins/$defs/Extensible"
+                }
+              ],
+              "unevaluatedProperties": false
+            }
+          },
+          "unevaluatedProperties": false,
+          "$defs": {
+            "Common": {
+              "$id": "#CommonFlow",
+              "properties": {
+                "refreshUrl": {
+                  "type": "string",
+                  "format": "uri-reference"
+                },
+                "scopes": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "Token": {
+              "$id": "#TokenFlow",
+              "required": [
+                "tokenUrl"
+              ],
+              "properties": {
+                "tokenUrl": {
+                  "type": "string",
+                  "format": "uri-reference"
+                }
+              }
+            },
+            "Authorization": {
+              "$id": "#AuthorizationFlow",
+              "required": [
+                "authorizationUrl"
+              ],
+              "properties": {
+                "authorizationUrl": {
+                  "type": "string",
+                  "format": "uri-reference"
+                }
+              }
+            }
+          }
+        },
+        "Link": {
+          "$id": "#Link",
+          "oneOf": [
+            {
+              "$ref": "#Reference"
+            },
+            {
+              "type": "object",
+              "allOf": [
+                {
+                  "$ref": "#/$defs/Mixins/$defs/Describable"
+                },
+                {
+                  "$ref": "#/$defs/Mixins/$defs/Extensible"
+                }
+              ],
+              "oneOf": [
+                {
+                  "properties": {
+                    "operationRef": {
+                      "type": "string",
+                      "format": "uri-reference"
+                    },
+                    "operationId": false
+                  }
+                },
+                {
+                  "properties": {
+                    "operationRef": false,
+                    "operationId": {
+                      "type": "string"
+                    }
+                  }
+                }
+              ],
+              "properties": {
+                "parameters": {
+                  "type": "object",
+                  "additionalProperties": true
+                },
+                "requestBody": true,
+                "server": {
+                  "$ref": "#Server"
+                }
+              },
+              "unevaluatedProperties": false
+            }
+          ]
+        },
+        "Callback": {
+          "$id": "#Callback",
+          "oneOf": [
+            {
+              "$ref": "#Reference"
+            },
+            {
+              "type": "object",
+              "allOf": [
+                {
+                  "$ref": "#/$defs/Mixins/$defs/Extensible"
+                }
+              ],
+              "unevaluatedProperties": false
+            }
+          ]
+        },
+        "Schema": {
+          "$id": "#Schema",
+          "oneOf": [
+            {
+              "$ref": "#Reference"
+            },
+            {
+              "type": "object",
+              "allOf": [
+                {
+                  "$ref": "http://json-schema.org/draft-04/schema#"
+                },
+                {
+                  "$ref": "#SchemaRestrictions"
+                },
+                {
+                  "$ref": "#SchemaExtensions"
+                },
+                {
+                  "$ref": "#/$defs/Mixins/$def/Extensible"
+                }
+              ],
+              "unevaluatedProperties": false
+            }
+          ],
+          "$defs": {
+            "Restrictions": {
+              "$id": "#SchemaRestrictions",
+              "properties": {
+                "type": {
+                  "not": {
+                    "const": "null"
+                  }
+                },
+                "not": {
+                  "$ref": "#/$defs/Schema"
+                },
+                "allOf": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/$defs/Schema"
+                  }
+                },
+                "oneOf": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/$defs/Schema"
+                  }
+                },
+                "anyOf": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/$defs/Schema"
+                  }
+                },
+                "items": {
+                  "$ref": "#/$defs/Schema"
+                },
+                "properties": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "$ref": "#/$defs/Schema"
+                  }
+                },
+                "additionalProperties": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/$defs/Schema"
+                    },
+                    {
+                      "type": "boolean"
+                    }
+                  ],
+                  "default": true
+                },
+                "patternProperties": false
+              }
+            },
+            "Extensions": {
+              "$id": "#SchemaExtensions",
+              "properties": {
+                "discriminator": {
+                  "$ref": "#Discriminator"
+                },
+                "externalDocs": {
+                  "$ref": "#ExternalDocumentation"
+                },
+                "xml": {
+                  "$ref": "#XML"
+                }
+              }
+            },
+            "Discriminator": {
+              "$id": "#Discriminator",
+              "type": "object",
+              "required": [
+                "propertyName"
+              ],
+              "properties": {
+                "propertyName": {
+                  "type": "string"
+                },
+                "mapping": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "XML": {
+              "$id": "#XML",
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "namespace": {
+                  "type": "string",
+                  "format": "url"
+                },
+                "prefix": {
+                  "type": "string"
+                },
+                "attribute": {
+                  "type": "boolean",
+                  "default": false
+                },
+                "wrapped": {
+                  "type": "boolean",
+                  "default": false
+                }
+              },
+              "patternProperties": {
+                "^x-": true
+              },
+              "additionalProperties": false
+            }
+          }
+        },
+        "Components": {
+          "$id": "#Components",
+          "type": "object",
+          "allOf": [
+            {
+              "$ref": "#/$defs/Mixins/$defs/Extensible"
+            },
+            {
+              "additionalProperties": {
+                "$comment": "All sub-objects have the same property name constraints",
+                "type": "object",
+                "propertyNames": {
+                  "pattern": "^[a-zA-Z0-9\\.\\-_]+$"
+                }
+              }
+            }
+          ],
+          "properties": {
+            "schemas": {
+              "additionalProperties": {
+                "$ref": "#Schema"
+              }
+            },
+            "responses": {
+              "additionalProperties": {
+                "$ref": "#Responses"
+              }
+            },
+            "parameters": {
+              "additionalProperties": {
+                "$ref": "#Parameter"
+              }
+            },
+            "examples": {
+              "additionalProperties": {
+                "$ref": "#Example"
+              }
+            },
+            "requestBodies": {
+              "additionalProperties": {
+                "$ref": "#RequestBody"
+              }
+            },
+            "headers": {
+              "additionalProperties": {
+                "$ref": "#Header"
+              }
+            },
+            "links": {
+              "additionalProperties": {
+                "$ref": "#Link"
+              }
+            },
+            "callbacks": {
+              "additionalProperties": {
+                "$ref": "#Callback"
+              }
+            }
+          },
+          "unevaluatedProperties": true
+        }
+      }
+    }
+  }
+}

--- a/schemas/v3.1/schema.json
+++ b/schemas/v3.1/schema.json
@@ -1,5 +1,5 @@
 {
-  "id": "https://spec.openapis.org/oas/3.1/schema/2021-02-18",
+  "$id": "https://spec.openapis.org/oas/3.1/schema/2021-02-18",
   "$schema": "https://json-schema.org/draft/2019-09/schema",
   "type": "object",
   "required": [
@@ -37,7 +37,7 @@
       "type": "string"
     },
     "info": {
-      "$ref": "#Info"
+      "$ref": "#/$defs/Info"
     },
     "externalDocs": {
       "$ref": "#ExternalDocumentation"
@@ -603,16 +603,14 @@
           "patternProperties": {
             "^\\/": {
               "type": "object",
-              "properties": {
-                "oneOf": [
-                  {
-                    "$ref": "#Reference"
-                  },
-                  {
-                    "type": "#PathItem"
-                  }
-                ]
-              }
+              "oneOf": [
+                {
+                  "$ref": "#Reference"
+                },
+                {
+                  "$ref": "#PathItem"
+                }
+              ]
             }
           },
           "unevaluatedProperties": false
@@ -981,7 +979,9 @@
             },
             {
               "type": "object",
-              "required": "-type",
+              "required": [
+                "type"
+              ],
               "allOf": [
                 {
                   "$ref": "#/$defs/Mixins/$defs/Describable"

--- a/schemas/v3.1/schema.yaml
+++ b/schemas/v3.1/schema.yaml
@@ -237,6 +237,8 @@ $defs:
               url:
                 type: string
                 format: uri-reference
+              identifier:
+                type: string
             unevaluatedProperties: false
 
       Server:

--- a/schemas/v3.1/schema.yaml
+++ b/schemas/v3.1/schema.yaml
@@ -11,12 +11,11 @@ anyOf:
       - paths
   - required:
       - webhooks
-allOf:
-  - $ref: '#/$defs/Mixins/$defs/Extensible'
+$ref: '#/$defs/Mixins/$defs/Extensible'
 properties:
   openapi:
     type: string
-    pattern: ^3\.1\.\d(-.+)?$
+    pattern: ^3\.1\.\d+(-.+)?$
   jsonSchemaDialect:
     type: string
     format: uri
@@ -36,6 +35,7 @@ properties:
     type: array
     items:
       $ref: '#Tag'
+    uniqueItems: true
   paths:
     $ref: '#Paths'
   webhooks:
@@ -289,7 +289,7 @@ $defs:
                   $ref: '#MediaType'
               links:
                 type: object
-                additionalProperteis:
+                additionalProperties:
                   $ref: '#Link'
             unevaluatedProperties: false
       MediaType:
@@ -372,9 +372,7 @@ $defs:
           parameters:
             type: array
             items:
-              oneOf:
-                - $ref: '#Parameter'
-                - $ref: '#Reference'
+              $ref: '#Parameter'
             uniqueItems: true
       Operation:
         $anchor: Operation
@@ -398,6 +396,7 @@ $defs:
             type: array
             items:
               $ref: '#Parameter'
+            uniqueItems: true
           requestBody:
             $ref: '#RequestBody'
           responses:
@@ -422,7 +421,7 @@ $defs:
           default:
             $ref: '#Response'
         patternProperties:
-          '[1-5](?:\d{2}|XX)':
+          '^[1-5](?:\d{2}|XX)$':
             $ref: '#Response'
         minProperties: 1
         unevaluatedProperties: false
@@ -451,12 +450,11 @@ $defs:
         $anchor: ExternalDocumentation
         allOf:
           - $ref: '#/$defs/Mixins/$defs/Extensible'
+          - $ref: '#/$defs/Mixins/$defs/Describable'
         type: object
         required:
           - url
         properties:
-          description:
-            type: string
           url:
             type: string
             format: uri-reference
@@ -556,7 +554,7 @@ $defs:
               - $ref: '#/$defs/Mixins/$defs/Extensible'
             properties:
               type:
-                string: null
+                type: string
                 enum:
                   - apiKey
                   - http
@@ -564,12 +562,12 @@ $defs:
                   - mutualTLS
                   - oauth2
                   - openIdConnect
-                oneOf:
-                  - $ref: '#APIKey'
-                  - $ref: '#HTTP'
-                  - $ref: '#MutualTLS'
-                  - $ref: '#OAuth2'
-                  - $ref: '#OpenIdConnect'
+            oneOf:
+              - $ref: '#APIKey'
+              - $ref: '#HTTP'
+              - $ref: '#MutualTLS'
+              - $ref: '#OAuth2'
+              - $ref: '#OpenIdConnect'
             unevaluatedProperties: false
         $defs:
           APIKey:
@@ -767,7 +765,7 @@ $defs:
                   wrapped:
                     type: boolean
                     default: false
-            additionalProperties: false
+            unevaluatedProperties: false
       Components:
         $anchor: Components
         type: object
@@ -784,7 +782,7 @@ $defs:
               $ref: '#Schema'
           responses:
             additionalProperties:
-              $ref: '#Responses'
+              $ref: '#Response'
           parameters:
             additionalProperties:
               $ref: '#Parameter'

--- a/schemas/v3.1/schema.yaml
+++ b/schemas/v3.1/schema.yaml
@@ -350,7 +350,7 @@ $defs:
         allOf:
           - $ref: '#/$defs/Mixins/$defs/Extensible'
         patternProperties:
-          ^\/:
+          ^/:
             type: object
             oneOf:
               - $ref: '#Reference'

--- a/schemas/v3.1/schema.yaml
+++ b/schemas/v3.1/schema.yaml
@@ -22,6 +22,8 @@ properties:
   openapi:
     type: string
     pattern: ^3\.1\.\d(-.+)?$
+  jsonSchemaDialect:
+    type: string
   info:
     $ref: '#Info'
   externalDocs:
@@ -372,19 +374,32 @@ $defs:
         patternProperties:
           '^\/':
             type: object
-            patternProperties:
-              '^(get|put|post|delete|options|head|patch|trace)$':
-                $ref: '#Operation'
             properties:
-              servers:
-                type: array
-                items:
-                  $ref: 'Server'
-              parameters:
-                type: array
-                items:
-                  $
+              oneOf:
+                - $ref: '#Reference'
+                - type: '#PathItem'    
         unevaluatedProperties: false
+
+      PathItem:
+        $id: '#PathItem'
+        type: object
+        allOf:
+          - $ref: '#/$defs/Mixins/$defs/Describable'
+          - $ref: '#/$defs/Mixins/$defs/Extensible'
+        properties:
+          summary:
+            type: string
+          servers:
+            type: array
+            items:
+              $ref: '#Server'
+          parameters:
+            type: array
+            items:
+              oneOf:
+                - $ref: '#Parameter'
+                - $ref: '#Reference'
+            uniqueItems: true
 
       Operation:
         $id: '#Operation'
@@ -567,11 +582,13 @@ $defs:
                   - apiKey
                   - http
                   - bearer
+                  - mutualTLS
                   - oauth2
                   - openIdConnect
                 oneOf:
                   - $ref: '#APIKey'
                   - $ref: '#HTTP'
+                  - $ref: '#MutualTLS'
                   - $ref: '#OAuth2'
                   - $ref: '#OpenIdConnect'
             unevaluatedProperties: false
@@ -602,6 +619,11 @@ $defs:
                     const: bearer
                   bearerFormat:
                     type: string
+          MutalTLS:
+            $id: '#MutalTLS'
+            properties:
+              type:
+                const: mutalTLS
           OAuth2:
             $id: '#OAuth2'
             required:
@@ -761,23 +783,23 @@ $defs:
     
           XML:
             $id: '#XML'
-            type: object
-            properties:
-              name:
-                type: string
-              namespace:
-                type: string
-                format: url
-              prefix:
-                type: string
-              attribute:
-                type: boolean
-                default: false
-              wrapped:
-                type: boolean
-                default: false
-            patternProperties:
-              '^x-': true
+            allOf:
+              - $ref: '#/$defs/Mixins/$defs/Extensible'
+              - type: object
+                properties:
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                    format: url
+                  prefix:
+                    type: string
+                  attribute:
+                    type: boolean
+                    default: false
+                  wrapped:
+                    type: boolean
+                    default: false
             additionalProperties: false
 
       Components:
@@ -802,7 +824,7 @@ $defs:
               $ref: '#Parameter'
           pathItems:
             additionalProperties:
-              $ref: '#PathItems'
+              $ref: '#PathItem'
           examples:
             additionalProperties:
               $ref: '#Example'

--- a/schemas/v3.1/schema.yaml
+++ b/schemas/v3.1/schema.yaml
@@ -1,4 +1,4 @@
-id: 'https://spec.openapis.org/oas/3.1/schema/2021-02-18'
+$id: 'https://spec.openapis.org/oas/3.1/schema/2021-02-18'
 $schema: 'https://json-schema.org/draft/2019-09/schema'
 type: object
 required:

--- a/schemas/v3.1/schema.yaml
+++ b/schemas/v3.1/schema.yaml
@@ -706,7 +706,7 @@ $defs:
           - $ref: '#Reference'
           - type: object
             allOf:
-              - $ref: 'https://json-schema.org/draft/2020-02/schema#'
+              - $ref: 'https://json-schema.org/draft/2020-12/schema'
               - $ref: '#SchemaExtensions'
               - $ref: '#/$defs/Mixins/$def/Extensible'
             unevaluatedProperties: false

--- a/schemas/v3.1/schema.yaml
+++ b/schemas/v3.1/schema.yaml
@@ -1,23 +1,18 @@
-# TODO Components Object now has a new entry pathItems, to allow for reusable Path Item Objects to be defined within a valid OpenAPI document.
-# TODO Added the jsonSchemaDialect top-level field to allow the definition of a default $schema value for Schema Objects.
-
-id: https://spec.openapis.org/oas/3.1/schema/2021-02-18
-$schema: 'https://json-schema.org/draft/2020-02/schema#'
-
+id: 'https://spec.openapis.org/oas/3.1/schema/2021-02-18'
+$schema: 'https://json-schema.org/draft/2019-09/schema'
 type: object
-
 required:
   - openapi
   - info
-
 oneOf:
-  - required: [components]
-  - required: [paths]
-  - required: [webhooks]
-
+  - required:
+      - components
+  - required:
+      - paths
+  - required:
+      - webhooks
 allOf:
   - $ref: '#/$defs/Mixins/$defs/Extensible'
-
 properties:
   openapi:
     type: string
@@ -25,7 +20,7 @@ properties:
   jsonSchemaDialect:
     type: string
   info:
-    $ref: '#Info'
+    $ref: '#/$defs/Info'
   externalDocs:
     $ref: '#ExternalDocumentation'
   servers:
@@ -45,7 +40,6 @@ properties:
   components:
     $ref: '#Components'
 unevaluatedProperties: false
-
 $defs:
   Mixins:
     $defs:
@@ -63,17 +57,14 @@ $defs:
           deprecated:
             type: boolean
             default: false
-
       DescReqDep:
         allOf:
           - $ref: '#/$defs/Mixins/$defs/Describable'
           - $ref: '#/$defs/Mixins/$defs/Requireable'
           - $ref: '#/$defs/Mixins/$defs/Deprecatable'
-
       Extensible:
         patternProperties:
-          '^x-': true
-
+          ^x-: true
       WithSingleExample:
         properties:
           example: true
@@ -89,18 +80,15 @@ $defs:
         oneOf:
           - $ref: '#/$defs/Mixins/$defs/WithSingleExample'
           - $ref: '#/$defs/Mixins/$defs/WithExampleObjects'
-
       WithSchema:
         properties:
           schema:
             $ref: '#Schema'
           content: false
-
       WithSchemaAndExamples:
         allOf:
           - $ref: '#/$defs/Mixins/$defs/WithSchema'
           - $ref: '#/$defs/Mixins/$defs/WithExamples'
-
       WithContent:
         properties:
           schema: false
@@ -110,7 +98,6 @@ $defs:
               $ref: '#MediaType'
             minProperties: 1
             maxProperties: 1
-
       WithNameAndLocation:
         required:
           - name
@@ -125,7 +112,6 @@ $defs:
               - query
               - header
               - cookie
-
       WithExplodeAndReserved:
         properties:
           explode:
@@ -133,18 +119,15 @@ $defs:
           allowReserved:
             type: boolean
             default: false
-
       WithEmpty:
         properties:
           allowEmptyValue:
             type: boolean
             default: false
-
       WithExplodeReservedAndEmpty:
         allOf:
           - $refs: '#/$defs/Mixins/$defs/WithExplodeAndReserved'
           - $refs: '#/$defs/Mixins/$defs/WithEmpty'
-
       StyledSimple:
         allOf:
           - $refs: '#/$defs/Mixins/$defs/WithExplodeReservedAndEmpty'
@@ -188,11 +171,10 @@ $defs:
         properties:
           style:
             default: form
-
   Objects:
     $defs:
       Reference:
-        $id: '#Reference'
+        $id: Reference
         type: object
         required:
           - $ref
@@ -200,7 +182,6 @@ $defs:
           $ref:
             type: string
             format: uri-reference
-
       Info:
         type: object
         required:
@@ -221,10 +202,9 @@ $defs:
             $ref: '#Contact'
           license:
             $ref: '#License'
-
         $defs:
           Contact:
-            $id: '#Contact'
+            $id: Contact
             type: object
             allOf:
               - $ref: '#/$defs/Mixins/$defs/Extensible'
@@ -238,9 +218,8 @@ $defs:
                 type: string
                 format: email
             unevaluatedProperties: false
-
           License:
-            $id: '#License'
+            $id: License
             type: object
             required:
               - name
@@ -255,9 +234,8 @@ $defs:
               identifier:
                 type: string
             unevaluatedProperties: false
-
       Server:
-        $id: '#Server'
+        $id: Server
         type: object
         required:
           - url
@@ -285,14 +263,13 @@ $defs:
                   type: string
               unevaluatedProperties: false
         unevaluatedProperties: false
-
       Response:
-        $id: '#Response'
+        $id: Response
         oneOf:
           - $ref: '#Reference'
           - type: object
             required:
-            - description
+              - description
             allOf:
               - $ref: '#/$defs/Mixins/$defs/Describable'
               - $ref: '#/$defs/Mixins/$defs/Extensible'
@@ -310,9 +287,8 @@ $defs:
                 additionalProperteis:
                   $ref: '#Link'
             unevaluatedProperties: false
-
       MediaType:
-        $id: '#MediaType'
+        $id: MediaType
         type: object
         allOf:
           - $ref: '#/$defs/Mixins/$defs/WithSchemaAndExamples'
@@ -329,9 +305,8 @@ $defs:
                 additionalProperties:
                   $ref: '#Header'
         unevaluatedProperties: false
-
       Example:
-        $id: '#Example'
+        $id: Example
         oneOf:
           - $ref: '#Reference'
           - type: object
@@ -346,9 +321,8 @@ $defs:
                 type: string
                 format: uri-reference
             unevaluatedProperties: false
-
       Header:
-        $id: '#Header'
+        $id: Header
         oneOf:
           - $ref: '#Reference'
           - type: object
@@ -365,23 +339,20 @@ $defs:
                   - $ref: '#/$defs/Mixins/$defs/WithContent'
                   - $ref: '#/$defs/Mixins/$defs/WithEmpty'
             unevaluatedProperties: false
-
       Paths:
-        $id: '#Paths'
+        $id: Paths
         type: object
         allOf:
           - $ref: '#/$defs/Mixins/$defs/Extensible'
         patternProperties:
-          '^\/':
+          ^\/:
             type: object
-            properties:
-              oneOf:
-                - $ref: '#Reference'
-                - type: '#PathItem'    
+            oneOf:
+              - $ref: '#Reference'
+              - $ref: '#PathItem'
         unevaluatedProperties: false
-
       PathItem:
-        $id: '#PathItem'
+        $id: PathItem
         type: object
         allOf:
           - $ref: '#/$defs/Mixins/$defs/Describable'
@@ -400,9 +371,8 @@ $defs:
                 - $ref: '#Parameter'
                 - $ref: '#Reference'
             uniqueItems: true
-
       Operation:
-        $id: '#Operation'
+        $id: Operation
         type: object
         required:
           - responses
@@ -440,9 +410,8 @@ $defs:
             items:
               $ref: '#Server'
         unevaluatedProperties: false
-
       Responses:
-        $id: '#Responses'
+        $id: Responses
         type: object
         allOf:
           - $ref: '#/$defs/Mixins/$defs/Extensible'
@@ -454,17 +423,15 @@ $defs:
             $ref: '#Response'
         minProperties: 1
         unevaluatedProperties: false
-
       SecurityRequirement:
-        $id: '#SecurityRequirement'
+        $id: SecurityRequirement
         type: object
         additionalProperties:
           type: array
           items:
             type: string
-
       Tag:
-        $id: '#Tag'
+        $id: Tag
         type: object
         required:
           - name
@@ -477,9 +444,8 @@ $defs:
           externalDocs:
             $ref: '#ExternalDocumentation'
         unevaluatedProperties: false
-
       Parameter:
-        $id: '#Parameter'
+        $id: Parameter
         oneOf:
           - $ref: '#Reference'
           - type: object
@@ -499,9 +465,9 @@ $defs:
                             default: true
                   - allOf:
                       - anyOf:
-                        - $ref: '#QueryParam'
-                        - $ref: '#HeaderParam'
-                        - $ref: '#CookieParam'
+                          - $ref: '#QueryParam'
+                          - $ref: '#HeaderParam'
+                          - $ref: '#CookieParam'
                       - $ref: '#/$defs/Mixins/$defs/DescReqDep'
             oneOf:
               - allOf:
@@ -527,31 +493,29 @@ $defs:
                   - $ref: '#/$defs/Mixins/$defs/WithContent'
                   - $ref: '#/$defs/Mixins/$defs/WithEmpty'
             unevaluatedProperties: false
-
         $defs:
           PathParam:
-            $id: '#PathParam'
+            $id: PathParam
             properties:
               in:
                 const: path
           QueryParam:
-            $id: '#QueryParam'
+            $id: QueryParam
             properties:
               in:
                 const: query
           HeaderParam:
-            $id: '#HeaderParam'
+            $id: HeaderParam
             properties:
               in:
                 const: header
           CookieParam:
-            $id: '#CookieParam'
+            $id: CookieParam
             properties:
               in:
                 const: cookie
-
       RequestBody:
-        $id: '#RequestBody'
+        $id: RequestBody
         required:
           - content
         allOf:
@@ -564,20 +528,19 @@ $defs:
             additionalProperties:
               $ref: '#MediaType'
         unevaluatedProperties: false
-
       SecurityScheme:
-        $id: '#SecurityScheme'
+        $id: SecurityScheme
         oneOf:
           - $ref: '#Reference'
           - type: object
             required:
-              -type
+              - type
             allOf:
               - $ref: '#/$defs/Mixins/$defs/Describable'
               - $ref: '#/$defs/Mixins/$defs/Extensible'
             properties:
               type:
-                string:
+                string: null
                 enum:
                   - apiKey
                   - http
@@ -592,10 +555,9 @@ $defs:
                   - $ref: '#OAuth2'
                   - $ref: '#OpenIdConnect'
             unevaluatedProperties: false
-
         $defs:
           APIKey:
-            $id: '#APIKey'
+            $id: APIKey
             properties:
               type:
                 const: apiKey
@@ -604,7 +566,7 @@ $defs:
             not:
               $ref: '#PathParam'
           HTTP:
-            $id: '#HTTP'
+            $id: HTTP
             required:
               - scheme
             properties:
@@ -620,12 +582,12 @@ $defs:
                   bearerFormat:
                     type: string
           MutalTLS:
-            $id: '#MutalTLS'
+            $id: MutalTLS
             properties:
               type:
                 const: mutalTLS
           OAuth2:
-            $id: '#OAuth2'
+            $id: OAuth2
             required:
               - flows
             properties:
@@ -634,7 +596,7 @@ $defs:
               flows:
                 $ref: '#OAuthFlows'
           OpenIdConnect:
-            $id: '#OpenIdConnect'
+            $id: OpenIdConnect
             required:
               - openIdConnectUrl
             properties:
@@ -643,9 +605,8 @@ $defs:
               openIdConnectUrl:
                 type: string
                 format: uri
-
       OAuthFlows:
-        $id: '#OAuthFlows'
+        $id: OAuthFlows
         type: object
         allOf:
           - $ref: '#/$defs/Mixins/$defs/Extensible'
@@ -664,14 +625,12 @@ $defs:
               - $ref: '#TokenFlow'
               - $ref: '#/$defs/Mixins/$defs/Extensible'
             unevaluatedProperties: false
-
           clientCredentials:
             allOf:
               - $ref: '#CommonFlow'
               - $ref: '#TokenFlow'
               - $ref: '#/$defs/Mixins/$defs/Extensible'
             unevaluatedProperties: false
-              
           authorizationCode:
             allOf:
               - $ref: '#CommonFlow'
@@ -680,10 +639,9 @@ $defs:
               - $ref: '#/$defs/Mixins/$defs/Extensible'
             unevaluatedProperties: false
         unevaluatedProperties: false
-
         $defs:
           Common:
-            $id: '#CommonFlow'
+            $id: CommonFlow
             properties:
               refreshUrl:
                 type: string
@@ -693,7 +651,7 @@ $defs:
                 additionalProperties:
                   type: string
           Token:
-            $id: '#TokenFlow'
+            $id: TokenFlow
             required:
               - tokenUrl
             properties:
@@ -701,16 +659,15 @@ $defs:
                 type: string
                 format: uri-reference
           Authorization:
-            $id: '#AuthorizationFlow'
+            $id: AuthorizationFlow
             required:
               - authorizationUrl
             properties:
               authorizationUrl:
                 type: string
                 format: uri-reference
-
       Link:
-        $id: '#Link'
+        $id: Link
         oneOf:
           - $ref: '#Reference'
           - type: object
@@ -735,18 +692,16 @@ $defs:
               server:
                 $ref: '#Server'
             unevaluatedProperties: false
-
       Callback:
-        $id: '#Callback'
+        $id: Callback
         oneOf:
           - $ref: '#Reference'
           - type: object
             allOf:
               - $ref: '#/$defs/Mixins/$defs/Extensible'
             unevaluatedProperties: false
-
       Schema:
-        $id: '#Schema'
+        $id: Schema
         oneOf:
           - $ref: '#Reference'
           - type: object
@@ -754,12 +709,10 @@ $defs:
               - $ref: 'https://json-schema.org/draft/2020-02/schema#'
               - $ref: '#SchemaExtensions'
               - $ref: '#/$defs/Mixins/$def/Extensible'
-            unevaluatedProperties: false   
-        
+            unevaluatedProperties: false
         $defs:
-
           Extensions:
-            $id: '#SchemaExtensions'
+            $id: SchemaExtensions
             properties:
               discriminator:
                 $ref: '#Discriminator'
@@ -767,9 +720,8 @@ $defs:
                 $ref: '#ExternalDocumentation'
               xml:
                 $ref: '#XML'
-      
           Discriminator:
-            $id: '#Discriminator'
+            $id: Discriminator
             type: object
             required:
               - propertyName
@@ -780,9 +732,8 @@ $defs:
                 type: object
                 additionalProperties:
                   type: string
-    
           XML:
-            $id: '#XML'
+            $id: XML
             allOf:
               - $ref: '#/$defs/Mixins/$defs/Extensible'
               - type: object
@@ -801,9 +752,8 @@ $defs:
                     type: boolean
                     default: false
             additionalProperties: false
-
       Components:
-        $id: '#Components'
+        $id: Components
         type: object
         allOf:
           - $ref: '#/$defs/Mixins/$defs/Extensible'

--- a/schemas/v3.1/schema.yaml
+++ b/schemas/v3.1/schema.yaml
@@ -1,4 +1,6 @@
+# TODO Components Object now has a new entry pathItems, to allow for reusable Path Item Objects to be defined within a valid OpenAPI document.
 # TODO Added the jsonSchemaDialect top-level field to allow the definition of a default $schema value for Schema Objects.
+
 id: https://spec.openapis.org/oas/3.1/schema/2021-02-18
 $schema: 'https://json-schema.org/draft/2020-02/schema#'
 
@@ -15,6 +17,7 @@ oneOf:
 
 allOf:
   - $ref: '#/$defs/Mixins/$defs/Extensible'
+
 properties:
   openapi:
     type: string
@@ -208,6 +211,7 @@ $defs:
           title:
             type: string
           summary:
+            type: string
           termsOfService:
             type: string
             format: uri-reference
@@ -725,46 +729,13 @@ $defs:
           - $ref: '#Reference'
           - type: object
             allOf:
-              - $ref: 'http://json-schema.org/draft-04/schema#'
-              - $ref: '#SchemaRestrictions'
+              - $ref: 'https://json-schema.org/draft/2020-02/schema#'
               - $ref: '#SchemaExtensions'
               - $ref: '#/$defs/Mixins/$def/Extensible'
-            unevaluatedProperties: false        
+            unevaluatedProperties: false   
         
         $defs:
-          Restrictions:
-            $id: '#SchemaRestrictions'
-            properties:
-              type:
-                not:
-                  const: 'null'
-              not:
-                $ref: '#/$defs/Schema'
-              allOf:
-                type: array
-                items:
-                  $ref: '#/$defs/Schema'
-              oneOf:
-                type: array
-                items:
-                  $ref: '#/$defs/Schema'
-              anyOf:
-                type: array
-                items:
-                  $ref: '#/$defs/Schema'
-              items:
-                $ref: '#/$defs/Schema'
-              properties:
-                type: object
-                additionalProperties:
-                  $ref: '#/$defs/Schema'
-              additionalProperties:
-                oneOf:
-                  - $ref: '#/$defs/Schema'
-                  - type: boolean
-                default: true
-              patternProperties: false
-    
+
           Extensions:
             $id: '#SchemaExtensions'
             properties:
@@ -829,6 +800,9 @@ $defs:
           parameters:
             additionalProperties:
               $ref: '#Parameter'
+          pathItems:
+            additionalProperties:
+              $ref: '#PathItems'
           examples:
             additionalProperties:
               $ref: '#Example'

--- a/schemas/v3.1/schema.yaml
+++ b/schemas/v3.1/schema.yaml
@@ -1,0 +1,836 @@
+id: https://spec.openapis.org/oas/3.1/schema/2021-02-18
+$schema: 'https://json-schema.org/draft/2020-02/schema#'
+type: object
+required:
+  - openapi
+  - info
+  - paths
+allOf:
+  - $ref: '#/$defs/Mixins/$defs/Extensible'
+properties:
+  openapi:
+    type: string
+    pattern: ^3\.1\.\d(-.+)?$
+  info:
+    $ref: '#Info'
+  externalDocs:
+    $ref: '#ExternalDocumentation'
+  servers:
+    type: array
+    items:
+      $ref: '#Server'
+  security:
+    type: array
+    items:
+      $ref: '#SecurityRequirement'
+  tags:
+    type: array
+    items:
+      $ref: '#Tag'
+  paths:
+    $ref: '#Paths'
+  components:
+    $ref: '#Components'
+unevaluatedProperties: false
+
+$defs:
+  Mixins:
+    $defs:
+      Describable:
+        properties:
+          description:
+            type: string
+      Requireable:
+        properties:
+          required:
+            type: boolean
+            default: false
+      Deprecatable:
+        properties:
+          deprecated:
+            type: boolean
+            default: false
+
+      DescReqDep:
+        allOf:
+          - $ref: '#/$defs/Mixins/$defs/Describable'
+          - $ref: '#/$defs/Mixins/$defs/Requireable'
+          - $ref: '#/$defs/Mixins/$defs/Deprecatable'
+
+      Extensible:
+        patternProperties:
+          '^x-': true
+
+      WithSingleExample:
+        properties:
+          example: true
+          examples: false
+      WithExampleObjects:
+        properties:
+          example: false
+          examples:
+            type: object
+            additionalProperties:
+              $ref: '#Example'
+      WithExamples:
+        oneOf:
+          - $ref: '#/$defs/Mixins/$defs/WithSingleExample'
+          - $ref: '#/$defs/Mixins/$defs/WithExampleObjects'
+
+      WithSchema:
+        properties:
+          schema:
+            $ref: '#Schema'
+          content: false
+
+      WithSchemaAndExamples:
+        allOf:
+          - $ref: '#/$defs/Mixins/$defs/WithSchema'
+          - $ref: '#/$defs/Mixins/$defs/WithExamples'
+
+      WithContent:
+        properties:
+          schema: false
+          content:
+            type: object
+            additionalProperties:
+              $ref: '#MediaType'
+            minProperties: 1
+            maxProperties: 1
+
+      WithNameAndLocation:
+        required:
+          - name
+          - in
+        properties:
+          name:
+            type: string
+          in:
+            type: string
+            enum:
+              - path
+              - query
+              - header
+              - cookie
+
+      WithExplodeAndReserved:
+        properties:
+          explode:
+            type: boolean
+          allowReserved:
+            type: boolean
+            default: false
+
+      WithEmpty:
+        properties:
+          allowEmptyValue:
+            type: boolean
+            default: false
+
+      WithExplodeReservedAndEmpty:
+        allOf:
+          - $refs: '#/$defs/Mixins/$defs/WithExplodeAndReserved'
+          - $refs: '#/$defs/Mixins/$defs/WithEmpty'
+
+      StyledSimple:
+        allOf:
+          - $refs: '#/$defs/Mixins/$defs/WithExplodeReservedAndEmpty'
+        properties:
+          style:
+            type: string
+            const: simple
+            default: simple
+      StyledMatrix:
+        properties:
+          style:
+            type: string
+            enum:
+              - matrix
+              - label
+              - simple
+            default: simple
+      StyledFormOnly:
+        allOf:
+          - $refs: '#/$defs/Mixins/$defs/WithExplodeReservedAndEmpty'
+        properties:
+          style:
+            type: string
+            const: form
+            default: form
+      StyledFormComplexNoDefaultOrEmpty:
+        allOf:
+          - $refs: '#/$defs/Mixins/$defs/WithExplodeAndReserved'
+        properties:
+          style:
+            type: string
+            enum:
+              - form
+              - spaceDelimited
+              - pipeDelimited
+              - deepObject
+      StyledFormComplex:
+        allOf:
+          - $refs: '#/$defs/Mixins/$defs/StyledFormComplexNoDefaultOrEmpty'
+          - $refs: '#/$defs/Mixins/$defs/WithExplodeReservedAndEmpty'
+        properties:
+          style:
+            default: form
+
+  Objects:
+    $defs:
+      Reference:
+        $id: '#Reference'
+        type: object
+        required:
+          - $ref
+        properties:
+          $ref:
+            type: string
+            format: uri-reference
+
+      Info:
+        type: object
+        required:
+          - title
+          - version
+        allOf:
+          - $ref: '#/$defs/Mixins/$defs/Describable'
+          - $ref: '#/$defs/Mixins/$defs/Extensible'
+        properties:
+          title:
+            type: string
+          termsOfService:
+            type: string
+            format: uri-reference
+          contact:
+            $ref: '#Contact'
+          license:
+            $ref: '#License'
+
+        $defs:
+          Contact:
+            $id: '#Contact'
+            type: object
+            allOf:
+              - $ref: '#/$defs/Mixins/$defs/Extensible'
+            properties:
+              name:
+                type: string
+              url:
+                type: string
+                format: uri-reference
+              email:
+                type: string
+                format: email
+            unevaluatedProperties: false
+
+          License:
+            $id: '#License'
+            type: object
+            required:
+              - name
+            allOf:
+              - $ref: '#/$defs/Mixins/$defs/Extensible'
+            properties:
+              name:
+                type: string
+              url:
+                type: string
+                format: uri-reference
+            unevaluatedProperties: false
+
+      Server:
+        $id: '#Server'
+        type: object
+        required:
+          - url
+        allOf:
+          - $ref: '#/$defs/Mixins/$defs/Describable'
+          - $ref: '#/$defs/Mixins/$defs/Extensible'
+        properties:
+          url:
+            type: string
+          variables:
+            type: object
+            additionalProperties:
+              type: object
+              required:
+                - default
+              allOf:
+                - $ref: '#/$defs/Mixins/$defs/Describable'
+                - $ref: '#/$defs/Mixins/$defs/Extensible'
+              properties:
+                enum:
+                  type: array
+                  items:
+                    type: string
+                default:
+                  type: string
+              unevaluatedProperties: false
+        unevaluatedProperties: false
+
+      Response:
+        $id: '#Response'
+        oneOf:
+          - $ref: '#Reference'
+          - type: object
+            required:
+            - description
+            allOf:
+              - $ref: '#/$defs/Mixins/$defs/Describable'
+              - $ref: '#/$defs/Mixins/$defs/Extensible'
+            properties:
+              headers:
+                type: object
+                additionalProperties:
+                  $ref: '#Header'
+              content:
+                type: object
+                additionalProperties:
+                  $ref: '#MediaType'
+              links:
+                type: object
+                additionalProperteis:
+                  $ref: '#Link'
+            unevaluatedProperties: false
+
+      MediaType:
+        $id: '#MediaType'
+        type: object
+        allOf:
+          - $ref: '#/$defs/Mixins/$defs/WithSchemaAndExamples'
+        properties:
+          encoding:
+            type: object
+            allOf:
+              - $ref: '#/$defs/Mixins/$defs/StyledFormComplexNoDefaultOrEmpty'
+            properties:
+              contentType:
+                type: string
+              headers:
+                type: object
+                additionalProperties:
+                  $ref: '#Header'
+        unevaluatedProperties: false
+
+      Example:
+        $id: '#Example'
+        oneOf:
+          - $ref: '#Reference'
+          - type: object
+            allOf:
+              - $ref: '#/$defs/Mixins/$defs/Describable'
+              - $ref: '#/$defs/Mixins/$defs/Extensible'
+            properties:
+              summary:
+                type: string
+              value: true
+              externalValue:
+                type: string
+                format: uri-reference
+            unevaluatedProperties: false
+
+      Header:
+        $id: '#Header'
+        oneOf:
+          - $ref: '#Reference'
+          - type: object
+            required:
+              - schema
+            allOf:
+              - $ref: '#/$defs/Mixins/$defs/DescReqDep'
+              - $ref: '#/$defs/Mixins/$defs/Extensible'
+            oneOf:
+              - allOf:
+                  - $ref: '#/$defs/Mixins/$defs/WithSchemaAndExamples'
+                  - $ref: '#/$defs/Mixins/$defs/StyledSimple'
+              - allOf:
+                  - $ref: '#/$defs/Mixins/$defs/WithContent'
+                  - $ref: '#/$defs/Mixins/$defs/WithEmpty'
+            unevaluatedProperties: false
+
+      Paths:
+        $id: '#Paths'
+        type: object
+        allOf:
+          - $ref: '#/$defs/Mixins/$defs/Extensible'
+        patternProperties:
+          '^\/':
+            type: object
+            patternProperties:
+              '^(get|put|post|delete|options|head|patch|trace)$':
+                $ref: '#Operation'
+            properties:
+              servers:
+                type: array
+                items:
+                  $ref: 'Server'
+              parameters:
+                type: array
+                items:
+                  $
+        unevaluatedProperties: false
+
+      Operation:
+        $id: '#Operation'
+        type: object
+        required:
+          - responses
+        allOf:
+          - $ref: '#/$defs/Mixins/$defs/Describable'
+          - $ref: '#/$defs/Mixins/$defs/Deprecatable'
+          - $ref: '#/$defs/Mixins/$defs/Extensible'
+        properties:
+          tags:
+            type: array
+            items:
+              type: string
+          summary:
+            type: string
+          externalDocs:
+            $ref: '#ExternalDocumentation'
+          operationId:
+            type: string
+          parameters:
+            type: array
+            items:
+              $ref: '#Parameter'
+          requestBody:
+            $ref: '#RequestBody'
+          responses:
+            $ref: '#Responses'
+          callback:
+            $ref: '#Callback'
+          security:
+            type: array
+            items:
+              $ref: '#SecurityRequirement'
+          servers:
+            type: array
+            items:
+              $ref: '#Server'
+        unevaluatedProperties: false
+
+      Responses:
+        $id: '#Responses'
+        type: object
+        allOf:
+          - $ref: '#/$defs/Mixins/$defs/Extensible'
+        properties:
+          default:
+            $ref: '#Response'
+        patternProperties:
+          '[1-5](?:\d{2}|XX)':
+            $ref: '#Response'
+        minProperties: 1
+        unevaluatedProperties: false
+
+      SecurityRequirement:
+        $id: '#SecurityRequirement'
+        type: object
+        additionalProperties:
+          type: array
+          items:
+            type: string
+
+      Tag:
+        $id: '#Tag'
+        type: object
+        required:
+          - name
+        allOf:
+          - $ref: '#/$defs/Mixins/$defs/Describable'
+          - $ref: '#/$defs/Mixins/$defs/Extensible'
+        properties:
+          name:
+            type: string
+          externalDocs:
+            $ref: '#ExternalDocumentation'
+        unevaluatedProperties: false
+
+      Parameter:
+        $id: '#Parameter'
+        oneOf:
+          - $ref: '#Reference'
+          - type: object
+            allOf:
+              - $ref: '#/$defs/Mixins/$defs/WithNameAndLocation'
+              - $ref: '#/$defs/Mixins/$defs/Extensible'
+              - oneOf:
+                  - allOf:
+                      - $ref: '#PathParam'
+                      - $ref: '#/$defs/Mixins/$defs/Describable'
+                      - $ref: '#/$defs/Mixins/$defs/Deprecatable'
+                      - required:
+                          - required
+                        properties:
+                          required:
+                            const: true
+                            default: true
+                  - allOf:
+                      - anyOf:
+                        - $ref: '#QueryParam'
+                        - $ref: '#HeaderParam'
+                        - $ref: '#CookieParam'
+                      - $ref: '#/$defs/Mixins/$defs/DescReqDep'
+            oneOf:
+              - allOf:
+                  - required:
+                      - schema
+                  - $ref: '#/$defs/Mixins/$defs/WithSchemaAndExamples'
+                  - oneOf:
+                      - allOf:
+                          - $ref: '#PathParam'
+                          - $ref: '#/$defs/Mixins/$defs/StyledMatrix'
+                      - allOf:
+                          - $refs: '#QueryParam'
+                          - $refs: '#/$defs/Mixins/$defs/StyledFormComplex'
+                      - allOf:
+                          - $ref: '#HeaderParam'
+                          - $ref: '#/$defs/Mixins/$defs/StyledSimple'
+                      - allOf:
+                          - $ref: '#CookieParam'
+                          - $refs: '#/$defs/Mixins/$defs/StyledFormOnly'
+              - allOf:
+                  - required:
+                      - content
+                  - $ref: '#/$defs/Mixins/$defs/WithContent'
+                  - $ref: '#/$defs/Mixins/$defs/WithEmpty'
+            unevaluatedProperties: false
+
+        $defs:
+          PathParam:
+            $id: '#PathParam'
+            properties:
+              in:
+                const: path
+          QueryParam:
+            $id: '#QueryParam'
+            properties:
+              in:
+                const: query
+          HeaderParam:
+            $id: '#HeaderParam'
+            properties:
+              in:
+                const: header
+          CookieParam:
+            $id: '#CookieParam'
+            properties:
+              in:
+                const: cookie
+
+      RequestBody:
+        $id: '#RequestBody'
+        required:
+          - content
+        allOf:
+          - $ref: '#/$defs/Mixins/$defs/Describable'
+          - $ref: '#/$defs/Mixins/$defs/Requireable'
+          - $ref: '#/$defs/Mixins/$defs/Extensible'
+        properties:
+          content:
+            type: object
+            additionalProperties:
+              $ref: '#MediaType'
+        unevaluatedProperties: false
+
+      SecurityScheme:
+        $id: '#SecurityScheme'
+        oneOf:
+          - $ref: '#Reference'
+          - type: object
+            required:
+              -type
+            allOf:
+              - $ref: '#/$defs/Mixins/$defs/Describable'
+              - $ref: '#/$defs/Mixins/$defs/Extensible'
+            properties:
+              type:
+                string:
+                enum:
+                  - apiKey
+                  - http
+                  - bearer
+                  - oauth2
+                  - openIdConnect
+                oneOf:
+                  - $ref: '#APIKey'
+                  - $ref: '#HTTP'
+                  - $ref: '#OAuth2'
+                  - $ref: '#OpenIdConnect'
+            unevaluatedProperties: false
+
+        $defs:
+          APIKey:
+            $id: '#APIKey'
+            properties:
+              type:
+                const: apiKey
+            allOf:
+              - $ref: '#/$defs/Mixins/$defs/WithNameAndLocation'
+            not:
+              $ref: '#PathParam'
+          HTTP:
+            $id: '#HTTP'
+            required:
+              - scheme
+            properties:
+              scheme:
+                type: string
+            oneOf:
+              - properties:
+                  type:
+                    const: http
+              - properties:
+                  type:
+                    const: bearer
+                  bearerFormat:
+                    type: string
+          OAuth2:
+            $id: '#OAuth2'
+            required:
+              - flows
+            properties:
+              type:
+                const: oauth2
+              flows:
+                $ref: '#OAuthFlows'
+          OpenIdConnect:
+            $id: '#OpenIdConnect'
+            required:
+              - openIdConnectUrl
+            properties:
+              type:
+                const: openIdConnect
+              openIdConnectUrl:
+                type: string
+                format: uri
+
+      OAuthFlows:
+        $id: '#OAuthFlows'
+        type: object
+        allOf:
+          - $ref: '#/$defs/Mixins/$defs/Extensible'
+        properties:
+          implicit:
+            allOf:
+              - required:
+                  - scopes
+              - $ref: '#CommonFlow'
+              - $ref: '#AuthorizationFlow'
+              - $ref: '#/$defs/Mixins/$defs/Extensible'
+            unevaluatedProperties: false
+          password:
+            allOf:
+              - $ref: '#CommonFlow'
+              - $ref: '#TokenFlow'
+              - $ref: '#/$defs/Mixins/$defs/Extensible'
+            unevaluatedProperties: false
+
+          clientCredentials:
+            allOf:
+              - $ref: '#CommonFlow'
+              - $ref: '#TokenFlow'
+              - $ref: '#/$defs/Mixins/$defs/Extensible'
+            unevaluatedProperties: false
+              
+          authorizationCode:
+            allOf:
+              - $ref: '#CommonFlow'
+              - $ref: '#TokenFlow'
+              - $ref: '#AuthorizationFlow'
+              - $ref: '#/$defs/Mixins/$defs/Extensible'
+            unevaluatedProperties: false
+        unevaluatedProperties: false
+
+        $defs:
+          Common:
+            $id: '#CommonFlow'
+            properties:
+              refreshUrl:
+                type: string
+                format: uri-reference
+              scopes:
+                type: object
+                additionalProperties:
+                  type: string
+          Token:
+            $id: '#TokenFlow'
+            required:
+              - tokenUrl
+            properties:
+              tokenUrl:
+                type: string
+                format: uri-reference
+          Authorization:
+            $id: '#AuthorizationFlow'
+            required:
+              - authorizationUrl
+            properties:
+              authorizationUrl:
+                type: string
+                format: uri-reference
+
+      Link:
+        $id: '#Link'
+        oneOf:
+          - $ref: '#Reference'
+          - type: object
+            allOf:
+              - $ref: '#/$defs/Mixins/$defs/Describable'
+              - $ref: '#/$defs/Mixins/$defs/Extensible'
+            oneOf:
+              - properties:
+                  operationRef:
+                    type: string
+                    format: uri-reference
+                  operationId: false
+              - properties:
+                  operationRef: false
+                  operationId:
+                    type: string
+            properties:
+              parameters:
+                type: object
+                additionalProperties: true
+              requestBody: true
+              server:
+                $ref: '#Server'
+            unevaluatedProperties: false
+
+      Callback:
+        $id: '#Callback'
+        oneOf:
+          - $ref: '#Reference'
+          - type: object
+            allOf:
+              - $ref: '#/$defs/Mixins/$defs/Extensible'
+            unevaluatedProperties: false
+
+      Schema:
+        $id: '#Schema'
+        oneOf:
+          - $ref: '#Reference'
+          - type: object
+            allOf:
+              - $ref: 'http://json-schema.org/draft-04/schema#'
+              - $ref: '#SchemaRestrictions'
+              - $ref: '#SchemaExtensions'
+              - $ref: '#/$defs/Mixins/$def/Extensible'
+            unevaluatedProperties: false        
+        
+        $defs:
+          Restrictions:
+            $id: '#SchemaRestrictions'
+            properties:
+              type:
+                not:
+                  const: 'null'
+              not:
+                $ref: '#/$defs/Schema'
+              allOf:
+                type: array
+                items:
+                  $ref: '#/$defs/Schema'
+              oneOf:
+                type: array
+                items:
+                  $ref: '#/$defs/Schema'
+              anyOf:
+                type: array
+                items:
+                  $ref: '#/$defs/Schema'
+              items:
+                $ref: '#/$defs/Schema'
+              properties:
+                type: object
+                additionalProperties:
+                  $ref: '#/$defs/Schema'
+              additionalProperties:
+                oneOf:
+                  - $ref: '#/$defs/Schema'
+                  - type: boolean
+                default: true
+              patternProperties: false
+    
+          Extensions:
+            $id: '#SchemaExtensions'
+            properties:
+              discriminator:
+                $ref: '#Discriminator'
+              externalDocs:
+                $ref: '#ExternalDocumentation'
+              xml:
+                $ref: '#XML'
+      
+          Discriminator:
+            $id: '#Discriminator'
+            type: object
+            required:
+              - propertyName
+            properties:
+              propertyName:
+                type: string
+              mapping:
+                type: object
+                additionalProperties:
+                  type: string
+    
+          XML:
+            $id: '#XML'
+            type: object
+            properties:
+              name:
+                type: string
+              namespace:
+                type: string
+                format: url
+              prefix:
+                type: string
+              attribute:
+                type: boolean
+                default: false
+              wrapped:
+                type: boolean
+                default: false
+            patternProperties:
+              '^x-': true
+            additionalProperties: false
+
+      Components:
+        $id: '#Components'
+        type: object
+        allOf:
+          - $ref: '#/$defs/Mixins/$defs/Extensible'
+          - additionalProperties:
+              $comment: All sub-objects have the same property name constraints
+              type: object
+              propertyNames:
+                pattern: '^[a-zA-Z0-9\.\-_]+$'
+        properties:
+          schemas:
+            additionalProperties:
+              $ref: '#Schema'
+          responses:
+            additionalProperties:
+              $ref: '#Responses'
+          parameters:
+            additionalProperties:
+              $ref: '#Parameter'
+          examples:
+            additionalProperties:
+              $ref: '#Example'
+          requestBodies:
+            additionalProperties:
+              $ref: '#RequestBody'
+          headers:
+            additionalProperties:
+              $ref: '#Header'
+          links:
+            additionalProperties:
+              $ref: '#Link'
+          callbacks:
+            additionalProperties:
+              $ref: '#Callback'
+        unevaluatedProperties: true

--- a/schemas/v3.1/schema.yaml
+++ b/schemas/v3.1/schema.yaml
@@ -1,3 +1,4 @@
+# TODO Added the jsonSchemaDialect top-level field to allow the definition of a default $schema value for Schema Objects.
 id: https://spec.openapis.org/oas/3.1/schema/2021-02-18
 $schema: 'https://json-schema.org/draft/2020-02/schema#'
 
@@ -206,6 +207,7 @@ $defs:
         properties:
           title:
             type: string
+          summary:
           termsOfService:
             type: string
             format: uri-reference

--- a/schemas/v3.1/schema.yaml
+++ b/schemas/v3.1/schema.yaml
@@ -185,6 +185,10 @@ $defs:
           $ref:
             type: string
             format: uri-reference
+          summary:
+            type: string
+        $ref: '#/$defs/Mixins/$defs/Describable'
+        unevaluatedProperties: false
       Info:
         $anchor: Info
         type: object

--- a/schemas/v3.1/schema.yaml
+++ b/schemas/v3.1/schema.yaml
@@ -19,6 +19,7 @@ properties:
     pattern: ^3\.1\.\d(-.+)?$
   jsonSchemaDialect:
     type: string
+    format: uri
   info:
     $ref: '#Info'
   externalDocs:
@@ -378,8 +379,6 @@ $defs:
       Operation:
         $anchor: Operation
         type: object
-        required:
-          - responses
         allOf:
           - $ref: '#/$defs/Mixins/$defs/Describable'
           - $ref: '#/$defs/Mixins/$defs/Deprecatable'
@@ -602,7 +601,7 @@ $defs:
             $anchor: MutualTLS
             properties:
               type:
-                const: mutalTLS
+                const: mutualTLS
           OAuth2:
             $anchor: OAuth2
             required:
@@ -807,4 +806,4 @@ $defs:
           callbacks:
             additionalProperties:
               $ref: '#Callback'
-        unevaluatedProperties: true
+        unevaluatedProperties: false

--- a/schemas/v3.1/schema.yaml
+++ b/schemas/v3.1/schema.yaml
@@ -1,10 +1,17 @@
 id: https://spec.openapis.org/oas/3.1/schema/2021-02-18
 $schema: 'https://json-schema.org/draft/2020-02/schema#'
+
 type: object
+
 required:
   - openapi
   - info
-  - paths
+
+oneOf:
+  - required: [components]
+  - required: [paths]
+  - required: [webhooks]
+
 allOf:
   - $ref: '#/$defs/Mixins/$defs/Extensible'
 properties:

--- a/schemas/v3.1/schema.yaml
+++ b/schemas/v3.1/schema.yaml
@@ -374,44 +374,6 @@ $defs:
             items:
               $ref: '#Parameter'
             uniqueItems: true
-      Operation:
-        $anchor: Operation
-        type: object
-        allOf:
-          - $ref: '#/$defs/Mixins/$defs/Describable'
-          - $ref: '#/$defs/Mixins/$defs/Deprecatable'
-          - $ref: '#/$defs/Mixins/$defs/Extensible'
-        properties:
-          tags:
-            type: array
-            items:
-              type: string
-          summary:
-            type: string
-          externalDocs:
-            $ref: '#ExternalDocumentation'
-          operationId:
-            type: string
-          parameters:
-            type: array
-            items:
-              $ref: '#Parameter'
-            uniqueItems: true
-          requestBody:
-            $ref: '#RequestBody'
-          responses:
-            $ref: '#Responses'
-          callback:
-            $ref: '#Callback'
-          security:
-            type: array
-            items:
-              $ref: '#SecurityRequirement'
-          servers:
-            type: array
-            items:
-              $ref: '#Server'
-        unevaluatedProperties: false
       Responses:
         $anchor: Responses
         type: object

--- a/schemas/v3.1/schema.yaml
+++ b/schemas/v3.1/schema.yaml
@@ -675,6 +675,8 @@ $defs:
           - type: object
             allOf:
               - $ref: '#/$defs/Mixins/$defs/Extensible'
+            additionalProperties:
+              $ref: '#PathItem'
             unevaluatedProperties: false
       Schema:
         $anchor: Schema
@@ -696,6 +698,8 @@ $defs:
                 $ref: '#ExternalDocumentation'
               xml:
                 $ref: '#XML'
+              example:
+                deprecated: true
           Discriminator:
             $anchor: Discriminator
             type: object
@@ -731,13 +735,12 @@ $defs:
       Components:
         $anchor: Components
         type: object
-        allOf:
-          - $ref: '#/$defs/Mixins/$defs/Extensible'
-          - additionalProperties:
-              $comment: All sub-objects have the same property name constraints
-              type: object
-              propertyNames:
-                pattern: '^[a-zA-Z0-9\.\-_]+$'
+        $ref: '#/$defs/Mixins/$defs/Extensible'
+        patternProperties:
+          '':
+            $comment: All sub-objects have the same property name constraints
+            propertyNames:
+              pattern: '^[a-zA-Z0-9\.\-_]+$'
         properties:
           schemas:
             additionalProperties:

--- a/schemas/v3.1/validate.js
+++ b/schemas/v3.1/validate.js
@@ -1,0 +1,19 @@
+const JsonSchema = require("@hyperjump/json-schema");
+JsonSchema.setMetaOutputFormat(JsonSchema.BASIC);
+JsonSchema.setShouldMetaValidate(false);
+(async function () {
+  try {
+    // Compile / meta-validate
+    const schema = await JsonSchema.get(`file://${__dirname}/schema.json`);
+    const validateSchema = await JsonSchema.validate(schema);
+    // Validate instance
+    const instance = "";
+    const results = validateSchema(instance, JsonSchema.DETAILED);
+    console.log(JSON.stringify(results, null, "  "));
+  } catch (error) {
+    console.log("************* Error ***************");
+    console.log(error);
+    console.log(JSON.stringify(error.output, null, "  "));
+    //console.log(error.output);
+  }
+}());


### PR DESCRIPTION
Closes #2314.

Adding a JSON Schema for the whole OpenAPI v3.1 document, as plenty of tooling requires this before they can upgrade to OpenAPI v3.1. 

This is based on a gist from @handrews, and is being tweaked for OpenAPI v3.1. https://gist.github.com/handrews/6dfebd56ef97328f9e4dc7a47a1e8bc7

This is different to the OpenAPI dialect/metaschema work being done first in #2016 but is starting again in another yet unmade PR. 