### PR TITLE
Inconsistent JSON spacing fix

### DIFF
--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -2859,9 +2859,9 @@ Basic string property:
 
 ```json
 {
-    "animals": {
-        "type": "string"
-    }
+  "animals": {
+    "type": "string"
+  }
 }
 ```
 
@@ -2878,12 +2878,12 @@ Basic string array property ([`wrapped`](#xmlWrapped) is `false` by default):
 
 ```json
 {
-    "animals": {
-        "type": "array",
-        "items": {
-            "type": "string"
-        }
+  "animals": {
+    "type": "array",
+    "items": {
+      "type": "string"
     }
+  }
 }
 ```
 


### PR DESCRIPTION
the whole document uses 2-space indentation but at some places, 4-space indentation is used which is not consistent with the others.