### PR TITLE
Fixes Inconsistent JSON spacing

### DIFF
--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -117,7 +117,7 @@ For example, if a field has an array value, the JSON array representation will b
 
 ```json
 {
-   "field": [ 1, 2, 3 ]
+  "field": [1, 2, 3]
 }
 ```
 All field names in the specification are **case sensitive**.

--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -2239,8 +2239,8 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
 
 ```json
 {
-	"name": "pet",
-	"description": "Pets operations"
+  "name": "pet",
+  "description": "Pets operations"
 }
 ```
 
@@ -2273,7 +2273,7 @@ Note that this restriction on additional properties is a difference between Refe
 
 ```json
 {
-	"$ref": "#/components/schemas/Pet"
+  "$ref": "#/components/schemas/Pet"
 }
 ```
 
@@ -2859,9 +2859,9 @@ Basic string property:
 
 ```json
 {
-    "animals": {
-        "type": "string"
-    }
+  "animals": {
+    "type": "string"
+  }
 }
 ```
 
@@ -2878,12 +2878,12 @@ Basic string array property ([`wrapped`](#xmlWrapped) is `false` by default):
 
 ```json
 {
-    "animals": {
-        "type": "array",
-        "items": {
-            "type": "string"
-        }
+  "animals": {
+    "type": "array",
+    "items": {
+      "type": "string"
     }
+  }
 }
 ```
 


### PR DESCRIPTION
the whole document uses 2-space indentation but at some places, 4-space indentation is used which is not consistent with the others.