### PR TITLE
feat: add agenda workflow/template

### DIFF
--- a/.github/templates/agenda.md
+++ b/.github/templates/agenda.md
@@ -1,0 +1,19 @@
+**NOTE: This meeting is on Thursday at 9am - 10am PT**
+
+Zoom Meeting link: [https://zoom.us/j/975841675](https://zoom.us/j/975841675?pwd=SUh4MjRLaEFKNlI3RElpWTdhRDVVUT09). Dial-in passcode: 763054
+
+In order to give some more visibility into the topics we cover in the TDC meetings here is the planned agenda for the next meeting.  Hopefully this will allow people to plan to attend meetings for topics that they have an interest in.  And for folks who cannot attend they can comment on this issue prior to the meeting.  Feel free to suggest other potential agenda topics.
+
+**Please submit comments below for topics or proposals that you wish to present in the TDC meeting**
+
+The agenda backlog is currently maintained in issue #2482
+
+| Topic | Owner | Decision/NextStep |
+|-------|---------|---------|  
+| | | |
+AOB (see below) | TDC | |
+New issues / PRs labelled [review](https://github.com/OAI/OpenAPI-Specification/labels/review) | @OAI/triage | |
+[New issues](https://github.com/search?q=repo%3Aoai%2Fopenapi-specification+is%3Aissue+comments%3A0+no%3Alabel+is%3Aopen) without response yet | @OAI/triage  | |
+
+
+/cc @OAI/tsc Please suggest items for inclusion

--- a/.github/workflows/agenda.yaml
+++ b/.github/workflows/agenda.yaml
@@ -1,0 +1,29 @@
+name: agenda
+
+# author: @MikeRalphson
+# issue: various
+
+#
+# This workflow creates the agenda issue each week. It runs on a cron every
+# Monday morning, raising an issue for the following Thursday.
+# It can also be run manually, in case GitHub Actions has a failure.
+#
+
+on:
+  schedule:
+    - cron: '0 9 * * 2'
+  workflow_dispatch: {}
+  
+jobs:
+  agenda:
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1 # checkout repo content
+
+    - name: Create agenda issue
+      run: gh issue create -l Housekeeping -t "Open Community (TDC) Meeting, `date --date='next Thu' +'%A %d %B %Y'`" -F .github/templates/agenda.md
+


### PR DESCRIPTION
This PR attempts to put me out of a job, by automating further the process of creating the agenda issue each week.

The workflow runs on a cron schedule and can also be run manually as a backup in case of GitHub Actions failing.

The issue is labelled `Housekeeping` automatically, but pinning and unpinning issues remains a manual process.

Signed-off-by: Mike Ralphson <mike.ralphson@gmail.com>