### PR TITLE
Make root.servers an array with Server Object items

### DIFF
--- a/schemas/v3.1/schema.yaml
+++ b/schemas/v3.1/schema.yaml
@@ -12,7 +12,9 @@ properties:
     $ref: '#/$defs/uri'
     default: 'https://spec.openapis.org/oas/3.1/dialect/base'
   servers:
-    $ref: '#/$defs/server'
+    type: array
+    items:
+      $ref: '#/$defs/server'
   paths:
     $ref: '#/$defs/paths'
   webhooks:


### PR DESCRIPTION
I noticed this differed from the spec: https://spec.openapis.org/oas/v3.1.0#openapi-object