### PR TITLE
[gh-pages] fix: regenerate respec versions, closes #2488

### DIFF
--- a/oas/v2.0.html
+++ b/oas/v2.0.html
@@ -1,4 +1,4 @@
-<html><head><meta charset="UTF-8"><title>OpenAPI Specification</title><script src="https://mermade.github.io/static/respec21/respec-oai.js" class="remove"></script><script class="remove">var respecConfig = {"specStatus":"base","editors":[{"name":"Darrel Miller "},{"name":"Jason Harmon "},{"name":"Jeremy Whitlock "},{"name":"Marsh Gardiner "},{"name":"Ron Ratovsky "},{"name":"Tony Tam "}],"formerEditors":[],"publishDate":"2014-09-08T00:00:00.000Z","subtitle":"Version 2.0","processVersion":2017,"edDraftURI":"http://github.com/OAI/openapi-specification/","github":{"repoURL":"https://github.com/OAI/openapi-specification/","branch":"master"},"shortName":"OAS","noTOC":false,"lint":false,"additionalCopyrightHolders":"the Linux Foundation","includePermalinks":true};</script><!-- Global site tag (gtag.js) - Google Analytics -->
+<html lang="en"><head><meta charset="UTF-8"><title>OpenAPI Specification</title><script src="https://spec.openapis.org/js/respec-oai.js" class="remove"></script><script class="remove">var respecConfig = {"specStatus":"base","editors":[{"name":"Darrel Miller "},{"name":"Jeremy Whitlock "},{"name":"Marsh Gardiner "},{"name":"Ron Ratovsky "}],"formerEditors":[{"name":"Jason Harmon "},{"name":"Tony Tam "}],"publishDate":null,"subtitle":"Version {name}","processVersion":2017,"edDraftURI":"https://github.com/OAI/OpenAPI-Specification/","github":{"repoURL":"https://github.com/OAI/OpenAPI-Specification/","branch":"master"},"shortName":"OAS","noTOC":false,"lint":false,"additionalCopyrightHolders":"the Linux Foundation","includePermalinks":true};</script><!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=UA-831873-42"></script>
 <script>
  window.dataLayer = window.dataLayer || [];
@@ -74,7 +74,7 @@ represent a Swagger specification file.</p>
 <p>For example, if a field is said to have an array value, the JSON array representation will be used:</p>
 <pre class="nohighlight"><code>
 {
-   <span class="hljs-string">"field"</span> : [...]
+   <span class="hljs-string">&quot;field&quot;</span> : [...]
 }
 </code></pre>
 <p>While the API is described using JSON it does not impose a JSON input/output to the API itself.</p>
@@ -336,32 +336,32 @@ represent a Swagger specification file.</p>
 </section><section><h4>Info Object Example:</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-string">"title"</span>: <span class="hljs-string">"Swagger Sample App"</span>,
-  <span class="hljs-string">"description"</span>: <span class="hljs-string">"This is a sample server Petstore server."</span>,
-  <span class="hljs-string">"termsOfService"</span>: <span class="hljs-string">"http://swagger.io/terms/"</span>,
-  <span class="hljs-string">"contact"</span>: {
-    <span class="hljs-string">"name"</span>: <span class="hljs-string">"API Support"</span>,
-    <span class="hljs-string">"url"</span>: <span class="hljs-string">"http://www.swagger.io/support"</span>,
-    <span class="hljs-string">"email"</span>: <span class="hljs-string">"support@swagger.io"</span>
+  <span class="hljs-string">&quot;title&quot;</span>: <span class="hljs-string">&quot;Swagger Sample App&quot;</span>,
+  <span class="hljs-string">&quot;description&quot;</span>: <span class="hljs-string">&quot;This is a sample server Petstore server.&quot;</span>,
+  <span class="hljs-string">&quot;termsOfService&quot;</span>: <span class="hljs-string">&quot;http://swagger.io/terms/&quot;</span>,
+  <span class="hljs-string">&quot;contact&quot;</span>: {
+    <span class="hljs-string">&quot;name&quot;</span>: <span class="hljs-string">&quot;API Support&quot;</span>,
+    <span class="hljs-string">&quot;url&quot;</span>: <span class="hljs-string">&quot;http://www.swagger.io/support&quot;</span>,
+    <span class="hljs-string">&quot;email&quot;</span>: <span class="hljs-string">&quot;support@swagger.io&quot;</span>
   },
-  <span class="hljs-string">"license"</span>: {
-    <span class="hljs-string">"name"</span>: <span class="hljs-string">"Apache 2.0"</span>,
-    <span class="hljs-string">"url"</span>: <span class="hljs-string">"http://www.apache.org/licenses/LICENSE-2.0.html"</span>
+  <span class="hljs-string">&quot;license&quot;</span>: {
+    <span class="hljs-string">&quot;name&quot;</span>: <span class="hljs-string">&quot;Apache 2.0&quot;</span>,
+    <span class="hljs-string">&quot;url&quot;</span>: <span class="hljs-string">&quot;http://www.apache.org/licenses/LICENSE-2.0.html&quot;</span>
   },
-  <span class="hljs-string">"version"</span>: <span class="hljs-string">"1.0.1"</span>
+  <span class="hljs-string">&quot;version&quot;</span>: <span class="hljs-string">&quot;1.0.1&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">title:</span> <span class="hljs-string">Swagger</span> <span class="hljs-string">Sample</span> <span class="hljs-string">App</span>
 <span class="hljs-attr">description:</span> <span class="hljs-string">This</span> <span class="hljs-string">is</span> <span class="hljs-string">a</span> <span class="hljs-string">sample</span> <span class="hljs-string">server</span> <span class="hljs-string">Petstore</span> <span class="hljs-string">server.</span>
-<span class="hljs-attr">termsOfService:</span> <span class="hljs-attr">http://swagger.io/terms/</span>
+<span class="hljs-attr">termsOfService:</span> <span class="hljs-string">http://swagger.io/terms/</span>
 <span class="hljs-attr">contact:</span>
-<span class="hljs-attr">  name:</span> <span class="hljs-string">API</span> <span class="hljs-string">Support</span>
-<span class="hljs-attr">  url:</span> <span class="hljs-attr">http://www.swagger.io/support</span>
-<span class="hljs-attr">  email:</span> <span class="hljs-string">support@swagger.io</span>
+  <span class="hljs-attr">name:</span> <span class="hljs-string">API</span> <span class="hljs-string">Support</span>
+  <span class="hljs-attr">url:</span> <span class="hljs-string">http://www.swagger.io/support</span>
+  <span class="hljs-attr">email:</span> <span class="hljs-string">support@swagger.io</span>
 <span class="hljs-attr">license:</span>
-<span class="hljs-attr">  name:</span> <span class="hljs-string">Apache</span> <span class="hljs-number">2.0</span>
-<span class="hljs-attr">  url:</span> <span class="hljs-attr">http://www.apache.org/licenses/LICENSE-2.0.html</span>
+  <span class="hljs-attr">name:</span> <span class="hljs-string">Apache</span> <span class="hljs-number">2.0</span>
+  <span class="hljs-attr">url:</span> <span class="hljs-string">http://www.apache.org/licenses/LICENSE-2.0.html</span>
 <span class="hljs-attr">version:</span> <span class="hljs-number">1.0</span><span class="hljs-number">.1</span>
 </code></pre>
 </section></section><section><h3><span id="contactObject">Contact Object</span></h3>
@@ -413,14 +413,14 @@ represent a Swagger specification file.</p>
 </section><section><h4>Contact Object Example:</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-string">"name"</span>: <span class="hljs-string">"API Support"</span>,
-  <span class="hljs-string">"url"</span>: <span class="hljs-string">"http://www.swagger.io/support"</span>,
-  <span class="hljs-string">"email"</span>: <span class="hljs-string">"support@swagger.io"</span>
+  <span class="hljs-string">&quot;name&quot;</span>: <span class="hljs-string">&quot;API Support&quot;</span>,
+  <span class="hljs-string">&quot;url&quot;</span>: <span class="hljs-string">&quot;http://www.swagger.io/support&quot;</span>,
+  <span class="hljs-string">&quot;email&quot;</span>: <span class="hljs-string">&quot;support@swagger.io&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">name:</span> <span class="hljs-string">API</span> <span class="hljs-string">Support</span>
-<span class="hljs-attr">url:</span> <span class="hljs-attr">http://www.swagger.io/support</span>
+<span class="hljs-attr">url:</span> <span class="hljs-string">http://www.swagger.io/support</span>
 <span class="hljs-attr">email:</span> <span class="hljs-string">support@swagger.io</span>
 </code></pre>
 </section></section><section><h3><span id="licenseObject">License Object</span></h3>
@@ -467,13 +467,13 @@ represent a Swagger specification file.</p>
 </section><section><h4>License Object Example:</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-string">"name"</span>: <span class="hljs-string">"Apache 2.0"</span>,
-  <span class="hljs-string">"url"</span>: <span class="hljs-string">"http://www.apache.org/licenses/LICENSE-2.0.html"</span>
+  <span class="hljs-string">&quot;name&quot;</span>: <span class="hljs-string">&quot;Apache 2.0&quot;</span>,
+  <span class="hljs-string">&quot;url&quot;</span>: <span class="hljs-string">&quot;http://www.apache.org/licenses/LICENSE-2.0.html&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">name:</span> <span class="hljs-string">Apache</span> <span class="hljs-number">2.0</span>
-<span class="hljs-attr">url:</span> <span class="hljs-attr">http://www.apache.org/licenses/LICENSE-2.0.html</span>
+<span class="hljs-attr">url:</span> <span class="hljs-string">http://www.apache.org/licenses/LICENSE-2.0.html</span>
 </code></pre>
 </section></section><section><h3><span id="pathsObject">Paths Object</span></h3>
 <p>Holds the relative paths to the individual endpoints. The path is appended to the <a href="#swaggerBasePath"><code>basePath</code></a> in order to construct the full URL.
@@ -503,19 +503,19 @@ The Paths may be empty, due to <a href="#securityFiltering">ACL constraints</a>.
 </section><section><h4>Paths Object Example</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-string">"/pets"</span>: {
-    <span class="hljs-string">"get"</span>: {
-      <span class="hljs-string">"description"</span>: <span class="hljs-string">"Returns all pets from the system that the user has access to"</span>,
-      <span class="hljs-string">"produces"</span>: [
-        <span class="hljs-string">"application/json"</span>
+  <span class="hljs-string">&quot;/pets&quot;</span>: {
+    <span class="hljs-string">&quot;get&quot;</span>: {
+      <span class="hljs-string">&quot;description&quot;</span>: <span class="hljs-string">&quot;Returns all pets from the system that the user has access to&quot;</span>,
+      <span class="hljs-string">&quot;produces&quot;</span>: [
+        <span class="hljs-string">&quot;application/json&quot;</span>
       ],
-      <span class="hljs-string">"responses"</span>: {
-        <span class="hljs-string">"200"</span>: {
-          <span class="hljs-string">"description"</span>: <span class="hljs-string">"A list of pets."</span>,
-          <span class="hljs-string">"schema"</span>: {
-            <span class="hljs-string">"type"</span>: <span class="hljs-string">"array"</span>,
-            <span class="hljs-string">"items"</span>: {
-              <span class="hljs-string">"$ref"</span>: <span class="hljs-string">"#/definitions/pet"</span>
+      <span class="hljs-string">&quot;responses&quot;</span>: {
+        <span class="hljs-string">&quot;200&quot;</span>: {
+          <span class="hljs-string">&quot;description&quot;</span>: <span class="hljs-string">&quot;A list of pets.&quot;</span>,
+          <span class="hljs-string">&quot;schema&quot;</span>: {
+            <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+            <span class="hljs-string">&quot;items&quot;</span>: {
+              <span class="hljs-string">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/definitions/pet&quot;</span>
             }
           }
         }
@@ -526,17 +526,17 @@ The Paths may be empty, due to <a href="#securityFiltering">ACL constraints</a>.
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-string">/pets:</span>
-<span class="hljs-attr">  get:</span>
-<span class="hljs-attr">    description:</span> <span class="hljs-string">Returns</span> <span class="hljs-string">all</span> <span class="hljs-string">pets</span> <span class="hljs-string">from</span> <span class="hljs-string">the</span> <span class="hljs-string">system</span> <span class="hljs-string">that</span> <span class="hljs-string">the</span> <span class="hljs-string">user</span> <span class="hljs-string">has</span> <span class="hljs-string">access</span> <span class="hljs-string">to</span>
-<span class="hljs-attr">    produces:</span>
-<span class="hljs-bullet">    -</span> <span class="hljs-string">application/json</span>
-<span class="hljs-attr">    responses:</span>
-      <span class="hljs-string">'200'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">        description:</span> <span class="hljs-string">A</span> <span class="hljs-string">list</span> <span class="hljs-string">of</span> <span class="hljs-string">pets.</span>
-<span class="hljs-attr">        schema:</span>
-<span class="hljs-attr">          type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">          items:</span>
-            <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/definitions/pet'</span>
+  <span class="hljs-attr">get:</span>
+    <span class="hljs-attr">description:</span> <span class="hljs-string">Returns</span> <span class="hljs-string">all</span> <span class="hljs-string">pets</span> <span class="hljs-string">from</span> <span class="hljs-string">the</span> <span class="hljs-string">system</span> <span class="hljs-string">that</span> <span class="hljs-string">the</span> <span class="hljs-string">user</span> <span class="hljs-string">has</span> <span class="hljs-string">access</span> <span class="hljs-string">to</span>
+    <span class="hljs-attr">produces:</span>
+    <span class="hljs-bullet">-</span> <span class="hljs-string">application/json</span>
+    <span class="hljs-attr">responses:</span>
+      <span class="hljs-attr">&#x27;200&#x27;:</span>
+        <span class="hljs-attr">description:</span> <span class="hljs-string">A</span> <span class="hljs-string">list</span> <span class="hljs-string">of</span> <span class="hljs-string">pets.</span>
+        <span class="hljs-attr">schema:</span>
+          <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+          <span class="hljs-attr">items:</span>
+            <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/definitions/pet&#x27;</span>
 </code></pre>
 </section></section><section><h3><span id="pathItemObject">Path Item Object</span></h3>
 <p>Describes the operations available on a single path.
@@ -593,7 +593,7 @@ A Path Item may be empty, due to <a href="#securityFiltering">ACL constraints</a
 </tr>
 <tr>
 <td><a id="pathItemParameters"> </a>parameters</td>
-<td style="text-align:center">[<a href="#parameterObject">Parameter Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:center">[<a href="#parameterObject">Parameter Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>A list of parameters that are applicable for all the operations described under this path. These parameters can be overridden at the operation level, but cannot be removed there. The list MUST NOT include duplicated parameters. A unique parameter is defined by a combination of a <a href="#parameterName">name</a> and <a href="#parameterIn">location</a>. The list can use the <a href="#referenceObject">Reference Object</a> to link to parameters that are defined at the <a href="#swaggerParameters">Swagger Object’s parameters</a>. There can be one “body” parameter at most.</td>
 </tr>
 </tbody>
@@ -618,75 +618,75 @@ A Path Item may be empty, due to <a href="#securityFiltering">ACL constraints</a
 </section><section><h4>Path Item Object Example</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-string">"get"</span>: {
-    <span class="hljs-string">"description"</span>: <span class="hljs-string">"Returns pets based on ID"</span>,
-    <span class="hljs-string">"summary"</span>: <span class="hljs-string">"Find pets by ID"</span>,
-    <span class="hljs-string">"operationId"</span>: <span class="hljs-string">"getPetsById"</span>,
-    <span class="hljs-string">"produces"</span>: [
-      <span class="hljs-string">"application/json"</span>,
-      <span class="hljs-string">"text/html"</span>
+  <span class="hljs-string">&quot;get&quot;</span>: {
+    <span class="hljs-string">&quot;description&quot;</span>: <span class="hljs-string">&quot;Returns pets based on ID&quot;</span>,
+    <span class="hljs-string">&quot;summary&quot;</span>: <span class="hljs-string">&quot;Find pets by ID&quot;</span>,
+    <span class="hljs-string">&quot;operationId&quot;</span>: <span class="hljs-string">&quot;getPetsById&quot;</span>,
+    <span class="hljs-string">&quot;produces&quot;</span>: [
+      <span class="hljs-string">&quot;application/json&quot;</span>,
+      <span class="hljs-string">&quot;text/html&quot;</span>
     ],
-    <span class="hljs-string">"responses"</span>: {
-      <span class="hljs-string">"200"</span>: {
-        <span class="hljs-string">"description"</span>: <span class="hljs-string">"pet response"</span>,
-        <span class="hljs-string">"schema"</span>: {
-          <span class="hljs-string">"type"</span>: <span class="hljs-string">"array"</span>,
-          <span class="hljs-string">"items"</span>: {
-            <span class="hljs-string">"$ref"</span>: <span class="hljs-string">"#/definitions/Pet"</span>
+    <span class="hljs-string">&quot;responses&quot;</span>: {
+      <span class="hljs-string">&quot;200&quot;</span>: {
+        <span class="hljs-string">&quot;description&quot;</span>: <span class="hljs-string">&quot;pet response&quot;</span>,
+        <span class="hljs-string">&quot;schema&quot;</span>: {
+          <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+          <span class="hljs-string">&quot;items&quot;</span>: {
+            <span class="hljs-string">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/definitions/Pet&quot;</span>
           }
         }
       },
-      <span class="hljs-string">"default"</span>: {
-        <span class="hljs-string">"description"</span>: <span class="hljs-string">"error payload"</span>,
-        <span class="hljs-string">"schema"</span>: {
-          <span class="hljs-string">"$ref"</span>: <span class="hljs-string">"#/definitions/ErrorModel"</span>
+      <span class="hljs-string">&quot;default&quot;</span>: {
+        <span class="hljs-string">&quot;description&quot;</span>: <span class="hljs-string">&quot;error payload&quot;</span>,
+        <span class="hljs-string">&quot;schema&quot;</span>: {
+          <span class="hljs-string">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/definitions/ErrorModel&quot;</span>
         }
       }
     }
   },
-  <span class="hljs-string">"parameters"</span>: [
+  <span class="hljs-string">&quot;parameters&quot;</span>: [
     {
-      <span class="hljs-string">"name"</span>: <span class="hljs-string">"id"</span>,
-      <span class="hljs-string">"in"</span>: <span class="hljs-string">"path"</span>,
-      <span class="hljs-string">"description"</span>: <span class="hljs-string">"ID of pet to use"</span>,
-      <span class="hljs-string">"required"</span>: <span class="hljs-literal">true</span>,
-      <span class="hljs-string">"type"</span>: <span class="hljs-string">"array"</span>,
-      <span class="hljs-string">"items"</span>: {
-        <span class="hljs-string">"type"</span>: <span class="hljs-string">"string"</span>
+      <span class="hljs-string">&quot;name&quot;</span>: <span class="hljs-string">&quot;id&quot;</span>,
+      <span class="hljs-string">&quot;in&quot;</span>: <span class="hljs-string">&quot;path&quot;</span>,
+      <span class="hljs-string">&quot;description&quot;</span>: <span class="hljs-string">&quot;ID of pet to use&quot;</span>,
+      <span class="hljs-string">&quot;required&quot;</span>: <span class="hljs-literal">true</span>,
+      <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+      <span class="hljs-string">&quot;items&quot;</span>: {
+        <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
       },
-      <span class="hljs-string">"collectionFormat"</span>: <span class="hljs-string">"csv"</span>
+      <span class="hljs-string">&quot;collectionFormat&quot;</span>: <span class="hljs-string">&quot;csv&quot;</span>
     }
   ]
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">get:</span>
-<span class="hljs-attr">  description:</span> <span class="hljs-string">Returns</span> <span class="hljs-string">pets</span> <span class="hljs-string">based</span> <span class="hljs-string">on</span> <span class="hljs-string">ID</span>
-<span class="hljs-attr">  summary:</span> <span class="hljs-string">Find</span> <span class="hljs-string">pets</span> <span class="hljs-string">by</span> <span class="hljs-string">ID</span>
-<span class="hljs-attr">  operationId:</span> <span class="hljs-string">getPetsById</span>
-<span class="hljs-attr">  produces:</span>
-<span class="hljs-bullet">  -</span> <span class="hljs-string">application/json</span>
-<span class="hljs-bullet">  -</span> <span class="hljs-string">text/html</span>
-<span class="hljs-attr">  responses:</span>
-    <span class="hljs-string">'200'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">      description:</span> <span class="hljs-string">pet</span> <span class="hljs-string">response</span>
-<span class="hljs-attr">      schema:</span>
-<span class="hljs-attr">        type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">        items:</span>
-          <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/definitions/Pet'</span>
-<span class="hljs-attr">    default:</span>
-<span class="hljs-attr">      description:</span> <span class="hljs-string">error</span> <span class="hljs-string">payload</span>
-<span class="hljs-attr">      schema:</span>
-        <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/definitions/ErrorModel'</span>
+  <span class="hljs-attr">description:</span> <span class="hljs-string">Returns</span> <span class="hljs-string">pets</span> <span class="hljs-string">based</span> <span class="hljs-string">on</span> <span class="hljs-string">ID</span>
+  <span class="hljs-attr">summary:</span> <span class="hljs-string">Find</span> <span class="hljs-string">pets</span> <span class="hljs-string">by</span> <span class="hljs-string">ID</span>
+  <span class="hljs-attr">operationId:</span> <span class="hljs-string">getPetsById</span>
+  <span class="hljs-attr">produces:</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-string">application/json</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-string">text/html</span>
+  <span class="hljs-attr">responses:</span>
+    <span class="hljs-attr">&#x27;200&#x27;:</span>
+      <span class="hljs-attr">description:</span> <span class="hljs-string">pet</span> <span class="hljs-string">response</span>
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+        <span class="hljs-attr">items:</span>
+          <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/definitions/Pet&#x27;</span>
+    <span class="hljs-attr">default:</span>
+      <span class="hljs-attr">description:</span> <span class="hljs-string">error</span> <span class="hljs-string">payload</span>
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/definitions/ErrorModel&#x27;</span>
 <span class="hljs-attr">parameters:</span>
-<span class="hljs-attr">- name:</span> <span class="hljs-string">id</span>
-<span class="hljs-attr">  in:</span> <span class="hljs-string">path</span>
-<span class="hljs-attr">  description:</span> <span class="hljs-string">ID</span> <span class="hljs-string">of</span> <span class="hljs-string">pet</span> <span class="hljs-string">to</span> <span class="hljs-string">use</span>
-<span class="hljs-attr">  required:</span> <span class="hljs-literal">true</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">  items:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">  collectionFormat:</span> <span class="hljs-string">csv</span>
+<span class="hljs-bullet">-</span> <span class="hljs-attr">name:</span> <span class="hljs-string">id</span>
+  <span class="hljs-attr">in:</span> <span class="hljs-string">path</span>
+  <span class="hljs-attr">description:</span> <span class="hljs-string">ID</span> <span class="hljs-string">of</span> <span class="hljs-string">pet</span> <span class="hljs-string">to</span> <span class="hljs-string">use</span>
+  <span class="hljs-attr">required:</span> <span class="hljs-literal">true</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+  <span class="hljs-attr">items:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">collectionFormat:</span> <span class="hljs-string">csv</span>
 </code></pre>
 </section></section><section><h3><span id="operationObject">Operation Object</span></h3>
 <p>Describes a single API operation on a path.</p>
@@ -737,7 +737,7 @@ A Path Item may be empty, due to <a href="#securityFiltering">ACL constraints</a
 </tr>
 <tr>
 <td><a id="operationParameters"> </a>parameters</td>
-<td style="text-align:center">[<a href="#parameterObject">Parameter Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:center">[<a href="#parameterObject">Parameter Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>A list of parameters that are applicable for this operation. If a parameter is already defined at the <a href="#pathItemParameters">Path Item</a>, the new definition will override it, but can never remove it. The list MUST NOT include duplicated parameters. A unique parameter is defined by a combination of a <a href="#parameterName">name</a> and <a href="#parameterIn">location</a>. The list can use the <a href="#referenceObject">Reference Object</a> to link to parameters that are defined at the <a href="#swaggerParameters">Swagger Object’s parameters</a>. There can be one “body” parameter at most.</td>
 </tr>
 <tr>
@@ -782,55 +782,55 @@ A Path Item may be empty, due to <a href="#securityFiltering">ACL constraints</a
 </section><section><h4>Operation Object Example</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-string">"tags"</span>: [
-    <span class="hljs-string">"pet"</span>
+  <span class="hljs-string">&quot;tags&quot;</span>: [
+    <span class="hljs-string">&quot;pet&quot;</span>
   ],
-  <span class="hljs-string">"summary"</span>: <span class="hljs-string">"Updates a pet in the store with form data"</span>,
-  <span class="hljs-string">"description"</span>: <span class="hljs-string">""</span>,
-  <span class="hljs-string">"operationId"</span>: <span class="hljs-string">"updatePetWithForm"</span>,
-  <span class="hljs-string">"consumes"</span>: [
-    <span class="hljs-string">"application/x-www-form-urlencoded"</span>
+  <span class="hljs-string">&quot;summary&quot;</span>: <span class="hljs-string">&quot;Updates a pet in the store with form data&quot;</span>,
+  <span class="hljs-string">&quot;description&quot;</span>: <span class="hljs-string">&quot;&quot;</span>,
+  <span class="hljs-string">&quot;operationId&quot;</span>: <span class="hljs-string">&quot;updatePetWithForm&quot;</span>,
+  <span class="hljs-string">&quot;consumes&quot;</span>: [
+    <span class="hljs-string">&quot;application/x-www-form-urlencoded&quot;</span>
   ],
-  <span class="hljs-string">"produces"</span>: [
-    <span class="hljs-string">"application/json"</span>,
-    <span class="hljs-string">"application/xml"</span>
+  <span class="hljs-string">&quot;produces&quot;</span>: [
+    <span class="hljs-string">&quot;application/json&quot;</span>,
+    <span class="hljs-string">&quot;application/xml&quot;</span>
   ],
-  <span class="hljs-string">"parameters"</span>: [
+  <span class="hljs-string">&quot;parameters&quot;</span>: [
     {
-      <span class="hljs-string">"name"</span>: <span class="hljs-string">"petId"</span>,
-      <span class="hljs-string">"in"</span>: <span class="hljs-string">"path"</span>,
-      <span class="hljs-string">"description"</span>: <span class="hljs-string">"ID of pet that needs to be updated"</span>,
-      <span class="hljs-string">"required"</span>: <span class="hljs-literal">true</span>,
-      <span class="hljs-string">"type"</span>: <span class="hljs-string">"string"</span>
+      <span class="hljs-string">&quot;name&quot;</span>: <span class="hljs-string">&quot;petId&quot;</span>,
+      <span class="hljs-string">&quot;in&quot;</span>: <span class="hljs-string">&quot;path&quot;</span>,
+      <span class="hljs-string">&quot;description&quot;</span>: <span class="hljs-string">&quot;ID of pet that needs to be updated&quot;</span>,
+      <span class="hljs-string">&quot;required&quot;</span>: <span class="hljs-literal">true</span>,
+      <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
     },
     {
-      <span class="hljs-string">"name"</span>: <span class="hljs-string">"name"</span>,
-      <span class="hljs-string">"in"</span>: <span class="hljs-string">"formData"</span>,
-      <span class="hljs-string">"description"</span>: <span class="hljs-string">"Updated name of the pet"</span>,
-      <span class="hljs-string">"required"</span>: <span class="hljs-literal">false</span>,
-      <span class="hljs-string">"type"</span>: <span class="hljs-string">"string"</span>
+      <span class="hljs-string">&quot;name&quot;</span>: <span class="hljs-string">&quot;name&quot;</span>,
+      <span class="hljs-string">&quot;in&quot;</span>: <span class="hljs-string">&quot;formData&quot;</span>,
+      <span class="hljs-string">&quot;description&quot;</span>: <span class="hljs-string">&quot;Updated name of the pet&quot;</span>,
+      <span class="hljs-string">&quot;required&quot;</span>: <span class="hljs-literal">false</span>,
+      <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
     },
     {
-      <span class="hljs-string">"name"</span>: <span class="hljs-string">"status"</span>,
-      <span class="hljs-string">"in"</span>: <span class="hljs-string">"formData"</span>,
-      <span class="hljs-string">"description"</span>: <span class="hljs-string">"Updated status of the pet"</span>,
-      <span class="hljs-string">"required"</span>: <span class="hljs-literal">false</span>,
-      <span class="hljs-string">"type"</span>: <span class="hljs-string">"string"</span>
+      <span class="hljs-string">&quot;name&quot;</span>: <span class="hljs-string">&quot;status&quot;</span>,
+      <span class="hljs-string">&quot;in&quot;</span>: <span class="hljs-string">&quot;formData&quot;</span>,
+      <span class="hljs-string">&quot;description&quot;</span>: <span class="hljs-string">&quot;Updated status of the pet&quot;</span>,
+      <span class="hljs-string">&quot;required&quot;</span>: <span class="hljs-literal">false</span>,
+      <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
     }
   ],
-  <span class="hljs-string">"responses"</span>: {
-    <span class="hljs-string">"200"</span>: {
-      <span class="hljs-string">"description"</span>: <span class="hljs-string">"Pet updated."</span>
+  <span class="hljs-string">&quot;responses&quot;</span>: {
+    <span class="hljs-string">&quot;200&quot;</span>: {
+      <span class="hljs-string">&quot;description&quot;</span>: <span class="hljs-string">&quot;Pet updated.&quot;</span>
     },
-    <span class="hljs-string">"405"</span>: {
-      <span class="hljs-string">"description"</span>: <span class="hljs-string">"Invalid input"</span>
+    <span class="hljs-string">&quot;405&quot;</span>: {
+      <span class="hljs-string">&quot;description&quot;</span>: <span class="hljs-string">&quot;Invalid input&quot;</span>
     }
   },
-  <span class="hljs-string">"security"</span>: [
+  <span class="hljs-string">&quot;security&quot;</span>: [
     {
-      <span class="hljs-string">"petstore_auth"</span>: [
-        <span class="hljs-string">"write:pets"</span>,
-        <span class="hljs-string">"read:pets"</span>
+      <span class="hljs-string">&quot;petstore_auth&quot;</span>: [
+        <span class="hljs-string">&quot;write:pets&quot;</span>,
+        <span class="hljs-string">&quot;read:pets&quot;</span>
       ]
     }
   ]
@@ -840,7 +840,7 @@ A Path Item may be empty, due to <a href="#securityFiltering">ACL constraints</a
 <span class="hljs-attr">tags:</span>
 <span class="hljs-bullet">-</span> <span class="hljs-string">pet</span>
 <span class="hljs-attr">summary:</span> <span class="hljs-string">Updates</span> <span class="hljs-string">a</span> <span class="hljs-string">pet</span> <span class="hljs-string">in</span> <span class="hljs-string">the</span> <span class="hljs-string">store</span> <span class="hljs-string">with</span> <span class="hljs-string">form</span> <span class="hljs-string">data</span>
-<span class="hljs-attr">description:</span> <span class="hljs-string">""</span>
+<span class="hljs-attr">description:</span> <span class="hljs-string">&quot;&quot;</span>
 <span class="hljs-attr">operationId:</span> <span class="hljs-string">updatePetWithForm</span>
 <span class="hljs-attr">consumes:</span>
 <span class="hljs-bullet">-</span> <span class="hljs-string">application/x-www-form-urlencoded</span>
@@ -848,30 +848,30 @@ A Path Item may be empty, due to <a href="#securityFiltering">ACL constraints</a
 <span class="hljs-bullet">-</span> <span class="hljs-string">application/json</span>
 <span class="hljs-bullet">-</span> <span class="hljs-string">application/xml</span>
 <span class="hljs-attr">parameters:</span>
-<span class="hljs-attr">- name:</span> <span class="hljs-string">petId</span>
-<span class="hljs-attr">  in:</span> <span class="hljs-string">path</span>
-<span class="hljs-attr">  description:</span> <span class="hljs-string">ID</span> <span class="hljs-string">of</span> <span class="hljs-string">pet</span> <span class="hljs-string">that</span> <span class="hljs-string">needs</span> <span class="hljs-string">to</span> <span class="hljs-string">be</span> <span class="hljs-string">updated</span>
-<span class="hljs-attr">  required:</span> <span class="hljs-literal">true</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">- name:</span> <span class="hljs-string">name</span>
-<span class="hljs-attr">  in:</span> <span class="hljs-string">formData</span>
-<span class="hljs-attr">  description:</span> <span class="hljs-string">Updated</span> <span class="hljs-string">name</span> <span class="hljs-string">of</span> <span class="hljs-string">the</span> <span class="hljs-string">pet</span>
-<span class="hljs-attr">  required:</span> <span class="hljs-literal">false</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">- name:</span> <span class="hljs-string">status</span>
-<span class="hljs-attr">  in:</span> <span class="hljs-string">formData</span>
-<span class="hljs-attr">  description:</span> <span class="hljs-string">Updated</span> <span class="hljs-string">status</span> <span class="hljs-string">of</span> <span class="hljs-string">the</span> <span class="hljs-string">pet</span>
-<span class="hljs-attr">  required:</span> <span class="hljs-literal">false</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">string</span>
+<span class="hljs-bullet">-</span> <span class="hljs-attr">name:</span> <span class="hljs-string">petId</span>
+  <span class="hljs-attr">in:</span> <span class="hljs-string">path</span>
+  <span class="hljs-attr">description:</span> <span class="hljs-string">ID</span> <span class="hljs-string">of</span> <span class="hljs-string">pet</span> <span class="hljs-string">that</span> <span class="hljs-string">needs</span> <span class="hljs-string">to</span> <span class="hljs-string">be</span> <span class="hljs-string">updated</span>
+  <span class="hljs-attr">required:</span> <span class="hljs-literal">true</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+<span class="hljs-bullet">-</span> <span class="hljs-attr">name:</span> <span class="hljs-string">name</span>
+  <span class="hljs-attr">in:</span> <span class="hljs-string">formData</span>
+  <span class="hljs-attr">description:</span> <span class="hljs-string">Updated</span> <span class="hljs-string">name</span> <span class="hljs-string">of</span> <span class="hljs-string">the</span> <span class="hljs-string">pet</span>
+  <span class="hljs-attr">required:</span> <span class="hljs-literal">false</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+<span class="hljs-bullet">-</span> <span class="hljs-attr">name:</span> <span class="hljs-string">status</span>
+  <span class="hljs-attr">in:</span> <span class="hljs-string">formData</span>
+  <span class="hljs-attr">description:</span> <span class="hljs-string">Updated</span> <span class="hljs-string">status</span> <span class="hljs-string">of</span> <span class="hljs-string">the</span> <span class="hljs-string">pet</span>
+  <span class="hljs-attr">required:</span> <span class="hljs-literal">false</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
 <span class="hljs-attr">responses:</span>
-  <span class="hljs-string">'200'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">    description:</span> <span class="hljs-string">Pet</span> <span class="hljs-string">updated.</span>
-  <span class="hljs-string">'405'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">    description:</span> <span class="hljs-string">Invalid</span> <span class="hljs-string">input</span>
+  <span class="hljs-attr">&#x27;200&#x27;:</span>
+    <span class="hljs-attr">description:</span> <span class="hljs-string">Pet</span> <span class="hljs-string">updated.</span>
+  <span class="hljs-attr">&#x27;405&#x27;:</span>
+    <span class="hljs-attr">description:</span> <span class="hljs-string">Invalid</span> <span class="hljs-string">input</span>
 <span class="hljs-attr">security:</span>
-<span class="hljs-attr">- petstore_auth:</span>
-<span class="hljs-attr">  - write:</span><span class="hljs-string">pets</span>
-<span class="hljs-attr">  - read:</span><span class="hljs-string">pets</span>
+<span class="hljs-bullet">-</span> <span class="hljs-attr">petstore_auth:</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-string">write:pets</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-string">read:pets</span>
 </code></pre>
 </section></section><section><h3><span id="externalDocumentationObject">External Documentation Object</span></h3>
 <p>Allows referencing an external resource for extended documentation.</p>
@@ -917,13 +917,13 @@ A Path Item may be empty, due to <a href="#securityFiltering">ACL constraints</a
 </section><section><h4>External Documentation Object Example</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-string">"description"</span>: <span class="hljs-string">"Find more info here"</span>,
-  <span class="hljs-string">"url"</span>: <span class="hljs-string">"https://swagger.io"</span>
+  <span class="hljs-string">&quot;description&quot;</span>: <span class="hljs-string">&quot;Find more info here&quot;</span>,
+  <span class="hljs-string">&quot;url&quot;</span>: <span class="hljs-string">&quot;https://swagger.io&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">description:</span> <span class="hljs-string">Find</span> <span class="hljs-string">more</span> <span class="hljs-string">info</span> <span class="hljs-string">here</span>
-<span class="hljs-attr">url:</span> <span class="hljs-attr">https://swagger.io</span>
+<span class="hljs-attr">url:</span> <span class="hljs-string">https://swagger.io</span>
 </code></pre>
 </section></section><section><h3><span id="parameterObject">Parameter Object</span></h3>
 <p>Describes a single operation parameter.</p>
@@ -1114,12 +1114,12 @@ A Path Item may be empty, due to <a href="#securityFiltering">ACL constraints</a
 <p>A body parameter with a referenced schema definition (normally for a model definition):</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-string">"name"</span>: <span class="hljs-string">"user"</span>,
-  <span class="hljs-string">"in"</span>: <span class="hljs-string">"body"</span>,
-  <span class="hljs-string">"description"</span>: <span class="hljs-string">"user to add to the system"</span>,
-  <span class="hljs-string">"required"</span>: <span class="hljs-literal">true</span>,
-  <span class="hljs-string">"schema"</span>: {
-    <span class="hljs-string">"$ref"</span>: <span class="hljs-string">"#/definitions/User"</span>
+  <span class="hljs-string">&quot;name&quot;</span>: <span class="hljs-string">&quot;user&quot;</span>,
+  <span class="hljs-string">&quot;in&quot;</span>: <span class="hljs-string">&quot;body&quot;</span>,
+  <span class="hljs-string">&quot;description&quot;</span>: <span class="hljs-string">&quot;user to add to the system&quot;</span>,
+  <span class="hljs-string">&quot;required&quot;</span>: <span class="hljs-literal">true</span>,
+  <span class="hljs-string">&quot;schema&quot;</span>: {
+    <span class="hljs-string">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/definitions/User&quot;</span>
   }
 }
 </code></pre>
@@ -1129,19 +1129,19 @@ A Path Item may be empty, due to <a href="#securityFiltering">ACL constraints</a
 <span class="hljs-attr">description:</span> <span class="hljs-string">user</span> <span class="hljs-string">to</span> <span class="hljs-string">add</span> <span class="hljs-string">to</span> <span class="hljs-string">the</span> <span class="hljs-string">system</span>
 <span class="hljs-attr">required:</span> <span class="hljs-literal">true</span>
 <span class="hljs-attr">schema:</span>
-  <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/definitions/User'</span>
+  <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/definitions/User&#x27;</span>
 </code></pre>
 <p>A body parameter that is an array of string values:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-string">"name"</span>: <span class="hljs-string">"user"</span>,
-  <span class="hljs-string">"in"</span>: <span class="hljs-string">"body"</span>,
-  <span class="hljs-string">"description"</span>: <span class="hljs-string">"user to add to the system"</span>,
-  <span class="hljs-string">"required"</span>: <span class="hljs-literal">true</span>,
-  <span class="hljs-string">"schema"</span>: {
-    <span class="hljs-string">"type"</span>: <span class="hljs-string">"array"</span>,
-    <span class="hljs-string">"items"</span>: {
-      <span class="hljs-string">"type"</span>: <span class="hljs-string">"string"</span>
+  <span class="hljs-string">&quot;name&quot;</span>: <span class="hljs-string">&quot;user&quot;</span>,
+  <span class="hljs-string">&quot;in&quot;</span>: <span class="hljs-string">&quot;body&quot;</span>,
+  <span class="hljs-string">&quot;description&quot;</span>: <span class="hljs-string">&quot;user to add to the system&quot;</span>,
+  <span class="hljs-string">&quot;required&quot;</span>: <span class="hljs-literal">true</span>,
+  <span class="hljs-string">&quot;schema&quot;</span>: {
+    <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+    <span class="hljs-string">&quot;items&quot;</span>: {
+      <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
     }
   }
 }
@@ -1152,24 +1152,24 @@ A Path Item may be empty, due to <a href="#securityFiltering">ACL constraints</a
 <span class="hljs-attr">description:</span> <span class="hljs-string">user</span> <span class="hljs-string">to</span> <span class="hljs-string">add</span> <span class="hljs-string">to</span> <span class="hljs-string">the</span> <span class="hljs-string">system</span>
 <span class="hljs-attr">required:</span> <span class="hljs-literal">true</span>
 <span class="hljs-attr">schema:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">  items:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+  <span class="hljs-attr">items:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
 </code></pre>
 </section><section><h5>Other Parameters</h5>
 <p>A header parameter with an array of 64 bit integer numbers:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-string">"name"</span>: <span class="hljs-string">"token"</span>,
-  <span class="hljs-string">"in"</span>: <span class="hljs-string">"header"</span>,
-  <span class="hljs-string">"description"</span>: <span class="hljs-string">"token to be passed as a header"</span>,
-  <span class="hljs-string">"required"</span>: <span class="hljs-literal">true</span>,
-  <span class="hljs-string">"type"</span>: <span class="hljs-string">"array"</span>,
-  <span class="hljs-string">"items"</span>: {
-    <span class="hljs-string">"type"</span>: <span class="hljs-string">"integer"</span>,
-    <span class="hljs-string">"format"</span>: <span class="hljs-string">"int64"</span>
+  <span class="hljs-string">&quot;name&quot;</span>: <span class="hljs-string">&quot;token&quot;</span>,
+  <span class="hljs-string">&quot;in&quot;</span>: <span class="hljs-string">&quot;header&quot;</span>,
+  <span class="hljs-string">&quot;description&quot;</span>: <span class="hljs-string">&quot;token to be passed as a header&quot;</span>,
+  <span class="hljs-string">&quot;required&quot;</span>: <span class="hljs-literal">true</span>,
+  <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+  <span class="hljs-string">&quot;items&quot;</span>: {
+    <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>,
+    <span class="hljs-string">&quot;format&quot;</span>: <span class="hljs-string">&quot;int64&quot;</span>
   },
-  <span class="hljs-string">"collectionFormat"</span>: <span class="hljs-string">"csv"</span>
+  <span class="hljs-string">&quot;collectionFormat&quot;</span>: <span class="hljs-string">&quot;csv&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -1179,18 +1179,18 @@ A Path Item may be empty, due to <a href="#securityFiltering">ACL constraints</a
 <span class="hljs-attr">required:</span> <span class="hljs-literal">true</span>
 <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
 <span class="hljs-attr">items:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">integer</span>
-<span class="hljs-attr">  format:</span> <span class="hljs-string">int64</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+  <span class="hljs-attr">format:</span> <span class="hljs-string">int64</span>
 <span class="hljs-attr">collectionFormat:</span> <span class="hljs-string">csv</span>
 </code></pre>
 <p>A path parameter of a string value:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-string">"name"</span>: <span class="hljs-string">"username"</span>,
-  <span class="hljs-string">"in"</span>: <span class="hljs-string">"path"</span>,
-  <span class="hljs-string">"description"</span>: <span class="hljs-string">"username to fetch"</span>,
-  <span class="hljs-string">"required"</span>: <span class="hljs-literal">true</span>,
-  <span class="hljs-string">"type"</span>: <span class="hljs-string">"string"</span>
+  <span class="hljs-string">&quot;name&quot;</span>: <span class="hljs-string">&quot;username&quot;</span>,
+  <span class="hljs-string">&quot;in&quot;</span>: <span class="hljs-string">&quot;path&quot;</span>,
+  <span class="hljs-string">&quot;description&quot;</span>: <span class="hljs-string">&quot;username to fetch&quot;</span>,
+  <span class="hljs-string">&quot;required&quot;</span>: <span class="hljs-literal">true</span>,
+  <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -1203,15 +1203,15 @@ A Path Item may be empty, due to <a href="#securityFiltering">ACL constraints</a
 <p>An optional query parameter of a string value, allowing multiple values by repeating the query parameter:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-string">"name"</span>: <span class="hljs-string">"id"</span>,
-  <span class="hljs-string">"in"</span>: <span class="hljs-string">"query"</span>,
-  <span class="hljs-string">"description"</span>: <span class="hljs-string">"ID of the object to fetch"</span>,
-  <span class="hljs-string">"required"</span>: <span class="hljs-literal">false</span>,
-  <span class="hljs-string">"type"</span>: <span class="hljs-string">"array"</span>,
-  <span class="hljs-string">"items"</span>: {
-    <span class="hljs-string">"type"</span>: <span class="hljs-string">"string"</span>
+  <span class="hljs-string">&quot;name&quot;</span>: <span class="hljs-string">&quot;id&quot;</span>,
+  <span class="hljs-string">&quot;in&quot;</span>: <span class="hljs-string">&quot;query&quot;</span>,
+  <span class="hljs-string">&quot;description&quot;</span>: <span class="hljs-string">&quot;ID of the object to fetch&quot;</span>,
+  <span class="hljs-string">&quot;required&quot;</span>: <span class="hljs-literal">false</span>,
+  <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+  <span class="hljs-string">&quot;items&quot;</span>: {
+    <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
   },
-  <span class="hljs-string">"collectionFormat"</span>: <span class="hljs-string">"multi"</span>
+  <span class="hljs-string">&quot;collectionFormat&quot;</span>: <span class="hljs-string">&quot;multi&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -1221,17 +1221,17 @@ A Path Item may be empty, due to <a href="#securityFiltering">ACL constraints</a
 <span class="hljs-attr">required:</span> <span class="hljs-literal">false</span>
 <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
 <span class="hljs-attr">items:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
 <span class="hljs-attr">collectionFormat:</span> <span class="hljs-string">multi</span>
 </code></pre>
 <p>A form data with file type for a file upload:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-string">"name"</span>: <span class="hljs-string">"avatar"</span>,
-  <span class="hljs-string">"in"</span>: <span class="hljs-string">"formData"</span>,
-  <span class="hljs-string">"description"</span>: <span class="hljs-string">"The avatar of the user"</span>,
-  <span class="hljs-string">"required"</span>: <span class="hljs-literal">true</span>,
-  <span class="hljs-string">"type"</span>: <span class="hljs-string">"file"</span>
+  <span class="hljs-string">&quot;name&quot;</span>: <span class="hljs-string">&quot;avatar&quot;</span>,
+  <span class="hljs-string">&quot;in&quot;</span>: <span class="hljs-string">&quot;formData&quot;</span>,
+  <span class="hljs-string">&quot;description&quot;</span>: <span class="hljs-string">&quot;The avatar of the user&quot;</span>,
+  <span class="hljs-string">&quot;required&quot;</span>: <span class="hljs-literal">true</span>,
+  <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;file&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -1361,8 +1361,8 @@ A Path Item may be empty, due to <a href="#securityFiltering">ACL constraints</a
 <p>Items must be of type  string and have the minimum length of  2 characters:</p>
 <pre class="nohighlight"><code>
 {
-    <span class="hljs-string">"type"</span>: <span class="hljs-string">"string"</span>,
-    <span class="hljs-string">"minLength"</span>: <span class="hljs-number">2</span>
+    <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>,
+    <span class="hljs-string">&quot;minLength&quot;</span>: <span class="hljs-number">2</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -1372,20 +1372,20 @@ A Path Item may be empty, due to <a href="#securityFiltering">ACL constraints</a
 <p>An array of arrays, the internal array being of type integer, numbers must be between 0 and 63 (inclusive):</p>
 <pre class="nohighlight"><code>
 {
-    <span class="hljs-string">"type"</span>: <span class="hljs-string">"array"</span>,
-    <span class="hljs-string">"items"</span>: {
-        <span class="hljs-string">"type"</span>: <span class="hljs-string">"integer"</span>,
-        <span class="hljs-string">"minimum"</span>: <span class="hljs-number">0</span>,
-        <span class="hljs-string">"maximum"</span>: <span class="hljs-number">63</span>
+    <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+    <span class="hljs-string">&quot;items&quot;</span>: {
+        <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>,
+        <span class="hljs-string">&quot;minimum&quot;</span>: <span class="hljs-number">0</span>,
+        <span class="hljs-string">&quot;maximum&quot;</span>: <span class="hljs-number">63</span>
     }
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
 <span class="hljs-attr">items:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">integer</span>
-<span class="hljs-attr">  minimum:</span> <span class="hljs-number">0</span>
-<span class="hljs-attr">  maximum:</span> <span class="hljs-number">63</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+  <span class="hljs-attr">minimum:</span> <span class="hljs-number">0</span>
+  <span class="hljs-attr">maximum:</span> <span class="hljs-number">63</span>
 </code></pre>
 </section></section><section><h3><span id="responsesObject">Responses Object</span></h3>
 <p>A container for the expected responses of an operation. The container maps a HTTP response code to the expected response. It is not expected from the documentation to necessarily cover all possible HTTP response codes, since they may not be known in advance. However, it is expected from the documentation to cover a successful operation response and any known errors.</p>
@@ -1403,7 +1403,7 @@ A Path Item may be empty, due to <a href="#securityFiltering">ACL constraints</a
 <tbody>
 <tr>
 <td><a id="responsesDefault"> </a>default</td>
-<td style="text-align:center"><a href="#responseObject">Response Object</a> ¦ <a href="#referenceObject">Reference Object</a></td>
+<td style="text-align:center"><a href="#responseObject">Response Object</a> | <a href="#referenceObject">Reference Object</a></td>
 <td>The documentation of responses other than the ones declared for specific HTTP response codes. It can be used to cover undeclared responses. <a href="#referenceObject">Reference Object</a> can be used to link to a response that is defined at the <a href="#swaggerResponses">Swagger Object’s responses</a> section.</td>
 </tr>
 </tbody>
@@ -1420,7 +1420,7 @@ A Path Item may be empty, due to <a href="#securityFiltering">ACL constraints</a
 <tbody>
 <tr>
 <td><a id="responsesCode"> </a>{<a href="#httpCodes">HTTP Status Code</a>}</td>
-<td style="text-align:center"><a href="#responseObject">Response Object</a> ¦ <a href="#referenceObject">Reference Object</a></td>
+<td style="text-align:center"><a href="#responseObject">Response Object</a> | <a href="#referenceObject">Reference Object</a></td>
 <td>Any <a href="#httpCodes">HTTP status code</a> can be used as the property name (one property per HTTP status code). Describes the expected response for that HTTP status code.  <a href="#referenceObject">Reference Object</a> can be used to link to a response that is defined at the <a href="#swaggerResponses">Swagger Object’s responses</a> section.</td>
 </tr>
 <tr>
@@ -1434,29 +1434,29 @@ A Path Item may be empty, due to <a href="#securityFiltering">ACL constraints</a
 <p>A 200 response for successful operation and a default response for others (implying an error):</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-string">"200"</span>: {
-    <span class="hljs-string">"description"</span>: <span class="hljs-string">"a pet to be returned"</span>,
-    <span class="hljs-string">"schema"</span>: {
-      <span class="hljs-string">"$ref"</span>: <span class="hljs-string">"#/definitions/Pet"</span>
+  <span class="hljs-string">&quot;200&quot;</span>: {
+    <span class="hljs-string">&quot;description&quot;</span>: <span class="hljs-string">&quot;a pet to be returned&quot;</span>,
+    <span class="hljs-string">&quot;schema&quot;</span>: {
+      <span class="hljs-string">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/definitions/Pet&quot;</span>
     }
   },
-  <span class="hljs-string">"default"</span>: {
-    <span class="hljs-string">"description"</span>: <span class="hljs-string">"Unexpected error"</span>,
-    <span class="hljs-string">"schema"</span>: {
-      <span class="hljs-string">"$ref"</span>: <span class="hljs-string">"#/definitions/ErrorModel"</span>
+  <span class="hljs-string">&quot;default&quot;</span>: {
+    <span class="hljs-string">&quot;description&quot;</span>: <span class="hljs-string">&quot;Unexpected error&quot;</span>,
+    <span class="hljs-string">&quot;schema&quot;</span>: {
+      <span class="hljs-string">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/definitions/ErrorModel&quot;</span>
     }
   }
 }
 </code></pre>
 <pre class="nohighlight"><code>
-<span class="hljs-string">'200'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">  description:</span> <span class="hljs-string">a</span> <span class="hljs-string">pet</span> <span class="hljs-string">to</span> <span class="hljs-string">be</span> <span class="hljs-string">returned</span>
-<span class="hljs-attr">  schema:</span>
-    <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/definitions/Pet'</span>
+<span class="hljs-attr">&#x27;200&#x27;:</span>
+  <span class="hljs-attr">description:</span> <span class="hljs-string">a</span> <span class="hljs-string">pet</span> <span class="hljs-string">to</span> <span class="hljs-string">be</span> <span class="hljs-string">returned</span>
+  <span class="hljs-attr">schema:</span>
+    <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/definitions/Pet&#x27;</span>
 <span class="hljs-attr">default:</span>
-<span class="hljs-attr">  description:</span> <span class="hljs-string">Unexpected</span> <span class="hljs-string">error</span>
-<span class="hljs-attr">  schema:</span>
-    <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/definitions/ErrorModel'</span>
+  <span class="hljs-attr">description:</span> <span class="hljs-string">Unexpected</span> <span class="hljs-string">error</span>
+  <span class="hljs-attr">schema:</span>
+    <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/definitions/ErrorModel&#x27;</span>
 </code></pre>
 </section></section><section><h3><span id="responseObject">Response Object</span></h3>
 <p>Describes a single response from an API Operation.</p>
@@ -1513,11 +1513,11 @@ A Path Item may be empty, due to <a href="#securityFiltering">ACL constraints</a
 <p>Response of an array of a complex type:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-string">"description"</span>: <span class="hljs-string">"A complex object array response"</span>,
-  <span class="hljs-string">"schema"</span>: {
-    <span class="hljs-string">"type"</span>: <span class="hljs-string">"array"</span>,
-    <span class="hljs-string">"items"</span>: {
-      <span class="hljs-string">"$ref"</span>: <span class="hljs-string">"#/definitions/VeryComplexType"</span>
+  <span class="hljs-string">&quot;description&quot;</span>: <span class="hljs-string">&quot;A complex object array response&quot;</span>,
+  <span class="hljs-string">&quot;schema&quot;</span>: {
+    <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+    <span class="hljs-string">&quot;items&quot;</span>: {
+      <span class="hljs-string">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/definitions/VeryComplexType&quot;</span>
     }
   }
 }
@@ -1525,43 +1525,43 @@ A Path Item may be empty, due to <a href="#securityFiltering">ACL constraints</a
 <pre class="nohighlight"><code>
 <span class="hljs-attr">description:</span> <span class="hljs-string">A</span> <span class="hljs-string">complex</span> <span class="hljs-string">object</span> <span class="hljs-string">array</span> <span class="hljs-string">response</span>
 <span class="hljs-attr">schema:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">  items:</span>
-    <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/definitions/VeryComplexType'</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+  <span class="hljs-attr">items:</span>
+    <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/definitions/VeryComplexType&#x27;</span>
 </code></pre>
 <p>Response with a string type:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-string">"description"</span>: <span class="hljs-string">"A simple string response"</span>,
-  <span class="hljs-string">"schema"</span>: {
-    <span class="hljs-string">"type"</span>: <span class="hljs-string">"string"</span>
+  <span class="hljs-string">&quot;description&quot;</span>: <span class="hljs-string">&quot;A simple string response&quot;</span>,
+  <span class="hljs-string">&quot;schema&quot;</span>: {
+    <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
   }
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">description:</span> <span class="hljs-string">A</span> <span class="hljs-string">simple</span> <span class="hljs-string">string</span> <span class="hljs-string">response</span>
 <span class="hljs-attr">schema:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
 </code></pre>
 <p>Response with headers:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-string">"description"</span>: <span class="hljs-string">"A simple string response"</span>,
-  <span class="hljs-string">"schema"</span>: {
-    <span class="hljs-string">"type"</span>: <span class="hljs-string">"string"</span>
+  <span class="hljs-string">&quot;description&quot;</span>: <span class="hljs-string">&quot;A simple string response&quot;</span>,
+  <span class="hljs-string">&quot;schema&quot;</span>: {
+    <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
   },
-  <span class="hljs-string">"headers"</span>: {
-    <span class="hljs-string">"X-Rate-Limit-Limit"</span>: {
-      <span class="hljs-string">"description"</span>: <span class="hljs-string">"The number of allowed requests in the current period"</span>,
-      <span class="hljs-string">"type"</span>: <span class="hljs-string">"integer"</span>
+  <span class="hljs-string">&quot;headers&quot;</span>: {
+    <span class="hljs-string">&quot;X-Rate-Limit-Limit&quot;</span>: {
+      <span class="hljs-string">&quot;description&quot;</span>: <span class="hljs-string">&quot;The number of allowed requests in the current period&quot;</span>,
+      <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>
     },
-    <span class="hljs-string">"X-Rate-Limit-Remaining"</span>: {
-      <span class="hljs-string">"description"</span>: <span class="hljs-string">"The number of remaining requests in the current period"</span>,
-      <span class="hljs-string">"type"</span>: <span class="hljs-string">"integer"</span>
+    <span class="hljs-string">&quot;X-Rate-Limit-Remaining&quot;</span>: {
+      <span class="hljs-string">&quot;description&quot;</span>: <span class="hljs-string">&quot;The number of remaining requests in the current period&quot;</span>,
+      <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>
     },
-    <span class="hljs-string">"X-Rate-Limit-Reset"</span>: {
-      <span class="hljs-string">"description"</span>: <span class="hljs-string">"The number of seconds left in the current period"</span>,
-      <span class="hljs-string">"type"</span>: <span class="hljs-string">"integer"</span>
+    <span class="hljs-string">&quot;X-Rate-Limit-Reset&quot;</span>: {
+      <span class="hljs-string">&quot;description&quot;</span>: <span class="hljs-string">&quot;The number of seconds left in the current period&quot;</span>,
+      <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>
     }
   }
 }
@@ -1569,22 +1569,22 @@ A Path Item may be empty, due to <a href="#securityFiltering">ACL constraints</a
 <pre class="nohighlight"><code>
 <span class="hljs-attr">description:</span> <span class="hljs-string">A</span> <span class="hljs-string">simple</span> <span class="hljs-string">string</span> <span class="hljs-string">response</span>
 <span class="hljs-attr">schema:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
 <span class="hljs-attr">headers:</span>
-<span class="hljs-attr">  X-Rate-Limit-Limit:</span>
-<span class="hljs-attr">    description:</span> <span class="hljs-string">The</span> <span class="hljs-string">number</span> <span class="hljs-string">of</span> <span class="hljs-string">allowed</span> <span class="hljs-string">requests</span> <span class="hljs-string">in</span> <span class="hljs-string">the</span> <span class="hljs-string">current</span> <span class="hljs-string">period</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">integer</span>
-<span class="hljs-attr">  X-Rate-Limit-Remaining:</span>
-<span class="hljs-attr">    description:</span> <span class="hljs-string">The</span> <span class="hljs-string">number</span> <span class="hljs-string">of</span> <span class="hljs-string">remaining</span> <span class="hljs-string">requests</span> <span class="hljs-string">in</span> <span class="hljs-string">the</span> <span class="hljs-string">current</span> <span class="hljs-string">period</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">integer</span>
-<span class="hljs-attr">  X-Rate-Limit-Reset:</span>
-<span class="hljs-attr">    description:</span> <span class="hljs-string">The</span> <span class="hljs-string">number</span> <span class="hljs-string">of</span> <span class="hljs-string">seconds</span> <span class="hljs-string">left</span> <span class="hljs-string">in</span> <span class="hljs-string">the</span> <span class="hljs-string">current</span> <span class="hljs-string">period</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">integer</span>
+  <span class="hljs-attr">X-Rate-Limit-Limit:</span>
+    <span class="hljs-attr">description:</span> <span class="hljs-string">The</span> <span class="hljs-string">number</span> <span class="hljs-string">of</span> <span class="hljs-string">allowed</span> <span class="hljs-string">requests</span> <span class="hljs-string">in</span> <span class="hljs-string">the</span> <span class="hljs-string">current</span> <span class="hljs-string">period</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+  <span class="hljs-attr">X-Rate-Limit-Remaining:</span>
+    <span class="hljs-attr">description:</span> <span class="hljs-string">The</span> <span class="hljs-string">number</span> <span class="hljs-string">of</span> <span class="hljs-string">remaining</span> <span class="hljs-string">requests</span> <span class="hljs-string">in</span> <span class="hljs-string">the</span> <span class="hljs-string">current</span> <span class="hljs-string">period</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+  <span class="hljs-attr">X-Rate-Limit-Reset:</span>
+    <span class="hljs-attr">description:</span> <span class="hljs-string">The</span> <span class="hljs-string">number</span> <span class="hljs-string">of</span> <span class="hljs-string">seconds</span> <span class="hljs-string">left</span> <span class="hljs-string">in</span> <span class="hljs-string">the</span> <span class="hljs-string">current</span> <span class="hljs-string">period</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
 </code></pre>
 <p>Response with no return value:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-string">"description"</span>: <span class="hljs-string">"object created"</span>
+  <span class="hljs-string">&quot;description&quot;</span>: <span class="hljs-string">&quot;object created&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -1613,30 +1613,30 @@ A Path Item may be empty, due to <a href="#securityFiltering">ACL constraints</a
 <p>Rate-limit headers:</p>
 <pre class="nohighlight"><code>
 {
-    <span class="hljs-string">"X-Rate-Limit-Limit"</span>: {
-        <span class="hljs-string">"description"</span>: <span class="hljs-string">"The number of allowed requests in the current period"</span>,
-        <span class="hljs-string">"type"</span>: <span class="hljs-string">"integer"</span>
+    <span class="hljs-string">&quot;X-Rate-Limit-Limit&quot;</span>: {
+        <span class="hljs-string">&quot;description&quot;</span>: <span class="hljs-string">&quot;The number of allowed requests in the current period&quot;</span>,
+        <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>
     },
-    <span class="hljs-string">"X-Rate-Limit-Remaining"</span>: {
-        <span class="hljs-string">"description"</span>: <span class="hljs-string">"The number of remaining requests in the current period"</span>,
-        <span class="hljs-string">"type"</span>: <span class="hljs-string">"integer"</span>
+    <span class="hljs-string">&quot;X-Rate-Limit-Remaining&quot;</span>: {
+        <span class="hljs-string">&quot;description&quot;</span>: <span class="hljs-string">&quot;The number of remaining requests in the current period&quot;</span>,
+        <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>
     },
-    <span class="hljs-string">"X-Rate-Limit-Reset"</span>: {
-        <span class="hljs-string">"description"</span>: <span class="hljs-string">"The number of seconds left in the current period"</span>,
-        <span class="hljs-string">"type"</span>: <span class="hljs-string">"integer"</span>
+    <span class="hljs-string">&quot;X-Rate-Limit-Reset&quot;</span>: {
+        <span class="hljs-string">&quot;description&quot;</span>: <span class="hljs-string">&quot;The number of seconds left in the current period&quot;</span>,
+        <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>
     }
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">X-Rate-Limit-Limit:</span>
-<span class="hljs-attr">  description:</span> <span class="hljs-string">The</span> <span class="hljs-string">number</span> <span class="hljs-string">of</span> <span class="hljs-string">allowed</span> <span class="hljs-string">requests</span> <span class="hljs-string">in</span> <span class="hljs-string">the</span> <span class="hljs-string">current</span> <span class="hljs-string">period</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">integer</span>
+  <span class="hljs-attr">description:</span> <span class="hljs-string">The</span> <span class="hljs-string">number</span> <span class="hljs-string">of</span> <span class="hljs-string">allowed</span> <span class="hljs-string">requests</span> <span class="hljs-string">in</span> <span class="hljs-string">the</span> <span class="hljs-string">current</span> <span class="hljs-string">period</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
 <span class="hljs-attr">X-Rate-Limit-Remaining:</span>
-<span class="hljs-attr">  description:</span> <span class="hljs-string">The</span> <span class="hljs-string">number</span> <span class="hljs-string">of</span> <span class="hljs-string">remaining</span> <span class="hljs-string">requests</span> <span class="hljs-string">in</span> <span class="hljs-string">the</span> <span class="hljs-string">current</span> <span class="hljs-string">period</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">integer</span>
+  <span class="hljs-attr">description:</span> <span class="hljs-string">The</span> <span class="hljs-string">number</span> <span class="hljs-string">of</span> <span class="hljs-string">remaining</span> <span class="hljs-string">requests</span> <span class="hljs-string">in</span> <span class="hljs-string">the</span> <span class="hljs-string">current</span> <span class="hljs-string">period</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
 <span class="hljs-attr">X-Rate-Limit-Reset:</span>
-<span class="hljs-attr">  description:</span> <span class="hljs-string">The</span> <span class="hljs-string">number</span> <span class="hljs-string">of</span> <span class="hljs-string">seconds</span> <span class="hljs-string">left</span> <span class="hljs-string">in</span> <span class="hljs-string">the</span> <span class="hljs-string">current</span> <span class="hljs-string">period</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">integer</span>
+  <span class="hljs-attr">description:</span> <span class="hljs-string">The</span> <span class="hljs-string">number</span> <span class="hljs-string">of</span> <span class="hljs-string">seconds</span> <span class="hljs-string">left</span> <span class="hljs-string">in</span> <span class="hljs-string">the</span> <span class="hljs-string">current</span> <span class="hljs-string">period</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
 </code></pre>
 </section></section><section><h3><span id="exampleObject">Example Object</span></h3>
 <p>Allows sharing examples for operation responses.</p>
@@ -1661,22 +1661,22 @@ A Path Item may be empty, due to <a href="#securityFiltering">ACL constraints</a
 <p>Example response for application/json mimetype of a Pet data type:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-string">"application/json"</span>: {
-    <span class="hljs-string">"name"</span>: <span class="hljs-string">"Puma"</span>,
-    <span class="hljs-string">"type"</span>: <span class="hljs-string">"Dog"</span>,
-    <span class="hljs-string">"color"</span>: <span class="hljs-string">"Black"</span>,
-    <span class="hljs-string">"gender"</span>: <span class="hljs-string">"Female"</span>,
-    <span class="hljs-string">"breed"</span>: <span class="hljs-string">"Mixed"</span>
+  <span class="hljs-string">&quot;application/json&quot;</span>: {
+    <span class="hljs-string">&quot;name&quot;</span>: <span class="hljs-string">&quot;Puma&quot;</span>,
+    <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;Dog&quot;</span>,
+    <span class="hljs-string">&quot;color&quot;</span>: <span class="hljs-string">&quot;Black&quot;</span>,
+    <span class="hljs-string">&quot;gender&quot;</span>: <span class="hljs-string">&quot;Female&quot;</span>,
+    <span class="hljs-string">&quot;breed&quot;</span>: <span class="hljs-string">&quot;Mixed&quot;</span>
   }
 }
 </code></pre>
 <pre class="nohighlight"><code>
-<span class="hljs-string">application/json:</span>
-<span class="hljs-attr">  name:</span> <span class="hljs-string">Puma</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">Dog</span>
-<span class="hljs-attr">  color:</span> <span class="hljs-string">Black</span>
-<span class="hljs-attr">  gender:</span> <span class="hljs-string">Female</span>
-<span class="hljs-attr">  breed:</span> <span class="hljs-string">Mixed</span>
+<span class="hljs-attr">application/json:</span>
+  <span class="hljs-attr">name:</span> <span class="hljs-string">Puma</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">Dog</span>
+  <span class="hljs-attr">color:</span> <span class="hljs-string">Black</span>
+  <span class="hljs-attr">gender:</span> <span class="hljs-string">Female</span>
+  <span class="hljs-attr">breed:</span> <span class="hljs-string">Mixed</span>
 </code></pre>
 </section></section><section><h3><span id="headerObject">Header Object</span></h3>
 <table>
@@ -1801,8 +1801,8 @@ A Path Item may be empty, due to <a href="#securityFiltering">ACL constraints</a
 <p>A simple header with of an integer type:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-string">"description"</span>: <span class="hljs-string">"The number of allowed requests in the current period"</span>,
-  <span class="hljs-string">"type"</span>: <span class="hljs-string">"integer"</span>
+  <span class="hljs-string">&quot;description&quot;</span>: <span class="hljs-string">&quot;The number of allowed requests in the current period&quot;</span>,
+  <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -1858,8 +1858,8 @@ A Path Item may be empty, due to <a href="#securityFiltering">ACL constraints</a
 </section><section><h4>Tag Object Example</h4>
 <pre class="nohighlight"><code>
 {
-	<span class="hljs-string">"name"</span>: <span class="hljs-string">"pet"</span>,
-	<span class="hljs-string">"description"</span>: <span class="hljs-string">"Pets operations"</span>
+	<span class="hljs-string">&quot;name&quot;</span>: <span class="hljs-string">&quot;pet&quot;</span>,
+	<span class="hljs-string">&quot;description&quot;</span>: <span class="hljs-string">&quot;Pets operations&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -1889,29 +1889,29 @@ A Path Item may be empty, due to <a href="#securityFiltering">ACL constraints</a
 </section><section><h4>Reference Object Example</h4>
 <pre class="nohighlight"><code>
 {
-	<span class="hljs-string">"$ref"</span>: <span class="hljs-string">"#/definitions/Pet"</span>
+	<span class="hljs-string">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/definitions/Pet&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
-<span class="hljs-string">$ref:</span> <span class="hljs-string">'#/definitions/Pet'</span>
+<span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/definitions/Pet&#x27;</span>
 </code></pre>
 </section><section><h4>Relative Schema File Example</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-string">"$ref"</span>: <span class="hljs-string">"Pet.json"</span>
+  <span class="hljs-string">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;Pet.json&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
-<span class="hljs-string">$ref:</span> <span class="hljs-string">'Pet.yaml'</span>
+<span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;Pet.yaml&#x27;</span>
 </code></pre>
 </section><section><h4>Relative Files With Embedded Schema Example</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-string">"$ref"</span>: <span class="hljs-string">"definitions.json#/Pet"</span>
+  <span class="hljs-string">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;definitions.json#/Pet&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
-<span class="hljs-string">$ref:</span> <span class="hljs-string">'definitions.yaml#/Pet'</span>
+<span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;definitions.yaml#/Pet&#x27;</span>
 </code></pre>
 </section></section><section><h3><span id="schemaObject">Schema Object</span></h3>
 <p>The Schema Object allows the definition of input and output data types. These types can be objects, but also primitives and arrays. This object is based on the <a href="http://json-schema.org/">JSON Schema Specification Draft 4</a> and uses a predefined subset of it. On top of this subset, there are extensions provided by this specification to allow for more complete documentation.</p>
@@ -2012,8 +2012,8 @@ A Path Item may be empty, due to <a href="#securityFiltering">ACL constraints</a
 <p>Unlike previous versions of Swagger, Schema definitions can be used to describe primitive and arrays as well.</p>
 <pre class="nohighlight"><code>
 {
-    <span class="hljs-string">"type"</span>: <span class="hljs-string">"string"</span>,
-    <span class="hljs-string">"format"</span>: <span class="hljs-string">"email"</span>
+    <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>,
+    <span class="hljs-string">&quot;format&quot;</span>: <span class="hljs-string">&quot;email&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -2023,21 +2023,21 @@ A Path Item may be empty, due to <a href="#securityFiltering">ACL constraints</a
 </section><section><h5>Simple Model</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-string">"type"</span>: <span class="hljs-string">"object"</span>,
-  <span class="hljs-string">"required"</span>: [
-    <span class="hljs-string">"name"</span>
+  <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+  <span class="hljs-string">&quot;required&quot;</span>: [
+    <span class="hljs-string">&quot;name&quot;</span>
   ],
-  <span class="hljs-string">"properties"</span>: {
-    <span class="hljs-string">"name"</span>: {
-      <span class="hljs-string">"type"</span>: <span class="hljs-string">"string"</span>
+  <span class="hljs-string">&quot;properties&quot;</span>: {
+    <span class="hljs-string">&quot;name&quot;</span>: {
+      <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
     },
-    <span class="hljs-string">"address"</span>: {
-      <span class="hljs-string">"$ref"</span>: <span class="hljs-string">"#/definitions/Address"</span>
+    <span class="hljs-string">&quot;address&quot;</span>: {
+      <span class="hljs-string">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/definitions/Address&quot;</span>
     },
-    <span class="hljs-string">"age"</span>: {
-      <span class="hljs-string">"type"</span>: <span class="hljs-string">"integer"</span>,
-      <span class="hljs-string">"format"</span>: <span class="hljs-string">"int32"</span>,
-      <span class="hljs-string">"minimum"</span>: <span class="hljs-number">0</span>
+    <span class="hljs-string">&quot;age&quot;</span>: {
+      <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>,
+      <span class="hljs-string">&quot;format&quot;</span>: <span class="hljs-string">&quot;int32&quot;</span>,
+      <span class="hljs-string">&quot;minimum&quot;</span>: <span class="hljs-number">0</span>
     }
   }
 }
@@ -2047,114 +2047,114 @@ A Path Item may be empty, due to <a href="#securityFiltering">ACL constraints</a
 <span class="hljs-attr">required:</span>
 <span class="hljs-bullet">-</span> <span class="hljs-string">name</span>
 <span class="hljs-attr">properties:</span>
-<span class="hljs-attr">  name:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">  address:</span>
-    <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/definitions/Address'</span>
-<span class="hljs-attr">  age:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">integer</span>
-<span class="hljs-attr">    format:</span> <span class="hljs-string">int32</span>
-<span class="hljs-attr">    minimum:</span> <span class="hljs-number">0</span>
+  <span class="hljs-attr">name:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">address:</span>
+    <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/definitions/Address&#x27;</span>
+  <span class="hljs-attr">age:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+    <span class="hljs-attr">format:</span> <span class="hljs-string">int32</span>
+    <span class="hljs-attr">minimum:</span> <span class="hljs-number">0</span>
 </code></pre>
 </section><section><h5>Model with Map/Dictionary Properties</h5>
 <p>For a simple string to string mapping:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-string">"type"</span>: <span class="hljs-string">"object"</span>,
-  <span class="hljs-string">"additionalProperties"</span>: {
-    <span class="hljs-string">"type"</span>: <span class="hljs-string">"string"</span>
+  <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+  <span class="hljs-string">&quot;additionalProperties&quot;</span>: {
+    <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
   }
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
 <span class="hljs-attr">additionalProperties:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
 </code></pre>
 <p>For a string to model mapping:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-string">"type"</span>: <span class="hljs-string">"object"</span>,
-  <span class="hljs-string">"additionalProperties"</span>: {
-    <span class="hljs-string">"$ref"</span>: <span class="hljs-string">"#/definitions/ComplexModel"</span>
+  <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+  <span class="hljs-string">&quot;additionalProperties&quot;</span>: {
+    <span class="hljs-string">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/definitions/ComplexModel&quot;</span>
   }
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
 <span class="hljs-attr">additionalProperties:</span>
-  <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/definitions/ComplexModel'</span>
+  <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/definitions/ComplexModel&#x27;</span>
 </code></pre>
 </section><section><h5>Model with Example</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-string">"type"</span>: <span class="hljs-string">"object"</span>,
-  <span class="hljs-string">"properties"</span>: {
-    <span class="hljs-string">"id"</span>: {
-      <span class="hljs-string">"type"</span>: <span class="hljs-string">"integer"</span>,
-      <span class="hljs-string">"format"</span>: <span class="hljs-string">"int64"</span>
+  <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+  <span class="hljs-string">&quot;properties&quot;</span>: {
+    <span class="hljs-string">&quot;id&quot;</span>: {
+      <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>,
+      <span class="hljs-string">&quot;format&quot;</span>: <span class="hljs-string">&quot;int64&quot;</span>
     },
-    <span class="hljs-string">"name"</span>: {
-      <span class="hljs-string">"type"</span>: <span class="hljs-string">"string"</span>
+    <span class="hljs-string">&quot;name&quot;</span>: {
+      <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
     }
   },
-  <span class="hljs-string">"required"</span>: [
-    <span class="hljs-string">"name"</span>
+  <span class="hljs-string">&quot;required&quot;</span>: [
+    <span class="hljs-string">&quot;name&quot;</span>
   ],
-  <span class="hljs-string">"example"</span>: {
-    <span class="hljs-string">"name"</span>: <span class="hljs-string">"Puma"</span>,
-    <span class="hljs-string">"id"</span>: <span class="hljs-number">1</span>
+  <span class="hljs-string">&quot;example&quot;</span>: {
+    <span class="hljs-string">&quot;name&quot;</span>: <span class="hljs-string">&quot;Puma&quot;</span>,
+    <span class="hljs-string">&quot;id&quot;</span>: <span class="hljs-number">1</span>
   }
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
 <span class="hljs-attr">properties:</span>
-<span class="hljs-attr">  id:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">integer</span>
-<span class="hljs-attr">    format:</span> <span class="hljs-string">int64</span>
-<span class="hljs-attr">  name:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">id:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+    <span class="hljs-attr">format:</span> <span class="hljs-string">int64</span>
+  <span class="hljs-attr">name:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
 <span class="hljs-attr">required:</span>
 <span class="hljs-bullet">-</span> <span class="hljs-string">name</span>
 <span class="hljs-attr">example:</span>
-<span class="hljs-attr">  name:</span> <span class="hljs-string">Puma</span>
-<span class="hljs-attr">  id:</span> <span class="hljs-number">1</span>
+  <span class="hljs-attr">name:</span> <span class="hljs-string">Puma</span>
+  <span class="hljs-attr">id:</span> <span class="hljs-number">1</span>
 </code></pre>
 </section><section><h5>Models with Composition</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-string">"definitions"</span>: {
-    <span class="hljs-string">"ErrorModel"</span>: {
-      <span class="hljs-string">"type"</span>: <span class="hljs-string">"object"</span>,
-      <span class="hljs-string">"required"</span>: [
-        <span class="hljs-string">"message"</span>,
-        <span class="hljs-string">"code"</span>
+  <span class="hljs-string">&quot;definitions&quot;</span>: {
+    <span class="hljs-string">&quot;ErrorModel&quot;</span>: {
+      <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+      <span class="hljs-string">&quot;required&quot;</span>: [
+        <span class="hljs-string">&quot;message&quot;</span>,
+        <span class="hljs-string">&quot;code&quot;</span>
       ],
-      <span class="hljs-string">"properties"</span>: {
-        <span class="hljs-string">"message"</span>: {
-          <span class="hljs-string">"type"</span>: <span class="hljs-string">"string"</span>
+      <span class="hljs-string">&quot;properties&quot;</span>: {
+        <span class="hljs-string">&quot;message&quot;</span>: {
+          <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
         },
-        <span class="hljs-string">"code"</span>: {
-          <span class="hljs-string">"type"</span>: <span class="hljs-string">"integer"</span>,
-          <span class="hljs-string">"minimum"</span>: <span class="hljs-number">100</span>,
-          <span class="hljs-string">"maximum"</span>: <span class="hljs-number">600</span>
+        <span class="hljs-string">&quot;code&quot;</span>: {
+          <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>,
+          <span class="hljs-string">&quot;minimum&quot;</span>: <span class="hljs-number">100</span>,
+          <span class="hljs-string">&quot;maximum&quot;</span>: <span class="hljs-number">600</span>
         }
       }
     },
-    <span class="hljs-string">"ExtendedErrorModel"</span>: {
-      <span class="hljs-string">"allOf"</span>: [
+    <span class="hljs-string">&quot;ExtendedErrorModel&quot;</span>: {
+      <span class="hljs-string">&quot;allOf&quot;</span>: [
         {
-          <span class="hljs-string">"$ref"</span>: <span class="hljs-string">"#/definitions/ErrorModel"</span>
+          <span class="hljs-string">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/definitions/ErrorModel&quot;</span>
         },
         {
-          <span class="hljs-string">"type"</span>: <span class="hljs-string">"object"</span>,
-          <span class="hljs-string">"required"</span>: [
-            <span class="hljs-string">"rootCause"</span>
+          <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+          <span class="hljs-string">&quot;required&quot;</span>: [
+            <span class="hljs-string">&quot;rootCause&quot;</span>
           ],
-          <span class="hljs-string">"properties"</span>: {
-            <span class="hljs-string">"rootCause"</span>: {
-              <span class="hljs-string">"type"</span>: <span class="hljs-string">"string"</span>
+          <span class="hljs-string">&quot;properties&quot;</span>: {
+            <span class="hljs-string">&quot;rootCause&quot;</span>: {
+              <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
             }
           }
         }
@@ -2165,94 +2165,94 @@ A Path Item may be empty, due to <a href="#securityFiltering">ACL constraints</a
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">definitions:</span>
-<span class="hljs-attr">  ErrorModel:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">    required:</span>
-<span class="hljs-bullet">    -</span> <span class="hljs-string">message</span>
-<span class="hljs-bullet">    -</span> <span class="hljs-string">code</span>
-<span class="hljs-attr">    properties:</span>
-<span class="hljs-attr">      message:</span>
-<span class="hljs-attr">        type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">      code:</span>
-<span class="hljs-attr">        type:</span> <span class="hljs-string">integer</span>
-<span class="hljs-attr">        minimum:</span> <span class="hljs-number">100</span>
-<span class="hljs-attr">        maximum:</span> <span class="hljs-number">600</span>
-<span class="hljs-attr">  ExtendedErrorModel:</span>
-<span class="hljs-attr">    allOf:</span>
-<span class="hljs-bullet">    -</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/definitions/ErrorModel'</span>
-<span class="hljs-attr">    - type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">      required:</span>
-<span class="hljs-bullet">      -</span> <span class="hljs-string">rootCause</span>
-<span class="hljs-attr">      properties:</span>
-<span class="hljs-attr">        rootCause:</span>
-<span class="hljs-attr">          type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">ErrorModel:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+    <span class="hljs-attr">required:</span>
+    <span class="hljs-bullet">-</span> <span class="hljs-string">message</span>
+    <span class="hljs-bullet">-</span> <span class="hljs-string">code</span>
+    <span class="hljs-attr">properties:</span>
+      <span class="hljs-attr">message:</span>
+        <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+      <span class="hljs-attr">code:</span>
+        <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+        <span class="hljs-attr">minimum:</span> <span class="hljs-number">100</span>
+        <span class="hljs-attr">maximum:</span> <span class="hljs-number">600</span>
+  <span class="hljs-attr">ExtendedErrorModel:</span>
+    <span class="hljs-attr">allOf:</span>
+    <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/definitions/ErrorModel&#x27;</span>
+    <span class="hljs-bullet">-</span> <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+      <span class="hljs-attr">required:</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-string">rootCause</span>
+      <span class="hljs-attr">properties:</span>
+        <span class="hljs-attr">rootCause:</span>
+          <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
 </code></pre>
 </section><section><h5>Models with Polymorphism Support</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-string">"definitions"</span>: {
-    <span class="hljs-string">"Pet"</span>: {
-      <span class="hljs-string">"type"</span>: <span class="hljs-string">"object"</span>,
-      <span class="hljs-string">"discriminator"</span>: <span class="hljs-string">"petType"</span>,
-      <span class="hljs-string">"properties"</span>: {
-        <span class="hljs-string">"name"</span>: {
-          <span class="hljs-string">"type"</span>: <span class="hljs-string">"string"</span>
+  <span class="hljs-string">&quot;definitions&quot;</span>: {
+    <span class="hljs-string">&quot;Pet&quot;</span>: {
+      <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+      <span class="hljs-string">&quot;discriminator&quot;</span>: <span class="hljs-string">&quot;petType&quot;</span>,
+      <span class="hljs-string">&quot;properties&quot;</span>: {
+        <span class="hljs-string">&quot;name&quot;</span>: {
+          <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
         },
-        <span class="hljs-string">"petType"</span>: {
-          <span class="hljs-string">"type"</span>: <span class="hljs-string">"string"</span>
+        <span class="hljs-string">&quot;petType&quot;</span>: {
+          <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
         }
       },
-      <span class="hljs-string">"required"</span>: [
-        <span class="hljs-string">"name"</span>,
-        <span class="hljs-string">"petType"</span>
+      <span class="hljs-string">&quot;required&quot;</span>: [
+        <span class="hljs-string">&quot;name&quot;</span>,
+        <span class="hljs-string">&quot;petType&quot;</span>
       ]
     },
-    <span class="hljs-string">"Cat"</span>: {
-      <span class="hljs-string">"description"</span>: <span class="hljs-string">"A representation of a cat"</span>,
-      <span class="hljs-string">"allOf"</span>: [
+    <span class="hljs-string">&quot;Cat&quot;</span>: {
+      <span class="hljs-string">&quot;description&quot;</span>: <span class="hljs-string">&quot;A representation of a cat&quot;</span>,
+      <span class="hljs-string">&quot;allOf&quot;</span>: [
         {
-          <span class="hljs-string">"$ref"</span>: <span class="hljs-string">"#/definitions/Pet"</span>
+          <span class="hljs-string">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/definitions/Pet&quot;</span>
         },
         {
-          <span class="hljs-string">"type"</span>: <span class="hljs-string">"object"</span>,
-          <span class="hljs-string">"properties"</span>: {
-            <span class="hljs-string">"huntingSkill"</span>: {
-              <span class="hljs-string">"type"</span>: <span class="hljs-string">"string"</span>,
-              <span class="hljs-string">"description"</span>: <span class="hljs-string">"The measured skill for hunting"</span>,
-              <span class="hljs-string">"default"</span>: <span class="hljs-string">"lazy"</span>,
-              <span class="hljs-string">"enum"</span>: [
-                <span class="hljs-string">"clueless"</span>,
-                <span class="hljs-string">"lazy"</span>,
-                <span class="hljs-string">"adventurous"</span>,
-                <span class="hljs-string">"aggressive"</span>
+          <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+          <span class="hljs-string">&quot;properties&quot;</span>: {
+            <span class="hljs-string">&quot;huntingSkill&quot;</span>: {
+              <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>,
+              <span class="hljs-string">&quot;description&quot;</span>: <span class="hljs-string">&quot;The measured skill for hunting&quot;</span>,
+              <span class="hljs-string">&quot;default&quot;</span>: <span class="hljs-string">&quot;lazy&quot;</span>,
+              <span class="hljs-string">&quot;enum&quot;</span>: [
+                <span class="hljs-string">&quot;clueless&quot;</span>,
+                <span class="hljs-string">&quot;lazy&quot;</span>,
+                <span class="hljs-string">&quot;adventurous&quot;</span>,
+                <span class="hljs-string">&quot;aggressive&quot;</span>
               ]
             }
           },
-          <span class="hljs-string">"required"</span>: [
-            <span class="hljs-string">"huntingSkill"</span>
+          <span class="hljs-string">&quot;required&quot;</span>: [
+            <span class="hljs-string">&quot;huntingSkill&quot;</span>
           ]
         }
       ]
     },
-    <span class="hljs-string">"Dog"</span>: {
-      <span class="hljs-string">"description"</span>: <span class="hljs-string">"A representation of a dog"</span>,
-      <span class="hljs-string">"allOf"</span>: [
+    <span class="hljs-string">&quot;Dog&quot;</span>: {
+      <span class="hljs-string">&quot;description&quot;</span>: <span class="hljs-string">&quot;A representation of a dog&quot;</span>,
+      <span class="hljs-string">&quot;allOf&quot;</span>: [
         {
-          <span class="hljs-string">"$ref"</span>: <span class="hljs-string">"#/definitions/Pet"</span>
+          <span class="hljs-string">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/definitions/Pet&quot;</span>
         },
         {
-          <span class="hljs-string">"type"</span>: <span class="hljs-string">"object"</span>,
-          <span class="hljs-string">"properties"</span>: {
-            <span class="hljs-string">"packSize"</span>: {
-              <span class="hljs-string">"type"</span>: <span class="hljs-string">"integer"</span>,
-              <span class="hljs-string">"format"</span>: <span class="hljs-string">"int32"</span>,
-              <span class="hljs-string">"description"</span>: <span class="hljs-string">"the size of the pack the dog is from"</span>,
-              <span class="hljs-string">"default"</span>: <span class="hljs-number">0</span>,
-              <span class="hljs-string">"minimum"</span>: <span class="hljs-number">0</span>
+          <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+          <span class="hljs-string">&quot;properties&quot;</span>: {
+            <span class="hljs-string">&quot;packSize&quot;</span>: {
+              <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>,
+              <span class="hljs-string">&quot;format&quot;</span>: <span class="hljs-string">&quot;int32&quot;</span>,
+              <span class="hljs-string">&quot;description&quot;</span>: <span class="hljs-string">&quot;the size of the pack the dog is from&quot;</span>,
+              <span class="hljs-string">&quot;default&quot;</span>: <span class="hljs-number">0</span>,
+              <span class="hljs-string">&quot;minimum&quot;</span>: <span class="hljs-number">0</span>
             }
           },
-          <span class="hljs-string">"required"</span>: [
-            <span class="hljs-string">"packSize"</span>
+          <span class="hljs-string">&quot;required&quot;</span>: [
+            <span class="hljs-string">&quot;packSize&quot;</span>
           ]
         }
       ]
@@ -2262,48 +2262,48 @@ A Path Item may be empty, due to <a href="#securityFiltering">ACL constraints</a
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">definitions:</span>
-<span class="hljs-attr">  Pet:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">    discriminator:</span> <span class="hljs-string">petType</span>
-<span class="hljs-attr">    properties:</span>
-<span class="hljs-attr">      name:</span>
-<span class="hljs-attr">        type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">      petType:</span>
-<span class="hljs-attr">        type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">    required:</span>
-<span class="hljs-bullet">    -</span> <span class="hljs-string">name</span>
-<span class="hljs-bullet">    -</span> <span class="hljs-string">petType</span>
-<span class="hljs-attr">  Cat:</span>
-<span class="hljs-attr">    description:</span> <span class="hljs-string">A</span> <span class="hljs-string">representation</span> <span class="hljs-string">of</span> <span class="hljs-string">a</span> <span class="hljs-string">cat</span>
-<span class="hljs-attr">    allOf:</span>
-<span class="hljs-bullet">    -</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/definitions/Pet'</span>
-<span class="hljs-attr">    - type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">      properties:</span>
-<span class="hljs-attr">        huntingSkill:</span>
-<span class="hljs-attr">          type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">          description:</span> <span class="hljs-string">The</span> <span class="hljs-string">measured</span> <span class="hljs-string">skill</span> <span class="hljs-string">for</span> <span class="hljs-string">hunting</span>
-<span class="hljs-attr">          default:</span> <span class="hljs-string">lazy</span>
-<span class="hljs-attr">          enum:</span>
-<span class="hljs-bullet">          -</span> <span class="hljs-string">clueless</span>
-<span class="hljs-bullet">          -</span> <span class="hljs-string">lazy</span>
-<span class="hljs-bullet">          -</span> <span class="hljs-string">adventurous</span>
-<span class="hljs-bullet">          -</span> <span class="hljs-string">aggressive</span>
-<span class="hljs-attr">      required:</span>
-<span class="hljs-bullet">      -</span> <span class="hljs-string">huntingSkill</span>
-<span class="hljs-attr">  Dog:</span>
-<span class="hljs-attr">    description:</span> <span class="hljs-string">A</span> <span class="hljs-string">representation</span> <span class="hljs-string">of</span> <span class="hljs-string">a</span> <span class="hljs-string">dog</span>
-<span class="hljs-attr">    allOf:</span>
-<span class="hljs-bullet">    -</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/definitions/Pet'</span>
-<span class="hljs-attr">    - type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">      properties:</span>
-<span class="hljs-attr">        packSize:</span>
-<span class="hljs-attr">          type:</span> <span class="hljs-string">integer</span>
-<span class="hljs-attr">          format:</span> <span class="hljs-string">int32</span>
-<span class="hljs-attr">          description:</span> <span class="hljs-string">the</span> <span class="hljs-string">size</span> <span class="hljs-string">of</span> <span class="hljs-string">the</span> <span class="hljs-string">pack</span> <span class="hljs-string">the</span> <span class="hljs-string">dog</span> <span class="hljs-string">is</span> <span class="hljs-string">from</span>
-<span class="hljs-attr">          default:</span> <span class="hljs-number">0</span>
-<span class="hljs-attr">          minimum:</span> <span class="hljs-number">0</span>
-<span class="hljs-attr">      required:</span>
-<span class="hljs-bullet">      -</span> <span class="hljs-string">packSize</span>
+  <span class="hljs-attr">Pet:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+    <span class="hljs-attr">discriminator:</span> <span class="hljs-string">petType</span>
+    <span class="hljs-attr">properties:</span>
+      <span class="hljs-attr">name:</span>
+        <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+      <span class="hljs-attr">petType:</span>
+        <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+    <span class="hljs-attr">required:</span>
+    <span class="hljs-bullet">-</span> <span class="hljs-string">name</span>
+    <span class="hljs-bullet">-</span> <span class="hljs-string">petType</span>
+  <span class="hljs-attr">Cat:</span>
+    <span class="hljs-attr">description:</span> <span class="hljs-string">A</span> <span class="hljs-string">representation</span> <span class="hljs-string">of</span> <span class="hljs-string">a</span> <span class="hljs-string">cat</span>
+    <span class="hljs-attr">allOf:</span>
+    <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/definitions/Pet&#x27;</span>
+    <span class="hljs-bullet">-</span> <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+      <span class="hljs-attr">properties:</span>
+        <span class="hljs-attr">huntingSkill:</span>
+          <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+          <span class="hljs-attr">description:</span> <span class="hljs-string">The</span> <span class="hljs-string">measured</span> <span class="hljs-string">skill</span> <span class="hljs-string">for</span> <span class="hljs-string">hunting</span>
+          <span class="hljs-attr">default:</span> <span class="hljs-string">lazy</span>
+          <span class="hljs-attr">enum:</span>
+          <span class="hljs-bullet">-</span> <span class="hljs-string">clueless</span>
+          <span class="hljs-bullet">-</span> <span class="hljs-string">lazy</span>
+          <span class="hljs-bullet">-</span> <span class="hljs-string">adventurous</span>
+          <span class="hljs-bullet">-</span> <span class="hljs-string">aggressive</span>
+      <span class="hljs-attr">required:</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-string">huntingSkill</span>
+  <span class="hljs-attr">Dog:</span>
+    <span class="hljs-attr">description:</span> <span class="hljs-string">A</span> <span class="hljs-string">representation</span> <span class="hljs-string">of</span> <span class="hljs-string">a</span> <span class="hljs-string">dog</span>
+    <span class="hljs-attr">allOf:</span>
+    <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/definitions/Pet&#x27;</span>
+    <span class="hljs-bullet">-</span> <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+      <span class="hljs-attr">properties:</span>
+        <span class="hljs-attr">packSize:</span>
+          <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+          <span class="hljs-attr">format:</span> <span class="hljs-string">int32</span>
+          <span class="hljs-attr">description:</span> <span class="hljs-string">the</span> <span class="hljs-string">size</span> <span class="hljs-string">of</span> <span class="hljs-string">the</span> <span class="hljs-string">pack</span> <span class="hljs-string">the</span> <span class="hljs-string">dog</span> <span class="hljs-string">is</span> <span class="hljs-string">from</span>
+          <span class="hljs-attr">default:</span> <span class="hljs-number">0</span>
+          <span class="hljs-attr">minimum:</span> <span class="hljs-number">0</span>
+      <span class="hljs-attr">required:</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-string">packSize</span>
 </code></pre>
 </section></section></section><section><h3><span id="xmlObject">XML Object</span></h3>
 <p>A metadata object that allows for more fine-tuned XML model definitions.</p>
@@ -2368,14 +2368,14 @@ A Path Item may be empty, due to <a href="#securityFiltering">ACL constraints</a
 <p>Basic string property:</p>
 <pre class="nohighlight"><code>
 {
-    <span class="hljs-string">"animals"</span>: {
-        <span class="hljs-string">"type"</span>: <span class="hljs-string">"string"</span>
+    <span class="hljs-string">&quot;animals&quot;</span>: {
+        <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
     }
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">animals:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-tag">&lt;<span class="hljs-name">animals</span>&gt;</span>...<span class="hljs-tag">&lt;/<span class="hljs-name">animals</span>&gt;</span>
@@ -2383,19 +2383,19 @@ A Path Item may be empty, due to <a href="#securityFiltering">ACL constraints</a
 <p>Basic string array property (<a href="#xmlWrapped"><code>wrapped</code></a> is <code>false</code> by default):</p>
 <pre class="nohighlight"><code>
 {
-    <span class="hljs-string">"animals"</span>: {
-        <span class="hljs-string">"type"</span>: <span class="hljs-string">"array"</span>,
-        <span class="hljs-string">"items"</span>: {
-            <span class="hljs-string">"type"</span>: <span class="hljs-string">"string"</span>
+    <span class="hljs-string">&quot;animals&quot;</span>: {
+        <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+        <span class="hljs-string">&quot;items&quot;</span>: {
+            <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
         }
     }
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">animals:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">  items:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+  <span class="hljs-attr">items:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-tag">&lt;<span class="hljs-name">animals</span>&gt;</span>...<span class="hljs-tag">&lt;/<span class="hljs-name">animals</span>&gt;</span>
@@ -2405,19 +2405,19 @@ A Path Item may be empty, due to <a href="#securityFiltering">ACL constraints</a
 </section><section><h5>XML Name Replacement</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-string">"animals"</span>: {
-    <span class="hljs-string">"type"</span>: <span class="hljs-string">"string"</span>,
-    <span class="hljs-string">"xml"</span>: {
-      <span class="hljs-string">"name"</span>: <span class="hljs-string">"animal"</span>
+  <span class="hljs-string">&quot;animals&quot;</span>: {
+    <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>,
+    <span class="hljs-string">&quot;xml&quot;</span>: {
+      <span class="hljs-string">&quot;name&quot;</span>: <span class="hljs-string">&quot;animal&quot;</span>
     }
   }
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">animals:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">  xml:</span>
-<span class="hljs-attr">    name:</span> <span class="hljs-string">animal</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">xml:</span>
+    <span class="hljs-attr">name:</span> <span class="hljs-string">animal</span>
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-tag">&lt;<span class="hljs-name">animal</span>&gt;</span>...<span class="hljs-tag">&lt;/<span class="hljs-name">animal</span>&gt;</span>
@@ -2426,21 +2426,21 @@ A Path Item may be empty, due to <a href="#securityFiltering">ACL constraints</a
 <p>In this example, a full model definition is shown.</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-string">"Person"</span>: {
-    <span class="hljs-string">"type"</span>: <span class="hljs-string">"object"</span>,
-    <span class="hljs-string">"properties"</span>: {
-      <span class="hljs-string">"id"</span>: {
-        <span class="hljs-string">"type"</span>: <span class="hljs-string">"integer"</span>,
-        <span class="hljs-string">"format"</span>: <span class="hljs-string">"int32"</span>,
-        <span class="hljs-string">"xml"</span>: {
-          <span class="hljs-string">"attribute"</span>: <span class="hljs-literal">true</span>
+  <span class="hljs-string">&quot;Person&quot;</span>: {
+    <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+    <span class="hljs-string">&quot;properties&quot;</span>: {
+      <span class="hljs-string">&quot;id&quot;</span>: {
+        <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>,
+        <span class="hljs-string">&quot;format&quot;</span>: <span class="hljs-string">&quot;int32&quot;</span>,
+        <span class="hljs-string">&quot;xml&quot;</span>: {
+          <span class="hljs-string">&quot;attribute&quot;</span>: <span class="hljs-literal">true</span>
         }
       },
-      <span class="hljs-string">"name"</span>: {
-        <span class="hljs-string">"type"</span>: <span class="hljs-string">"string"</span>,
-        <span class="hljs-string">"xml"</span>: {
-          <span class="hljs-string">"namespace"</span>: <span class="hljs-string">"http://swagger.io/schema/sample"</span>,
-          <span class="hljs-string">"prefix"</span>: <span class="hljs-string">"sample"</span>
+      <span class="hljs-string">&quot;name&quot;</span>: {
+        <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>,
+        <span class="hljs-string">&quot;xml&quot;</span>: {
+          <span class="hljs-string">&quot;namespace&quot;</span>: <span class="hljs-string">&quot;http://swagger.io/schema/sample&quot;</span>,
+          <span class="hljs-string">&quot;prefix&quot;</span>: <span class="hljs-string">&quot;sample&quot;</span>
         }
       }
     }
@@ -2449,34 +2449,34 @@ A Path Item may be empty, due to <a href="#securityFiltering">ACL constraints</a
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">Person:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">  properties:</span>
-<span class="hljs-attr">    id:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">integer</span>
-<span class="hljs-attr">      format:</span> <span class="hljs-string">int32</span>
-<span class="hljs-attr">      xml:</span>
-<span class="hljs-attr">        attribute:</span> <span class="hljs-literal">true</span>
-<span class="hljs-attr">    name:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">      xml:</span>
-<span class="hljs-attr">        namespace:</span> <span class="hljs-attr">http://swagger.io/schema/sample</span>
-<span class="hljs-attr">        prefix:</span> <span class="hljs-string">sample</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+  <span class="hljs-attr">properties:</span>
+    <span class="hljs-attr">id:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+      <span class="hljs-attr">format:</span> <span class="hljs-string">int32</span>
+      <span class="hljs-attr">xml:</span>
+        <span class="hljs-attr">attribute:</span> <span class="hljs-literal">true</span>
+    <span class="hljs-attr">name:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+      <span class="hljs-attr">xml:</span>
+        <span class="hljs-attr">namespace:</span> <span class="hljs-string">http://swagger.io/schema/sample</span>
+        <span class="hljs-attr">prefix:</span> <span class="hljs-string">sample</span>
 </code></pre>
 <pre class="nohighlight"><code>
-<span class="hljs-tag">&lt;<span class="hljs-name">Person</span> <span class="hljs-attr">id</span>=<span class="hljs-string">"123"</span>&gt;</span>
-    <span class="hljs-tag">&lt;<span class="hljs-name">sample:name</span> <span class="hljs-attr">xmlns:sample</span>=<span class="hljs-string">"http://swagger.io/schema/sample"</span>&gt;</span>example<span class="hljs-tag">&lt;/<span class="hljs-name">sample:name</span>&gt;</span>
+<span class="hljs-tag">&lt;<span class="hljs-name">Person</span> <span class="hljs-attr">id</span>=<span class="hljs-string">&quot;123&quot;</span>&gt;</span>
+    <span class="hljs-tag">&lt;<span class="hljs-name">sample:name</span> <span class="hljs-attr">xmlns:sample</span>=<span class="hljs-string">&quot;http://swagger.io/schema/sample&quot;</span>&gt;</span>example<span class="hljs-tag">&lt;/<span class="hljs-name">sample:name</span>&gt;</span>
 <span class="hljs-tag">&lt;/<span class="hljs-name">Person</span>&gt;</span>
 </code></pre>
 </section><section><h5>XML Arrays</h5>
 <p>Changing the element names:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-string">"animals"</span>: {
-    <span class="hljs-string">"type"</span>: <span class="hljs-string">"array"</span>,
-    <span class="hljs-string">"items"</span>: {
-      <span class="hljs-string">"type"</span>: <span class="hljs-string">"string"</span>,
-      <span class="hljs-string">"xml"</span>: {
-        <span class="hljs-string">"name"</span>: <span class="hljs-string">"animal"</span>
+  <span class="hljs-string">&quot;animals&quot;</span>: {
+    <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+    <span class="hljs-string">&quot;items&quot;</span>: {
+      <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>,
+      <span class="hljs-string">&quot;xml&quot;</span>: {
+        <span class="hljs-string">&quot;name&quot;</span>: <span class="hljs-string">&quot;animal&quot;</span>
       }
     }
   }
@@ -2484,11 +2484,11 @@ A Path Item may be empty, due to <a href="#securityFiltering">ACL constraints</a
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">animals:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">  items:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">    xml:</span>
-<span class="hljs-attr">      name:</span> <span class="hljs-string">animal</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+  <span class="hljs-attr">items:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+    <span class="hljs-attr">xml:</span>
+      <span class="hljs-attr">name:</span> <span class="hljs-string">animal</span>
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-tag">&lt;<span class="hljs-name">animal</span>&gt;</span>value<span class="hljs-tag">&lt;/<span class="hljs-name">animal</span>&gt;</span>
@@ -2497,29 +2497,29 @@ A Path Item may be empty, due to <a href="#securityFiltering">ACL constraints</a
 <p>The external <code>name</code> property has no effect on the XML:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-string">"animals"</span>: {
-    <span class="hljs-string">"type"</span>: <span class="hljs-string">"array"</span>,
-    <span class="hljs-string">"items"</span>: {
-      <span class="hljs-string">"type"</span>: <span class="hljs-string">"string"</span>,
-      <span class="hljs-string">"xml"</span>: {
-        <span class="hljs-string">"name"</span>: <span class="hljs-string">"animal"</span>
+  <span class="hljs-string">&quot;animals&quot;</span>: {
+    <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+    <span class="hljs-string">&quot;items&quot;</span>: {
+      <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>,
+      <span class="hljs-string">&quot;xml&quot;</span>: {
+        <span class="hljs-string">&quot;name&quot;</span>: <span class="hljs-string">&quot;animal&quot;</span>
       }
     },
-    <span class="hljs-string">"xml"</span>: {
-      <span class="hljs-string">"name"</span>: <span class="hljs-string">"aliens"</span>
+    <span class="hljs-string">&quot;xml&quot;</span>: {
+      <span class="hljs-string">&quot;name&quot;</span>: <span class="hljs-string">&quot;aliens&quot;</span>
     }
   }
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">animals:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">  items:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">    xml:</span>
-<span class="hljs-attr">      name:</span> <span class="hljs-string">animal</span>
-<span class="hljs-attr">  xml:</span>
-<span class="hljs-attr">    name:</span> <span class="hljs-string">aliens</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+  <span class="hljs-attr">items:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+    <span class="hljs-attr">xml:</span>
+      <span class="hljs-attr">name:</span> <span class="hljs-string">animal</span>
+  <span class="hljs-attr">xml:</span>
+    <span class="hljs-attr">name:</span> <span class="hljs-string">aliens</span>
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-tag">&lt;<span class="hljs-name">animal</span>&gt;</span>value<span class="hljs-tag">&lt;/<span class="hljs-name">animal</span>&gt;</span>
@@ -2528,24 +2528,24 @@ A Path Item may be empty, due to <a href="#securityFiltering">ACL constraints</a
 <p>Even when the array is wrapped, if no name is explicitly defined, the same name will be used both internally and externally:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-string">"animals"</span>: {
-    <span class="hljs-string">"type"</span>: <span class="hljs-string">"array"</span>,
-    <span class="hljs-string">"items"</span>: {
-      <span class="hljs-string">"type"</span>: <span class="hljs-string">"string"</span>
+  <span class="hljs-string">&quot;animals&quot;</span>: {
+    <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+    <span class="hljs-string">&quot;items&quot;</span>: {
+      <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
     },
-    <span class="hljs-string">"xml"</span>: {
-      <span class="hljs-string">"wrapped"</span>: <span class="hljs-literal">true</span>
+    <span class="hljs-string">&quot;xml&quot;</span>: {
+      <span class="hljs-string">&quot;wrapped&quot;</span>: <span class="hljs-literal">true</span>
     }
   }
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">animals:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">  items:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">  xml:</span>
-<span class="hljs-attr">    wrapped:</span> <span class="hljs-literal">true</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+  <span class="hljs-attr">items:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">xml:</span>
+    <span class="hljs-attr">wrapped:</span> <span class="hljs-literal">true</span>
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-tag">&lt;<span class="hljs-name">animals</span>&gt;</span>
@@ -2556,29 +2556,29 @@ A Path Item may be empty, due to <a href="#securityFiltering">ACL constraints</a
 <p>To overcome the above example, the following definition can be used:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-string">"animals"</span>: {
-    <span class="hljs-string">"type"</span>: <span class="hljs-string">"array"</span>,
-    <span class="hljs-string">"items"</span>: {
-      <span class="hljs-string">"type"</span>: <span class="hljs-string">"string"</span>,
-      <span class="hljs-string">"xml"</span>: {
-        <span class="hljs-string">"name"</span>: <span class="hljs-string">"animal"</span>
+  <span class="hljs-string">&quot;animals&quot;</span>: {
+    <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+    <span class="hljs-string">&quot;items&quot;</span>: {
+      <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>,
+      <span class="hljs-string">&quot;xml&quot;</span>: {
+        <span class="hljs-string">&quot;name&quot;</span>: <span class="hljs-string">&quot;animal&quot;</span>
       }
     },
-    <span class="hljs-string">"xml"</span>: {
-      <span class="hljs-string">"wrapped"</span>: <span class="hljs-literal">true</span>
+    <span class="hljs-string">&quot;xml&quot;</span>: {
+      <span class="hljs-string">&quot;wrapped&quot;</span>: <span class="hljs-literal">true</span>
     }
   }
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">animals:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">  items:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">    xml:</span>
-<span class="hljs-attr">      name:</span> <span class="hljs-string">animal</span>
-<span class="hljs-attr">  xml:</span>
-<span class="hljs-attr">    wrapped:</span> <span class="hljs-literal">true</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+  <span class="hljs-attr">items:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+    <span class="hljs-attr">xml:</span>
+      <span class="hljs-attr">name:</span> <span class="hljs-string">animal</span>
+  <span class="hljs-attr">xml:</span>
+    <span class="hljs-attr">wrapped:</span> <span class="hljs-literal">true</span>
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-tag">&lt;<span class="hljs-name">animals</span>&gt;</span>
@@ -2589,31 +2589,31 @@ A Path Item may be empty, due to <a href="#securityFiltering">ACL constraints</a
 <p>Affecting both internal and external names:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-string">"animals"</span>: {
-    <span class="hljs-string">"type"</span>: <span class="hljs-string">"array"</span>,
-    <span class="hljs-string">"items"</span>: {
-      <span class="hljs-string">"type"</span>: <span class="hljs-string">"string"</span>,
-      <span class="hljs-string">"xml"</span>: {
-        <span class="hljs-string">"name"</span>: <span class="hljs-string">"animal"</span>
+  <span class="hljs-string">&quot;animals&quot;</span>: {
+    <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+    <span class="hljs-string">&quot;items&quot;</span>: {
+      <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>,
+      <span class="hljs-string">&quot;xml&quot;</span>: {
+        <span class="hljs-string">&quot;name&quot;</span>: <span class="hljs-string">&quot;animal&quot;</span>
       }
     },
-    <span class="hljs-string">"xml"</span>: {
-      <span class="hljs-string">"name"</span>: <span class="hljs-string">"aliens"</span>,
-      <span class="hljs-string">"wrapped"</span>: <span class="hljs-literal">true</span>
+    <span class="hljs-string">&quot;xml&quot;</span>: {
+      <span class="hljs-string">&quot;name&quot;</span>: <span class="hljs-string">&quot;aliens&quot;</span>,
+      <span class="hljs-string">&quot;wrapped&quot;</span>: <span class="hljs-literal">true</span>
     }
   }
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">animals:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">  items:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">    xml:</span>
-<span class="hljs-attr">      name:</span> <span class="hljs-string">animal</span>
-<span class="hljs-attr">  xml:</span>
-<span class="hljs-attr">    name:</span> <span class="hljs-string">aliens</span>
-<span class="hljs-attr">    wrapped:</span> <span class="hljs-literal">true</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+  <span class="hljs-attr">items:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+    <span class="hljs-attr">xml:</span>
+      <span class="hljs-attr">name:</span> <span class="hljs-string">animal</span>
+  <span class="hljs-attr">xml:</span>
+    <span class="hljs-attr">name:</span> <span class="hljs-string">aliens</span>
+    <span class="hljs-attr">wrapped:</span> <span class="hljs-literal">true</span>
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-tag">&lt;<span class="hljs-name">aliens</span>&gt;</span>
@@ -2624,26 +2624,26 @@ A Path Item may be empty, due to <a href="#securityFiltering">ACL constraints</a
 <p>If we change the external element but not the internal ones:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-string">"animals"</span>: {
-    <span class="hljs-string">"type"</span>: <span class="hljs-string">"array"</span>,
-    <span class="hljs-string">"items"</span>: {
-      <span class="hljs-string">"type"</span>: <span class="hljs-string">"string"</span>
+  <span class="hljs-string">&quot;animals&quot;</span>: {
+    <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+    <span class="hljs-string">&quot;items&quot;</span>: {
+      <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
     },
-    <span class="hljs-string">"xml"</span>: {
-      <span class="hljs-string">"name"</span>: <span class="hljs-string">"aliens"</span>,
-      <span class="hljs-string">"wrapped"</span>: <span class="hljs-literal">true</span>
+    <span class="hljs-string">&quot;xml&quot;</span>: {
+      <span class="hljs-string">&quot;name&quot;</span>: <span class="hljs-string">&quot;aliens&quot;</span>,
+      <span class="hljs-string">&quot;wrapped&quot;</span>: <span class="hljs-literal">true</span>
     }
   }
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">animals:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">  items:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">  xml:</span>
-<span class="hljs-attr">    name:</span> <span class="hljs-string">aliens</span>
-<span class="hljs-attr">    wrapped:</span> <span class="hljs-literal">true</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+  <span class="hljs-attr">items:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">xml:</span>
+    <span class="hljs-attr">name:</span> <span class="hljs-string">aliens</span>
+    <span class="hljs-attr">wrapped:</span> <span class="hljs-literal">true</span>
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-tag">&lt;<span class="hljs-name">aliens</span>&gt;</span>
@@ -2673,27 +2673,27 @@ A Path Item may be empty, due to <a href="#securityFiltering">ACL constraints</a
 </section><section><h4>Definitions Object Example</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-string">"Category"</span>: {
-    <span class="hljs-string">"type"</span>: <span class="hljs-string">"object"</span>,
-    <span class="hljs-string">"properties"</span>: {
-      <span class="hljs-string">"id"</span>: {
-        <span class="hljs-string">"type"</span>: <span class="hljs-string">"integer"</span>,
-        <span class="hljs-string">"format"</span>: <span class="hljs-string">"int64"</span>
+  <span class="hljs-string">&quot;Category&quot;</span>: {
+    <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+    <span class="hljs-string">&quot;properties&quot;</span>: {
+      <span class="hljs-string">&quot;id&quot;</span>: {
+        <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>,
+        <span class="hljs-string">&quot;format&quot;</span>: <span class="hljs-string">&quot;int64&quot;</span>
       },
-      <span class="hljs-string">"name"</span>: {
-        <span class="hljs-string">"type"</span>: <span class="hljs-string">"string"</span>
+      <span class="hljs-string">&quot;name&quot;</span>: {
+        <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
       }
     }
   },
-  <span class="hljs-string">"Tag"</span>: {
-    <span class="hljs-string">"type"</span>: <span class="hljs-string">"object"</span>,
-    <span class="hljs-string">"properties"</span>: {
-      <span class="hljs-string">"id"</span>: {
-        <span class="hljs-string">"type"</span>: <span class="hljs-string">"integer"</span>,
-        <span class="hljs-string">"format"</span>: <span class="hljs-string">"int64"</span>
+  <span class="hljs-string">&quot;Tag&quot;</span>: {
+    <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+    <span class="hljs-string">&quot;properties&quot;</span>: {
+      <span class="hljs-string">&quot;id&quot;</span>: {
+        <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>,
+        <span class="hljs-string">&quot;format&quot;</span>: <span class="hljs-string">&quot;int64&quot;</span>
       },
-      <span class="hljs-string">"name"</span>: {
-        <span class="hljs-string">"type"</span>: <span class="hljs-string">"string"</span>
+      <span class="hljs-string">&quot;name&quot;</span>: {
+        <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
       }
     }
   }
@@ -2701,21 +2701,21 @@ A Path Item may be empty, due to <a href="#securityFiltering">ACL constraints</a
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">Category:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">  properties:</span>
-<span class="hljs-attr">    id:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">integer</span>
-<span class="hljs-attr">      format:</span> <span class="hljs-string">int64</span>
-<span class="hljs-attr">    name:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+  <span class="hljs-attr">properties:</span>
+    <span class="hljs-attr">id:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+      <span class="hljs-attr">format:</span> <span class="hljs-string">int64</span>
+    <span class="hljs-attr">name:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
 <span class="hljs-attr">Tag:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">  properties:</span>
-<span class="hljs-attr">    id:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">integer</span>
-<span class="hljs-attr">      format:</span> <span class="hljs-string">int64</span>
-<span class="hljs-attr">    name:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+  <span class="hljs-attr">properties:</span>
+    <span class="hljs-attr">id:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+      <span class="hljs-attr">format:</span> <span class="hljs-string">int64</span>
+    <span class="hljs-attr">name:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
 </code></pre>
 </section></section><section><h3><span id="parametersDefinitionsObject">Parameters Definitions Object</span></h3>
 <p>An object to hold parameters to be reused across operations. Parameter definitions can be referenced to the ones defined here.</p>
@@ -2740,39 +2740,39 @@ A Path Item may be empty, due to <a href="#securityFiltering">ACL constraints</a
 </section><section><h4>Parameters Definition Object Example</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-string">"skipParam"</span>: {
-    <span class="hljs-string">"name"</span>: <span class="hljs-string">"skip"</span>,
-    <span class="hljs-string">"in"</span>: <span class="hljs-string">"query"</span>,
-    <span class="hljs-string">"description"</span>: <span class="hljs-string">"number of items to skip"</span>,
-    <span class="hljs-string">"required"</span>: <span class="hljs-literal">true</span>,
-    <span class="hljs-string">"type"</span>: <span class="hljs-string">"integer"</span>,
-    <span class="hljs-string">"format"</span>: <span class="hljs-string">"int32"</span>
+  <span class="hljs-string">&quot;skipParam&quot;</span>: {
+    <span class="hljs-string">&quot;name&quot;</span>: <span class="hljs-string">&quot;skip&quot;</span>,
+    <span class="hljs-string">&quot;in&quot;</span>: <span class="hljs-string">&quot;query&quot;</span>,
+    <span class="hljs-string">&quot;description&quot;</span>: <span class="hljs-string">&quot;number of items to skip&quot;</span>,
+    <span class="hljs-string">&quot;required&quot;</span>: <span class="hljs-literal">true</span>,
+    <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>,
+    <span class="hljs-string">&quot;format&quot;</span>: <span class="hljs-string">&quot;int32&quot;</span>
   },
-  <span class="hljs-string">"limitParam"</span>: {
-    <span class="hljs-string">"name"</span>: <span class="hljs-string">"limit"</span>,
-    <span class="hljs-string">"in"</span>: <span class="hljs-string">"query"</span>,
-    <span class="hljs-string">"description"</span>: <span class="hljs-string">"max records to return"</span>,
-    <span class="hljs-string">"required"</span>: <span class="hljs-literal">true</span>,
-    <span class="hljs-string">"type"</span>: <span class="hljs-string">"integer"</span>,
-    <span class="hljs-string">"format"</span>: <span class="hljs-string">"int32"</span>
+  <span class="hljs-string">&quot;limitParam&quot;</span>: {
+    <span class="hljs-string">&quot;name&quot;</span>: <span class="hljs-string">&quot;limit&quot;</span>,
+    <span class="hljs-string">&quot;in&quot;</span>: <span class="hljs-string">&quot;query&quot;</span>,
+    <span class="hljs-string">&quot;description&quot;</span>: <span class="hljs-string">&quot;max records to return&quot;</span>,
+    <span class="hljs-string">&quot;required&quot;</span>: <span class="hljs-literal">true</span>,
+    <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>,
+    <span class="hljs-string">&quot;format&quot;</span>: <span class="hljs-string">&quot;int32&quot;</span>
   }
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">skipParam:</span>
-<span class="hljs-attr">  name:</span> <span class="hljs-string">skip</span>
-<span class="hljs-attr">  in:</span> <span class="hljs-string">query</span>
-<span class="hljs-attr">  description:</span> <span class="hljs-string">number</span> <span class="hljs-string">of</span> <span class="hljs-string">items</span> <span class="hljs-string">to</span> <span class="hljs-string">skip</span>
-<span class="hljs-attr">  required:</span> <span class="hljs-literal">true</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">integer</span>
-<span class="hljs-attr">  format:</span> <span class="hljs-string">int32</span>
+  <span class="hljs-attr">name:</span> <span class="hljs-string">skip</span>
+  <span class="hljs-attr">in:</span> <span class="hljs-string">query</span>
+  <span class="hljs-attr">description:</span> <span class="hljs-string">number</span> <span class="hljs-string">of</span> <span class="hljs-string">items</span> <span class="hljs-string">to</span> <span class="hljs-string">skip</span>
+  <span class="hljs-attr">required:</span> <span class="hljs-literal">true</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+  <span class="hljs-attr">format:</span> <span class="hljs-string">int32</span>
 <span class="hljs-attr">limitParam:</span>
-<span class="hljs-attr">  name:</span> <span class="hljs-string">limit</span>
-<span class="hljs-attr">  in:</span> <span class="hljs-string">query</span>
-<span class="hljs-attr">  description:</span> <span class="hljs-string">max</span> <span class="hljs-string">records</span> <span class="hljs-string">to</span> <span class="hljs-string">return</span>
-<span class="hljs-attr">  required:</span> <span class="hljs-literal">true</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">integer</span>
-<span class="hljs-attr">  format:</span> <span class="hljs-string">int32</span>
+  <span class="hljs-attr">name:</span> <span class="hljs-string">limit</span>
+  <span class="hljs-attr">in:</span> <span class="hljs-string">query</span>
+  <span class="hljs-attr">description:</span> <span class="hljs-string">max</span> <span class="hljs-string">records</span> <span class="hljs-string">to</span> <span class="hljs-string">return</span>
+  <span class="hljs-attr">required:</span> <span class="hljs-literal">true</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+  <span class="hljs-attr">format:</span> <span class="hljs-string">int32</span>
 </code></pre>
 </section></section><section><h3><span id="responsesDefinitionsObject">Responses Definitions Object</span></h3>
 <p>An object to hold responses to be reused across operations. Response definitions can be referenced to the ones defined here.</p>
@@ -2797,29 +2797,29 @@ A Path Item may be empty, due to <a href="#securityFiltering">ACL constraints</a
 </section><section><h4>Responses Definitions Object Example</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-string">"NotFound"</span>: {
-    <span class="hljs-string">"description"</span>: <span class="hljs-string">"Entity not found."</span>
+  <span class="hljs-string">&quot;NotFound&quot;</span>: {
+    <span class="hljs-string">&quot;description&quot;</span>: <span class="hljs-string">&quot;Entity not found.&quot;</span>
   },
-  <span class="hljs-string">"IllegalInput"</span>: {
-  	<span class="hljs-string">"description"</span>: <span class="hljs-string">"Illegal input for operation."</span>
+  <span class="hljs-string">&quot;IllegalInput&quot;</span>: {
+  	<span class="hljs-string">&quot;description&quot;</span>: <span class="hljs-string">&quot;Illegal input for operation.&quot;</span>
   },
-  <span class="hljs-string">"GeneralError"</span>: {
-  	<span class="hljs-string">"description"</span>: <span class="hljs-string">"General Error"</span>,
-  	<span class="hljs-string">"schema"</span>: {
-  		<span class="hljs-string">"$ref"</span>: <span class="hljs-string">"#/definitions/GeneralError"</span>
+  <span class="hljs-string">&quot;GeneralError&quot;</span>: {
+  	<span class="hljs-string">&quot;description&quot;</span>: <span class="hljs-string">&quot;General Error&quot;</span>,
+  	<span class="hljs-string">&quot;schema&quot;</span>: {
+  		<span class="hljs-string">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/definitions/GeneralError&quot;</span>
   	}
   }
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">NotFound:</span>
-<span class="hljs-attr">  description:</span> <span class="hljs-string">Entity</span> <span class="hljs-string">not</span> <span class="hljs-string">found.</span>
+  <span class="hljs-attr">description:</span> <span class="hljs-string">Entity</span> <span class="hljs-string">not</span> <span class="hljs-string">found.</span>
 <span class="hljs-attr">IllegalInput:</span>
-<span class="hljs-attr">  description:</span> <span class="hljs-string">Illegal</span> <span class="hljs-string">input</span> <span class="hljs-string">for</span> <span class="hljs-string">operation.</span>
+  <span class="hljs-attr">description:</span> <span class="hljs-string">Illegal</span> <span class="hljs-string">input</span> <span class="hljs-string">for</span> <span class="hljs-string">operation.</span>
 <span class="hljs-attr">GeneralError:</span>
-<span class="hljs-attr">  description:</span> <span class="hljs-string">General</span> <span class="hljs-string">Error</span>
-<span class="hljs-attr">  schema:</span>
-    <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/definitions/GeneralError'</span>
+  <span class="hljs-attr">description:</span> <span class="hljs-string">General</span> <span class="hljs-string">Error</span>
+  <span class="hljs-attr">schema:</span>
+    <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/definitions/GeneralError&#x27;</span>
 </code></pre>
 </section></section><section><h3><span id="securityDefinitionsObject">Security Definitions Object</span></h3>
 <p>A declaration of the security schemes available to be used in the specification. This does not enforce the security schemes on the operations and only serves to provide the relevant details for each scheme.</p>
@@ -2843,34 +2843,34 @@ A Path Item may be empty, due to <a href="#securityFiltering">ACL constraints</a
 </section><section><h4>Security Definitions Object Example</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-string">"api_key"</span>: {
-    <span class="hljs-string">"type"</span>: <span class="hljs-string">"apiKey"</span>,
-    <span class="hljs-string">"name"</span>: <span class="hljs-string">"api_key"</span>,
-    <span class="hljs-string">"in"</span>: <span class="hljs-string">"header"</span>
+  <span class="hljs-string">&quot;api_key&quot;</span>: {
+    <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;apiKey&quot;</span>,
+    <span class="hljs-string">&quot;name&quot;</span>: <span class="hljs-string">&quot;api_key&quot;</span>,
+    <span class="hljs-string">&quot;in&quot;</span>: <span class="hljs-string">&quot;header&quot;</span>
   },
-  <span class="hljs-string">"petstore_auth"</span>: {
-    <span class="hljs-string">"type"</span>: <span class="hljs-string">"oauth2"</span>,
-    <span class="hljs-string">"authorizationUrl"</span>: <span class="hljs-string">"http://swagger.io/api/oauth/dialog"</span>,
-    <span class="hljs-string">"flow"</span>: <span class="hljs-string">"implicit"</span>,
-    <span class="hljs-string">"scopes"</span>: {
-      <span class="hljs-string">"write:pets"</span>: <span class="hljs-string">"modify pets in your account"</span>,
-      <span class="hljs-string">"read:pets"</span>: <span class="hljs-string">"read your pets"</span>
+  <span class="hljs-string">&quot;petstore_auth&quot;</span>: {
+    <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;oauth2&quot;</span>,
+    <span class="hljs-string">&quot;authorizationUrl&quot;</span>: <span class="hljs-string">&quot;http://swagger.io/api/oauth/dialog&quot;</span>,
+    <span class="hljs-string">&quot;flow&quot;</span>: <span class="hljs-string">&quot;implicit&quot;</span>,
+    <span class="hljs-string">&quot;scopes&quot;</span>: {
+      <span class="hljs-string">&quot;write:pets&quot;</span>: <span class="hljs-string">&quot;modify pets in your account&quot;</span>,
+      <span class="hljs-string">&quot;read:pets&quot;</span>: <span class="hljs-string">&quot;read your pets&quot;</span>
     }
   }
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">api_key:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">apiKey</span>
-<span class="hljs-attr">  name:</span> <span class="hljs-string">api_key</span>
-<span class="hljs-attr">  in:</span> <span class="hljs-string">header</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">apiKey</span>
+  <span class="hljs-attr">name:</span> <span class="hljs-string">api_key</span>
+  <span class="hljs-attr">in:</span> <span class="hljs-string">header</span>
 <span class="hljs-attr">petstore_auth:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">oauth2</span>
-<span class="hljs-attr">  authorizationUrl:</span> <span class="hljs-attr">http://swagger.io/api/oauth/dialog</span>
-<span class="hljs-attr">  flow:</span> <span class="hljs-string">implicit</span>
-<span class="hljs-attr">  scopes:</span>
-<span class="hljs-attr">    write:</span><span class="hljs-attr">pets:</span> <span class="hljs-string">modify</span> <span class="hljs-string">pets</span> <span class="hljs-string">in</span> <span class="hljs-string">your</span> <span class="hljs-string">account</span>
-<span class="hljs-attr">    read:</span><span class="hljs-attr">pets:</span> <span class="hljs-string">read</span> <span class="hljs-string">your</span> <span class="hljs-string">pets</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">oauth2</span>
+  <span class="hljs-attr">authorizationUrl:</span> <span class="hljs-string">http://swagger.io/api/oauth/dialog</span>
+  <span class="hljs-attr">flow:</span> <span class="hljs-string">implicit</span>
+  <span class="hljs-attr">scopes:</span>
+    <span class="hljs-attr">write:pets:</span> <span class="hljs-string">modify</span> <span class="hljs-string">pets</span> <span class="hljs-string">in</span> <span class="hljs-string">your</span> <span class="hljs-string">account</span>
+    <span class="hljs-attr">read:pets:</span> <span class="hljs-string">read</span> <span class="hljs-string">your</span> <span class="hljs-string">pets</span>
 </code></pre>
 </section></section><section><h3><span id="securitySchemeObject">Security Scheme Object</span></h3>
 <p>Allows the definition of a security scheme that can be used by the operations. Supported schemes are basic authentication, an API key (either as a header or as a query parameter) and OAuth2’s common flows (implicit, password, application and access code).</p>
@@ -2956,7 +2956,7 @@ A Path Item may be empty, due to <a href="#securityFiltering">ACL constraints</a
 <section><h5>Basic Authentication Sample</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-string">"type"</span>: <span class="hljs-string">"basic"</span>
+  <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;basic&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -2965,9 +2965,9 @@ A Path Item may be empty, due to <a href="#securityFiltering">ACL constraints</a
 </section><section><h5>API Key Sample</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-string">"type"</span>: <span class="hljs-string">"apiKey"</span>,
-  <span class="hljs-string">"name"</span>: <span class="hljs-string">"api_key"</span>,
-  <span class="hljs-string">"in"</span>: <span class="hljs-string">"header"</span>
+  <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;apiKey&quot;</span>,
+  <span class="hljs-string">&quot;name&quot;</span>: <span class="hljs-string">&quot;api_key&quot;</span>,
+  <span class="hljs-string">&quot;in&quot;</span>: <span class="hljs-string">&quot;header&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -2978,22 +2978,22 @@ A Path Item may be empty, due to <a href="#securityFiltering">ACL constraints</a
 </section><section><h5>Implicit OAuth2 Sample</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-string">"type"</span>: <span class="hljs-string">"oauth2"</span>,
-  <span class="hljs-string">"authorizationUrl"</span>: <span class="hljs-string">"http://swagger.io/api/oauth/dialog"</span>,
-  <span class="hljs-string">"flow"</span>: <span class="hljs-string">"implicit"</span>,
-  <span class="hljs-string">"scopes"</span>: {
-    <span class="hljs-string">"write:pets"</span>: <span class="hljs-string">"modify pets in your account"</span>,
-    <span class="hljs-string">"read:pets"</span>: <span class="hljs-string">"read your pets"</span>
+  <span class="hljs-string">&quot;type&quot;</span>: <span class="hljs-string">&quot;oauth2&quot;</span>,
+  <span class="hljs-string">&quot;authorizationUrl&quot;</span>: <span class="hljs-string">&quot;http://swagger.io/api/oauth/dialog&quot;</span>,
+  <span class="hljs-string">&quot;flow&quot;</span>: <span class="hljs-string">&quot;implicit&quot;</span>,
+  <span class="hljs-string">&quot;scopes&quot;</span>: {
+    <span class="hljs-string">&quot;write:pets&quot;</span>: <span class="hljs-string">&quot;modify pets in your account&quot;</span>,
+    <span class="hljs-string">&quot;read:pets&quot;</span>: <span class="hljs-string">&quot;read your pets&quot;</span>
   }
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">type:</span> <span class="hljs-string">oauth2</span>
-<span class="hljs-attr">authorizationUrl:</span> <span class="hljs-attr">http://swagger.io/api/oauth/dialog</span>
+<span class="hljs-attr">authorizationUrl:</span> <span class="hljs-string">http://swagger.io/api/oauth/dialog</span>
 <span class="hljs-attr">flow:</span> <span class="hljs-string">implicit</span>
 <span class="hljs-attr">scopes:</span>
-<span class="hljs-attr">  write:</span><span class="hljs-attr">pets:</span> <span class="hljs-string">modify</span> <span class="hljs-string">pets</span> <span class="hljs-string">in</span> <span class="hljs-string">your</span> <span class="hljs-string">account</span>
-<span class="hljs-attr">  read:</span><span class="hljs-attr">pets:</span> <span class="hljs-string">read</span> <span class="hljs-string">your</span> <span class="hljs-string">pets</span>
+  <span class="hljs-attr">write:pets:</span> <span class="hljs-string">modify</span> <span class="hljs-string">pets</span> <span class="hljs-string">in</span> <span class="hljs-string">your</span> <span class="hljs-string">account</span>
+  <span class="hljs-attr">read:pets:</span> <span class="hljs-string">read</span> <span class="hljs-string">your</span> <span class="hljs-string">pets</span>
 </code></pre>
 </section></section></section><section><h3><span id="scopesObject">Scopes Object</span></h3>
 <p>Lists the available scopes for an OAuth2 security scheme.</p>
@@ -3034,13 +3034,13 @@ A Path Item may be empty, due to <a href="#securityFiltering">ACL constraints</a
 </section><section><h4>Scopes Object Example</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-string">"write:pets"</span>: <span class="hljs-string">"modify pets in your account"</span>,
-  <span class="hljs-string">"read:pets"</span>: <span class="hljs-string">"read your pets"</span>
+  <span class="hljs-string">&quot;write:pets&quot;</span>: <span class="hljs-string">&quot;modify pets in your account&quot;</span>,
+  <span class="hljs-string">&quot;read:pets&quot;</span>: <span class="hljs-string">&quot;read your pets&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
-<span class="hljs-attr">write:</span><span class="hljs-attr">pets:</span> <span class="hljs-string">modify</span> <span class="hljs-string">pets</span> <span class="hljs-string">in</span> <span class="hljs-string">your</span> <span class="hljs-string">account</span>
-<span class="hljs-attr">read:</span><span class="hljs-attr">pets:</span> <span class="hljs-string">read</span> <span class="hljs-string">your</span> <span class="hljs-string">pets</span>
+<span class="hljs-attr">write:pets:</span> <span class="hljs-string">modify</span> <span class="hljs-string">pets</span> <span class="hljs-string">in</span> <span class="hljs-string">your</span> <span class="hljs-string">account</span>
+<span class="hljs-attr">read:pets:</span> <span class="hljs-string">read</span> <span class="hljs-string">your</span> <span class="hljs-string">pets</span>
 </code></pre>
 </section></section><section><h3><span id="securityRequirementObject">Security Requirement Object</span></h3>
 <p>Lists the required security schemes to execute this operation. The object can have multiple security schemes declared in it which are all required (that is, there is a logical AND between the schemes).</p>
@@ -3066,25 +3066,25 @@ A Path Item may be empty, due to <a href="#securityFiltering">ACL constraints</a
 <section><h5>Non-OAuth2 Security Requirement</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-string">"api_key"</span>: []
+  <span class="hljs-string">&quot;api_key&quot;</span>: []
 }
 </code></pre>
 <pre class="nohighlight"><code>
-<span class="hljs-attr">api_key:</span> <span class="hljs-string">[]</span>
+<span class="hljs-attr">api_key:</span> []
 </code></pre>
 </section><section><h5>OAuth2 Security Requirement</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-string">"petstore_auth"</span>: [
-    <span class="hljs-string">"write:pets"</span>,
-    <span class="hljs-string">"read:pets"</span>
+  <span class="hljs-string">&quot;petstore_auth&quot;</span>: [
+    <span class="hljs-string">&quot;write:pets&quot;</span>,
+    <span class="hljs-string">&quot;read:pets&quot;</span>
   ]
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">petstore_auth:</span>
-<span class="hljs-attr">- write:</span><span class="hljs-string">pets</span>
-<span class="hljs-attr">- read:</span><span class="hljs-string">pets</span>
+<span class="hljs-bullet">-</span> <span class="hljs-string">write:pets</span>
+<span class="hljs-bullet">-</span> <span class="hljs-string">read:pets</span>
 </code></pre>
 </section></section></section></section><section><h2><span id="vendorExtensions">Specification Extensions</span></h2>
 <p>While the Swagger Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.</p>

--- a/oas/v3.0.0.html
+++ b/oas/v3.0.0.html
@@ -1,4 +1,4 @@
-<html><head><meta charset="UTF-8"><title>OpenAPI Specification</title><script src="https://mermade.github.io/static/respec21/respec-oai.js" class="remove"></script><script class="remove">var respecConfig = {"specStatus":"base","editors":[{"name":"Darrel Miller "},{"name":"Jeremy Whitlock "},{"name":"Marsh Gardiner "},{"name":"Mike Ralphson "},{"name":"Ron Ratovsky "},{"name":"Uri Sarid "}],"formerEditors":[{"name":"Jason Harmon "},{"name":"Tony Tam "}],"publishDate":"2017-07-26T00:00:00.000Z","subtitle":"Version 3.0.0","processVersion":2017,"edDraftURI":"http://github.com/OAI/openapi-specification/","github":{"repoURL":"https://github.com/OAI/openapi-specification/","branch":"master"},"shortName":"OAS","noTOC":false,"lint":false,"additionalCopyrightHolders":"the Linux Foundation","includePermalinks":true};</script><!-- Global site tag (gtag.js) - Google Analytics -->
+<html lang="en"><head><meta charset="UTF-8"><title>OpenAPI Specification</title><script src="https://spec.openapis.org/js/respec-oai.js" class="remove"></script><script class="remove">var respecConfig = {"specStatus":"base","editors":[{"name":"Darrel Miller "},{"name":"Jeremy Whitlock "},{"name":"Marsh Gardiner "},{"name":"Mike Ralphson "},{"name":"Ron Ratovsky "},{"name":"Uri Sarid "}],"formerEditors":[{"name":"Jason Harmon "},{"name":"Tony Tam "}],"publishDate":"2017-07-26T00:00:00.000Z","subtitle":"Version 3.0.0","processVersion":2017,"edDraftURI":"https://github.com/OAI/OpenAPI-Specification/","github":{"repoURL":"https://github.com/OAI/OpenAPI-Specification/","branch":"master"},"shortName":"OAS","noTOC":false,"lint":false,"additionalCopyrightHolders":"the Linux Foundation","includePermalinks":true};</script><!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=UA-831873-42"></script>
 <script>
  window.dataLayer = window.dataLayer || [];
@@ -50,7 +50,7 @@ The available status codes are defined by [[!RFC7231]] and registered status cod
 <p>For example, if a field has an array value, the JSON array representation will be used:</p>
 <pre class="nohighlight"><code>
 {
-   <span class="hljs-attr">"field"</span>: [ <span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span> ]
+   <span class="hljs-attr">&quot;field&quot;</span>: [ <span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span> ]
 }
 </code></pre>
 <p>All field names in the specification are <strong>case sensitive</strong>.</p>
@@ -267,32 +267,32 @@ The metadata MAY be used by the clients if needed, and MAY be presented in editi
 </section><section><h4>Info Object Example:</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"title"</span>: <span class="hljs-string">"Sample Pet Store App"</span>,
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"This is a sample server for a pet store."</span>,
-  <span class="hljs-attr">"termsOfService"</span>: <span class="hljs-string">"http://example.com/terms/"</span>,
-  <span class="hljs-attr">"contact"</span>: {
-    <span class="hljs-attr">"name"</span>: <span class="hljs-string">"API Support"</span>,
-    <span class="hljs-attr">"url"</span>: <span class="hljs-string">"http://www.example.com/support"</span>,
-    <span class="hljs-attr">"email"</span>: <span class="hljs-string">"support@example.com"</span>
+  <span class="hljs-attr">&quot;title&quot;</span>: <span class="hljs-string">&quot;Sample Pet Store App&quot;</span>,
+  <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;This is a sample server for a pet store.&quot;</span>,
+  <span class="hljs-attr">&quot;termsOfService&quot;</span>: <span class="hljs-string">&quot;http://example.com/terms/&quot;</span>,
+  <span class="hljs-attr">&quot;contact&quot;</span>: {
+    <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;API Support&quot;</span>,
+    <span class="hljs-attr">&quot;url&quot;</span>: <span class="hljs-string">&quot;http://www.example.com/support&quot;</span>,
+    <span class="hljs-attr">&quot;email&quot;</span>: <span class="hljs-string">&quot;support@example.com&quot;</span>
   },
-  <span class="hljs-attr">"license"</span>: {
-    <span class="hljs-attr">"name"</span>: <span class="hljs-string">"Apache 2.0"</span>,
-    <span class="hljs-attr">"url"</span>: <span class="hljs-string">"http://www.apache.org/licenses/LICENSE-2.0.html"</span>
+  <span class="hljs-attr">&quot;license&quot;</span>: {
+    <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;Apache 2.0&quot;</span>,
+    <span class="hljs-attr">&quot;url&quot;</span>: <span class="hljs-string">&quot;http://www.apache.org/licenses/LICENSE-2.0.html&quot;</span>
   },
-  <span class="hljs-attr">"version"</span>: <span class="hljs-string">"1.0.1"</span>
+  <span class="hljs-attr">&quot;version&quot;</span>: <span class="hljs-string">&quot;1.0.1&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">title:</span> <span class="hljs-string">Sample</span> <span class="hljs-string">Pet</span> <span class="hljs-string">Store</span> <span class="hljs-string">App</span>
 <span class="hljs-attr">description:</span> <span class="hljs-string">This</span> <span class="hljs-string">is</span> <span class="hljs-string">a</span> <span class="hljs-string">sample</span> <span class="hljs-string">server</span> <span class="hljs-string">for</span> <span class="hljs-string">a</span> <span class="hljs-string">pet</span> <span class="hljs-string">store.</span>
-<span class="hljs-attr">termsOfService:</span> <span class="hljs-attr">http://example.com/terms/</span>
+<span class="hljs-attr">termsOfService:</span> <span class="hljs-string">http://example.com/terms/</span>
 <span class="hljs-attr">contact:</span>
-<span class="hljs-attr">  name:</span> <span class="hljs-string">API</span> <span class="hljs-string">Support</span>
-<span class="hljs-attr">  url:</span> <span class="hljs-attr">http://www.example.com/support</span>
-<span class="hljs-attr">  email:</span> <span class="hljs-string">support@example.com</span>
+  <span class="hljs-attr">name:</span> <span class="hljs-string">API</span> <span class="hljs-string">Support</span>
+  <span class="hljs-attr">url:</span> <span class="hljs-string">http://www.example.com/support</span>
+  <span class="hljs-attr">email:</span> <span class="hljs-string">support@example.com</span>
 <span class="hljs-attr">license:</span>
-<span class="hljs-attr">  name:</span> <span class="hljs-string">Apache</span> <span class="hljs-number">2.0</span>
-<span class="hljs-attr">  url:</span> <span class="hljs-attr">http://www.apache.org/licenses/LICENSE-2.0.html</span>
+  <span class="hljs-attr">name:</span> <span class="hljs-string">Apache</span> <span class="hljs-number">2.0</span>
+  <span class="hljs-attr">url:</span> <span class="hljs-string">http://www.apache.org/licenses/LICENSE-2.0.html</span>
 <span class="hljs-attr">version:</span> <span class="hljs-number">1.0</span><span class="hljs-number">.1</span>
 </code></pre>
 </section></section><section><h3><span id="contactObject">Contact Object</span></h3>
@@ -328,14 +328,14 @@ The metadata MAY be used by the clients if needed, and MAY be presented in editi
 </section><section><h4>Contact Object Example:</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"name"</span>: <span class="hljs-string">"API Support"</span>,
-  <span class="hljs-attr">"url"</span>: <span class="hljs-string">"http://www.example.com/support"</span>,
-  <span class="hljs-attr">"email"</span>: <span class="hljs-string">"support@example.com"</span>
+  <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;API Support&quot;</span>,
+  <span class="hljs-attr">&quot;url&quot;</span>: <span class="hljs-string">&quot;http://www.example.com/support&quot;</span>,
+  <span class="hljs-attr">&quot;email&quot;</span>: <span class="hljs-string">&quot;support@example.com&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">name:</span> <span class="hljs-string">API</span> <span class="hljs-string">Support</span>
-<span class="hljs-attr">url:</span> <span class="hljs-attr">http://www.example.com/support</span>
+<span class="hljs-attr">url:</span> <span class="hljs-string">http://www.example.com/support</span>
 <span class="hljs-attr">email:</span> <span class="hljs-string">support@example.com</span>
 </code></pre>
 </section></section><section><h3><span id="licenseObject">License Object</span></h3>
@@ -366,13 +366,13 @@ The metadata MAY be used by the clients if needed, and MAY be presented in editi
 </section><section><h4>License Object Example:</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"name"</span>: <span class="hljs-string">"Apache 2.0"</span>,
-  <span class="hljs-attr">"url"</span>: <span class="hljs-string">"http://www.apache.org/licenses/LICENSE-2.0.html"</span>
+  <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;Apache 2.0&quot;</span>,
+  <span class="hljs-attr">&quot;url&quot;</span>: <span class="hljs-string">&quot;http://www.apache.org/licenses/LICENSE-2.0.html&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">name:</span> <span class="hljs-string">Apache</span> <span class="hljs-number">2.0</span>
-<span class="hljs-attr">url:</span> <span class="hljs-attr">http://www.apache.org/licenses/LICENSE-2.0.html</span>
+<span class="hljs-attr">url:</span> <span class="hljs-string">http://www.apache.org/licenses/LICENSE-2.0.html</span>
 </code></pre>
 </section></section><section><h3><span id="serverObject">Server Object</span></h3>
 <p>An object representing a Server.</p>
@@ -408,63 +408,63 @@ The metadata MAY be used by the clients if needed, and MAY be presented in editi
 <p>A single server would be described as:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"url"</span>: <span class="hljs-string">"https://development.gigantic-server.com/v1"</span>,
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Development server"</span>
+  <span class="hljs-attr">&quot;url&quot;</span>: <span class="hljs-string">&quot;https://development.gigantic-server.com/v1&quot;</span>,
+  <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;Development server&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
-<span class="hljs-attr">url:</span> <span class="hljs-attr">https://development.gigantic-server.com/v1</span>
+<span class="hljs-attr">url:</span> <span class="hljs-string">https://development.gigantic-server.com/v1</span>
 <span class="hljs-attr">description:</span> <span class="hljs-string">Development</span> <span class="hljs-string">server</span>
 </code></pre>
 <p>The following shows how multiple servers can be described, for example, at the OpenAPI Object’s <a href="#oasServers"><code>servers</code></a>:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"servers"</span>: [
+  <span class="hljs-attr">&quot;servers&quot;</span>: [
     {
-      <span class="hljs-attr">"url"</span>: <span class="hljs-string">"https://development.gigantic-server.com/v1"</span>,
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Development server"</span>
+      <span class="hljs-attr">&quot;url&quot;</span>: <span class="hljs-string">&quot;https://development.gigantic-server.com/v1&quot;</span>,
+      <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;Development server&quot;</span>
     },
     {
-      <span class="hljs-attr">"url"</span>: <span class="hljs-string">"https://staging.gigantic-server.com/v1"</span>,
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Staging server"</span>
+      <span class="hljs-attr">&quot;url&quot;</span>: <span class="hljs-string">&quot;https://staging.gigantic-server.com/v1&quot;</span>,
+      <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;Staging server&quot;</span>
     },
     {
-      <span class="hljs-attr">"url"</span>: <span class="hljs-string">"https://api.gigantic-server.com/v1"</span>,
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Production server"</span>
+      <span class="hljs-attr">&quot;url&quot;</span>: <span class="hljs-string">&quot;https://api.gigantic-server.com/v1&quot;</span>,
+      <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;Production server&quot;</span>
     }
   ]
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">servers:</span>
-<span class="hljs-attr">- url:</span> <span class="hljs-attr">https://development.gigantic-server.com/v1</span>
-<span class="hljs-attr">  description:</span> <span class="hljs-string">Development</span> <span class="hljs-string">server</span>
-<span class="hljs-attr">- url:</span> <span class="hljs-attr">https://staging.gigantic-server.com/v1</span>
-<span class="hljs-attr">  description:</span> <span class="hljs-string">Staging</span> <span class="hljs-string">server</span>
-<span class="hljs-attr">- url:</span> <span class="hljs-attr">https://api.gigantic-server.com/v1</span>
-<span class="hljs-attr">  description:</span> <span class="hljs-string">Production</span> <span class="hljs-string">server</span>
+<span class="hljs-bullet">-</span> <span class="hljs-attr">url:</span> <span class="hljs-string">https://development.gigantic-server.com/v1</span>
+  <span class="hljs-attr">description:</span> <span class="hljs-string">Development</span> <span class="hljs-string">server</span>
+<span class="hljs-bullet">-</span> <span class="hljs-attr">url:</span> <span class="hljs-string">https://staging.gigantic-server.com/v1</span>
+  <span class="hljs-attr">description:</span> <span class="hljs-string">Staging</span> <span class="hljs-string">server</span>
+<span class="hljs-bullet">-</span> <span class="hljs-attr">url:</span> <span class="hljs-string">https://api.gigantic-server.com/v1</span>
+  <span class="hljs-attr">description:</span> <span class="hljs-string">Production</span> <span class="hljs-string">server</span>
 </code></pre>
 <p>The following shows how variables can be used for a server configuration:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"servers"</span>: [
+  <span class="hljs-attr">&quot;servers&quot;</span>: [
     {
-      <span class="hljs-attr">"url"</span>: <span class="hljs-string">"https://{username}.gigantic-server.com:{port}/{basePath}"</span>,
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"The production API server"</span>,
-      <span class="hljs-attr">"variables"</span>: {
-        <span class="hljs-attr">"username"</span>: {
-          <span class="hljs-attr">"default"</span>: <span class="hljs-string">"demo"</span>,
-          <span class="hljs-attr">"description"</span>: <span class="hljs-string">"this value is assigned by the service provider, in this example `gigantic-server.com`"</span>
+      <span class="hljs-attr">&quot;url&quot;</span>: <span class="hljs-string">&quot;https://{username}.gigantic-server.com:{port}/{basePath}&quot;</span>,
+      <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;The production API server&quot;</span>,
+      <span class="hljs-attr">&quot;variables&quot;</span>: {
+        <span class="hljs-attr">&quot;username&quot;</span>: {
+          <span class="hljs-attr">&quot;default&quot;</span>: <span class="hljs-string">&quot;demo&quot;</span>,
+          <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;this value is assigned by the service provider, in this example `gigantic-server.com`&quot;</span>
         },
-        <span class="hljs-attr">"port"</span>: {
-          <span class="hljs-attr">"enum"</span>: [
-            <span class="hljs-string">"8443"</span>,
-            <span class="hljs-string">"443"</span>
+        <span class="hljs-attr">&quot;port&quot;</span>: {
+          <span class="hljs-attr">&quot;enum&quot;</span>: [
+            <span class="hljs-string">&quot;8443&quot;</span>,
+            <span class="hljs-string">&quot;443&quot;</span>
           ],
-          <span class="hljs-attr">"default"</span>: <span class="hljs-string">"8443"</span>
+          <span class="hljs-attr">&quot;default&quot;</span>: <span class="hljs-string">&quot;8443&quot;</span>
         },
-        <span class="hljs-attr">"basePath"</span>: {
-          <span class="hljs-attr">"default"</span>: <span class="hljs-string">"v2"</span>
+        <span class="hljs-attr">&quot;basePath&quot;</span>: {
+          <span class="hljs-attr">&quot;default&quot;</span>: <span class="hljs-string">&quot;v2&quot;</span>
         }
       }
     }
@@ -473,21 +473,21 @@ The metadata MAY be used by the clients if needed, and MAY be presented in editi
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">servers:</span>
-<span class="hljs-attr">- url:</span> <span class="hljs-attr">https://{username}.gigantic-server.com:{port}/{basePath}</span>
-<span class="hljs-attr">  description:</span> <span class="hljs-string">The</span> <span class="hljs-string">production</span> <span class="hljs-string">API</span> <span class="hljs-string">server</span>
-<span class="hljs-attr">  variables:</span>
-<span class="hljs-attr">    username:</span>
+<span class="hljs-bullet">-</span> <span class="hljs-attr">url:</span> <span class="hljs-string">https://{username}.gigantic-server.com:{port}/{basePath}</span>
+  <span class="hljs-attr">description:</span> <span class="hljs-string">The</span> <span class="hljs-string">production</span> <span class="hljs-string">API</span> <span class="hljs-string">server</span>
+  <span class="hljs-attr">variables:</span>
+    <span class="hljs-attr">username:</span>
       <span class="hljs-comment"># note! no enum here means it is an open value</span>
-<span class="hljs-attr">      default:</span> <span class="hljs-string">demo</span>
-<span class="hljs-attr">      description:</span> <span class="hljs-string">this</span> <span class="hljs-string">value</span> <span class="hljs-string">is</span> <span class="hljs-string">assigned</span> <span class="hljs-string">by</span> <span class="hljs-string">the</span> <span class="hljs-string">service</span> <span class="hljs-string">provider,</span> <span class="hljs-string">in</span> <span class="hljs-string">this</span> <span class="hljs-string">example</span> <span class="hljs-string">`gigantic-server.com`</span>
-<span class="hljs-attr">    port:</span>
-<span class="hljs-attr">      enum:</span>
-<span class="hljs-bullet">        -</span> <span class="hljs-string">'8443'</span>
-<span class="hljs-bullet">        -</span> <span class="hljs-string">'443'</span>
-<span class="hljs-attr">      default:</span> <span class="hljs-string">'8443'</span>
-<span class="hljs-attr">    basePath:</span>
+      <span class="hljs-attr">default:</span> <span class="hljs-string">demo</span>
+      <span class="hljs-attr">description:</span> <span class="hljs-string">this</span> <span class="hljs-string">value</span> <span class="hljs-string">is</span> <span class="hljs-string">assigned</span> <span class="hljs-string">by</span> <span class="hljs-string">the</span> <span class="hljs-string">service</span> <span class="hljs-string">provider,</span> <span class="hljs-string">in</span> <span class="hljs-string">this</span> <span class="hljs-string">example</span> <span class="hljs-string">`gigantic-server.com`</span>
+    <span class="hljs-attr">port:</span>
+      <span class="hljs-attr">enum:</span>
+        <span class="hljs-bullet">-</span> <span class="hljs-string">&#x27;8443&#x27;</span>
+        <span class="hljs-bullet">-</span> <span class="hljs-string">&#x27;443&#x27;</span>
+      <span class="hljs-attr">default:</span> <span class="hljs-string">&#x27;8443&#x27;</span>
+    <span class="hljs-attr">basePath:</span>
       <span class="hljs-comment"># open meaning there is the opportunity to use special base paths as assigned by the provider, default is `v2`</span>
-<span class="hljs-attr">      default:</span> <span class="hljs-string">v2</span>
+      <span class="hljs-attr">default:</span> <span class="hljs-string">v2</span>
 </code></pre>
 </section></section><section><h3><span id="serverVariableObject">Server Variable Object</span></h3>
 <p>An object representing a Server Variable for server URL template substitution.</p>
@@ -534,47 +534,47 @@ All objects defined within the components object will have no effect on the API 
 <tbody>
 <tr>
 <td><a id="componentsSchemas"> </a> schemas</td>
-<td style="text-align:left">Map[<code>string</code>, <a href="#schemaObject">Schema Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:left">Map[<code>string</code>, <a href="#schemaObject">Schema Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>An object to hold reusable <a href="#schemaObject">Schema Objects</a>.</td>
 </tr>
 <tr>
 <td><a id="componentsResponses"> </a> responses</td>
-<td style="text-align:left">Map[<code>string</code>, <a href="#responseObject">Response Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:left">Map[<code>string</code>, <a href="#responseObject">Response Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>An object to hold reusable <a href="#responseObject">Response Objects</a>.</td>
 </tr>
 <tr>
 <td><a id="componentsParameters"> </a> parameters</td>
-<td style="text-align:left">Map[<code>string</code>, <a href="#parameterObject">Parameter Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:left">Map[<code>string</code>, <a href="#parameterObject">Parameter Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>An object to hold reusable <a href="#parameterObject">Parameter Objects</a>.</td>
 </tr>
 <tr>
 <td><a id="componentsExamples"> </a> examples</td>
-<td style="text-align:left">Map[<code>string</code>, <a href="#exampleObject">Example Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:left">Map[<code>string</code>, <a href="#exampleObject">Example Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>An object to hold reusable <a href="#exampleObject">Example Objects</a>.</td>
 </tr>
 <tr>
 <td><a id="componentsRequestBodies"> </a> requestBodies</td>
-<td style="text-align:left">Map[<code>string</code>, <a href="#requestBodyObject">Request Body Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:left">Map[<code>string</code>, <a href="#requestBodyObject">Request Body Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>An object to hold reusable <a href="#requestBodyObject">Request Body Objects</a>.</td>
 </tr>
 <tr>
 <td><a id="componentsHeaders"> </a> headers</td>
-<td style="text-align:left">Map[<code>string</code>, <a href="#headerObject">Header Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:left">Map[<code>string</code>, <a href="#headerObject">Header Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>An object to hold reusable <a href="#headerObject">Header Objects</a>.</td>
 </tr>
 <tr>
 <td><a id="componentsSecuritySchemes"> </a> securitySchemes</td>
-<td style="text-align:left">Map[<code>string</code>, <a href="#securitySchemeObject">Security Scheme Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:left">Map[<code>string</code>, <a href="#securitySchemeObject">Security Scheme Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>An object to hold reusable <a href="#securitySchemeObject">Security Scheme Objects</a>.</td>
 </tr>
 <tr>
 <td><a id="componentsLinks"> </a> links</td>
-<td style="text-align:left">Map[<code>string</code>, <a href="#linkObject">Link Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:left">Map[<code>string</code>, <a href="#linkObject">Link Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>An object to hold reusable <a href="#linkObject">Link Objects</a>.</td>
 </tr>
 <tr>
 <td><a id="componentsCallbacks"> </a> callbacks</td>
-<td style="text-align:left">Map[<code>string</code>, <a href="#callbackObject">Callback Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:left">Map[<code>string</code>, <a href="#callbackObject">Callback Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>An object to hold reusable <a href="#callbackObject">Callback Objects</a>.</td>
 </tr>
 </tbody>
@@ -591,87 +591,87 @@ my.org.User
 </code></pre>
 </section><section><h4>Components Object Example</h4>
 <pre class="nohighlight"><code>
-<span class="hljs-string">"components"</span>: {
-  <span class="hljs-attr">"schemas"</span>: {
-    <span class="hljs-attr">"Category"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-      <span class="hljs-attr">"properties"</span>: {
-        <span class="hljs-attr">"id"</span>: {
-          <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>,
-          <span class="hljs-attr">"format"</span>: <span class="hljs-string">"int64"</span>
+&quot;components&quot;: {
+  &quot;schemas&quot;: {
+    &quot;Category&quot;: {
+      &quot;type&quot;: &quot;object&quot;,
+      &quot;properties&quot;: {
+        &quot;id&quot;: {
+          &quot;type&quot;: &quot;integer&quot;,
+          &quot;format&quot;: &quot;int64&quot;
         },
-        <span class="hljs-attr">"name"</span>: {
-          <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+        &quot;name&quot;: {
+          &quot;type&quot;: &quot;string&quot;
         }
       }
     },
-    <span class="hljs-attr">"Tag"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-      <span class="hljs-attr">"properties"</span>: {
-        <span class="hljs-attr">"id"</span>: {
-          <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>,
-          <span class="hljs-attr">"format"</span>: <span class="hljs-string">"int64"</span>
+    &quot;Tag&quot;: {
+      &quot;type&quot;: &quot;object&quot;,
+      &quot;properties&quot;: {
+        &quot;id&quot;: {
+          &quot;type&quot;: &quot;integer&quot;,
+          &quot;format&quot;: &quot;int64&quot;
         },
-        <span class="hljs-attr">"name"</span>: {
-          <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+        &quot;name&quot;: {
+          &quot;type&quot;: &quot;string&quot;
         }
       }
     }
   },
-  <span class="hljs-attr">"parameters"</span>: {
-    <span class="hljs-attr">"skipParam"</span>: {
-      <span class="hljs-attr">"name"</span>: <span class="hljs-string">"skip"</span>,
-      <span class="hljs-attr">"in"</span>: <span class="hljs-string">"query"</span>,
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"number of items to skip"</span>,
-      <span class="hljs-attr">"required"</span>: <span class="hljs-literal">true</span>,
-      <span class="hljs-attr">"schema"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>,
-        <span class="hljs-attr">"format"</span>: <span class="hljs-string">"int32"</span>
+  &quot;parameters&quot;: {
+    &quot;skipParam&quot;: {
+      &quot;name&quot;: &quot;skip&quot;,
+      &quot;in&quot;: &quot;query&quot;,
+      &quot;description&quot;: &quot;number of items to skip&quot;,
+      &quot;required&quot;: true,
+      &quot;schema&quot;: {
+        &quot;type&quot;: &quot;integer&quot;,
+        &quot;format&quot;: &quot;int32&quot;
       }
     },
-    <span class="hljs-attr">"limitParam"</span>: {
-      <span class="hljs-attr">"name"</span>: <span class="hljs-string">"limit"</span>,
-      <span class="hljs-attr">"in"</span>: <span class="hljs-string">"query"</span>,
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"max records to return"</span>,
-      <span class="hljs-attr">"required"</span>: <span class="hljs-literal">true</span>,
-      <span class="hljs-attr">"schema"</span> : {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>,
-        <span class="hljs-attr">"format"</span>: <span class="hljs-string">"int32"</span>
+    &quot;limitParam&quot;: {
+      &quot;name&quot;: &quot;limit&quot;,
+      &quot;in&quot;: &quot;query&quot;,
+      &quot;description&quot;: &quot;max records to return&quot;,
+      &quot;required&quot;: true,
+      &quot;schema&quot; : {
+        &quot;type&quot;: &quot;integer&quot;,
+        &quot;format&quot;: &quot;int32&quot;
       }
     }
   },
-  <span class="hljs-attr">"responses"</span>: {
-    <span class="hljs-attr">"NotFound"</span>: {
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Entity not found."</span>
+  &quot;responses&quot;: {
+    &quot;NotFound&quot;: {
+      &quot;description&quot;: &quot;Entity not found.&quot;
     },
-    <span class="hljs-attr">"IllegalInput"</span>: {
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Illegal input for operation."</span>
+    &quot;IllegalInput&quot;: {
+      &quot;description&quot;: &quot;Illegal input for operation.&quot;
     },
-    <span class="hljs-attr">"GeneralError"</span>: {
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"General Error"</span>,
-      <span class="hljs-attr">"content"</span>: {
-        <span class="hljs-attr">"application/json"</span>: {
-          <span class="hljs-attr">"schema"</span>: {
-            <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/GeneralError"</span>
+    &quot;GeneralError&quot;: {
+      &quot;description&quot;: &quot;General Error&quot;,
+      &quot;content&quot;: {
+        &quot;application/json&quot;: {
+          &quot;schema&quot;: {
+            &quot;$ref&quot;: &quot;#/components/schemas/GeneralError&quot;
           }
         }
       }
     }
   },
-  <span class="hljs-attr">"securitySchemes"</span>: {
-    <span class="hljs-attr">"api_key"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"apiKey"</span>,
-      <span class="hljs-attr">"name"</span>: <span class="hljs-string">"api_key"</span>,
-      <span class="hljs-attr">"in"</span>: <span class="hljs-string">"header"</span>
+  &quot;securitySchemes&quot;: {
+    &quot;api_key&quot;: {
+      &quot;type&quot;: &quot;apiKey&quot;,
+      &quot;name&quot;: &quot;api_key&quot;,
+      &quot;in&quot;: &quot;header&quot;
     },
-    <span class="hljs-attr">"petstore_auth"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"oauth2"</span>,
-      <span class="hljs-attr">"flows"</span>: {
-        <span class="hljs-attr">"implicit"</span>: {
-          <span class="hljs-attr">"authorizationUrl"</span>: <span class="hljs-string">"http://example.org/api/oauth/dialog"</span>,
-          <span class="hljs-attr">"scopes"</span>: {
-            <span class="hljs-attr">"write:pets"</span>: <span class="hljs-string">"modify pets in your account"</span>,
-            <span class="hljs-attr">"read:pets"</span>: <span class="hljs-string">"read your pets"</span>
+    &quot;petstore_auth&quot;: {
+      &quot;type&quot;: &quot;oauth2&quot;,
+      &quot;flows&quot;: {
+        &quot;implicit&quot;: {
+          &quot;authorizationUrl&quot;: &quot;http://example.org/api/oauth/dialog&quot;,
+          &quot;scopes&quot;: {
+            &quot;write:pets&quot;: &quot;modify pets in your account&quot;,
+            &quot;read:pets&quot;: &quot;read your pets&quot;
           }
         }
       }
@@ -681,64 +681,64 @@ my.org.User
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">components:</span>
-<span class="hljs-attr">  schemas:</span>
-<span class="hljs-attr">    Category:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">      properties:</span>
-<span class="hljs-attr">        id:</span>
-<span class="hljs-attr">          type:</span> <span class="hljs-string">integer</span>
-<span class="hljs-attr">          format:</span> <span class="hljs-string">int64</span>
-<span class="hljs-attr">        name:</span>
-<span class="hljs-attr">          type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">    Tag:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">      properties:</span>
-<span class="hljs-attr">        id:</span>
-<span class="hljs-attr">          type:</span> <span class="hljs-string">integer</span>
-<span class="hljs-attr">          format:</span> <span class="hljs-string">int64</span>
-<span class="hljs-attr">        name:</span>
-<span class="hljs-attr">          type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">  parameters:</span>
-<span class="hljs-attr">    skipParam:</span>
-<span class="hljs-attr">      name:</span> <span class="hljs-string">skip</span>
-<span class="hljs-attr">      in:</span> <span class="hljs-string">query</span>
-<span class="hljs-attr">      description:</span> <span class="hljs-string">number</span> <span class="hljs-string">of</span> <span class="hljs-string">items</span> <span class="hljs-string">to</span> <span class="hljs-string">skip</span>
-<span class="hljs-attr">      required:</span> <span class="hljs-literal">true</span>
-<span class="hljs-attr">      schema:</span>
-<span class="hljs-attr">        type:</span> <span class="hljs-string">integer</span>
-<span class="hljs-attr">        format:</span> <span class="hljs-string">int32</span>
-<span class="hljs-attr">    limitParam:</span>
-<span class="hljs-attr">      name:</span> <span class="hljs-string">limit</span>
-<span class="hljs-attr">      in:</span> <span class="hljs-string">query</span>
-<span class="hljs-attr">      description:</span> <span class="hljs-string">max</span> <span class="hljs-string">records</span> <span class="hljs-string">to</span> <span class="hljs-string">return</span>
-<span class="hljs-attr">      required:</span> <span class="hljs-literal">true</span>
-<span class="hljs-attr">      schema:</span>
-<span class="hljs-attr">        type:</span> <span class="hljs-string">integer</span>
-<span class="hljs-attr">        format:</span> <span class="hljs-string">int32</span>
-<span class="hljs-attr">  responses:</span>
-<span class="hljs-attr">    NotFound:</span>
-<span class="hljs-attr">      description:</span> <span class="hljs-string">Entity</span> <span class="hljs-string">not</span> <span class="hljs-string">found.</span>
-<span class="hljs-attr">    IllegalInput:</span>
-<span class="hljs-attr">      description:</span> <span class="hljs-string">Illegal</span> <span class="hljs-string">input</span> <span class="hljs-string">for</span> <span class="hljs-string">operation.</span>
-<span class="hljs-attr">    GeneralError:</span>
-<span class="hljs-attr">      description:</span> <span class="hljs-string">General</span> <span class="hljs-string">Error</span>
-<span class="hljs-attr">      content:</span>
-        <span class="hljs-string">application/json:</span>
-<span class="hljs-attr">          schema:</span>
-            <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/GeneralError'</span>
-<span class="hljs-attr">  securitySchemes:</span>
-<span class="hljs-attr">    api_key:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">apiKey</span>
-<span class="hljs-attr">      name:</span> <span class="hljs-string">api_key</span>
-<span class="hljs-attr">      in:</span> <span class="hljs-string">header</span>
-<span class="hljs-attr">    petstore_auth:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">oauth2</span>
-<span class="hljs-attr">      flows:</span> 
-<span class="hljs-attr">        implicit:</span>
-<span class="hljs-attr">          authorizationUrl:</span> <span class="hljs-attr">http://example.org/api/oauth/dialog</span>
-<span class="hljs-attr">          scopes:</span>
-<span class="hljs-attr">            write:</span><span class="hljs-attr">pets:</span> <span class="hljs-string">modify</span> <span class="hljs-string">pets</span> <span class="hljs-string">in</span> <span class="hljs-string">your</span> <span class="hljs-string">account</span>
-<span class="hljs-attr">            read:</span><span class="hljs-attr">pets:</span> <span class="hljs-string">read</span> <span class="hljs-string">your</span> <span class="hljs-string">pets</span>
+  <span class="hljs-attr">schemas:</span>
+    <span class="hljs-attr">Category:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+      <span class="hljs-attr">properties:</span>
+        <span class="hljs-attr">id:</span>
+          <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+          <span class="hljs-attr">format:</span> <span class="hljs-string">int64</span>
+        <span class="hljs-attr">name:</span>
+          <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+    <span class="hljs-attr">Tag:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+      <span class="hljs-attr">properties:</span>
+        <span class="hljs-attr">id:</span>
+          <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+          <span class="hljs-attr">format:</span> <span class="hljs-string">int64</span>
+        <span class="hljs-attr">name:</span>
+          <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">parameters:</span>
+    <span class="hljs-attr">skipParam:</span>
+      <span class="hljs-attr">name:</span> <span class="hljs-string">skip</span>
+      <span class="hljs-attr">in:</span> <span class="hljs-string">query</span>
+      <span class="hljs-attr">description:</span> <span class="hljs-string">number</span> <span class="hljs-string">of</span> <span class="hljs-string">items</span> <span class="hljs-string">to</span> <span class="hljs-string">skip</span>
+      <span class="hljs-attr">required:</span> <span class="hljs-literal">true</span>
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+        <span class="hljs-attr">format:</span> <span class="hljs-string">int32</span>
+    <span class="hljs-attr">limitParam:</span>
+      <span class="hljs-attr">name:</span> <span class="hljs-string">limit</span>
+      <span class="hljs-attr">in:</span> <span class="hljs-string">query</span>
+      <span class="hljs-attr">description:</span> <span class="hljs-string">max</span> <span class="hljs-string">records</span> <span class="hljs-string">to</span> <span class="hljs-string">return</span>
+      <span class="hljs-attr">required:</span> <span class="hljs-literal">true</span>
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+        <span class="hljs-attr">format:</span> <span class="hljs-string">int32</span>
+  <span class="hljs-attr">responses:</span>
+    <span class="hljs-attr">NotFound:</span>
+      <span class="hljs-attr">description:</span> <span class="hljs-string">Entity</span> <span class="hljs-string">not</span> <span class="hljs-string">found.</span>
+    <span class="hljs-attr">IllegalInput:</span>
+      <span class="hljs-attr">description:</span> <span class="hljs-string">Illegal</span> <span class="hljs-string">input</span> <span class="hljs-string">for</span> <span class="hljs-string">operation.</span>
+    <span class="hljs-attr">GeneralError:</span>
+      <span class="hljs-attr">description:</span> <span class="hljs-string">General</span> <span class="hljs-string">Error</span>
+      <span class="hljs-attr">content:</span>
+        <span class="hljs-attr">application/json:</span>
+          <span class="hljs-attr">schema:</span>
+            <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/GeneralError&#x27;</span>
+  <span class="hljs-attr">securitySchemes:</span>
+    <span class="hljs-attr">api_key:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">apiKey</span>
+      <span class="hljs-attr">name:</span> <span class="hljs-string">api_key</span>
+      <span class="hljs-attr">in:</span> <span class="hljs-string">header</span>
+    <span class="hljs-attr">petstore_auth:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">oauth2</span>
+      <span class="hljs-attr">flows:</span> 
+        <span class="hljs-attr">implicit:</span>
+          <span class="hljs-attr">authorizationUrl:</span> <span class="hljs-string">http://example.org/api/oauth/dialog</span>
+          <span class="hljs-attr">scopes:</span>
+            <span class="hljs-attr">write:pets:</span> <span class="hljs-string">modify</span> <span class="hljs-string">pets</span> <span class="hljs-string">in</span> <span class="hljs-string">your</span> <span class="hljs-string">account</span>
+            <span class="hljs-attr">read:pets:</span> <span class="hljs-string">read</span> <span class="hljs-string">your</span> <span class="hljs-string">pets</span>
 </code></pre>
 </section></section><section><h3><span id="pathsObject">Paths Object</span></h3>
 <p>Holds the relative paths to the individual endpoints and their operations.
@@ -756,7 +756,7 @@ The path is appended to the URL from the <a href="#serverObject"><code>Server Ob
 <tr>
 <td><a id="pathsPath"> </a>/{path}</td>
 <td style="text-align:center"><a href="#pathItemObject">Path Item Object</a></td>
-<td>A relative path to an individual endpoint. The field name MUST begin with a slash. The path is <strong>appended</strong> (no relative URL resolution) to the expanded URL from the <a href="#serverObject"><code>Server Object</code></a>'s <code>url</code> field in order to construct the full URL. <a href="#pathTemplating">Path templating</a> is allowed. When matching URLs, concrete (non-templated) paths would be matched before their templated counterparts. Templated paths with the same hierarchy but different templated names MUST NOT exist as they are identical. In case of ambiguous matching, it’s up to the tooling to decide which one to use.</td>
+<td>A relative path to an individual endpoint. The field name MUST begin with a slash. The path is <strong>appended</strong> (no relative URL resolution) to the expanded URL from the <a href="#serverObject"><code>Server Object</code></a>’s <code>url</code> field in order to construct the full URL. <a href="#pathTemplating">Path templating</a> is allowed. When matching URLs, concrete (non-templated) paths would be matched before their templated counterparts. Templated paths with the same hierarchy but different templated names MUST NOT exist as they are identical. In case of ambiguous matching, it’s up to the tooling to decide which one to use.</td>
 </tr>
 </tbody>
 </table>
@@ -780,18 +780,18 @@ The path is appended to the URL from the <a href="#serverObject"><code>Server Ob
 </section><section><h4>Paths Object Example</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"/pets"</span>: {
-    <span class="hljs-attr">"get"</span>: {
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Returns all pets from the system that the user has access to"</span>,
-      <span class="hljs-attr">"responses"</span>: {
-        <span class="hljs-attr">"200"</span>: {          
-          <span class="hljs-attr">"description"</span>: <span class="hljs-string">"A list of pets."</span>,
-          <span class="hljs-attr">"content"</span>: {
-            <span class="hljs-attr">"application/json"</span>: {
-              <span class="hljs-attr">"schema"</span>: {
-                <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-                <span class="hljs-attr">"items"</span>: {
-                  <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/pet"</span>
+  <span class="hljs-attr">&quot;/pets&quot;</span>: {
+    <span class="hljs-attr">&quot;get&quot;</span>: {
+      <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;Returns all pets from the system that the user has access to&quot;</span>,
+      <span class="hljs-attr">&quot;responses&quot;</span>: {
+        <span class="hljs-attr">&quot;200&quot;</span>: {          
+          <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;A list of pets.&quot;</span>,
+          <span class="hljs-attr">&quot;content&quot;</span>: {
+            <span class="hljs-attr">&quot;application/json&quot;</span>: {
+              <span class="hljs-attr">&quot;schema&quot;</span>: {
+                <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+                <span class="hljs-attr">&quot;items&quot;</span>: {
+                  <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/pet&quot;</span>
                 }
               }
             }
@@ -804,17 +804,17 @@ The path is appended to the URL from the <a href="#serverObject"><code>Server Ob
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-string">/pets:</span>
-<span class="hljs-attr">  get:</span>
-<span class="hljs-attr">    description:</span> <span class="hljs-string">Returns</span> <span class="hljs-string">all</span> <span class="hljs-string">pets</span> <span class="hljs-string">from</span> <span class="hljs-string">the</span> <span class="hljs-string">system</span> <span class="hljs-string">that</span> <span class="hljs-string">the</span> <span class="hljs-string">user</span> <span class="hljs-string">has</span> <span class="hljs-string">access</span> <span class="hljs-string">to</span>
-<span class="hljs-attr">    responses:</span>
-      <span class="hljs-string">'200'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">        description:</span> <span class="hljs-string">A</span> <span class="hljs-string">list</span> <span class="hljs-string">of</span> <span class="hljs-string">pets.</span>
-<span class="hljs-attr">        content:</span>
-          <span class="hljs-string">application/json:</span>
-<span class="hljs-attr">            schema:</span>
-<span class="hljs-attr">              type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">              items:</span>
-                <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/pet'</span>
+  <span class="hljs-attr">get:</span>
+    <span class="hljs-attr">description:</span> <span class="hljs-string">Returns</span> <span class="hljs-string">all</span> <span class="hljs-string">pets</span> <span class="hljs-string">from</span> <span class="hljs-string">the</span> <span class="hljs-string">system</span> <span class="hljs-string">that</span> <span class="hljs-string">the</span> <span class="hljs-string">user</span> <span class="hljs-string">has</span> <span class="hljs-string">access</span> <span class="hljs-string">to</span>
+    <span class="hljs-attr">responses:</span>
+      <span class="hljs-attr">&#x27;200&#x27;:</span>
+        <span class="hljs-attr">description:</span> <span class="hljs-string">A</span> <span class="hljs-string">list</span> <span class="hljs-string">of</span> <span class="hljs-string">pets.</span>
+        <span class="hljs-attr">content:</span>
+          <span class="hljs-attr">application/json:</span>
+            <span class="hljs-attr">schema:</span>
+              <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+              <span class="hljs-attr">items:</span>
+                <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/pet&#x27;</span>
 </code></pre>
 </section></section><section><h3><span id="pathItemObject">Path Item Object</span></h3>
 <p>Describes the operations available on a single path.
@@ -892,7 +892,7 @@ The path itself is still exposed to the documentation viewer but they will not k
 </tr>
 <tr>
 <td><a id="pathItemParameters"> </a>parameters</td>
-<td style="text-align:center">[<a href="#parameterObject">Parameter Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:center">[<a href="#parameterObject">Parameter Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>A list of parameters that are applicable for all the operations described under this path. These parameters can be overridden at the operation level, but cannot be removed there. The list MUST NOT include duplicated parameters. A unique parameter is defined by a combination of a <a href="#parameterName">name</a> and <a href="#parameterIn">location</a>. The list can use the <a href="#referenceObject">Reference Object</a> to link to parameters that are defined at the <a href="#componentsParameters">OpenAPI Object’s components/parameters</a>.</td>
 </tr>
 </tbody>
@@ -901,83 +901,83 @@ The path itself is still exposed to the documentation viewer but they will not k
 </section><section><h4>Path Item Object Example</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"get"</span>: {
-    <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Returns pets based on ID"</span>,
-    <span class="hljs-attr">"summary"</span>: <span class="hljs-string">"Find pets by ID"</span>,
-    <span class="hljs-attr">"operationId"</span>: <span class="hljs-string">"getPetsById"</span>,
-    <span class="hljs-attr">"responses"</span>: {
-      <span class="hljs-attr">"200"</span>: {
-        <span class="hljs-attr">"description"</span>: <span class="hljs-string">"pet response"</span>,
-        <span class="hljs-attr">"content"</span>: {
-          <span class="hljs-attr">"*/*"</span>: {
-            <span class="hljs-attr">"schema"</span>: {
-              <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-              <span class="hljs-attr">"items"</span>: {
-                <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/Pet"</span>
+  <span class="hljs-attr">&quot;get&quot;</span>: {
+    <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;Returns pets based on ID&quot;</span>,
+    <span class="hljs-attr">&quot;summary&quot;</span>: <span class="hljs-string">&quot;Find pets by ID&quot;</span>,
+    <span class="hljs-attr">&quot;operationId&quot;</span>: <span class="hljs-string">&quot;getPetsById&quot;</span>,
+    <span class="hljs-attr">&quot;responses&quot;</span>: {
+      <span class="hljs-attr">&quot;200&quot;</span>: {
+        <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;pet response&quot;</span>,
+        <span class="hljs-attr">&quot;content&quot;</span>: {
+          <span class="hljs-attr">&quot;*/*&quot;</span>: {
+            <span class="hljs-attr">&quot;schema&quot;</span>: {
+              <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+              <span class="hljs-attr">&quot;items&quot;</span>: {
+                <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/Pet&quot;</span>
               }
             }
           }
         }
       },
-      <span class="hljs-attr">"default"</span>: {
-        <span class="hljs-attr">"description"</span>: <span class="hljs-string">"error payload"</span>,
-        <span class="hljs-attr">"content"</span>: {
-          <span class="hljs-attr">"text/html"</span>: {
-            <span class="hljs-attr">"schema"</span>: {
-              <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/ErrorModel"</span>
+      <span class="hljs-attr">&quot;default&quot;</span>: {
+        <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;error payload&quot;</span>,
+        <span class="hljs-attr">&quot;content&quot;</span>: {
+          <span class="hljs-attr">&quot;text/html&quot;</span>: {
+            <span class="hljs-attr">&quot;schema&quot;</span>: {
+              <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/ErrorModel&quot;</span>
             }
           }
         }
       }
     }
   },
-  <span class="hljs-attr">"parameters"</span>: [
+  <span class="hljs-attr">&quot;parameters&quot;</span>: [
     {
-      <span class="hljs-attr">"name"</span>: <span class="hljs-string">"id"</span>,
-      <span class="hljs-attr">"in"</span>: <span class="hljs-string">"path"</span>,
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"ID of pet to use"</span>,
-      <span class="hljs-attr">"required"</span>: <span class="hljs-literal">true</span>,
-      <span class="hljs-attr">"schema"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-        <span class="hljs-attr">"items"</span>: {
-          <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+      <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;id&quot;</span>,
+      <span class="hljs-attr">&quot;in&quot;</span>: <span class="hljs-string">&quot;path&quot;</span>,
+      <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;ID of pet to use&quot;</span>,
+      <span class="hljs-attr">&quot;required&quot;</span>: <span class="hljs-literal">true</span>,
+      <span class="hljs-attr">&quot;schema&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+        <span class="hljs-attr">&quot;items&quot;</span>: {
+          <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
         }
       },
-      <span class="hljs-attr">"style"</span>: <span class="hljs-string">"simple"</span>
+      <span class="hljs-attr">&quot;style&quot;</span>: <span class="hljs-string">&quot;simple&quot;</span>
     }
   ]
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">get:</span>
-<span class="hljs-attr">  description:</span> <span class="hljs-string">Returns</span> <span class="hljs-string">pets</span> <span class="hljs-string">based</span> <span class="hljs-string">on</span> <span class="hljs-string">ID</span>
-<span class="hljs-attr">  summary:</span> <span class="hljs-string">Find</span> <span class="hljs-string">pets</span> <span class="hljs-string">by</span> <span class="hljs-string">ID</span>
-<span class="hljs-attr">  operationId:</span> <span class="hljs-string">getPetsById</span>
-<span class="hljs-attr">  responses:</span>
-    <span class="hljs-string">'200'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">      description:</span> <span class="hljs-string">pet</span> <span class="hljs-string">response</span>
-<span class="hljs-attr">      content:</span>
-        <span class="hljs-string">'*/*'</span> <span class="hljs-string">:</span>
-<span class="hljs-attr">          schema:</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">            items:</span>
-              <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Pet'</span>
-<span class="hljs-attr">    default:</span>
-<span class="hljs-attr">      description:</span> <span class="hljs-string">error</span> <span class="hljs-string">payload</span>
-<span class="hljs-attr">      content:</span>
-        <span class="hljs-string">'text/html'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">          schema:</span>
-            <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/ErrorModel'</span>
+  <span class="hljs-attr">description:</span> <span class="hljs-string">Returns</span> <span class="hljs-string">pets</span> <span class="hljs-string">based</span> <span class="hljs-string">on</span> <span class="hljs-string">ID</span>
+  <span class="hljs-attr">summary:</span> <span class="hljs-string">Find</span> <span class="hljs-string">pets</span> <span class="hljs-string">by</span> <span class="hljs-string">ID</span>
+  <span class="hljs-attr">operationId:</span> <span class="hljs-string">getPetsById</span>
+  <span class="hljs-attr">responses:</span>
+    <span class="hljs-attr">&#x27;200&#x27;:</span>
+      <span class="hljs-attr">description:</span> <span class="hljs-string">pet</span> <span class="hljs-string">response</span>
+      <span class="hljs-attr">content:</span>
+        <span class="hljs-string">&#x27;*/*&#x27;</span> <span class="hljs-string">:</span>
+          <span class="hljs-attr">schema:</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+            <span class="hljs-attr">items:</span>
+              <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/Pet&#x27;</span>
+    <span class="hljs-attr">default:</span>
+      <span class="hljs-attr">description:</span> <span class="hljs-string">error</span> <span class="hljs-string">payload</span>
+      <span class="hljs-attr">content:</span>
+        <span class="hljs-attr">&#x27;text/html&#x27;:</span>
+          <span class="hljs-attr">schema:</span>
+            <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/ErrorModel&#x27;</span>
 <span class="hljs-attr">parameters:</span>
-<span class="hljs-attr">- name:</span> <span class="hljs-string">id</span>
-<span class="hljs-attr">  in:</span> <span class="hljs-string">path</span>
-<span class="hljs-attr">  description:</span> <span class="hljs-string">ID</span> <span class="hljs-string">of</span> <span class="hljs-string">pet</span> <span class="hljs-string">to</span> <span class="hljs-string">use</span>
-<span class="hljs-attr">  required:</span> <span class="hljs-literal">true</span>
-<span class="hljs-attr">  schema:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">    style:</span> <span class="hljs-string">simple</span>
-<span class="hljs-attr">    items:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">string</span>  
+<span class="hljs-bullet">-</span> <span class="hljs-attr">name:</span> <span class="hljs-string">id</span>
+  <span class="hljs-attr">in:</span> <span class="hljs-string">path</span>
+  <span class="hljs-attr">description:</span> <span class="hljs-string">ID</span> <span class="hljs-string">of</span> <span class="hljs-string">pet</span> <span class="hljs-string">to</span> <span class="hljs-string">use</span>
+  <span class="hljs-attr">required:</span> <span class="hljs-literal">true</span>
+  <span class="hljs-attr">schema:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+    <span class="hljs-attr">style:</span> <span class="hljs-string">simple</span>
+    <span class="hljs-attr">items:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>  
 </code></pre>
 </section></section><section><h3><span id="operationObject">Operation Object</span></h3>
 <p>Describes a single API operation on a path.</p>
@@ -1018,12 +1018,12 @@ The path itself is still exposed to the documentation viewer but they will not k
 </tr>
 <tr>
 <td><a id="operationParameters"> </a>parameters</td>
-<td style="text-align:center">[<a href="#parameterObject">Parameter Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:center">[<a href="#parameterObject">Parameter Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>A list of parameters that are applicable for this operation. If a parameter is already defined at the <a href="#pathItemParameters">Path Item</a>, the new definition will override it but can never remove it. The list MUST NOT include duplicated parameters. A unique parameter is defined by a combination of a <a href="#parameterName">name</a> and <a href="#parameterIn">location</a>. The list can use the <a href="#referenceObject">Reference Object</a> to link to parameters that are defined at the <a href="#componentsParameters">OpenAPI Object’s components/parameters</a>.</td>
 </tr>
 <tr>
 <td><a id="operationRequestBody"> </a>requestBody</td>
-<td style="text-align:center"><a href="#requestBodyObject">Request Body Object</a> ¦ <a href="#referenceObject">Reference Object</a></td>
+<td style="text-align:center"><a href="#requestBodyObject">Request Body Object</a> | <a href="#referenceObject">Reference Object</a></td>
 <td>The request body applicable for this operation.  The <code>requestBody</code> is only supported in HTTP methods where the HTTP 1.1 specification [[!RFC7231]] has explicitly defined semantics for request bodies.  In other cases where the HTTP spec is vague, <code>requestBody</code> SHALL be ignored by consumers.</td>
 </tr>
 <tr>
@@ -1033,7 +1033,7 @@ The path itself is still exposed to the documentation viewer but they will not k
 </tr>
 <tr>
 <td><a id="operationCallbacks"> </a>callbacks</td>
-<td style="text-align:center">Map[<code>string</code>, <a href="#callbackObject">Callback Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:center">Map[<code>string</code>, <a href="#callbackObject">Callback Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>A map of possible out-of band callbacks related to the parent operation. The key is a unique identifier for the Callback Object. Each value in the map is a <a href="#callbackObject">Callback Object</a> that describes a request that may be initiated by the API provider and the expected responses. The key value used to identify the callback object is an expression, evaluated at runtime, that identifies a URL to use for the callback operation.</td>
 </tr>
 <tr>
@@ -1057,63 +1057,63 @@ The path itself is still exposed to the documentation viewer but they will not k
 </section><section><h4>Operation Object Example</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"tags"</span>: [
-    <span class="hljs-string">"pet"</span>
+  <span class="hljs-attr">&quot;tags&quot;</span>: [
+    <span class="hljs-string">&quot;pet&quot;</span>
   ],
-  <span class="hljs-attr">"summary"</span>: <span class="hljs-string">"Updates a pet in the store with form data"</span>,
-  <span class="hljs-attr">"operationId"</span>: <span class="hljs-string">"updatePetWithForm"</span>,
-  <span class="hljs-attr">"parameters"</span>: [
+  <span class="hljs-attr">&quot;summary&quot;</span>: <span class="hljs-string">&quot;Updates a pet in the store with form data&quot;</span>,
+  <span class="hljs-attr">&quot;operationId&quot;</span>: <span class="hljs-string">&quot;updatePetWithForm&quot;</span>,
+  <span class="hljs-attr">&quot;parameters&quot;</span>: [
     {
-      <span class="hljs-attr">"name"</span>: <span class="hljs-string">"petId"</span>,
-      <span class="hljs-attr">"in"</span>: <span class="hljs-string">"path"</span>,
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"ID of pet that needs to be updated"</span>,
-      <span class="hljs-attr">"required"</span>: <span class="hljs-literal">true</span>,
-      <span class="hljs-attr">"schema"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+      <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;petId&quot;</span>,
+      <span class="hljs-attr">&quot;in&quot;</span>: <span class="hljs-string">&quot;path&quot;</span>,
+      <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;ID of pet that needs to be updated&quot;</span>,
+      <span class="hljs-attr">&quot;required&quot;</span>: <span class="hljs-literal">true</span>,
+      <span class="hljs-attr">&quot;schema&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
       }
     }
   ],
-  <span class="hljs-attr">"requestBody"</span>: {
-    <span class="hljs-attr">"content"</span>: {
-      <span class="hljs-attr">"application/x-www-form-urlencoded"</span>: {
-        <span class="hljs-attr">"schema"</span>: {
-          <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-           <span class="hljs-attr">"properties"</span>: {
-              <span class="hljs-attr">"name"</span>: { 
-                <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Updated name of the pet"</span>,
-                <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+  <span class="hljs-attr">&quot;requestBody&quot;</span>: {
+    <span class="hljs-attr">&quot;content&quot;</span>: {
+      <span class="hljs-attr">&quot;application/x-www-form-urlencoded&quot;</span>: {
+        <span class="hljs-attr">&quot;schema&quot;</span>: {
+          <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+           <span class="hljs-attr">&quot;properties&quot;</span>: {
+              <span class="hljs-attr">&quot;name&quot;</span>: { 
+                <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;Updated name of the pet&quot;</span>,
+                <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
               },
-              <span class="hljs-attr">"status"</span>: {
-                <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Updated status of the pet"</span>,
-                <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+              <span class="hljs-attr">&quot;status&quot;</span>: {
+                <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;Updated status of the pet&quot;</span>,
+                <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
              }
            },
-        <span class="hljs-attr">"required"</span>: [<span class="hljs-string">"status"</span>] 
+        <span class="hljs-attr">&quot;required&quot;</span>: [<span class="hljs-string">&quot;status&quot;</span>] 
         }
       }
     }
   },
-  <span class="hljs-attr">"responses"</span>: {
-    <span class="hljs-attr">"200"</span>: {
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Pet updated."</span>,
-      <span class="hljs-attr">"content"</span>: {
-        <span class="hljs-attr">"application/json"</span>: {},
-        <span class="hljs-attr">"application/xml"</span>: {}
+  <span class="hljs-attr">&quot;responses&quot;</span>: {
+    <span class="hljs-attr">&quot;200&quot;</span>: {
+      <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;Pet updated.&quot;</span>,
+      <span class="hljs-attr">&quot;content&quot;</span>: {
+        <span class="hljs-attr">&quot;application/json&quot;</span>: {},
+        <span class="hljs-attr">&quot;application/xml&quot;</span>: {}
       }
     },
-    <span class="hljs-attr">"405"</span>: {
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Invalid input"</span>,
-      <span class="hljs-attr">"content"</span>: {
-        <span class="hljs-attr">"application/json"</span>: {},
-        <span class="hljs-attr">"application/xml"</span>: {}
+    <span class="hljs-attr">&quot;405&quot;</span>: {
+      <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;Invalid input&quot;</span>,
+      <span class="hljs-attr">&quot;content&quot;</span>: {
+        <span class="hljs-attr">&quot;application/json&quot;</span>: {},
+        <span class="hljs-attr">&quot;application/xml&quot;</span>: {}
       }
     }
   },
-  <span class="hljs-attr">"security"</span>: [
+  <span class="hljs-attr">&quot;security&quot;</span>: [
     {
-      <span class="hljs-attr">"petstore_auth"</span>: [
-        <span class="hljs-string">"write:pets"</span>,
-        <span class="hljs-string">"read:pets"</span>
+      <span class="hljs-attr">&quot;petstore_auth&quot;</span>: [
+        <span class="hljs-string">&quot;write:pets&quot;</span>,
+        <span class="hljs-string">&quot;read:pets&quot;</span>
       ]
     }
   ]
@@ -1125,40 +1125,40 @@ The path itself is still exposed to the documentation viewer but they will not k
 <span class="hljs-attr">summary:</span> <span class="hljs-string">Updates</span> <span class="hljs-string">a</span> <span class="hljs-string">pet</span> <span class="hljs-string">in</span> <span class="hljs-string">the</span> <span class="hljs-string">store</span> <span class="hljs-string">with</span> <span class="hljs-string">form</span> <span class="hljs-string">data</span>
 <span class="hljs-attr">operationId:</span> <span class="hljs-string">updatePetWithForm</span>
 <span class="hljs-attr">parameters:</span>
-<span class="hljs-attr">- name:</span> <span class="hljs-string">petId</span>
-<span class="hljs-attr">  in:</span> <span class="hljs-string">path</span>
-<span class="hljs-attr">  description:</span> <span class="hljs-string">ID</span> <span class="hljs-string">of</span> <span class="hljs-string">pet</span> <span class="hljs-string">that</span> <span class="hljs-string">needs</span> <span class="hljs-string">to</span> <span class="hljs-string">be</span> <span class="hljs-string">updated</span>
-<span class="hljs-attr">  required:</span> <span class="hljs-literal">true</span>
-<span class="hljs-attr">  schema:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">string</span>
+<span class="hljs-bullet">-</span> <span class="hljs-attr">name:</span> <span class="hljs-string">petId</span>
+  <span class="hljs-attr">in:</span> <span class="hljs-string">path</span>
+  <span class="hljs-attr">description:</span> <span class="hljs-string">ID</span> <span class="hljs-string">of</span> <span class="hljs-string">pet</span> <span class="hljs-string">that</span> <span class="hljs-string">needs</span> <span class="hljs-string">to</span> <span class="hljs-string">be</span> <span class="hljs-string">updated</span>
+  <span class="hljs-attr">required:</span> <span class="hljs-literal">true</span>
+  <span class="hljs-attr">schema:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
 <span class="hljs-attr">requestBody:</span>
-<span class="hljs-attr">  content:</span>
-    <span class="hljs-string">'application/x-www-form-urlencoded'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">      schema:</span>
-<span class="hljs-attr">       properties:</span>
-<span class="hljs-attr">          name:</span> 
-<span class="hljs-attr">            description:</span> <span class="hljs-string">Updated</span> <span class="hljs-string">name</span> <span class="hljs-string">of</span> <span class="hljs-string">the</span> <span class="hljs-string">pet</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">          status:</span>
-<span class="hljs-attr">            description:</span> <span class="hljs-string">Updated</span> <span class="hljs-string">status</span> <span class="hljs-string">of</span> <span class="hljs-string">the</span> <span class="hljs-string">pet</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">       required:</span>
-<span class="hljs-bullet">         -</span> <span class="hljs-string">status</span>
+  <span class="hljs-attr">content:</span>
+    <span class="hljs-attr">&#x27;application/x-www-form-urlencoded&#x27;:</span>
+      <span class="hljs-attr">schema:</span>
+       <span class="hljs-attr">properties:</span>
+          <span class="hljs-attr">name:</span> 
+            <span class="hljs-attr">description:</span> <span class="hljs-string">Updated</span> <span class="hljs-string">name</span> <span class="hljs-string">of</span> <span class="hljs-string">the</span> <span class="hljs-string">pet</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+          <span class="hljs-attr">status:</span>
+            <span class="hljs-attr">description:</span> <span class="hljs-string">Updated</span> <span class="hljs-string">status</span> <span class="hljs-string">of</span> <span class="hljs-string">the</span> <span class="hljs-string">pet</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+       <span class="hljs-attr">required:</span>
+         <span class="hljs-bullet">-</span> <span class="hljs-string">status</span>
 <span class="hljs-attr">responses:</span>
-  <span class="hljs-string">'200'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">    description:</span> <span class="hljs-string">Pet</span> <span class="hljs-string">updated.</span>
-<span class="hljs-attr">    content:</span> 
-      <span class="hljs-string">'application/json'</span><span class="hljs-string">:</span> <span class="hljs-string">{}</span>
-      <span class="hljs-string">'application/xml'</span><span class="hljs-string">:</span> <span class="hljs-string">{}</span>
-  <span class="hljs-string">'405'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">    description:</span> <span class="hljs-string">Invalid</span> <span class="hljs-string">input</span>
-<span class="hljs-attr">    content:</span> 
-      <span class="hljs-string">'application/json'</span><span class="hljs-string">:</span> <span class="hljs-string">{}</span>
-      <span class="hljs-string">'application/xml'</span><span class="hljs-string">:</span> <span class="hljs-string">{}</span>
+  <span class="hljs-attr">&#x27;200&#x27;:</span>
+    <span class="hljs-attr">description:</span> <span class="hljs-string">Pet</span> <span class="hljs-string">updated.</span>
+    <span class="hljs-attr">content:</span> 
+      <span class="hljs-attr">&#x27;application/json&#x27;:</span> {}
+      <span class="hljs-attr">&#x27;application/xml&#x27;:</span> {}
+  <span class="hljs-attr">&#x27;405&#x27;:</span>
+    <span class="hljs-attr">description:</span> <span class="hljs-string">Invalid</span> <span class="hljs-string">input</span>
+    <span class="hljs-attr">content:</span> 
+      <span class="hljs-attr">&#x27;application/json&#x27;:</span> {}
+      <span class="hljs-attr">&#x27;application/xml&#x27;:</span> {}
 <span class="hljs-attr">security:</span>
-<span class="hljs-attr">- petstore_auth:</span>
-<span class="hljs-attr">  - write:</span><span class="hljs-string">pets</span>
-<span class="hljs-attr">  - read:</span><span class="hljs-string">pets</span>
+<span class="hljs-bullet">-</span> <span class="hljs-attr">petstore_auth:</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-string">write:pets</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-string">read:pets</span>
 </code></pre>
 </section></section><section><h3><span id="externalDocumentationObject">External Documentation Object</span></h3>
 <p>Allows referencing an external resource for extended documentation.</p>
@@ -1188,13 +1188,13 @@ The path itself is still exposed to the documentation viewer but they will not k
 </section><section><h4>External Documentation Object Example</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Find more info here"</span>,
-  <span class="hljs-attr">"url"</span>: <span class="hljs-string">"https://example.com"</span>
+  <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;Find more info here&quot;</span>,
+  <span class="hljs-attr">&quot;url&quot;</span>: <span class="hljs-string">&quot;https://example.com&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">description:</span> <span class="hljs-string">Find</span> <span class="hljs-string">more</span> <span class="hljs-string">info</span> <span class="hljs-string">here</span>
-<span class="hljs-attr">url:</span> <span class="hljs-attr">https://example.com</span>
+<span class="hljs-attr">url:</span> <span class="hljs-string">https://example.com</span>
 </code></pre>
 </section></section><section><h3><span id="parameterObject">Parameter Object</span></h3>
 <p>Describes a single operation parameter.</p>
@@ -1277,7 +1277,7 @@ For simpler scenarios, a <a href="#parameterSchema"><code>schema</code></a> and 
 </tr>
 <tr>
 <td><a id="parameterSchema"> </a>schema</td>
-<td style="text-align:center"><a href="#schemaObject">Schema Object</a> ¦ <a href="#referenceObject">Reference Object</a></td>
+<td style="text-align:center"><a href="#schemaObject">Schema Object</a> | <a href="#referenceObject">Reference Object</a></td>
 <td>The schema defining the type used for the parameter.</td>
 </tr>
 <tr>
@@ -1287,7 +1287,7 @@ For simpler scenarios, a <a href="#parameterSchema"><code>schema</code></a> and 
 </tr>
 <tr>
 <td><a id="parameterExamples"> </a>examples</td>
-<td style="text-align:center">Map[ <code>string</code>, <a href="#exampleObject">Example Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:center">Map[ <code>string</code>, <a href="#exampleObject">Example Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>Examples of the media type.  Each example SHOULD contain a value in the correct format as specified in the parameter encoding.  The <code>examples</code> object is mutually exclusive of the <code>example</code> object.  Furthermore, if referencing a <code>schema</code> which contains an example, the <code>examples</code> value SHALL <em>override</em> the example provided by the schema.</td>
 </tr>
 </tbody>
@@ -1464,8 +1464,8 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 <td>false</td>
 <td>n/a</td>
 <td>n/a</td>
-<td>blue¦black¦brown</td>
-<td>R¦100¦G¦200</td>
+<td>blue|black|brown</td>
+<td>R|100|G|200</td>
 </tr>
 <tr>
 <td>deepObject</td>
@@ -1473,7 +1473,7 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 <td>n/a</td>
 <td>n/a</td>
 <td>n/a</td>
-<td>color\R=100&amp;color\G=200&amp;color\B=150</td>
+<td>color&#91;R&#93;=100&amp;color&#91;G&#93;=200&amp;color&#91;B&#93;=150</td>
 </tr>
 </tbody>
 </table>
@@ -1482,18 +1482,18 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 <p>A header parameter with an array of 64 bit integer numbers:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"name"</span>: <span class="hljs-string">"token"</span>,
-  <span class="hljs-attr">"in"</span>: <span class="hljs-string">"header"</span>,
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"token to be passed as a header"</span>,
-  <span class="hljs-attr">"required"</span>: <span class="hljs-literal">true</span>,
-  <span class="hljs-attr">"schema"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-    <span class="hljs-attr">"items"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>,
-      <span class="hljs-attr">"format"</span>: <span class="hljs-string">"int64"</span>
+  <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;token&quot;</span>,
+  <span class="hljs-attr">&quot;in&quot;</span>: <span class="hljs-string">&quot;header&quot;</span>,
+  <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;token to be passed as a header&quot;</span>,
+  <span class="hljs-attr">&quot;required&quot;</span>: <span class="hljs-literal">true</span>,
+  <span class="hljs-attr">&quot;schema&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+    <span class="hljs-attr">&quot;items&quot;</span>: {
+      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>,
+      <span class="hljs-attr">&quot;format&quot;</span>: <span class="hljs-string">&quot;int64&quot;</span>
     }
   },
-  <span class="hljs-attr">"style"</span>: <span class="hljs-string">"simple"</span>
+  <span class="hljs-attr">&quot;style&quot;</span>: <span class="hljs-string">&quot;simple&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -1502,21 +1502,21 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 <span class="hljs-attr">description:</span> <span class="hljs-string">token</span> <span class="hljs-string">to</span> <span class="hljs-string">be</span> <span class="hljs-string">passed</span> <span class="hljs-string">as</span> <span class="hljs-string">a</span> <span class="hljs-string">header</span>
 <span class="hljs-attr">required:</span> <span class="hljs-literal">true</span>
 <span class="hljs-attr">schema:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">  items:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">integer</span>
-<span class="hljs-attr">    format:</span> <span class="hljs-string">int64</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+  <span class="hljs-attr">items:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+    <span class="hljs-attr">format:</span> <span class="hljs-string">int64</span>
 <span class="hljs-attr">style:</span> <span class="hljs-string">simple</span>
 </code></pre>
 <p>A path parameter of a string value:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"name"</span>: <span class="hljs-string">"username"</span>,
-  <span class="hljs-attr">"in"</span>: <span class="hljs-string">"path"</span>,
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"username to fetch"</span>,
-  <span class="hljs-attr">"required"</span>: <span class="hljs-literal">true</span>,
-  <span class="hljs-attr">"schema"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+  <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;username&quot;</span>,
+  <span class="hljs-attr">&quot;in&quot;</span>: <span class="hljs-string">&quot;path&quot;</span>,
+  <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;username to fetch&quot;</span>,
+  <span class="hljs-attr">&quot;required&quot;</span>: <span class="hljs-literal">true</span>,
+  <span class="hljs-attr">&quot;schema&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
   }
 }
 </code></pre>
@@ -1526,23 +1526,23 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 <span class="hljs-attr">description:</span> <span class="hljs-string">username</span> <span class="hljs-string">to</span> <span class="hljs-string">fetch</span>
 <span class="hljs-attr">required:</span> <span class="hljs-literal">true</span>
 <span class="hljs-attr">schema:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
 </code></pre>
 <p>An optional query parameter of a string value, allowing multiple values by repeating the query parameter:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"name"</span>: <span class="hljs-string">"id"</span>,
-  <span class="hljs-attr">"in"</span>: <span class="hljs-string">"query"</span>,
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"ID of the object to fetch"</span>,
-  <span class="hljs-attr">"required"</span>: <span class="hljs-literal">false</span>,
-  <span class="hljs-attr">"schema"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-    <span class="hljs-attr">"items"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+  <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;id&quot;</span>,
+  <span class="hljs-attr">&quot;in&quot;</span>: <span class="hljs-string">&quot;query&quot;</span>,
+  <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;ID of the object to fetch&quot;</span>,
+  <span class="hljs-attr">&quot;required&quot;</span>: <span class="hljs-literal">false</span>,
+  <span class="hljs-attr">&quot;schema&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+    <span class="hljs-attr">&quot;items&quot;</span>: {
+      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
     }
   },
-  <span class="hljs-attr">"style"</span>: <span class="hljs-string">"form"</span>,
-  <span class="hljs-attr">"explode"</span>: <span class="hljs-literal">true</span>
+  <span class="hljs-attr">&quot;style&quot;</span>: <span class="hljs-string">&quot;form&quot;</span>,
+  <span class="hljs-attr">&quot;explode&quot;</span>: <span class="hljs-literal">true</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -1551,54 +1551,54 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 <span class="hljs-attr">description:</span> <span class="hljs-string">ID</span> <span class="hljs-string">of</span> <span class="hljs-string">the</span> <span class="hljs-string">object</span> <span class="hljs-string">to</span> <span class="hljs-string">fetch</span>
 <span class="hljs-attr">required:</span> <span class="hljs-literal">false</span>
 <span class="hljs-attr">schema:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">  items:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+  <span class="hljs-attr">items:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
 <span class="hljs-attr">style:</span> <span class="hljs-string">form</span>
 <span class="hljs-attr">explode:</span> <span class="hljs-literal">true</span>
 </code></pre>
 <p>A free-form query parameter, allowing undefined parameters of a specific type:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"in"</span>: <span class="hljs-string">"query"</span>,
-  <span class="hljs-attr">"name"</span>: <span class="hljs-string">"freeForm"</span>,
-  <span class="hljs-attr">"schema"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-    <span class="hljs-attr">"additionalProperties"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>
+  <span class="hljs-attr">&quot;in&quot;</span>: <span class="hljs-string">&quot;query&quot;</span>,
+  <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;freeForm&quot;</span>,
+  <span class="hljs-attr">&quot;schema&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+    <span class="hljs-attr">&quot;additionalProperties&quot;</span>: {
+      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>
     },
   },
-  <span class="hljs-attr">"style"</span>: <span class="hljs-string">"form"</span>
+  <span class="hljs-attr">&quot;style&quot;</span>: <span class="hljs-string">&quot;form&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">in:</span> <span class="hljs-string">query</span>
 <span class="hljs-attr">name:</span> <span class="hljs-string">freeForm</span>
 <span class="hljs-attr">schema:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">  additionalProperties:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">integer</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+  <span class="hljs-attr">additionalProperties:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
 <span class="hljs-attr">style:</span> <span class="hljs-string">form</span>
 </code></pre>
 <p>A complex parameter using <code>content</code> to define serialization:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"in"</span>: <span class="hljs-string">"query"</span>,
-  <span class="hljs-attr">"name"</span>: <span class="hljs-string">"coordinates"</span>,
-  <span class="hljs-attr">"content"</span>: {
-    <span class="hljs-attr">"application/json"</span>: {
-      <span class="hljs-attr">"schema"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-        <span class="hljs-attr">"required"</span>: [
-          <span class="hljs-string">"lat"</span>,
-          <span class="hljs-string">"long"</span>
+  <span class="hljs-attr">&quot;in&quot;</span>: <span class="hljs-string">&quot;query&quot;</span>,
+  <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;coordinates&quot;</span>,
+  <span class="hljs-attr">&quot;content&quot;</span>: {
+    <span class="hljs-attr">&quot;application/json&quot;</span>: {
+      <span class="hljs-attr">&quot;schema&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+        <span class="hljs-attr">&quot;required&quot;</span>: [
+          <span class="hljs-string">&quot;lat&quot;</span>,
+          <span class="hljs-string">&quot;long&quot;</span>
         ],
-        <span class="hljs-attr">"properties"</span>: {
-          <span class="hljs-attr">"lat"</span>: {
-            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"number"</span>
+        <span class="hljs-attr">&quot;properties&quot;</span>: {
+          <span class="hljs-attr">&quot;lat&quot;</span>: {
+            <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;number&quot;</span>
           },
-          <span class="hljs-attr">"long"</span>: {
-            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"number"</span>
+          <span class="hljs-attr">&quot;long&quot;</span>: {
+            <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;number&quot;</span>
           }
         }
       }
@@ -1610,17 +1610,17 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 <span class="hljs-attr">in:</span> <span class="hljs-string">query</span>
 <span class="hljs-attr">name:</span> <span class="hljs-string">coordinates</span>
 <span class="hljs-attr">content:</span>
-  <span class="hljs-string">application/json:</span>
-<span class="hljs-attr">    schema:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">      required:</span>
-<span class="hljs-bullet">        -</span> <span class="hljs-string">lat</span>
-<span class="hljs-bullet">        -</span> <span class="hljs-string">long</span>
-<span class="hljs-attr">      properties:</span>
-<span class="hljs-attr">        lat:</span>
-<span class="hljs-attr">          type:</span> <span class="hljs-string">number</span>
-<span class="hljs-attr">        long:</span>
-<span class="hljs-attr">          type:</span> <span class="hljs-string">number</span>
+  <span class="hljs-attr">application/json:</span>
+    <span class="hljs-attr">schema:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+      <span class="hljs-attr">required:</span>
+        <span class="hljs-bullet">-</span> <span class="hljs-string">lat</span>
+        <span class="hljs-bullet">-</span> <span class="hljs-string">long</span>
+      <span class="hljs-attr">properties:</span>
+        <span class="hljs-attr">lat:</span>
+          <span class="hljs-attr">type:</span> <span class="hljs-string">number</span>
+        <span class="hljs-attr">long:</span>
+          <span class="hljs-attr">type:</span> <span class="hljs-string">number</span>
 </code></pre>
 </section></section><section><h3><span id="requestBodyObject">Request Body Object</span></h3>
 <p>Describes a single request body.</p>
@@ -1656,43 +1656,43 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 <p>A request body with a referenced model definition.</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"user to add to the system"</span>,
-  <span class="hljs-attr">"content"</span>: {
-    <span class="hljs-attr">"application/json"</span>: {
-      <span class="hljs-attr">"schema"</span>: {
-        <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/User"</span>
+  <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;user to add to the system&quot;</span>,
+  <span class="hljs-attr">&quot;content&quot;</span>: {
+    <span class="hljs-attr">&quot;application/json&quot;</span>: {
+      <span class="hljs-attr">&quot;schema&quot;</span>: {
+        <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/User&quot;</span>
       },
-      <span class="hljs-attr">"examples"</span>: {
-          <span class="hljs-attr">"user"</span> : {
-            <span class="hljs-attr">"summary"</span>: <span class="hljs-string">"User Example"</span>, 
-            <span class="hljs-attr">"externalValue"</span>: <span class="hljs-string">"http://foo.bar/examples/user-example.json"</span>
+      <span class="hljs-attr">&quot;examples&quot;</span>: {
+          <span class="hljs-attr">&quot;user&quot;</span> : {
+            <span class="hljs-attr">&quot;summary&quot;</span>: <span class="hljs-string">&quot;User Example&quot;</span>, 
+            <span class="hljs-attr">&quot;externalValue&quot;</span>: <span class="hljs-string">&quot;http://foo.bar/examples/user-example.json&quot;</span>
           } 
         }
     },
-    <span class="hljs-attr">"application/xml"</span>: {
-      <span class="hljs-attr">"schema"</span>: {
-        <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/User"</span>
+    <span class="hljs-attr">&quot;application/xml&quot;</span>: {
+      <span class="hljs-attr">&quot;schema&quot;</span>: {
+        <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/User&quot;</span>
       },
-      <span class="hljs-attr">"examples"</span>: {
-          <span class="hljs-attr">"user"</span> : {
-            <span class="hljs-attr">"summary"</span>: <span class="hljs-string">"User example in XML"</span>,
-            <span class="hljs-attr">"externalValue"</span>: <span class="hljs-string">"http://foo.bar/examples/user-example.xml"</span>
+      <span class="hljs-attr">&quot;examples&quot;</span>: {
+          <span class="hljs-attr">&quot;user&quot;</span> : {
+            <span class="hljs-attr">&quot;summary&quot;</span>: <span class="hljs-string">&quot;User example in XML&quot;</span>,
+            <span class="hljs-attr">&quot;externalValue&quot;</span>: <span class="hljs-string">&quot;http://foo.bar/examples/user-example.xml&quot;</span>
           }
         }
     },
-    <span class="hljs-attr">"text/plain"</span>: {
-      <span class="hljs-attr">"examples"</span>: {
-        <span class="hljs-attr">"user"</span> : {
-            <span class="hljs-attr">"summary"</span>: <span class="hljs-string">"User example in Plain text"</span>,
-            <span class="hljs-attr">"externalValue"</span>: <span class="hljs-string">"http://foo.bar/examples/user-example.txt"</span> 
+    <span class="hljs-attr">&quot;text/plain&quot;</span>: {
+      <span class="hljs-attr">&quot;examples&quot;</span>: {
+        <span class="hljs-attr">&quot;user&quot;</span> : {
+            <span class="hljs-attr">&quot;summary&quot;</span>: <span class="hljs-string">&quot;User example in Plain text&quot;</span>,
+            <span class="hljs-attr">&quot;externalValue&quot;</span>: <span class="hljs-string">&quot;http://foo.bar/examples/user-example.txt&quot;</span> 
         }
       } 
     },
-    <span class="hljs-attr">"*/*"</span>: {
-      <span class="hljs-attr">"examples"</span>: {
-        <span class="hljs-attr">"user"</span> : {
-            <span class="hljs-attr">"summary"</span>: <span class="hljs-string">"User example in other format"</span>,
-            <span class="hljs-attr">"externalValue"</span>: <span class="hljs-string">"http://foo.bar/examples/user-example.whatever"</span>
+    <span class="hljs-attr">&quot;*/*&quot;</span>: {
+      <span class="hljs-attr">&quot;examples&quot;</span>: {
+        <span class="hljs-attr">&quot;user&quot;</span> : {
+            <span class="hljs-attr">&quot;summary&quot;</span>: <span class="hljs-string">&quot;User example in other format&quot;</span>,
+            <span class="hljs-attr">&quot;externalValue&quot;</span>: <span class="hljs-string">&quot;http://foo.bar/examples/user-example.whatever&quot;</span>
         }
       }
     }
@@ -1702,41 +1702,41 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 <pre class="nohighlight"><code>
 <span class="hljs-attr">description:</span> <span class="hljs-string">user</span> <span class="hljs-string">to</span> <span class="hljs-string">add</span> <span class="hljs-string">to</span> <span class="hljs-string">the</span> <span class="hljs-string">system</span>
 <span class="hljs-attr">content:</span> 
-  <span class="hljs-string">'application/json'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">    schema:</span>
-      <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/User'</span>
-<span class="hljs-attr">    examples:</span>
-<span class="hljs-attr">      user:</span>
-<span class="hljs-attr">        summary:</span> <span class="hljs-string">User</span> <span class="hljs-string">Example</span>
-<span class="hljs-attr">        externalValue:</span> <span class="hljs-string">'http://foo.bar/examples/user-example.json'</span>
-  <span class="hljs-string">'application/xml'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">    schema:</span>
-      <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/User'</span>
-<span class="hljs-attr">    examples:</span>
-<span class="hljs-attr">      user:</span>
-<span class="hljs-attr">        summary:</span> <span class="hljs-string">User</span> <span class="hljs-string">Example</span> <span class="hljs-string">in</span> <span class="hljs-string">XML</span>
-<span class="hljs-attr">        externalValue:</span> <span class="hljs-string">'http://foo.bar/examples/user-example.xml'</span>
-  <span class="hljs-string">'text/plain'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">    examples:</span>
-<span class="hljs-attr">      user:</span>
-<span class="hljs-attr">        summary:</span> <span class="hljs-string">User</span> <span class="hljs-string">example</span> <span class="hljs-string">in</span> <span class="hljs-string">text</span> <span class="hljs-string">plain</span> <span class="hljs-string">format</span>
-<span class="hljs-attr">        externalValue:</span> <span class="hljs-string">'http://foo.bar/examples/user-example.txt'</span>
-  <span class="hljs-string">'*/*'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">    examples:</span>
-<span class="hljs-attr">      user:</span> 
-<span class="hljs-attr">        summary:</span> <span class="hljs-string">User</span> <span class="hljs-string">example</span> <span class="hljs-string">in</span> <span class="hljs-string">other</span> <span class="hljs-string">format</span>
-<span class="hljs-attr">        externalValue:</span> <span class="hljs-string">'http://foo.bar/examples/user-example.whatever'</span>
+  <span class="hljs-attr">&#x27;application/json&#x27;:</span>
+    <span class="hljs-attr">schema:</span>
+      <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/User&#x27;</span>
+    <span class="hljs-attr">examples:</span>
+      <span class="hljs-attr">user:</span>
+        <span class="hljs-attr">summary:</span> <span class="hljs-string">User</span> <span class="hljs-string">Example</span>
+        <span class="hljs-attr">externalValue:</span> <span class="hljs-string">&#x27;http://foo.bar/examples/user-example.json&#x27;</span>
+  <span class="hljs-attr">&#x27;application/xml&#x27;:</span>
+    <span class="hljs-attr">schema:</span>
+      <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/User&#x27;</span>
+    <span class="hljs-attr">examples:</span>
+      <span class="hljs-attr">user:</span>
+        <span class="hljs-attr">summary:</span> <span class="hljs-string">User</span> <span class="hljs-string">Example</span> <span class="hljs-string">in</span> <span class="hljs-string">XML</span>
+        <span class="hljs-attr">externalValue:</span> <span class="hljs-string">&#x27;http://foo.bar/examples/user-example.xml&#x27;</span>
+  <span class="hljs-attr">&#x27;text/plain&#x27;:</span>
+    <span class="hljs-attr">examples:</span>
+      <span class="hljs-attr">user:</span>
+        <span class="hljs-attr">summary:</span> <span class="hljs-string">User</span> <span class="hljs-string">example</span> <span class="hljs-string">in</span> <span class="hljs-string">text</span> <span class="hljs-string">plain</span> <span class="hljs-string">format</span>
+        <span class="hljs-attr">externalValue:</span> <span class="hljs-string">&#x27;http://foo.bar/examples/user-example.txt&#x27;</span>
+  <span class="hljs-string">&#x27;*/*&#x27;</span><span class="hljs-string">:</span>
+    <span class="hljs-attr">examples:</span>
+      <span class="hljs-attr">user:</span> 
+        <span class="hljs-attr">summary:</span> <span class="hljs-string">User</span> <span class="hljs-string">example</span> <span class="hljs-string">in</span> <span class="hljs-string">other</span> <span class="hljs-string">format</span>
+        <span class="hljs-attr">externalValue:</span> <span class="hljs-string">&#x27;http://foo.bar/examples/user-example.whatever&#x27;</span>
 </code></pre>
 <p>A body parameter that is an array of string values:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"user to add to the system"</span>,
-  <span class="hljs-attr">"content"</span>: {
-    <span class="hljs-attr">"text/plain"</span>: {
-      <span class="hljs-attr">"schema"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-        <span class="hljs-attr">"items"</span>: {
-          <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+  <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;user to add to the system&quot;</span>,
+  <span class="hljs-attr">&quot;content&quot;</span>: {
+    <span class="hljs-attr">&quot;text/plain&quot;</span>: {
+      <span class="hljs-attr">&quot;schema&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+        <span class="hljs-attr">&quot;items&quot;</span>: {
+          <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
         }
       }
     }
@@ -1747,11 +1747,11 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 <span class="hljs-attr">description:</span> <span class="hljs-string">user</span> <span class="hljs-string">to</span> <span class="hljs-string">add</span> <span class="hljs-string">to</span> <span class="hljs-string">the</span> <span class="hljs-string">system</span>
 <span class="hljs-attr">required:</span> <span class="hljs-literal">true</span>
 <span class="hljs-attr">content:</span>
-  <span class="hljs-string">text/plain:</span>
-<span class="hljs-attr">    schema:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">      items:</span>
-<span class="hljs-attr">        type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">text/plain:</span>
+    <span class="hljs-attr">schema:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+      <span class="hljs-attr">items:</span>
+        <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
 </code></pre>
 </section></section><section><h3><span id="mediaTypeObject">Media Type Object</span></h3>
 <p>Each Media Type Object provides schema and examples for the media type identified by its key.</p>
@@ -1767,7 +1767,7 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 <tbody>
 <tr>
 <td><a id="mediaTypeSchema"> </a>schema</td>
-<td style="text-align:center"><a href="#schemaObject">Schema Object</a> ¦ <a href="#referenceObject">Reference Object</a></td>
+<td style="text-align:center"><a href="#schemaObject">Schema Object</a> | <a href="#referenceObject">Reference Object</a></td>
 <td>The schema defining the type used for the request body.</td>
 </tr>
 <tr>
@@ -1777,7 +1777,7 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 </tr>
 <tr>
 <td><a id="mediaTypeExamples"> </a>examples</td>
-<td style="text-align:center">Map[ <code>string</code>, <a href="#exampleObject">Example Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:center">Map[ <code>string</code>, <a href="#exampleObject">Example Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>Examples of the media type.  Each example object SHOULD  match the media type and specified schema if present.  The <code>examples</code> object is mutually exclusive of the <code>example</code> object.  Furthermore, if referencing a <code>schema</code> which contains an example, the <code>examples</code> value SHALL <em>override</em> the example provided by the schema.</td>
 </tr>
 <tr>
@@ -1791,33 +1791,33 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 </section><section><h4>Media Type Examples</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-string">"application/json"</span>: {
-    <span class="hljs-string">"schema"</span>: {
-         <span class="hljs-string">"$ref"</span>: <span class="hljs-string">"#/components/schemas/Pet"</span>
+  <span class="hljs-string">&quot;application/json&quot;</span>: {
+    <span class="hljs-string">&quot;schema&quot;</span>: {
+         <span class="hljs-string">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/Pet&quot;</span>
     },
-    <span class="hljs-string">"examples"</span>: {
-      <span class="hljs-string">"cat"</span> : {
-        <span class="hljs-string">"summary"</span>: <span class="hljs-string">"An example of a cat"</span>,
-        <span class="hljs-string">"value"</span>: 
+    <span class="hljs-string">&quot;examples&quot;</span>: {
+      <span class="hljs-string">&quot;cat&quot;</span> : {
+        <span class="hljs-string">&quot;summary&quot;</span>: <span class="hljs-string">&quot;An example of a cat&quot;</span>,
+        <span class="hljs-string">&quot;value&quot;</span>: 
           {
-            <span class="hljs-string">"name"</span>: <span class="hljs-string">"Fluffy"</span>,
-            <span class="hljs-string">"petType"</span>: <span class="hljs-string">"Cat"</span>,
-            <span class="hljs-string">"color"</span>: <span class="hljs-string">"White"</span>,
-            <span class="hljs-string">"gender"</span>: <span class="hljs-string">"male"</span>,
-            <span class="hljs-string">"breed"</span>: <span class="hljs-string">"Persian"</span>
+            <span class="hljs-string">&quot;name&quot;</span>: <span class="hljs-string">&quot;Fluffy&quot;</span>,
+            <span class="hljs-string">&quot;petType&quot;</span>: <span class="hljs-string">&quot;Cat&quot;</span>,
+            <span class="hljs-string">&quot;color&quot;</span>: <span class="hljs-string">&quot;White&quot;</span>,
+            <span class="hljs-string">&quot;gender&quot;</span>: <span class="hljs-string">&quot;male&quot;</span>,
+            <span class="hljs-string">&quot;breed&quot;</span>: <span class="hljs-string">&quot;Persian&quot;</span>
           }
       },
-      <span class="hljs-string">"dog"</span>: {
-        <span class="hljs-string">"summary"</span>: <span class="hljs-string">"An example of a dog with a cat's name"</span>,
-        <span class="hljs-string">"value"</span> :  { 
-          <span class="hljs-string">"name"</span>: <span class="hljs-string">"Puma"</span>,
-          <span class="hljs-string">"petType"</span>: <span class="hljs-string">"Dog"</span>,
-          <span class="hljs-string">"color"</span>: <span class="hljs-string">"Black"</span>,
-          <span class="hljs-string">"gender"</span>: <span class="hljs-string">"Female"</span>,
-          <span class="hljs-string">"breed"</span>: <span class="hljs-string">"Mixed"</span>
+      <span class="hljs-string">&quot;dog&quot;</span>: {
+        <span class="hljs-string">&quot;summary&quot;</span>: <span class="hljs-string">&quot;An example of a dog with a cat&#x27;s name&quot;</span>,
+        <span class="hljs-string">&quot;value&quot;</span> :  { 
+          <span class="hljs-string">&quot;name&quot;</span>: <span class="hljs-string">&quot;Puma&quot;</span>,
+          <span class="hljs-string">&quot;petType&quot;</span>: <span class="hljs-string">&quot;Dog&quot;</span>,
+          <span class="hljs-string">&quot;color&quot;</span>: <span class="hljs-string">&quot;Black&quot;</span>,
+          <span class="hljs-string">&quot;gender&quot;</span>: <span class="hljs-string">&quot;Female&quot;</span>,
+          <span class="hljs-string">&quot;breed&quot;</span>: <span class="hljs-string">&quot;Mixed&quot;</span>
         },
-      <span class="hljs-string">"frog"</span>: {
-          <span class="hljs-string">"$ref"</span>: <span class="hljs-string">"#/components/examples/frog-example"</span>
+      <span class="hljs-string">&quot;frog&quot;</span>: {
+          <span class="hljs-string">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/examples/frog-example&quot;</span>
         }
       }
     }
@@ -1825,83 +1825,83 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 }
 </code></pre>
 <pre class="nohighlight"><code>
-<span class="hljs-string">application/json:</span> 
-<span class="hljs-attr">  schema:</span>
-    <span class="hljs-string">$ref:</span> <span class="hljs-string">"#/components/schemas/Pet"</span>
-<span class="hljs-attr">  examples:</span>
-<span class="hljs-attr">    cat:</span>
-<span class="hljs-attr">      summary:</span> <span class="hljs-string">An</span> <span class="hljs-string">example</span> <span class="hljs-string">of</span> <span class="hljs-string">a</span> <span class="hljs-string">cat</span>
-<span class="hljs-attr">      value:</span>
-<span class="hljs-attr">        name:</span> <span class="hljs-string">Fluffy</span>
-<span class="hljs-attr">        petType:</span> <span class="hljs-string">Cat</span>
-<span class="hljs-attr">        color:</span> <span class="hljs-string">White</span>
-<span class="hljs-attr">        gender:</span> <span class="hljs-string">male</span>
-<span class="hljs-attr">        breed:</span> <span class="hljs-string">Persian</span>
-<span class="hljs-attr">    dog:</span>
-<span class="hljs-attr">      summary:</span> <span class="hljs-string">An</span> <span class="hljs-string">example</span> <span class="hljs-string">of</span> <span class="hljs-string">a</span> <span class="hljs-string">dog</span> <span class="hljs-string">with</span> <span class="hljs-string">a</span> <span class="hljs-string">cat's</span> <span class="hljs-string">name</span>
-<span class="hljs-attr">      value:</span>
-<span class="hljs-attr">        name:</span> <span class="hljs-string">Puma</span>
-<span class="hljs-attr">        petType:</span> <span class="hljs-string">Dog</span>
-<span class="hljs-attr">        color:</span> <span class="hljs-string">Black</span>
-<span class="hljs-attr">        gender:</span> <span class="hljs-string">Female</span>
-<span class="hljs-attr">        breed:</span> <span class="hljs-string">Mixed</span>
-<span class="hljs-attr">    frog:</span>
-      <span class="hljs-string">$ref:</span> <span class="hljs-string">"#/components/examples/frog-example"</span>
+<span class="hljs-attr">application/json:</span> 
+  <span class="hljs-attr">schema:</span>
+    <span class="hljs-string">$ref:</span> <span class="hljs-string">&quot;#/components/schemas/Pet&quot;</span>
+  <span class="hljs-attr">examples:</span>
+    <span class="hljs-attr">cat:</span>
+      <span class="hljs-attr">summary:</span> <span class="hljs-string">An</span> <span class="hljs-string">example</span> <span class="hljs-string">of</span> <span class="hljs-string">a</span> <span class="hljs-string">cat</span>
+      <span class="hljs-attr">value:</span>
+        <span class="hljs-attr">name:</span> <span class="hljs-string">Fluffy</span>
+        <span class="hljs-attr">petType:</span> <span class="hljs-string">Cat</span>
+        <span class="hljs-attr">color:</span> <span class="hljs-string">White</span>
+        <span class="hljs-attr">gender:</span> <span class="hljs-string">male</span>
+        <span class="hljs-attr">breed:</span> <span class="hljs-string">Persian</span>
+    <span class="hljs-attr">dog:</span>
+      <span class="hljs-attr">summary:</span> <span class="hljs-string">An</span> <span class="hljs-string">example</span> <span class="hljs-string">of</span> <span class="hljs-string">a</span> <span class="hljs-string">dog</span> <span class="hljs-string">with</span> <span class="hljs-string">a</span> <span class="hljs-string">cat&#x27;s</span> <span class="hljs-string">name</span>
+      <span class="hljs-attr">value:</span>
+        <span class="hljs-attr">name:</span> <span class="hljs-string">Puma</span>
+        <span class="hljs-attr">petType:</span> <span class="hljs-string">Dog</span>
+        <span class="hljs-attr">color:</span> <span class="hljs-string">Black</span>
+        <span class="hljs-attr">gender:</span> <span class="hljs-string">Female</span>
+        <span class="hljs-attr">breed:</span> <span class="hljs-string">Mixed</span>
+    <span class="hljs-attr">frog:</span>
+      <span class="hljs-string">$ref:</span> <span class="hljs-string">&quot;#/components/examples/frog-example&quot;</span>
 </code></pre>
 </section><section><h4>Considerations for File Uploads</h4>
 <p>In contrast with the 2.0 specification, <code>file</code> input/output content in OpenAPI is described with the same semantics as any other schema type. Specifically:</p>
 <pre class="nohighlight"><code>
 <span class="hljs-comment"># content transferred with base64 encoding</span>
 <span class="hljs-attr">schema:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">  format:</span> <span class="hljs-string">base64</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">format:</span> <span class="hljs-string">base64</span>
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-comment"># content transferred in binary (octet-stream):</span>
 <span class="hljs-attr">schema:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">  format:</span> <span class="hljs-string">binary</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">format:</span> <span class="hljs-string">binary</span>
 </code></pre>
 <p>These examples apply to either input payloads of file uploads or response payloads.</p>
 <p>A <code>requestBody</code> for submitting a file in a <code>POST</code> operation may look like the following example:</p>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">requestBody:</span>
-<span class="hljs-attr">  content:</span>
-    <span class="hljs-string">application/octet-stream:</span>
+  <span class="hljs-attr">content:</span>
+    <span class="hljs-attr">application/octet-stream:</span>
       <span class="hljs-comment"># any media type is accepted, functionally equivalent to `*/*`</span>
-<span class="hljs-attr">      schema:</span>
+      <span class="hljs-attr">schema:</span>
         <span class="hljs-comment"># a binary file of any type</span>
-<span class="hljs-attr">        type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">        format:</span> <span class="hljs-string">binary</span>
+        <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+        <span class="hljs-attr">format:</span> <span class="hljs-string">binary</span>
 </code></pre>
 <p>In addition, specific media types MAY be specified:</p>
 <pre class="nohighlight"><code>
 <span class="hljs-comment"># multiple, specific media types may be specified:</span>
 <span class="hljs-attr">requestBody:</span>
-<span class="hljs-attr">  content:</span>
+  <span class="hljs-attr">content:</span>
       <span class="hljs-comment"># a binary file of type png or jpeg</span>
-    <span class="hljs-string">'image/jpeg'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">      schema:</span>
-<span class="hljs-attr">        type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">        format:</span> <span class="hljs-string">binary</span>
-    <span class="hljs-string">'image/png'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">      schema:</span>
-<span class="hljs-attr">        type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">        format:</span> <span class="hljs-string">binary</span>        
+    <span class="hljs-attr">&#x27;image/jpeg&#x27;:</span>
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+        <span class="hljs-attr">format:</span> <span class="hljs-string">binary</span>
+    <span class="hljs-attr">&#x27;image/png&#x27;:</span>
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+        <span class="hljs-attr">format:</span> <span class="hljs-string">binary</span>        
 </code></pre>
 <p>To upload multiple files, a <code>multipart</code> media type MUST be used:</p>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">requestBody:</span>
-<span class="hljs-attr">  content:</span>
-    <span class="hljs-string">multipart/form-data:</span>
-<span class="hljs-attr">      schema:</span>
-<span class="hljs-attr">        properties:</span>
-          <span class="hljs-comment"># The property name 'file' will be used for all files.</span>
-<span class="hljs-attr">          file:</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">            items:</span>
-<span class="hljs-attr">              type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">              format:</span> <span class="hljs-string">binary</span>
+  <span class="hljs-attr">content:</span>
+    <span class="hljs-attr">multipart/form-data:</span>
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-attr">properties:</span>
+          <span class="hljs-comment"># The property name &#x27;file&#x27; will be used for all files.</span>
+          <span class="hljs-attr">file:</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+            <span class="hljs-attr">items:</span>
+              <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+              <span class="hljs-attr">format:</span> <span class="hljs-string">binary</span>
 
 </code></pre>
 </section><section><h4>Support for x-www-form-urlencoded Request Bodies</h4>
@@ -1909,21 +1909,21 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 definition may be used:</p>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">requestBody:</span>
-<span class="hljs-attr">  content:</span>
-    <span class="hljs-string">application/x-www-form-urlencoded:</span>
-<span class="hljs-attr">      schema:</span>
-<span class="hljs-attr">        type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">        properties:</span>
-<span class="hljs-attr">          id:</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">            format:</span> <span class="hljs-string">uuid</span>
-<span class="hljs-attr">          address:</span>
+  <span class="hljs-attr">content:</span>
+    <span class="hljs-attr">application/x-www-form-urlencoded:</span>
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+        <span class="hljs-attr">properties:</span>
+          <span class="hljs-attr">id:</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+            <span class="hljs-attr">format:</span> <span class="hljs-string">uuid</span>
+          <span class="hljs-attr">address:</span>
             <span class="hljs-comment"># complex types are stringified to support RFC 1866</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">            properties:</span> <span class="hljs-string">{}</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+            <span class="hljs-attr">properties:</span> {}
 </code></pre>
 <p>In this example, the contents in the <code>requestBody</code> MUST be stringified per [[!RFC1866]] when passed to the server.  In addition, the <code>address</code> field complex object will be stringified.</p>
-<p>When passing complex objects in the <code>application/x-www-form-urlencoded</code> content type, the default serialization strategy of such properties is described in the <a href="#encodingObject"><code>Encoding Object</code></a>'s <a href="#encodingStyle"><code>style</code></a> property as <code>form</code>.</p>
+<p>When passing complex objects in the <code>application/x-www-form-urlencoded</code> content type, the default serialization strategy of such properties is described in the <a href="#encodingObject"><code>Encoding Object</code></a>’s <a href="#encodingStyle"><code>style</code></a> property as <code>form</code>.</p>
 </section><section><h4>Special Considerations for <code>multipart</code> Content</h4>
 <p>It is common to use <code>multipart/form-data</code> as a <code>Content-Type</code> when transferring request bodies to operations.  In contrast to 2.0, a <code>schema</code> is REQUIRED to define the input parameters to the operation when using <code>multipart</code> content.  This supports complex structures as well as supporting mechanisms for multiple file uploads.</p>
 <p>When passing in <code>multipart</code> types, boundaries MAY be used to separate sections of the content being transferred — thus, the following default <code>Content-Type</code>s are defined for <code>multipart</code>:</p>
@@ -1935,32 +1935,32 @@ definition may be used:</p>
 <p>Examples:</p>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">requestBody:</span>
-<span class="hljs-attr">  content:</span>
-    <span class="hljs-string">multipart/form-data:</span>
-<span class="hljs-attr">      schema:</span>
-<span class="hljs-attr">        type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">        properties:</span>
-<span class="hljs-attr">          id:</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">            format:</span> <span class="hljs-string">uuid</span>
-<span class="hljs-attr">          address:</span>
+  <span class="hljs-attr">content:</span>
+    <span class="hljs-attr">multipart/form-data:</span>
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+        <span class="hljs-attr">properties:</span>
+          <span class="hljs-attr">id:</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+            <span class="hljs-attr">format:</span> <span class="hljs-string">uuid</span>
+          <span class="hljs-attr">address:</span>
             <span class="hljs-comment"># default Content-Type for objects is `application/json`</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">            properties:</span> <span class="hljs-string">{}</span>
-<span class="hljs-attr">          profileImage:</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+            <span class="hljs-attr">properties:</span> {}
+          <span class="hljs-attr">profileImage:</span>
             <span class="hljs-comment"># default Content-Type for string/binary is `application/octet-stream`</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">            format:</span> <span class="hljs-string">binary</span>
-<span class="hljs-attr">          children:</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+            <span class="hljs-attr">format:</span> <span class="hljs-string">binary</span>
+          <span class="hljs-attr">children:</span>
             <span class="hljs-comment"># default Content-Type for arrays is based on the `inner` type (text/plain here)</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">            items:</span>
-<span class="hljs-attr">              type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">          addresses:</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+            <span class="hljs-attr">items:</span>
+              <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+          <span class="hljs-attr">addresses:</span>
             <span class="hljs-comment"># default Content-Type for arrays is based on the `inner` type (object shown, so `application/json` in this example)</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">            items:</span>
-<span class="hljs-attr">              type:</span> <span class="hljs-string">'#/components/schemas/Address'</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+            <span class="hljs-attr">items:</span>
+              <span class="hljs-attr">type:</span> <span class="hljs-string">&#x27;#/components/schemas/Address&#x27;</span>
 </code></pre>
 <p>An <code>encoding</code> attribute is introduced to give you control over the serialization of parts of <code>multipart</code> request bodies.  This attribute is <em>only</em> applicable to <code>multipart</code> and <code>application/x-www-form-urlencoded</code> request bodies.</p>
 </section></section><section><h3><span id="encodingObject">Encoding Object</span></h3>
@@ -1982,7 +1982,7 @@ definition may be used:</p>
 </tr>
 <tr>
 <td><a id="encodingHeaders"> </a>headers</td>
-<td style="text-align:center">Map[<code>string</code>, <a href="#headerObject">Header Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:center">Map[<code>string</code>, <a href="#headerObject">Header Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>A map allowing additional information to be provided as headers, for example <code>Content-Disposition</code>.  <code>Content-Type</code> is described separately and SHALL be ignored in this section. This property SHALL be ignored if the request body media type is not a <code>multipart</code>.</td>
 </tr>
 <tr>
@@ -2006,40 +2006,40 @@ definition may be used:</p>
 </section><section><h4>Encoding Object Example</h4>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">requestBody:</span>
-<span class="hljs-attr">  content:</span>
-    <span class="hljs-string">multipart/mixed:</span>
-<span class="hljs-attr">      schema:</span>
-<span class="hljs-attr">        type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">        properties:</span>
-<span class="hljs-attr">          id:</span>
+  <span class="hljs-attr">content:</span>
+    <span class="hljs-attr">multipart/mixed:</span>
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+        <span class="hljs-attr">properties:</span>
+          <span class="hljs-attr">id:</span>
             <span class="hljs-comment"># default is text/plain</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">            format:</span> <span class="hljs-string">uuid</span>
-<span class="hljs-attr">          address:</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+            <span class="hljs-attr">format:</span> <span class="hljs-string">uuid</span>
+          <span class="hljs-attr">address:</span>
             <span class="hljs-comment"># default is application/json</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">            properties:</span> <span class="hljs-string">{}</span>
-<span class="hljs-attr">          historyMetadata:</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+            <span class="hljs-attr">properties:</span> {}
+          <span class="hljs-attr">historyMetadata:</span>
             <span class="hljs-comment"># need to declare XML format!</span>
-<span class="hljs-attr">            description:</span> <span class="hljs-string">metadata</span> <span class="hljs-string">in</span> <span class="hljs-string">XML</span> <span class="hljs-string">format</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">            properties:</span> <span class="hljs-string">{}</span>
-<span class="hljs-attr">          profileImage:</span>
+            <span class="hljs-attr">description:</span> <span class="hljs-string">metadata</span> <span class="hljs-string">in</span> <span class="hljs-string">XML</span> <span class="hljs-string">format</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+            <span class="hljs-attr">properties:</span> {}
+          <span class="hljs-attr">profileImage:</span>
             <span class="hljs-comment"># default is application/octet-stream, need to declare an image type only!</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">            format:</span> <span class="hljs-string">binary</span>
-<span class="hljs-attr">      encoding:</span>
-<span class="hljs-attr">        historyMetadata:</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+            <span class="hljs-attr">format:</span> <span class="hljs-string">binary</span>
+      <span class="hljs-attr">encoding:</span>
+        <span class="hljs-attr">historyMetadata:</span>
           <span class="hljs-comment"># require XML Content-Type in utf-8 encoding</span>
-<span class="hljs-attr">          contentType:</span> <span class="hljs-string">application/xml;</span> <span class="hljs-string">charset=utf-8</span>
-<span class="hljs-attr">        profileImage:</span>
+          <span class="hljs-attr">contentType:</span> <span class="hljs-string">application/xml;</span> <span class="hljs-string">charset=utf-8</span>
+        <span class="hljs-attr">profileImage:</span>
           <span class="hljs-comment"># only accept png/jpeg</span>
-<span class="hljs-attr">          contentType:</span> <span class="hljs-string">image/png,</span> <span class="hljs-string">image/jpeg</span>
-<span class="hljs-attr">          headers:</span>
-<span class="hljs-attr">            X-Rate-Limit-Limit:</span>
-<span class="hljs-attr">              description:</span> <span class="hljs-string">The</span> <span class="hljs-string">number</span> <span class="hljs-string">of</span> <span class="hljs-string">allowed</span> <span class="hljs-string">requests</span> <span class="hljs-string">in</span> <span class="hljs-string">the</span> <span class="hljs-string">current</span> <span class="hljs-string">period</span>
-<span class="hljs-attr">              schema:</span>
-<span class="hljs-attr">                type:</span> <span class="hljs-string">integer</span>
+          <span class="hljs-attr">contentType:</span> <span class="hljs-string">image/png,</span> <span class="hljs-string">image/jpeg</span>
+          <span class="hljs-attr">headers:</span>
+            <span class="hljs-attr">X-Rate-Limit-Limit:</span>
+              <span class="hljs-attr">description:</span> <span class="hljs-string">The</span> <span class="hljs-string">number</span> <span class="hljs-string">of</span> <span class="hljs-string">allowed</span> <span class="hljs-string">requests</span> <span class="hljs-string">in</span> <span class="hljs-string">the</span> <span class="hljs-string">current</span> <span class="hljs-string">period</span>
+              <span class="hljs-attr">schema:</span>
+                <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
 </code></pre>
 </section></section><section><h3><span id="responsesObject">Responses Object</span></h3>
 <p>A container for the expected responses of an operation.
@@ -2062,7 +2062,7 @@ SHOULD be the response for a successful operation call.</p>
 <tbody>
 <tr>
 <td><a id="responsesDefault"> </a>default</td>
-<td style="text-align:center"><a href="#responseObject">Response Object</a> ¦ <a href="#referenceObject">Reference Object</a></td>
+<td style="text-align:center"><a href="#responseObject">Response Object</a> | <a href="#referenceObject">Reference Object</a></td>
 <td>The documentation of responses other than the ones declared for specific HTTP response codes. Use this field to cover undeclared responses. A <a href="#referenceObject">Reference Object</a> can link to a response that the <a href="#componentsResponses">OpenAPI Object’s components/responses</a> section defines.</td>
 </tr>
 </tbody>
@@ -2079,7 +2079,7 @@ SHOULD be the response for a successful operation call.</p>
 <tbody>
 <tr>
 <td><a id="responsesCode"> </a><a href="#httpCodes">HTTP Status Code</a></td>
-<td style="text-align:center"><a href="#responseObject">Response Object</a> ¦ <a href="#referenceObject">Reference Object</a></td>
+<td style="text-align:center"><a href="#responseObject">Response Object</a> | <a href="#referenceObject">Reference Object</a></td>
 <td>Any <a href="#httpCodes">HTTP status code</a> can be used as the property name, but only one property per code, to describe the expected response for that HTTP status code.  A <a href="#referenceObject">Reference Object</a> can link to a response that is defined in the <a href="#componentsResponses">OpenAPI Object’s components/responses</a> section. This field MUST be enclosed in quotation marks (for example, “200”) for compatibility between JSON and YAML. To define a range of response codes, this field MAY contain the uppercase wildcard character <code>X</code>. For example, <code>2XX</code> represents all response codes between <code>[200-299]</code>. The following range definitions are allowed: <code>1XX</code>, <code>2XX</code>, <code>3XX</code>, <code>4XX</code>, and <code>5XX</code>. If a response range is defined using an explicit code, the explicit code definition takes precedence over the range definition for that code.</td>
 </tr>
 </tbody>
@@ -2089,22 +2089,22 @@ SHOULD be the response for a successful operation call.</p>
 <p>A 200 response for a successful operation and a default response for others (implying an error):</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"200"</span>: {
-    <span class="hljs-attr">"description"</span>: <span class="hljs-string">"a pet to be returned"</span>,
-    <span class="hljs-attr">"content"</span>: {
-      <span class="hljs-attr">"application/json"</span>: {
-        <span class="hljs-attr">"schema"</span>: {
-          <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/Pet"</span>
+  <span class="hljs-attr">&quot;200&quot;</span>: {
+    <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;a pet to be returned&quot;</span>,
+    <span class="hljs-attr">&quot;content&quot;</span>: {
+      <span class="hljs-attr">&quot;application/json&quot;</span>: {
+        <span class="hljs-attr">&quot;schema&quot;</span>: {
+          <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/Pet&quot;</span>
         }
       }
     }
   },
-  <span class="hljs-attr">"default"</span>: {
-    <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Unexpected error"</span>,
-    <span class="hljs-attr">"content"</span>: {
-      <span class="hljs-attr">"application/json"</span>: {
-        <span class="hljs-attr">"schema"</span>: {
-          <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/ErrorModel"</span>
+  <span class="hljs-attr">&quot;default&quot;</span>: {
+    <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;Unexpected error&quot;</span>,
+    <span class="hljs-attr">&quot;content&quot;</span>: {
+      <span class="hljs-attr">&quot;application/json&quot;</span>: {
+        <span class="hljs-attr">&quot;schema&quot;</span>: {
+          <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/ErrorModel&quot;</span>
         }
       }
     }
@@ -2112,18 +2112,18 @@ SHOULD be the response for a successful operation call.</p>
 }
 </code></pre>
 <pre class="nohighlight"><code>
-<span class="hljs-string">'200'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">  description:</span> <span class="hljs-string">a</span> <span class="hljs-string">pet</span> <span class="hljs-string">to</span> <span class="hljs-string">be</span> <span class="hljs-string">returned</span>
-<span class="hljs-attr">  content:</span> 
-    <span class="hljs-string">application/json:</span>
-<span class="hljs-attr">      schema:</span>
-        <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Pet'</span>
+<span class="hljs-attr">&#x27;200&#x27;:</span>
+  <span class="hljs-attr">description:</span> <span class="hljs-string">a</span> <span class="hljs-string">pet</span> <span class="hljs-string">to</span> <span class="hljs-string">be</span> <span class="hljs-string">returned</span>
+  <span class="hljs-attr">content:</span> 
+    <span class="hljs-attr">application/json:</span>
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/Pet&#x27;</span>
 <span class="hljs-attr">default:</span>
-<span class="hljs-attr">  description:</span> <span class="hljs-string">Unexpected</span> <span class="hljs-string">error</span>
-<span class="hljs-attr">  content:</span>
-    <span class="hljs-string">application/json:</span>
-<span class="hljs-attr">      schema:</span>
-        <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/ErrorModel'</span>
+  <span class="hljs-attr">description:</span> <span class="hljs-string">Unexpected</span> <span class="hljs-string">error</span>
+  <span class="hljs-attr">content:</span>
+    <span class="hljs-attr">application/json:</span>
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/ErrorModel&#x27;</span>
 </code></pre>
 </section></section><section><h3><span id="responseObject">Response Object</span></h3>
 <p>Describes a single response from an API Operation, including design-time, static
@@ -2145,7 +2145,7 @@ SHOULD be the response for a successful operation call.</p>
 </tr>
 <tr>
 <td><a id="responseHeaders"> </a>headers</td>
-<td style="text-align:center">Map[<code>string</code>, <a href="#headerObject">Header Object</a>  ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:center">Map[<code>string</code>, <a href="#headerObject">Header Object</a>  | <a href="#referenceObject">Reference Object</a>]</td>
 <td>Maps a header name to its definition. [[!RFC7230]] states header names are case insensitive. If a response header is defined with the name <code>&quot;Content-Type&quot;</code>, it SHALL be ignored.</td>
 </tr>
 <tr>
@@ -2155,7 +2155,7 @@ SHOULD be the response for a successful operation call.</p>
 </tr>
 <tr>
 <td><a id="responseLinks"> </a>links</td>
-<td style="text-align:center">Map[<code>string</code>, <a href="#linkObject">Link Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:center">Map[<code>string</code>, <a href="#linkObject">Link Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>A map of operations links that can be followed from the response. The key of the map is a short name for the link, following the naming constraints of the names for <a href="#componentsObject">Component Objects</a>.</td>
 </tr>
 </tbody>
@@ -2165,13 +2165,13 @@ SHOULD be the response for a successful operation call.</p>
 <p>Response of an array of a complex type:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"A complex object array response"</span>,
-  <span class="hljs-attr">"content"</span>: {
-    <span class="hljs-attr">"application/json"</span>: {
-      <span class="hljs-attr">"schema"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-        <span class="hljs-attr">"items"</span>: {
-          <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/VeryComplexType"</span>
+  <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;A complex object array response&quot;</span>,
+  <span class="hljs-attr">&quot;content&quot;</span>: {
+    <span class="hljs-attr">&quot;application/json&quot;</span>: {
+      <span class="hljs-attr">&quot;schema&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+        <span class="hljs-attr">&quot;items&quot;</span>: {
+          <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/VeryComplexType&quot;</span>
         }
       }
     }
@@ -2181,20 +2181,20 @@ SHOULD be the response for a successful operation call.</p>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">description:</span> <span class="hljs-string">A</span> <span class="hljs-string">complex</span> <span class="hljs-string">object</span> <span class="hljs-string">array</span> <span class="hljs-string">response</span>
 <span class="hljs-attr">content:</span> 
-  <span class="hljs-string">application/json:</span>
-<span class="hljs-attr">    schema:</span> 
-<span class="hljs-attr">      type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">      items:</span>
-        <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/VeryComplexType'</span>
+  <span class="hljs-attr">application/json:</span>
+    <span class="hljs-attr">schema:</span> 
+      <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+      <span class="hljs-attr">items:</span>
+        <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/VeryComplexType&#x27;</span>
 </code></pre>
 <p>Response with a string type:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"A simple string response"</span>,
-  <span class="hljs-attr">"content"</span>: {
-    <span class="hljs-attr">"text/plain"</span>: {
-      <span class="hljs-attr">"schema"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+  <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;A simple string response&quot;</span>,
+  <span class="hljs-attr">&quot;content&quot;</span>: {
+    <span class="hljs-attr">&quot;text/plain&quot;</span>: {
+      <span class="hljs-attr">&quot;schema&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
       }
     }
   }
@@ -2204,38 +2204,38 @@ SHOULD be the response for a successful operation call.</p>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">description:</span> <span class="hljs-string">A</span> <span class="hljs-string">simple</span> <span class="hljs-string">string</span> <span class="hljs-string">response</span>
 <span class="hljs-attr">representations:</span>
-  <span class="hljs-string">text/plain:</span>
-<span class="hljs-attr">    schema:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">text/plain:</span>
+    <span class="hljs-attr">schema:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
 </code></pre>
 <p>Plain text response with headers:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"A simple string response"</span>,
-  <span class="hljs-attr">"content"</span>: {
-    <span class="hljs-attr">"text/plain"</span>: {
-      <span class="hljs-attr">"schema"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+  <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;A simple string response&quot;</span>,
+  <span class="hljs-attr">&quot;content&quot;</span>: {
+    <span class="hljs-attr">&quot;text/plain&quot;</span>: {
+      <span class="hljs-attr">&quot;schema&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
       }
     }
   },
-  <span class="hljs-attr">"headers"</span>: {
-    <span class="hljs-attr">"X-Rate-Limit-Limit"</span>: {
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"The number of allowed requests in the current period"</span>,
-      <span class="hljs-attr">"schema"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>
+  <span class="hljs-attr">&quot;headers&quot;</span>: {
+    <span class="hljs-attr">&quot;X-Rate-Limit-Limit&quot;</span>: {
+      <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;The number of allowed requests in the current period&quot;</span>,
+      <span class="hljs-attr">&quot;schema&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>
       }
     },
-    <span class="hljs-attr">"X-Rate-Limit-Remaining"</span>: {
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"The number of remaining requests in the current period"</span>,
-      <span class="hljs-attr">"schema"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>
+    <span class="hljs-attr">&quot;X-Rate-Limit-Remaining&quot;</span>: {
+      <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;The number of remaining requests in the current period&quot;</span>,
+      <span class="hljs-attr">&quot;schema&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>
       }
     },
-    <span class="hljs-attr">"X-Rate-Limit-Reset"</span>: {
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"The number of seconds left in the current period"</span>,
-      <span class="hljs-attr">"schema"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>
+    <span class="hljs-attr">&quot;X-Rate-Limit-Reset&quot;</span>: {
+      <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;The number of seconds left in the current period&quot;</span>,
+      <span class="hljs-attr">&quot;schema&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>
       }
     }
   }
@@ -2244,28 +2244,28 @@ SHOULD be the response for a successful operation call.</p>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">description:</span> <span class="hljs-string">A</span> <span class="hljs-string">simple</span> <span class="hljs-string">string</span> <span class="hljs-string">response</span>
 <span class="hljs-attr">content:</span>
-  <span class="hljs-string">text/plain:</span>
-<span class="hljs-attr">    schema:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">    example:</span> <span class="hljs-string">'whoa!'</span>
+  <span class="hljs-attr">text/plain:</span>
+    <span class="hljs-attr">schema:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+    <span class="hljs-attr">example:</span> <span class="hljs-string">&#x27;whoa!&#x27;</span>
 <span class="hljs-attr">headers:</span>
-<span class="hljs-attr">  X-Rate-Limit-Limit:</span>
-<span class="hljs-attr">    description:</span> <span class="hljs-string">The</span> <span class="hljs-string">number</span> <span class="hljs-string">of</span> <span class="hljs-string">allowed</span> <span class="hljs-string">requests</span> <span class="hljs-string">in</span> <span class="hljs-string">the</span> <span class="hljs-string">current</span> <span class="hljs-string">period</span>
-<span class="hljs-attr">    schema:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">integer</span>
-<span class="hljs-attr">  X-Rate-Limit-Remaining:</span>
-<span class="hljs-attr">    description:</span> <span class="hljs-string">The</span> <span class="hljs-string">number</span> <span class="hljs-string">of</span> <span class="hljs-string">remaining</span> <span class="hljs-string">requests</span> <span class="hljs-string">in</span> <span class="hljs-string">the</span> <span class="hljs-string">current</span> <span class="hljs-string">period</span>
-<span class="hljs-attr">    schema:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">integer</span>
-<span class="hljs-attr">  X-Rate-Limit-Reset:</span>
-<span class="hljs-attr">    description:</span> <span class="hljs-string">The</span> <span class="hljs-string">number</span> <span class="hljs-string">of</span> <span class="hljs-string">seconds</span> <span class="hljs-string">left</span> <span class="hljs-string">in</span> <span class="hljs-string">the</span> <span class="hljs-string">current</span> <span class="hljs-string">period</span>
-<span class="hljs-attr">    schema:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">integer</span>
+  <span class="hljs-attr">X-Rate-Limit-Limit:</span>
+    <span class="hljs-attr">description:</span> <span class="hljs-string">The</span> <span class="hljs-string">number</span> <span class="hljs-string">of</span> <span class="hljs-string">allowed</span> <span class="hljs-string">requests</span> <span class="hljs-string">in</span> <span class="hljs-string">the</span> <span class="hljs-string">current</span> <span class="hljs-string">period</span>
+    <span class="hljs-attr">schema:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+  <span class="hljs-attr">X-Rate-Limit-Remaining:</span>
+    <span class="hljs-attr">description:</span> <span class="hljs-string">The</span> <span class="hljs-string">number</span> <span class="hljs-string">of</span> <span class="hljs-string">remaining</span> <span class="hljs-string">requests</span> <span class="hljs-string">in</span> <span class="hljs-string">the</span> <span class="hljs-string">current</span> <span class="hljs-string">period</span>
+    <span class="hljs-attr">schema:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+  <span class="hljs-attr">X-Rate-Limit-Reset:</span>
+    <span class="hljs-attr">description:</span> <span class="hljs-string">The</span> <span class="hljs-string">number</span> <span class="hljs-string">of</span> <span class="hljs-string">seconds</span> <span class="hljs-string">left</span> <span class="hljs-string">in</span> <span class="hljs-string">the</span> <span class="hljs-string">current</span> <span class="hljs-string">period</span>
+    <span class="hljs-attr">schema:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
 </code></pre>
 <p>Response with no return value:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"object created"</span>
+  <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;object created&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -2288,7 +2288,7 @@ The key value used to identify the callback object is an expression, evaluated a
 <tr>
 <td><a id="callbackExpression"> </a>{expression}</td>
 <td style="text-align:center"><a href="#pathItemObject">Path Item Object</a></td>
-<td>A Path Item Object used to define a callback request and expected responses.  A <a href="../examples/v3.0/callback-example.yaml">complete example</a> is available.</td>
+<td>A Path Item Object used to define a callback request and expected responses.  A <a href="https://github.com/OAI/OpenAPI-Specification/tree/master/examples/v3.0/callback-example.yaml">complete example</a> is available.</td>
 </tr>
 </tbody>
 </table>
@@ -2300,22 +2300,22 @@ However, using a <a href="#runtimeExpression">runtime expression</a> the complet
 This includes accessing any part of a body that a JSON Pointer [[!RFC6901]] can reference.</p>
 <p>For example, given the following HTTP request:</p>
 <pre class="nohighlight"><code>
-<span class="hljs-keyword">POST</span> <span class="hljs-string">/subscribe/myevent?queryUrl=http://clientdomain.com/stillrunning</span> HTTP/1.1
-<span class="hljs-attribute">Host</span>: example.org
-<span class="hljs-attribute">Content-Type</span>: application/json
-<span class="hljs-attribute">Content-Length</span>: 187
+<span class="hljs-keyword">POST</span> <span class="hljs-string">/subscribe/myevent?queryUrl=http://clientdomain.com/stillrunning</span> <span class="hljs-meta">HTTP/1.1</span>
+<span class="hljs-attribute">Host</span><span class="hljs-punctuation">: </span>example.org
+<span class="hljs-attribute">Content-Type</span><span class="hljs-punctuation">: </span>application/json
+<span class="hljs-attribute">Content-Length</span><span class="hljs-punctuation">: </span>187
 
-<span class="groovy">{
-  <span class="hljs-string">"failedUrl"</span> : <span class="hljs-string">"http://clientdomain.com/failed"</span>,
-  <span class="hljs-string">"successUrls"</span> : [
-    <span class="hljs-string">"http://clientdomain.com/fast"</span>,
-    <span class="hljs-string">"http://clientdomain.com/medium"</span>,
-    <span class="hljs-string">"http://clientdomain.com/slow"</span>
+<span class="awk">{
+  <span class="hljs-string">&quot;failedUrl&quot;</span> : <span class="hljs-string">&quot;http://clientdomain.com/failed&quot;</span>,
+  <span class="hljs-string">&quot;successUrls&quot;</span> : [
+    <span class="hljs-string">&quot;http://clientdomain.com/fast&quot;</span>,
+    <span class="hljs-string">&quot;http://clientdomain.com/medium&quot;</span>,
+    <span class="hljs-string">&quot;http://clientdomain.com/slow&quot;</span>
   ] 
 }
 
 <span class="hljs-number">201</span> Created
-<span class="hljs-string">Location:</span> <span class="hljs-string">http:</span><span class="hljs-comment">//example.org/subscription/1</span>
+Location: http:<span class="hljs-regexp">//</span>example.org<span class="hljs-regexp">/subscription/</span><span class="hljs-number">1</span>
 </span></code></pre>
 <p>The following examples show how the various expressions evaluate, assuming the callback operation has a path parameter named <code>eventType</code> and a query parameter named <code>queryUrl</code>.</p>
 <table>
@@ -2364,17 +2364,17 @@ This includes accessing any part of a body that a JSON Pointer [[!RFC6901]] can 
 <p>The following example shows a callback to the URL specified by the <code>id</code> and <code>email</code> property in the request body.</p>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">myWebhook:</span>
-  <span class="hljs-string">'http://notificationServer.com?transactionId={$request.body#/id}&amp;email={$request.body#/email}'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">    post:</span>
-<span class="hljs-attr">      requestBody:</span>
-<span class="hljs-attr">        description:</span> <span class="hljs-string">Callback</span> <span class="hljs-string">payload</span>
-<span class="hljs-attr">        content:</span> 
-          <span class="hljs-string">'application/json'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">            schema:</span>
-              <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/SomePayload'</span>
-<span class="hljs-attr">      responses:</span>
-        <span class="hljs-string">'200'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">          description:</span> <span class="hljs-string">webhook</span> <span class="hljs-string">successfully</span> <span class="hljs-string">processed</span> <span class="hljs-string">and</span> <span class="hljs-literal">no</span> <span class="hljs-string">retries</span> <span class="hljs-string">will</span> <span class="hljs-string">be</span> <span class="hljs-string">performed</span>
+  <span class="hljs-string">&#x27;http://notificationServer.com?transactionId={$request.body#/id}&amp;email={$request.body#/email}&#x27;</span><span class="hljs-string">:</span>
+    <span class="hljs-attr">post:</span>
+      <span class="hljs-attr">requestBody:</span>
+        <span class="hljs-attr">description:</span> <span class="hljs-string">Callback</span> <span class="hljs-string">payload</span>
+        <span class="hljs-attr">content:</span> 
+          <span class="hljs-attr">&#x27;application/json&#x27;:</span>
+            <span class="hljs-attr">schema:</span>
+              <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/SomePayload&#x27;</span>
+      <span class="hljs-attr">responses:</span>
+        <span class="hljs-attr">&#x27;200&#x27;:</span>
+          <span class="hljs-attr">description:</span> <span class="hljs-string">webhook</span> <span class="hljs-string">successfully</span> <span class="hljs-string">processed</span> <span class="hljs-string">and</span> <span class="hljs-literal">no</span> <span class="hljs-string">retries</span> <span class="hljs-string">will</span> <span class="hljs-string">be</span> <span class="hljs-string">performed</span>
 </code></pre>
 </section></section><section><h3><span id="exampleObject">Example Object</span></h3>
 <section><h4>Fixed Fields</h4>
@@ -2417,60 +2417,60 @@ validate compatibility automatically, and reject the example value(s) if incompa
 <pre class="nohighlight"><code>
 <span class="hljs-comment"># in a model</span>
 <span class="hljs-attr">schemas:</span>
-<span class="hljs-attr">  properties:</span>
-<span class="hljs-attr">    name:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">      examples:</span>
-<span class="hljs-attr">        name:</span>
-          <span class="hljs-string">$ref:</span> <span class="hljs-attr">http://example.org/petapi-examples/openapi.json#/components/examples/name-example</span>
+  <span class="hljs-attr">properties:</span>
+    <span class="hljs-attr">name:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+      <span class="hljs-attr">examples:</span>
+        <span class="hljs-attr">name:</span>
+          <span class="hljs-string">$ref:</span> <span class="hljs-string">http://example.org/petapi-examples/openapi.json#/components/examples/name-example</span>
 
 <span class="hljs-comment"># in a request body:</span>
-<span class="hljs-attr">  requestBody:</span>
-<span class="hljs-attr">    content:</span>
-      <span class="hljs-string">'application/json'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">        schema:</span>
-          <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Address'</span>
-<span class="hljs-attr">        examples:</span> 
-<span class="hljs-attr">          foo:</span>
-<span class="hljs-attr">            summary:</span> <span class="hljs-string">A</span> <span class="hljs-string">foo</span> <span class="hljs-string">example</span>
-<span class="hljs-attr">            value:</span> <span class="hljs-string">{"foo":</span> <span class="hljs-string">"bar"</span><span class="hljs-string">}</span>
-<span class="hljs-attr">          bar:</span>
-<span class="hljs-attr">            summary:</span> <span class="hljs-string">A</span> <span class="hljs-string">bar</span> <span class="hljs-string">example</span>
-<span class="hljs-attr">            value:</span> <span class="hljs-string">{"bar":</span> <span class="hljs-string">"baz"</span><span class="hljs-string">}</span>
-      <span class="hljs-string">'application/xml'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">        examples:</span> 
-<span class="hljs-attr">          xmlExample:</span>
-<span class="hljs-attr">            summary:</span> <span class="hljs-string">This</span> <span class="hljs-string">is</span> <span class="hljs-string">an</span> <span class="hljs-string">example</span> <span class="hljs-string">in</span> <span class="hljs-string">XML</span>
-<span class="hljs-attr">            externalValue:</span> <span class="hljs-string">'http://example.org/examples/address-example.xml'</span>
-      <span class="hljs-string">'text/plain'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">        examples:</span>
-<span class="hljs-attr">          textExample:</span> 
-<span class="hljs-attr">            summary:</span> <span class="hljs-string">This</span> <span class="hljs-string">is</span> <span class="hljs-string">a</span> <span class="hljs-string">text</span> <span class="hljs-string">example</span>
-<span class="hljs-attr">            externalValue:</span> <span class="hljs-string">'http://foo.bar/examples/address-example.txt'</span> 
+  <span class="hljs-attr">requestBody:</span>
+    <span class="hljs-attr">content:</span>
+      <span class="hljs-attr">&#x27;application/json&#x27;:</span>
+        <span class="hljs-attr">schema:</span>
+          <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/Address&#x27;</span>
+        <span class="hljs-attr">examples:</span> 
+          <span class="hljs-attr">foo:</span>
+            <span class="hljs-attr">summary:</span> <span class="hljs-string">A</span> <span class="hljs-string">foo</span> <span class="hljs-string">example</span>
+            <span class="hljs-attr">value:</span> {<span class="hljs-attr">&quot;foo&quot;:</span> <span class="hljs-string">&quot;bar&quot;</span>}
+          <span class="hljs-attr">bar:</span>
+            <span class="hljs-attr">summary:</span> <span class="hljs-string">A</span> <span class="hljs-string">bar</span> <span class="hljs-string">example</span>
+            <span class="hljs-attr">value:</span> {<span class="hljs-attr">&quot;bar&quot;:</span> <span class="hljs-string">&quot;baz&quot;</span>}
+      <span class="hljs-attr">&#x27;application/xml&#x27;:</span>
+        <span class="hljs-attr">examples:</span> 
+          <span class="hljs-attr">xmlExample:</span>
+            <span class="hljs-attr">summary:</span> <span class="hljs-string">This</span> <span class="hljs-string">is</span> <span class="hljs-string">an</span> <span class="hljs-string">example</span> <span class="hljs-string">in</span> <span class="hljs-string">XML</span>
+            <span class="hljs-attr">externalValue:</span> <span class="hljs-string">&#x27;http://example.org/examples/address-example.xml&#x27;</span>
+      <span class="hljs-attr">&#x27;text/plain&#x27;:</span>
+        <span class="hljs-attr">examples:</span>
+          <span class="hljs-attr">textExample:</span> 
+            <span class="hljs-attr">summary:</span> <span class="hljs-string">This</span> <span class="hljs-string">is</span> <span class="hljs-string">a</span> <span class="hljs-string">text</span> <span class="hljs-string">example</span>
+            <span class="hljs-attr">externalValue:</span> <span class="hljs-string">&#x27;http://foo.bar/examples/address-example.txt&#x27;</span> 
 
 
 <span class="hljs-comment"># in a parameter</span>
-<span class="hljs-attr">  parameters:</span>
-<span class="hljs-attr">    - name:</span> <span class="hljs-string">'zipCode'</span>
-<span class="hljs-attr">      in:</span> <span class="hljs-string">'query'</span>
-<span class="hljs-attr">      schema:</span>
-<span class="hljs-attr">        type:</span> <span class="hljs-string">'string'</span>
-<span class="hljs-attr">        format:</span> <span class="hljs-string">'zip-code'</span>
-<span class="hljs-attr">        examples:</span>
-<span class="hljs-attr">          zip-example:</span> 
-            <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/examples/zip-example'</span>
+  <span class="hljs-attr">parameters:</span>
+    <span class="hljs-bullet">-</span> <span class="hljs-attr">name:</span> <span class="hljs-string">&#x27;zipCode&#x27;</span>
+      <span class="hljs-attr">in:</span> <span class="hljs-string">&#x27;query&#x27;</span>
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-attr">type:</span> <span class="hljs-string">&#x27;string&#x27;</span>
+        <span class="hljs-attr">format:</span> <span class="hljs-string">&#x27;zip-code&#x27;</span>
+        <span class="hljs-attr">examples:</span>
+          <span class="hljs-attr">zip-example:</span> 
+            <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/examples/zip-example&#x27;</span>
 
 <span class="hljs-comment"># in a response</span>
-<span class="hljs-attr">  responses:</span>
-    <span class="hljs-string">'200'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">      description:</span> <span class="hljs-string">your</span> <span class="hljs-string">car</span> <span class="hljs-string">appointment</span> <span class="hljs-string">has</span> <span class="hljs-string">been</span> <span class="hljs-string">booked</span>
-<span class="hljs-attr">      content:</span> 
-        <span class="hljs-string">application/json:</span>
-<span class="hljs-attr">          schema:</span>
-            <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/SuccessResponse'</span>
-<span class="hljs-attr">          examples:</span>
-<span class="hljs-attr">            confirmation-success:</span>
-              <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/examples/confirmation-success'</span>
+  <span class="hljs-attr">responses:</span>
+    <span class="hljs-attr">&#x27;200&#x27;:</span>
+      <span class="hljs-attr">description:</span> <span class="hljs-string">your</span> <span class="hljs-string">car</span> <span class="hljs-string">appointment</span> <span class="hljs-string">has</span> <span class="hljs-string">been</span> <span class="hljs-string">booked</span>
+      <span class="hljs-attr">content:</span> 
+        <span class="hljs-attr">application/json:</span>
+          <span class="hljs-attr">schema:</span>
+            <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/SuccessResponse&#x27;</span>
+          <span class="hljs-attr">examples:</span>
+            <span class="hljs-attr">confirmation-success:</span>
+              <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/examples/confirmation-success&#x27;</span>
 </code></pre>
 </section></section><section><h3><span id="linkObject">Link Object</span></h3>
 <p>The <code>Link object</code> represents a possible design-time link for a response.
@@ -2499,12 +2499,12 @@ The presence of a link does not guarantee the caller’s ability to successfully
 </tr>
 <tr>
 <td><a id="linkParameters"> </a>parameters</td>
-<td style="text-align:center">Map[<code>string</code>, Any ¦ <a href="#runtimeExpression">{expression}</a>]</td>
+<td style="text-align:center">Map[<code>string</code>, Any | <a href="#runtimeExpression">{expression}</a>]</td>
 <td>A map representing parameters to pass to an operation as specified with <code>operationId</code> or identified via <code>operationRef</code>. The key is the parameter name to be used, whereas the value can be a constant or an expression to be evaluated and passed to the linked operation.  The parameter name can be qualified using the <a href="#parameterIn">parameter location</a> <code>[{in}.]{name}</code> for operations that use the same parameter name in different locations (e.g. <a href="http://path.id">path.id</a>).</td>
 </tr>
 <tr>
 <td><a id="linkRequestBody"> </a>requestBody</td>
-<td style="text-align:center">Any ¦ <a href="#runtimeExpression">{expression}</a></td>
+<td style="text-align:center">Any | <a href="#runtimeExpression">{expression}</a></td>
 <td>A literal value or <a href="#runtimeExpression">{expression}</a> to use as a request body when calling the target operation.</td>
 </tr>
 <tr>
@@ -2529,57 +2529,57 @@ for specifications with external references.</p>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">paths:</span>
   <span class="hljs-string">/users/{id}:</span>
-<span class="hljs-attr">    parameters:</span>
-<span class="hljs-attr">    - name:</span> <span class="hljs-string">id</span>
-<span class="hljs-attr">      in:</span> <span class="hljs-string">path</span>
-<span class="hljs-attr">      required:</span> <span class="hljs-literal">true</span>
-<span class="hljs-attr">      description:</span> <span class="hljs-string">the</span> <span class="hljs-string">user</span> <span class="hljs-string">identifier,</span> <span class="hljs-string">as</span> <span class="hljs-string">userId</span> 
-<span class="hljs-attr">      schema:</span>
-<span class="hljs-attr">        type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">    get:</span>
-<span class="hljs-attr">      responses:</span>
-        <span class="hljs-string">'200'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">          description:</span> <span class="hljs-string">the</span> <span class="hljs-string">user</span> <span class="hljs-string">being</span> <span class="hljs-string">returned</span>
-<span class="hljs-attr">          content:</span>
-            <span class="hljs-string">application/json:</span>
-<span class="hljs-attr">              schema:</span>
-<span class="hljs-attr">                type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">                properties:</span>
-<span class="hljs-attr">                  uuid:</span> <span class="hljs-comment"># the unique user id</span>
-<span class="hljs-attr">                    type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">                    format:</span> <span class="hljs-string">uuid</span>
-<span class="hljs-attr">        links:</span>
-<span class="hljs-attr">          address:</span>
+    <span class="hljs-attr">parameters:</span>
+    <span class="hljs-bullet">-</span> <span class="hljs-attr">name:</span> <span class="hljs-string">id</span>
+      <span class="hljs-attr">in:</span> <span class="hljs-string">path</span>
+      <span class="hljs-attr">required:</span> <span class="hljs-literal">true</span>
+      <span class="hljs-attr">description:</span> <span class="hljs-string">the</span> <span class="hljs-string">user</span> <span class="hljs-string">identifier,</span> <span class="hljs-string">as</span> <span class="hljs-string">userId</span> 
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+    <span class="hljs-attr">get:</span>
+      <span class="hljs-attr">responses:</span>
+        <span class="hljs-attr">&#x27;200&#x27;:</span>
+          <span class="hljs-attr">description:</span> <span class="hljs-string">the</span> <span class="hljs-string">user</span> <span class="hljs-string">being</span> <span class="hljs-string">returned</span>
+          <span class="hljs-attr">content:</span>
+            <span class="hljs-attr">application/json:</span>
+              <span class="hljs-attr">schema:</span>
+                <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+                <span class="hljs-attr">properties:</span>
+                  <span class="hljs-attr">uuid:</span> <span class="hljs-comment"># the unique user id</span>
+                    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+                    <span class="hljs-attr">format:</span> <span class="hljs-string">uuid</span>
+        <span class="hljs-attr">links:</span>
+          <span class="hljs-attr">address:</span>
             <span class="hljs-comment"># the target link operationId</span>
-<span class="hljs-attr">            operationId:</span> <span class="hljs-string">getUserAddress</span>
-<span class="hljs-attr">            parameters:</span>
+            <span class="hljs-attr">operationId:</span> <span class="hljs-string">getUserAddress</span>
+            <span class="hljs-attr">parameters:</span>
               <span class="hljs-comment"># get the `id` field from the request path parameter named `id`</span>
-<span class="hljs-attr">              userId:</span> <span class="hljs-string">$request.path.id</span>
+              <span class="hljs-attr">userId:</span> <span class="hljs-string">$request.path.id</span>
   <span class="hljs-comment"># the path item of the linked operation</span>
   <span class="hljs-string">/users/{userid}/address:</span>
-<span class="hljs-attr">    parameters:</span>
-<span class="hljs-attr">    - name:</span> <span class="hljs-string">userid</span>
-<span class="hljs-attr">      in:</span> <span class="hljs-string">path</span>
-<span class="hljs-attr">      required:</span> <span class="hljs-literal">true</span>
-<span class="hljs-attr">      description:</span> <span class="hljs-string">the</span> <span class="hljs-string">user</span> <span class="hljs-string">identifier,</span> <span class="hljs-string">as</span> <span class="hljs-string">userId</span> 
-<span class="hljs-attr">      schema:</span>
-<span class="hljs-attr">        type:</span> <span class="hljs-string">string</span>
+    <span class="hljs-attr">parameters:</span>
+    <span class="hljs-bullet">-</span> <span class="hljs-attr">name:</span> <span class="hljs-string">userid</span>
+      <span class="hljs-attr">in:</span> <span class="hljs-string">path</span>
+      <span class="hljs-attr">required:</span> <span class="hljs-literal">true</span>
+      <span class="hljs-attr">description:</span> <span class="hljs-string">the</span> <span class="hljs-string">user</span> <span class="hljs-string">identifier,</span> <span class="hljs-string">as</span> <span class="hljs-string">userId</span> 
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
       <span class="hljs-comment"># linked operation</span>
-<span class="hljs-attr">      get:</span>
-<span class="hljs-attr">        operationId:</span> <span class="hljs-string">getUserAddress</span>
-<span class="hljs-attr">        responses:</span>
-          <span class="hljs-string">'200'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">            description:</span> <span class="hljs-string">the</span> <span class="hljs-string">user's</span> <span class="hljs-string">address</span>
+      <span class="hljs-attr">get:</span>
+        <span class="hljs-attr">operationId:</span> <span class="hljs-string">getUserAddress</span>
+        <span class="hljs-attr">responses:</span>
+          <span class="hljs-attr">&#x27;200&#x27;:</span>
+            <span class="hljs-attr">description:</span> <span class="hljs-string">the</span> <span class="hljs-string">user&#x27;s</span> <span class="hljs-string">address</span>
 </code></pre>
 <p>When a runtime expression fails to evaluate, no parameter value is passed to the target operation.</p>
 <p>Values from the response body can be used to drive a linked operation.</p>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">links:</span>
-<span class="hljs-attr">  address:</span>
-<span class="hljs-attr">    operationId:</span> <span class="hljs-string">getUserAddressByUUID</span>
-<span class="hljs-attr">    parameters:</span>
+  <span class="hljs-attr">address:</span>
+    <span class="hljs-attr">operationId:</span> <span class="hljs-string">getUserAddressByUUID</span>
+    <span class="hljs-attr">parameters:</span>
       <span class="hljs-comment"># get the `id` field from the request path parameter named `id`</span>
-<span class="hljs-attr">      userUuid:</span> <span class="hljs-string">$response.body#/uuid</span>
+      <span class="hljs-attr">userUuid:</span> <span class="hljs-string">$response.body#/uuid</span>
 </code></pre>
 <p>Clients follow all links at their discretion.
 Neither permissions, nor the capability to make a successful call to that link, is guaranteed
@@ -2589,27 +2589,27 @@ solely by the existence of a relationship.</p>
 value), references MAY also be made through a relative <code>operationRef</code>:</p>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">links:</span>
-<span class="hljs-attr">  UserRepositories:</span>
-    <span class="hljs-comment"># returns array of '#/components/schemas/repository'</span>
-<span class="hljs-attr">    operationRef:</span> <span class="hljs-string">'#/paths/~12.0~1repositories~1{username}/get'</span>
-<span class="hljs-attr">    parameters:</span>
-<span class="hljs-attr">      username:</span> <span class="hljs-string">$response.body#/username</span>
+  <span class="hljs-attr">UserRepositories:</span>
+    <span class="hljs-comment"># returns array of &#x27;#/components/schemas/repository&#x27;</span>
+    <span class="hljs-attr">operationRef:</span> <span class="hljs-string">&#x27;#/paths/~12.0~1repositories~1{username}/get&#x27;</span>
+    <span class="hljs-attr">parameters:</span>
+      <span class="hljs-attr">username:</span> <span class="hljs-string">$response.body#/username</span>
 </code></pre>
 <p>or an absolute <code>operationRef</code>:</p>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">links:</span>
-<span class="hljs-attr">  UserRepositories:</span>
-    <span class="hljs-comment"># returns array of '#/components/schemas/repository'</span>
-<span class="hljs-attr">    operationRef:</span> <span class="hljs-string">'https://na2.gigantic-server.com/#/paths/~12.0~1repositories~1{username}/get'</span>
-<span class="hljs-attr">    parameters:</span>
-<span class="hljs-attr">      username:</span> <span class="hljs-string">$response.body#/username</span>
+  <span class="hljs-attr">UserRepositories:</span>
+    <span class="hljs-comment"># returns array of &#x27;#/components/schemas/repository&#x27;</span>
+    <span class="hljs-attr">operationRef:</span> <span class="hljs-string">&#x27;https://na2.gigantic-server.com/#/paths/~12.0~1repositories~1{username}/get&#x27;</span>
+    <span class="hljs-attr">parameters:</span>
+      <span class="hljs-attr">username:</span> <span class="hljs-string">$response.body#/username</span>
 </code></pre>
 <p>Note that in the use of <code>operationRef</code>, the <em>escaped forward-slash</em> is necessary when
 using JSON references.</p>
 </section><section><h4><span id="runtimeExpression">Runtime Expressions</span></h4>
 <p>Runtime expressions allow defining values based on information that will only be available within the HTTP message in an actual API call.
 This mechanism is used by <a href="#linkObject">Link Objects</a> and <a href="#callbackObject">Callback Objects</a>.</p>
-<p>The runtime expression is defined by the following [Augmented Backus-Naur Form] syntax</p>
+<p>The runtime expression is defined by the following [ABNF] syntax</p>
 <pre class="highlight "><code>
       expression = ( &quot;$url&quot; | &quot;$method&quot; | &quot;$statusCode&quot; | &quot;$request.&quot; source | &quot;$response.&quot; source )
       source = ( header-reference | query-reference | path-reference | body-reference )  
@@ -2684,16 +2684,16 @@ Expressions can be embedded into string values by surrounding the expression wit
 <p>A simple header of type <code>integer</code>:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"The number of allowed requests in the current period"</span>,
-  <span class="hljs-attr">"schema"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>
+  <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;The number of allowed requests in the current period&quot;</span>,
+  <span class="hljs-attr">&quot;schema&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>
   }
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">description:</span> <span class="hljs-string">The</span> <span class="hljs-string">number</span> <span class="hljs-string">of</span> <span class="hljs-string">allowed</span> <span class="hljs-string">requests</span> <span class="hljs-string">in</span> <span class="hljs-string">the</span> <span class="hljs-string">current</span> <span class="hljs-string">period</span>
 <span class="hljs-attr">schema:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">integer</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
 </code></pre>
 </section></section><section><h3><span id="tagObject">Tag Object</span></h3>
 <p>Adds metadata to a single tag that is used by the <a href="#operationObject">Operation Object</a>.
@@ -2729,8 +2729,8 @@ It is not mandatory to have a Tag Object per tag defined in the Operation Object
 </section><section><h4>Tag Object Example</h4>
 <pre class="nohighlight"><code>
 {
-	<span class="hljs-attr">"name"</span>: <span class="hljs-string">"pet"</span>,
-	<span class="hljs-attr">"description"</span>: <span class="hljs-string">"Pets operations"</span>
+	<span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;pet&quot;</span>,
+	<span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;Pets operations&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -2749,52 +2749,52 @@ are incompatible.</p>
 <pre class="nohighlight"><code>
 <span class="hljs-comment"># in a model</span>
 <span class="hljs-attr">schemas:</span>
-<span class="hljs-attr">  properties:</span>
-<span class="hljs-attr">    name:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">      example:</span>
-        <span class="hljs-string">$ref:</span> <span class="hljs-attr">http://foo.bar#/examples/name-example</span>
+  <span class="hljs-attr">properties:</span>
+    <span class="hljs-attr">name:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+      <span class="hljs-attr">example:</span>
+        <span class="hljs-string">$ref:</span> <span class="hljs-string">http://foo.bar#/examples/name-example</span>
 
 <span class="hljs-comment"># in a request body, note the plural `examples`</span>
-<span class="hljs-attr">  requestBody:</span>
-<span class="hljs-attr">    content:</span>
-      <span class="hljs-string">'application/json'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">        schema:</span>
-          <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Address'</span>
-<span class="hljs-attr">        examples:</span>
-<span class="hljs-attr">          foo:</span>
-<span class="hljs-attr">            value:</span> <span class="hljs-string">{"foo":</span> <span class="hljs-string">"bar"</span><span class="hljs-string">}</span>
-<span class="hljs-attr">          bar:</span>
-<span class="hljs-attr">            value:</span> <span class="hljs-string">{"bar":</span> <span class="hljs-string">"baz"</span><span class="hljs-string">}</span>
-      <span class="hljs-string">'application/xml'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">        examples:</span>
-<span class="hljs-attr">          xml:</span>
-<span class="hljs-attr">            externalValue:</span> <span class="hljs-string">'http://foo.bar/examples/address-example.xml'</span>
-      <span class="hljs-string">'text/plain'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">        examples:</span>
-<span class="hljs-attr">          text:</span>
-<span class="hljs-attr">            externalValue:</span> <span class="hljs-string">'http://foo.bar/examples/address-example.txt'</span>
+  <span class="hljs-attr">requestBody:</span>
+    <span class="hljs-attr">content:</span>
+      <span class="hljs-attr">&#x27;application/json&#x27;:</span>
+        <span class="hljs-attr">schema:</span>
+          <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/Address&#x27;</span>
+        <span class="hljs-attr">examples:</span>
+          <span class="hljs-attr">foo:</span>
+            <span class="hljs-attr">value:</span> {<span class="hljs-attr">&quot;foo&quot;:</span> <span class="hljs-string">&quot;bar&quot;</span>}
+          <span class="hljs-attr">bar:</span>
+            <span class="hljs-attr">value:</span> {<span class="hljs-attr">&quot;bar&quot;:</span> <span class="hljs-string">&quot;baz&quot;</span>}
+      <span class="hljs-attr">&#x27;application/xml&#x27;:</span>
+        <span class="hljs-attr">examples:</span>
+          <span class="hljs-attr">xml:</span>
+            <span class="hljs-attr">externalValue:</span> <span class="hljs-string">&#x27;http://foo.bar/examples/address-example.xml&#x27;</span>
+      <span class="hljs-attr">&#x27;text/plain&#x27;:</span>
+        <span class="hljs-attr">examples:</span>
+          <span class="hljs-attr">text:</span>
+            <span class="hljs-attr">externalValue:</span> <span class="hljs-string">&#x27;http://foo.bar/examples/address-example.txt&#x27;</span>
         
 <span class="hljs-comment"># in a parameter</span>
-<span class="hljs-attr">  parameters:</span>
-<span class="hljs-attr">    - name:</span> <span class="hljs-string">'zipCode'</span>
-<span class="hljs-attr">      in:</span> <span class="hljs-string">'query'</span>
-<span class="hljs-attr">      schema:</span>
-<span class="hljs-attr">        type:</span> <span class="hljs-string">'string'</span>
-<span class="hljs-attr">        format:</span> <span class="hljs-string">'zip-code'</span>
-<span class="hljs-attr">        example:</span> 
-          <span class="hljs-string">$ref:</span> <span class="hljs-string">'http://foo.bar#/examples/zip-example'</span>
+  <span class="hljs-attr">parameters:</span>
+    <span class="hljs-bullet">-</span> <span class="hljs-attr">name:</span> <span class="hljs-string">&#x27;zipCode&#x27;</span>
+      <span class="hljs-attr">in:</span> <span class="hljs-string">&#x27;query&#x27;</span>
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-attr">type:</span> <span class="hljs-string">&#x27;string&#x27;</span>
+        <span class="hljs-attr">format:</span> <span class="hljs-string">&#x27;zip-code&#x27;</span>
+        <span class="hljs-attr">example:</span> 
+          <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;http://foo.bar#/examples/zip-example&#x27;</span>
 
 <span class="hljs-comment"># in a response, note the singular `example`:</span>
-<span class="hljs-attr">  responses:</span>
-    <span class="hljs-string">'200'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">      description:</span> <span class="hljs-string">your</span> <span class="hljs-string">car</span> <span class="hljs-string">appointment</span> <span class="hljs-string">has</span> <span class="hljs-string">been</span> <span class="hljs-string">booked</span>
-<span class="hljs-attr">      content:</span> 
-        <span class="hljs-string">application/json:</span>
-<span class="hljs-attr">          schema:</span>
-            <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/SuccessResponse'</span>
-<span class="hljs-attr">          example:</span>
-            <span class="hljs-string">$ref:</span> <span class="hljs-attr">http://foo.bar#/examples/address-example.json</span>
+  <span class="hljs-attr">responses:</span>
+    <span class="hljs-attr">&#x27;200&#x27;:</span>
+      <span class="hljs-attr">description:</span> <span class="hljs-string">your</span> <span class="hljs-string">car</span> <span class="hljs-string">appointment</span> <span class="hljs-string">has</span> <span class="hljs-string">been</span> <span class="hljs-string">booked</span>
+      <span class="hljs-attr">content:</span> 
+        <span class="hljs-attr">application/json:</span>
+          <span class="hljs-attr">schema:</span>
+            <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/SuccessResponse&#x27;</span>
+          <span class="hljs-attr">example:</span>
+            <span class="hljs-string">$ref:</span> <span class="hljs-string">http://foo.bar#/examples/address-example.json</span>
 </code></pre>
 </section><section><h3><span id="referenceObject">Reference Object</span></h3>
 <p>A simple object to allow referencing other components in the specification, internally and externally.</p>
@@ -2821,16 +2821,16 @@ are incompatible.</p>
 </section><section><h4>Reference Object Example</h4>
 <pre class="nohighlight"><code>
 {
-	<span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/Pet"</span>
+	<span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/Pet&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
-<span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Pet'</span>
+<span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/Pet&#x27;</span>
 </code></pre>
 </section><section><h4>Relative Schema Document Example</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"Pet.json"</span>
+  <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;Pet.json&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -2839,7 +2839,7 @@ are incompatible.</p>
 </section><section><h4>Relative Documents With Embedded Schema Example</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"definitions.json#/Pet"</span>
+  <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;definitions.json#/Pet&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -2961,8 +2961,8 @@ The <a href="#xmlObject">XML Object</a> contains additional information about th
 <section><h5>Primitive Sample</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
-  <span class="hljs-attr">"format"</span>: <span class="hljs-string">"email"</span>
+  <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>,
+  <span class="hljs-attr">&quot;format&quot;</span>: <span class="hljs-string">&quot;email&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -2972,21 +2972,21 @@ The <a href="#xmlObject">XML Object</a> contains additional information about th
 </section><section><h5>Simple Model</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-  <span class="hljs-attr">"required"</span>: [
-    <span class="hljs-string">"name"</span>
+  <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+  <span class="hljs-attr">&quot;required&quot;</span>: [
+    <span class="hljs-string">&quot;name&quot;</span>
   ],
-  <span class="hljs-attr">"properties"</span>: {
-    <span class="hljs-attr">"name"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+  <span class="hljs-attr">&quot;properties&quot;</span>: {
+    <span class="hljs-attr">&quot;name&quot;</span>: {
+      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
     },
-    <span class="hljs-attr">"address"</span>: {
-      <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/Address"</span>
+    <span class="hljs-attr">&quot;address&quot;</span>: {
+      <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/Address&quot;</span>
     },
-    <span class="hljs-attr">"age"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>,
-      <span class="hljs-attr">"format"</span>: <span class="hljs-string">"int32"</span>,
-      <span class="hljs-attr">"minimum"</span>: <span class="hljs-number">0</span>
+    <span class="hljs-attr">&quot;age&quot;</span>: {
+      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>,
+      <span class="hljs-attr">&quot;format&quot;</span>: <span class="hljs-string">&quot;int32&quot;</span>,
+      <span class="hljs-attr">&quot;minimum&quot;</span>: <span class="hljs-number">0</span>
     }
   }
 }
@@ -2996,115 +2996,115 @@ The <a href="#xmlObject">XML Object</a> contains additional information about th
 <span class="hljs-attr">required:</span>
 <span class="hljs-bullet">-</span> <span class="hljs-string">name</span>
 <span class="hljs-attr">properties:</span>
-<span class="hljs-attr">  name:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">  address:</span>
-    <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Address'</span>
-<span class="hljs-attr">  age:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">integer</span>
-<span class="hljs-attr">    format:</span> <span class="hljs-string">int32</span>
-<span class="hljs-attr">    minimum:</span> <span class="hljs-number">0</span>
+  <span class="hljs-attr">name:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">address:</span>
+    <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/Address&#x27;</span>
+  <span class="hljs-attr">age:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+    <span class="hljs-attr">format:</span> <span class="hljs-string">int32</span>
+    <span class="hljs-attr">minimum:</span> <span class="hljs-number">0</span>
 </code></pre>
 </section><section><h5>Model with Map/Dictionary Properties</h5>
 <p>For a simple string to string mapping:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-  <span class="hljs-attr">"additionalProperties"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+  <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+  <span class="hljs-attr">&quot;additionalProperties&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
   }
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
 <span class="hljs-attr">additionalProperties:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
 </code></pre>
 <p>For a string to model mapping:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-  <span class="hljs-attr">"additionalProperties"</span>: {
-    <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/ComplexModel"</span>
+  <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+  <span class="hljs-attr">&quot;additionalProperties&quot;</span>: {
+    <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/ComplexModel&quot;</span>
   }
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
 <span class="hljs-attr">additionalProperties:</span>
-  <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/ComplexModel'</span>
+  <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/ComplexModel&#x27;</span>
 </code></pre>
 </section><section><h5>Model with Example</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-  <span class="hljs-attr">"properties"</span>: {
-    <span class="hljs-attr">"id"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>,
-      <span class="hljs-attr">"format"</span>: <span class="hljs-string">"int64"</span>
+  <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+  <span class="hljs-attr">&quot;properties&quot;</span>: {
+    <span class="hljs-attr">&quot;id&quot;</span>: {
+      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>,
+      <span class="hljs-attr">&quot;format&quot;</span>: <span class="hljs-string">&quot;int64&quot;</span>
     },
-    <span class="hljs-attr">"name"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+    <span class="hljs-attr">&quot;name&quot;</span>: {
+      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
     }
   },
-  <span class="hljs-attr">"required"</span>: [
-    <span class="hljs-string">"name"</span>
+  <span class="hljs-attr">&quot;required&quot;</span>: [
+    <span class="hljs-string">&quot;name&quot;</span>
   ],
-  <span class="hljs-attr">"example"</span>: {
-    <span class="hljs-attr">"name"</span>: <span class="hljs-string">"Puma"</span>,
-    <span class="hljs-attr">"id"</span>: <span class="hljs-number">1</span>
+  <span class="hljs-attr">&quot;example&quot;</span>: {
+    <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;Puma&quot;</span>,
+    <span class="hljs-attr">&quot;id&quot;</span>: <span class="hljs-number">1</span>
   }
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
 <span class="hljs-attr">properties:</span>
-<span class="hljs-attr">  id:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">integer</span>
-<span class="hljs-attr">    format:</span> <span class="hljs-string">int64</span>
-<span class="hljs-attr">  name:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">id:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+    <span class="hljs-attr">format:</span> <span class="hljs-string">int64</span>
+  <span class="hljs-attr">name:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
 <span class="hljs-attr">required:</span>
 <span class="hljs-bullet">-</span> <span class="hljs-string">name</span>
 <span class="hljs-attr">example:</span>
-<span class="hljs-attr">  name:</span> <span class="hljs-string">Puma</span>
-<span class="hljs-attr">  id:</span> <span class="hljs-number">1</span>
+  <span class="hljs-attr">name:</span> <span class="hljs-string">Puma</span>
+  <span class="hljs-attr">id:</span> <span class="hljs-number">1</span>
 </code></pre>
 </section><section><h5>Models with Composition</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"components"</span>: {
-    <span class="hljs-attr">"schemas"</span>: {
-      <span class="hljs-attr">"ErrorModel"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-        <span class="hljs-attr">"required"</span>: [
-          <span class="hljs-string">"message"</span>,
-          <span class="hljs-string">"code"</span>
+  <span class="hljs-attr">&quot;components&quot;</span>: {
+    <span class="hljs-attr">&quot;schemas&quot;</span>: {
+      <span class="hljs-attr">&quot;ErrorModel&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+        <span class="hljs-attr">&quot;required&quot;</span>: [
+          <span class="hljs-string">&quot;message&quot;</span>,
+          <span class="hljs-string">&quot;code&quot;</span>
         ],
-        <span class="hljs-attr">"properties"</span>: {
-          <span class="hljs-attr">"message"</span>: {
-            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+        <span class="hljs-attr">&quot;properties&quot;</span>: {
+          <span class="hljs-attr">&quot;message&quot;</span>: {
+            <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
           },
-          <span class="hljs-attr">"code"</span>: {
-            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>,
-            <span class="hljs-attr">"minimum"</span>: <span class="hljs-number">100</span>,
-            <span class="hljs-attr">"maximum"</span>: <span class="hljs-number">600</span>
+          <span class="hljs-attr">&quot;code&quot;</span>: {
+            <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>,
+            <span class="hljs-attr">&quot;minimum&quot;</span>: <span class="hljs-number">100</span>,
+            <span class="hljs-attr">&quot;maximum&quot;</span>: <span class="hljs-number">600</span>
           }
         }
       },
-      <span class="hljs-attr">"ExtendedErrorModel"</span>: {
-        <span class="hljs-attr">"allOf"</span>: [
+      <span class="hljs-attr">&quot;ExtendedErrorModel&quot;</span>: {
+        <span class="hljs-attr">&quot;allOf&quot;</span>: [
           {
-            <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/ErrorModel"</span>
+            <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/ErrorModel&quot;</span>
           },
           {
-            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-            <span class="hljs-attr">"required"</span>: [
-              <span class="hljs-string">"rootCause"</span>
+            <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+            <span class="hljs-attr">&quot;required&quot;</span>: [
+              <span class="hljs-string">&quot;rootCause&quot;</span>
             ],
-            <span class="hljs-attr">"properties"</span>: {
-              <span class="hljs-attr">"rootCause"</span>: {
-                <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+            <span class="hljs-attr">&quot;properties&quot;</span>: {
+              <span class="hljs-attr">&quot;rootCause&quot;</span>: {
+                <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
               }
             }
           }
@@ -3116,98 +3116,98 @@ The <a href="#xmlObject">XML Object</a> contains additional information about th
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">components:</span>
-<span class="hljs-attr">  schemas:</span>
-<span class="hljs-attr">    ErrorModel:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">      required:</span>
-<span class="hljs-bullet">      -</span> <span class="hljs-string">message</span>
-<span class="hljs-bullet">      -</span> <span class="hljs-string">code</span>
-<span class="hljs-attr">      properties:</span>
-<span class="hljs-attr">        message:</span>
-<span class="hljs-attr">          type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">        code:</span>
-<span class="hljs-attr">          type:</span> <span class="hljs-string">integer</span>
-<span class="hljs-attr">          minimum:</span> <span class="hljs-number">100</span>
-<span class="hljs-attr">          maximum:</span> <span class="hljs-number">600</span>
-<span class="hljs-attr">    ExtendedErrorModel:</span>
-<span class="hljs-attr">      allOf:</span>
-<span class="hljs-bullet">      -</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/ErrorModel'</span>
-<span class="hljs-attr">      - type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">        required:</span>
-<span class="hljs-bullet">        -</span> <span class="hljs-string">rootCause</span>
-<span class="hljs-attr">        properties:</span>
-<span class="hljs-attr">          rootCause:</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">schemas:</span>
+    <span class="hljs-attr">ErrorModel:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+      <span class="hljs-attr">required:</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-string">message</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-string">code</span>
+      <span class="hljs-attr">properties:</span>
+        <span class="hljs-attr">message:</span>
+          <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+        <span class="hljs-attr">code:</span>
+          <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+          <span class="hljs-attr">minimum:</span> <span class="hljs-number">100</span>
+          <span class="hljs-attr">maximum:</span> <span class="hljs-number">600</span>
+    <span class="hljs-attr">ExtendedErrorModel:</span>
+      <span class="hljs-attr">allOf:</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/ErrorModel&#x27;</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+        <span class="hljs-attr">required:</span>
+        <span class="hljs-bullet">-</span> <span class="hljs-string">rootCause</span>
+        <span class="hljs-attr">properties:</span>
+          <span class="hljs-attr">rootCause:</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
 </code></pre>
 </section><section><h5>Models with Polymorphism Support</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"components"</span>: {
-    <span class="hljs-attr">"schemas"</span>: {
-      <span class="hljs-attr">"Pet"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-        <span class="hljs-attr">"discriminator"</span>: {
-          <span class="hljs-attr">"propertyName"</span>: <span class="hljs-string">"petType"</span>
+  <span class="hljs-attr">&quot;components&quot;</span>: {
+    <span class="hljs-attr">&quot;schemas&quot;</span>: {
+      <span class="hljs-attr">&quot;Pet&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+        <span class="hljs-attr">&quot;discriminator&quot;</span>: {
+          <span class="hljs-attr">&quot;propertyName&quot;</span>: <span class="hljs-string">&quot;petType&quot;</span>
         },
-        <span class="hljs-attr">"properties"</span>: {
-          <span class="hljs-attr">"name"</span>: {
-            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+        <span class="hljs-attr">&quot;properties&quot;</span>: {
+          <span class="hljs-attr">&quot;name&quot;</span>: {
+            <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
           },
-          <span class="hljs-attr">"petType"</span>: {
-            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+          <span class="hljs-attr">&quot;petType&quot;</span>: {
+            <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
           }
         },
-        <span class="hljs-attr">"required"</span>: [
-          <span class="hljs-string">"name"</span>,
-          <span class="hljs-string">"petType"</span>
+        <span class="hljs-attr">&quot;required&quot;</span>: [
+          <span class="hljs-string">&quot;name&quot;</span>,
+          <span class="hljs-string">&quot;petType&quot;</span>
         ]
       },
-      <span class="hljs-attr">"Cat"</span>: {
-        <span class="hljs-attr">"description"</span>: <span class="hljs-string">"A representation of a cat. Note that `Cat` will be used as the discriminator value."</span>,
-        <span class="hljs-attr">"allOf"</span>: [
+      <span class="hljs-attr">&quot;Cat&quot;</span>: {
+        <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;A representation of a cat. Note that `Cat` will be used as the discriminator value.&quot;</span>,
+        <span class="hljs-attr">&quot;allOf&quot;</span>: [
           {
-            <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/Pet"</span>
+            <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/Pet&quot;</span>
           },
           {
-            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-            <span class="hljs-attr">"properties"</span>: {
-              <span class="hljs-attr">"huntingSkill"</span>: {
-                <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
-                <span class="hljs-attr">"description"</span>: <span class="hljs-string">"The measured skill for hunting"</span>,
-                <span class="hljs-attr">"default"</span>: <span class="hljs-string">"lazy"</span>,
-                <span class="hljs-attr">"enum"</span>: [
-                  <span class="hljs-string">"clueless"</span>,
-                  <span class="hljs-string">"lazy"</span>,
-                  <span class="hljs-string">"adventurous"</span>,
-                  <span class="hljs-string">"aggressive"</span>
+            <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+            <span class="hljs-attr">&quot;properties&quot;</span>: {
+              <span class="hljs-attr">&quot;huntingSkill&quot;</span>: {
+                <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>,
+                <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;The measured skill for hunting&quot;</span>,
+                <span class="hljs-attr">&quot;default&quot;</span>: <span class="hljs-string">&quot;lazy&quot;</span>,
+                <span class="hljs-attr">&quot;enum&quot;</span>: [
+                  <span class="hljs-string">&quot;clueless&quot;</span>,
+                  <span class="hljs-string">&quot;lazy&quot;</span>,
+                  <span class="hljs-string">&quot;adventurous&quot;</span>,
+                  <span class="hljs-string">&quot;aggressive&quot;</span>
                 ]
               }
             },
-            <span class="hljs-attr">"required"</span>: [
-              <span class="hljs-string">"huntingSkill"</span>
+            <span class="hljs-attr">&quot;required&quot;</span>: [
+              <span class="hljs-string">&quot;huntingSkill&quot;</span>
             ]
           }
         ]
       },
-      <span class="hljs-attr">"Dog"</span>: {
-        <span class="hljs-attr">"description"</span>: <span class="hljs-string">"A representation of a dog. Note that `Dog` will be used as the discriminator value."</span>,
-        <span class="hljs-attr">"allOf"</span>: [
+      <span class="hljs-attr">&quot;Dog&quot;</span>: {
+        <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;A representation of a dog. Note that `Dog` will be used as the discriminator value.&quot;</span>,
+        <span class="hljs-attr">&quot;allOf&quot;</span>: [
           {
-            <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/Pet"</span>
+            <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/Pet&quot;</span>
           },
           {
-            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-            <span class="hljs-attr">"properties"</span>: {
-              <span class="hljs-attr">"packSize"</span>: {
-                <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>,
-                <span class="hljs-attr">"format"</span>: <span class="hljs-string">"int32"</span>,
-                <span class="hljs-attr">"description"</span>: <span class="hljs-string">"the size of the pack the dog is from"</span>,
-                <span class="hljs-attr">"default"</span>: <span class="hljs-number">0</span>,
-                <span class="hljs-attr">"minimum"</span>: <span class="hljs-number">0</span>
+            <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+            <span class="hljs-attr">&quot;properties&quot;</span>: {
+              <span class="hljs-attr">&quot;packSize&quot;</span>: {
+                <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>,
+                <span class="hljs-attr">&quot;format&quot;</span>: <span class="hljs-string">&quot;int32&quot;</span>,
+                <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;the size of the pack the dog is from&quot;</span>,
+                <span class="hljs-attr">&quot;default&quot;</span>: <span class="hljs-number">0</span>,
+                <span class="hljs-attr">&quot;minimum&quot;</span>: <span class="hljs-number">0</span>
               }
             },
-            <span class="hljs-attr">"required"</span>: [
-              <span class="hljs-string">"packSize"</span>
+            <span class="hljs-attr">&quot;required&quot;</span>: [
+              <span class="hljs-string">&quot;packSize&quot;</span>
             ]
           }
         ]
@@ -3218,49 +3218,49 @@ The <a href="#xmlObject">XML Object</a> contains additional information about th
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">components:</span>
-<span class="hljs-attr">  schemas:</span>
-<span class="hljs-attr">    Pet:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">      discriminator:</span>
-<span class="hljs-attr">        propertyName:</span> <span class="hljs-string">petType</span>
-<span class="hljs-attr">      properties:</span>
-<span class="hljs-attr">        name:</span>
-<span class="hljs-attr">          type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">        petType:</span>
-<span class="hljs-attr">          type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">      required:</span>
-<span class="hljs-bullet">      -</span> <span class="hljs-string">name</span>
-<span class="hljs-bullet">      -</span> <span class="hljs-string">petType</span>
-<span class="hljs-attr">    Cat:</span>  <span class="hljs-comment">## "Cat" will be used as the discriminator value</span>
-<span class="hljs-attr">      description:</span> <span class="hljs-string">A</span> <span class="hljs-string">representation</span> <span class="hljs-string">of</span> <span class="hljs-string">a</span> <span class="hljs-string">cat</span>
-<span class="hljs-attr">      allOf:</span>
-<span class="hljs-bullet">      -</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Pet'</span>
-<span class="hljs-attr">      - type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">        properties:</span>
-<span class="hljs-attr">          huntingSkill:</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">            description:</span> <span class="hljs-string">The</span> <span class="hljs-string">measured</span> <span class="hljs-string">skill</span> <span class="hljs-string">for</span> <span class="hljs-string">hunting</span>
-<span class="hljs-attr">            enum:</span>
-<span class="hljs-bullet">            -</span> <span class="hljs-string">clueless</span>
-<span class="hljs-bullet">            -</span> <span class="hljs-string">lazy</span>
-<span class="hljs-bullet">            -</span> <span class="hljs-string">adventurous</span>
-<span class="hljs-bullet">            -</span> <span class="hljs-string">aggressive</span>
-<span class="hljs-attr">        required:</span>
-<span class="hljs-bullet">        -</span> <span class="hljs-string">huntingSkill</span>
-<span class="hljs-attr">    Dog:</span>  <span class="hljs-comment">## "Dog" will be used as the discriminator value</span>
-<span class="hljs-attr">      description:</span> <span class="hljs-string">A</span> <span class="hljs-string">representation</span> <span class="hljs-string">of</span> <span class="hljs-string">a</span> <span class="hljs-string">dog</span>
-<span class="hljs-attr">      allOf:</span>
-<span class="hljs-bullet">      -</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Pet'</span>
-<span class="hljs-attr">      - type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">        properties:</span>
-<span class="hljs-attr">          packSize:</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">integer</span>
-<span class="hljs-attr">            format:</span> <span class="hljs-string">int32</span>
-<span class="hljs-attr">            description:</span> <span class="hljs-string">the</span> <span class="hljs-string">size</span> <span class="hljs-string">of</span> <span class="hljs-string">the</span> <span class="hljs-string">pack</span> <span class="hljs-string">the</span> <span class="hljs-string">dog</span> <span class="hljs-string">is</span> <span class="hljs-string">from</span>
-<span class="hljs-attr">            default:</span> <span class="hljs-number">0</span>
-<span class="hljs-attr">            minimum:</span> <span class="hljs-number">0</span>
-<span class="hljs-attr">        required:</span>
-<span class="hljs-bullet">        -</span> <span class="hljs-string">packSize</span>
+  <span class="hljs-attr">schemas:</span>
+    <span class="hljs-attr">Pet:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+      <span class="hljs-attr">discriminator:</span>
+        <span class="hljs-attr">propertyName:</span> <span class="hljs-string">petType</span>
+      <span class="hljs-attr">properties:</span>
+        <span class="hljs-attr">name:</span>
+          <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+        <span class="hljs-attr">petType:</span>
+          <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+      <span class="hljs-attr">required:</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-string">name</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-string">petType</span>
+    <span class="hljs-attr">Cat:</span>  <span class="hljs-comment">## &quot;Cat&quot; will be used as the discriminator value</span>
+      <span class="hljs-attr">description:</span> <span class="hljs-string">A</span> <span class="hljs-string">representation</span> <span class="hljs-string">of</span> <span class="hljs-string">a</span> <span class="hljs-string">cat</span>
+      <span class="hljs-attr">allOf:</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/Pet&#x27;</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+        <span class="hljs-attr">properties:</span>
+          <span class="hljs-attr">huntingSkill:</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+            <span class="hljs-attr">description:</span> <span class="hljs-string">The</span> <span class="hljs-string">measured</span> <span class="hljs-string">skill</span> <span class="hljs-string">for</span> <span class="hljs-string">hunting</span>
+            <span class="hljs-attr">enum:</span>
+            <span class="hljs-bullet">-</span> <span class="hljs-string">clueless</span>
+            <span class="hljs-bullet">-</span> <span class="hljs-string">lazy</span>
+            <span class="hljs-bullet">-</span> <span class="hljs-string">adventurous</span>
+            <span class="hljs-bullet">-</span> <span class="hljs-string">aggressive</span>
+        <span class="hljs-attr">required:</span>
+        <span class="hljs-bullet">-</span> <span class="hljs-string">huntingSkill</span>
+    <span class="hljs-attr">Dog:</span>  <span class="hljs-comment">## &quot;Dog&quot; will be used as the discriminator value</span>
+      <span class="hljs-attr">description:</span> <span class="hljs-string">A</span> <span class="hljs-string">representation</span> <span class="hljs-string">of</span> <span class="hljs-string">a</span> <span class="hljs-string">dog</span>
+      <span class="hljs-attr">allOf:</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/Pet&#x27;</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+        <span class="hljs-attr">properties:</span>
+          <span class="hljs-attr">packSize:</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+            <span class="hljs-attr">format:</span> <span class="hljs-string">int32</span>
+            <span class="hljs-attr">description:</span> <span class="hljs-string">the</span> <span class="hljs-string">size</span> <span class="hljs-string">of</span> <span class="hljs-string">the</span> <span class="hljs-string">pack</span> <span class="hljs-string">the</span> <span class="hljs-string">dog</span> <span class="hljs-string">is</span> <span class="hljs-string">from</span>
+            <span class="hljs-attr">default:</span> <span class="hljs-number">0</span>
+            <span class="hljs-attr">minimum:</span> <span class="hljs-number">0</span>
+        <span class="hljs-attr">required:</span>
+        <span class="hljs-bullet">-</span> <span class="hljs-string">packSize</span>
 </code></pre>
 </section></section></section><section><h3><span id="discriminatorObject">Discriminator Object</span></h3>
 <p>When request bodies or response payloads may be one of a number of different schemas, a <code>discriminator</code> object can be used to aid in serialization, deserialization, and validation.  The discriminator is a specific object in a schema which is used to inform the consumer of the specification of an alternative schema based on the value associated with it.</p>
@@ -3434,14 +3434,14 @@ See examples for expected behavior.</p>
 <p>Basic string property:</p>
 <pre class="nohighlight"><code>
 {
-    <span class="hljs-attr">"animals"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+    <span class="hljs-attr">&quot;animals&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
     }
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">animals:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-tag">&lt;<span class="hljs-name">animals</span>&gt;</span>...<span class="hljs-tag">&lt;/<span class="hljs-name">animals</span>&gt;</span>
@@ -3449,19 +3449,19 @@ See examples for expected behavior.</p>
 <p>Basic string array property (<a href="#xmlWrapped"><code>wrapped</code></a> is <code>false</code> by default):</p>
 <pre class="nohighlight"><code>
 {
-    <span class="hljs-attr">"animals"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-        <span class="hljs-attr">"items"</span>: {
-            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+    <span class="hljs-attr">&quot;animals&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+        <span class="hljs-attr">&quot;items&quot;</span>: {
+            <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
         }
     }
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">animals:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">  items:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+  <span class="hljs-attr">items:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-tag">&lt;<span class="hljs-name">animals</span>&gt;</span>...<span class="hljs-tag">&lt;/<span class="hljs-name">animals</span>&gt;</span>
@@ -3471,19 +3471,19 @@ See examples for expected behavior.</p>
 </section><section><h5>XML Name Replacement</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"animals"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
-    <span class="hljs-attr">"xml"</span>: {
-      <span class="hljs-attr">"name"</span>: <span class="hljs-string">"animal"</span>
+  <span class="hljs-attr">&quot;animals&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>,
+    <span class="hljs-attr">&quot;xml&quot;</span>: {
+      <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;animal&quot;</span>
     }
   }
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">animals:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">  xml:</span>
-<span class="hljs-attr">    name:</span> <span class="hljs-string">animal</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">xml:</span>
+    <span class="hljs-attr">name:</span> <span class="hljs-string">animal</span>
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-tag">&lt;<span class="hljs-name">animal</span>&gt;</span>...<span class="hljs-tag">&lt;/<span class="hljs-name">animal</span>&gt;</span>
@@ -3492,21 +3492,21 @@ See examples for expected behavior.</p>
 <p>In this example, a full model definition is shown.</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"Person"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-    <span class="hljs-attr">"properties"</span>: {
-      <span class="hljs-attr">"id"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>,
-        <span class="hljs-attr">"format"</span>: <span class="hljs-string">"int32"</span>,
-        <span class="hljs-attr">"xml"</span>: {
-          <span class="hljs-attr">"attribute"</span>: <span class="hljs-literal">true</span>
+  <span class="hljs-attr">&quot;Person&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+    <span class="hljs-attr">&quot;properties&quot;</span>: {
+      <span class="hljs-attr">&quot;id&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>,
+        <span class="hljs-attr">&quot;format&quot;</span>: <span class="hljs-string">&quot;int32&quot;</span>,
+        <span class="hljs-attr">&quot;xml&quot;</span>: {
+          <span class="hljs-attr">&quot;attribute&quot;</span>: <span class="hljs-literal">true</span>
         }
       },
-      <span class="hljs-attr">"name"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
-        <span class="hljs-attr">"xml"</span>: {
-          <span class="hljs-attr">"namespace"</span>: <span class="hljs-string">"http://example.com/schema/sample"</span>,
-          <span class="hljs-attr">"prefix"</span>: <span class="hljs-string">"sample"</span>
+      <span class="hljs-attr">&quot;name&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>,
+        <span class="hljs-attr">&quot;xml&quot;</span>: {
+          <span class="hljs-attr">&quot;namespace&quot;</span>: <span class="hljs-string">&quot;http://example.com/schema/sample&quot;</span>,
+          <span class="hljs-attr">&quot;prefix&quot;</span>: <span class="hljs-string">&quot;sample&quot;</span>
         }
       }
     }
@@ -3515,34 +3515,34 @@ See examples for expected behavior.</p>
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">Person:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">  properties:</span>
-<span class="hljs-attr">    id:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">integer</span>
-<span class="hljs-attr">      format:</span> <span class="hljs-string">int32</span>
-<span class="hljs-attr">      xml:</span>
-<span class="hljs-attr">        attribute:</span> <span class="hljs-literal">true</span>
-<span class="hljs-attr">    name:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">      xml:</span>
-<span class="hljs-attr">        namespace:</span> <span class="hljs-attr">http://example.com/schema/sample</span>
-<span class="hljs-attr">        prefix:</span> <span class="hljs-string">sample</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+  <span class="hljs-attr">properties:</span>
+    <span class="hljs-attr">id:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+      <span class="hljs-attr">format:</span> <span class="hljs-string">int32</span>
+      <span class="hljs-attr">xml:</span>
+        <span class="hljs-attr">attribute:</span> <span class="hljs-literal">true</span>
+    <span class="hljs-attr">name:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+      <span class="hljs-attr">xml:</span>
+        <span class="hljs-attr">namespace:</span> <span class="hljs-string">http://example.com/schema/sample</span>
+        <span class="hljs-attr">prefix:</span> <span class="hljs-string">sample</span>
 </code></pre>
 <pre class="nohighlight"><code>
-<span class="hljs-tag">&lt;<span class="hljs-name">Person</span> <span class="hljs-attr">id</span>=<span class="hljs-string">"123"</span>&gt;</span>
-    <span class="hljs-tag">&lt;<span class="hljs-name">sample:name</span> <span class="hljs-attr">xmlns:sample</span>=<span class="hljs-string">"http://example.com/schema/sample"</span>&gt;</span>example<span class="hljs-tag">&lt;/<span class="hljs-name">sample:name</span>&gt;</span>
+<span class="hljs-tag">&lt;<span class="hljs-name">Person</span> <span class="hljs-attr">id</span>=<span class="hljs-string">&quot;123&quot;</span>&gt;</span>
+    <span class="hljs-tag">&lt;<span class="hljs-name">sample:name</span> <span class="hljs-attr">xmlns:sample</span>=<span class="hljs-string">&quot;http://example.com/schema/sample&quot;</span>&gt;</span>example<span class="hljs-tag">&lt;/<span class="hljs-name">sample:name</span>&gt;</span>
 <span class="hljs-tag">&lt;/<span class="hljs-name">Person</span>&gt;</span>
 </code></pre>
 </section><section><h5>XML Arrays</h5>
 <p>Changing the element names:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"animals"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-    <span class="hljs-attr">"items"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
-      <span class="hljs-attr">"xml"</span>: {
-        <span class="hljs-attr">"name"</span>: <span class="hljs-string">"animal"</span>
+  <span class="hljs-attr">&quot;animals&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+    <span class="hljs-attr">&quot;items&quot;</span>: {
+      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>,
+      <span class="hljs-attr">&quot;xml&quot;</span>: {
+        <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;animal&quot;</span>
       }
     }
   }
@@ -3550,11 +3550,11 @@ See examples for expected behavior.</p>
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">animals:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">  items:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">    xml:</span>
-<span class="hljs-attr">      name:</span> <span class="hljs-string">animal</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+  <span class="hljs-attr">items:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+    <span class="hljs-attr">xml:</span>
+      <span class="hljs-attr">name:</span> <span class="hljs-string">animal</span>
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-tag">&lt;<span class="hljs-name">animal</span>&gt;</span>value<span class="hljs-tag">&lt;/<span class="hljs-name">animal</span>&gt;</span>
@@ -3563,29 +3563,29 @@ See examples for expected behavior.</p>
 <p>The external <code>name</code> property has no effect on the XML:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"animals"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-    <span class="hljs-attr">"items"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
-      <span class="hljs-attr">"xml"</span>: {
-        <span class="hljs-attr">"name"</span>: <span class="hljs-string">"animal"</span>
+  <span class="hljs-attr">&quot;animals&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+    <span class="hljs-attr">&quot;items&quot;</span>: {
+      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>,
+      <span class="hljs-attr">&quot;xml&quot;</span>: {
+        <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;animal&quot;</span>
       }
     },
-    <span class="hljs-attr">"xml"</span>: {
-      <span class="hljs-attr">"name"</span>: <span class="hljs-string">"aliens"</span>
+    <span class="hljs-attr">&quot;xml&quot;</span>: {
+      <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;aliens&quot;</span>
     }
   }
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">animals:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">  items:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">    xml:</span>
-<span class="hljs-attr">      name:</span> <span class="hljs-string">animal</span>
-<span class="hljs-attr">  xml:</span>
-<span class="hljs-attr">    name:</span> <span class="hljs-string">aliens</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+  <span class="hljs-attr">items:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+    <span class="hljs-attr">xml:</span>
+      <span class="hljs-attr">name:</span> <span class="hljs-string">animal</span>
+  <span class="hljs-attr">xml:</span>
+    <span class="hljs-attr">name:</span> <span class="hljs-string">aliens</span>
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-tag">&lt;<span class="hljs-name">animal</span>&gt;</span>value<span class="hljs-tag">&lt;/<span class="hljs-name">animal</span>&gt;</span>
@@ -3594,24 +3594,24 @@ See examples for expected behavior.</p>
 <p>Even when the array is wrapped, if a name is not explicitly defined, the same name will be used both internally and externally:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"animals"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-    <span class="hljs-attr">"items"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+  <span class="hljs-attr">&quot;animals&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+    <span class="hljs-attr">&quot;items&quot;</span>: {
+      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
     },
-    <span class="hljs-attr">"xml"</span>: {
-      <span class="hljs-attr">"wrapped"</span>: <span class="hljs-literal">true</span>
+    <span class="hljs-attr">&quot;xml&quot;</span>: {
+      <span class="hljs-attr">&quot;wrapped&quot;</span>: <span class="hljs-literal">true</span>
     }
   }
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">animals:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">  items:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">  xml:</span>
-<span class="hljs-attr">    wrapped:</span> <span class="hljs-literal">true</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+  <span class="hljs-attr">items:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">xml:</span>
+    <span class="hljs-attr">wrapped:</span> <span class="hljs-literal">true</span>
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-tag">&lt;<span class="hljs-name">animals</span>&gt;</span>
@@ -3622,29 +3622,29 @@ See examples for expected behavior.</p>
 <p>To overcome the naming problem in the example above, the following definition can be used:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"animals"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-    <span class="hljs-attr">"items"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
-      <span class="hljs-attr">"xml"</span>: {
-        <span class="hljs-attr">"name"</span>: <span class="hljs-string">"animal"</span>
+  <span class="hljs-attr">&quot;animals&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+    <span class="hljs-attr">&quot;items&quot;</span>: {
+      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>,
+      <span class="hljs-attr">&quot;xml&quot;</span>: {
+        <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;animal&quot;</span>
       }
     },
-    <span class="hljs-attr">"xml"</span>: {
-      <span class="hljs-attr">"wrapped"</span>: <span class="hljs-literal">true</span>
+    <span class="hljs-attr">&quot;xml&quot;</span>: {
+      <span class="hljs-attr">&quot;wrapped&quot;</span>: <span class="hljs-literal">true</span>
     }
   }
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">animals:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">  items:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">    xml:</span>
-<span class="hljs-attr">      name:</span> <span class="hljs-string">animal</span>
-<span class="hljs-attr">  xml:</span>
-<span class="hljs-attr">    wrapped:</span> <span class="hljs-literal">true</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+  <span class="hljs-attr">items:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+    <span class="hljs-attr">xml:</span>
+      <span class="hljs-attr">name:</span> <span class="hljs-string">animal</span>
+  <span class="hljs-attr">xml:</span>
+    <span class="hljs-attr">wrapped:</span> <span class="hljs-literal">true</span>
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-tag">&lt;<span class="hljs-name">animals</span>&gt;</span>
@@ -3655,31 +3655,31 @@ See examples for expected behavior.</p>
 <p>Affecting both internal and external names:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"animals"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-    <span class="hljs-attr">"items"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
-      <span class="hljs-attr">"xml"</span>: {
-        <span class="hljs-attr">"name"</span>: <span class="hljs-string">"animal"</span>
+  <span class="hljs-attr">&quot;animals&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+    <span class="hljs-attr">&quot;items&quot;</span>: {
+      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>,
+      <span class="hljs-attr">&quot;xml&quot;</span>: {
+        <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;animal&quot;</span>
       }
     },
-    <span class="hljs-attr">"xml"</span>: {
-      <span class="hljs-attr">"name"</span>: <span class="hljs-string">"aliens"</span>,
-      <span class="hljs-attr">"wrapped"</span>: <span class="hljs-literal">true</span>
+    <span class="hljs-attr">&quot;xml&quot;</span>: {
+      <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;aliens&quot;</span>,
+      <span class="hljs-attr">&quot;wrapped&quot;</span>: <span class="hljs-literal">true</span>
     }
   }
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">animals:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">  items:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">    xml:</span>
-<span class="hljs-attr">      name:</span> <span class="hljs-string">animal</span>
-<span class="hljs-attr">  xml:</span>
-<span class="hljs-attr">    name:</span> <span class="hljs-string">aliens</span>
-<span class="hljs-attr">    wrapped:</span> <span class="hljs-literal">true</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+  <span class="hljs-attr">items:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+    <span class="hljs-attr">xml:</span>
+      <span class="hljs-attr">name:</span> <span class="hljs-string">animal</span>
+  <span class="hljs-attr">xml:</span>
+    <span class="hljs-attr">name:</span> <span class="hljs-string">aliens</span>
+    <span class="hljs-attr">wrapped:</span> <span class="hljs-literal">true</span>
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-tag">&lt;<span class="hljs-name">aliens</span>&gt;</span>
@@ -3690,26 +3690,26 @@ See examples for expected behavior.</p>
 <p>If we change the external element but not the internal ones:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"animals"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-    <span class="hljs-attr">"items"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+  <span class="hljs-attr">&quot;animals&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+    <span class="hljs-attr">&quot;items&quot;</span>: {
+      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
     },
-    <span class="hljs-attr">"xml"</span>: {
-      <span class="hljs-attr">"name"</span>: <span class="hljs-string">"aliens"</span>,
-      <span class="hljs-attr">"wrapped"</span>: <span class="hljs-literal">true</span>
+    <span class="hljs-attr">&quot;xml&quot;</span>: {
+      <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;aliens&quot;</span>,
+      <span class="hljs-attr">&quot;wrapped&quot;</span>: <span class="hljs-literal">true</span>
     }
   }
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">animals:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">  items:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">  xml:</span>
-<span class="hljs-attr">    name:</span> <span class="hljs-string">aliens</span>
-<span class="hljs-attr">    wrapped:</span> <span class="hljs-literal">true</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+  <span class="hljs-attr">items:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">xml:</span>
+    <span class="hljs-attr">name:</span> <span class="hljs-string">aliens</span>
+    <span class="hljs-attr">wrapped:</span> <span class="hljs-literal">true</span>
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-tag">&lt;<span class="hljs-name">aliens</span>&gt;</span>
@@ -3786,8 +3786,8 @@ Supported schemes are HTTP authentication, an API key (either as a header or as 
 <section><h5>Basic Authentication Sample</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"http"</span>,
-  <span class="hljs-attr">"scheme"</span>: <span class="hljs-string">"basic"</span>
+  <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;http&quot;</span>,
+  <span class="hljs-attr">&quot;scheme&quot;</span>: <span class="hljs-string">&quot;basic&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -3797,9 +3797,9 @@ Supported schemes are HTTP authentication, an API key (either as a header or as 
 </section><section><h5>API Key Sample</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"apiKey"</span>,
-  <span class="hljs-attr">"name"</span>: <span class="hljs-string">"api_key"</span>,
-  <span class="hljs-attr">"in"</span>: <span class="hljs-string">"header"</span>
+  <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;apiKey&quot;</span>,
+  <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;api_key&quot;</span>,
+  <span class="hljs-attr">&quot;in&quot;</span>: <span class="hljs-string">&quot;header&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -3810,9 +3810,9 @@ Supported schemes are HTTP authentication, an API key (either as a header or as 
 </section><section><h5>JWT Bearer Sample</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"http"</span>,
-  <span class="hljs-attr">"scheme"</span>: <span class="hljs-string">"bearer"</span>,
-  <span class="hljs-attr">"bearerFormat"</span>: <span class="hljs-string">"JWT"</span>,
+  <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;http&quot;</span>,
+  <span class="hljs-attr">&quot;scheme&quot;</span>: <span class="hljs-string">&quot;bearer&quot;</span>,
+  <span class="hljs-attr">&quot;bearerFormat&quot;</span>: <span class="hljs-string">&quot;JWT&quot;</span>,
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -3823,13 +3823,13 @@ Supported schemes are HTTP authentication, an API key (either as a header or as 
 </section><section><h5>Implicit OAuth2 Sample</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"oauth2"</span>,
-  <span class="hljs-attr">"flows"</span>: {
-    <span class="hljs-attr">"implicit"</span>: {
-      <span class="hljs-attr">"authorizationUrl"</span>: <span class="hljs-string">"https://example.com/api/oauth/dialog"</span>,
-      <span class="hljs-attr">"scopes"</span>: {
-        <span class="hljs-attr">"write:pets"</span>: <span class="hljs-string">"modify pets in your account"</span>,
-        <span class="hljs-attr">"read:pets"</span>: <span class="hljs-string">"read your pets"</span>
+  <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;oauth2&quot;</span>,
+  <span class="hljs-attr">&quot;flows&quot;</span>: {
+    <span class="hljs-attr">&quot;implicit&quot;</span>: {
+      <span class="hljs-attr">&quot;authorizationUrl&quot;</span>: <span class="hljs-string">&quot;https://example.com/api/oauth/dialog&quot;</span>,
+      <span class="hljs-attr">&quot;scopes&quot;</span>: {
+        <span class="hljs-attr">&quot;write:pets&quot;</span>: <span class="hljs-string">&quot;modify pets in your account&quot;</span>,
+        <span class="hljs-attr">&quot;read:pets&quot;</span>: <span class="hljs-string">&quot;read your pets&quot;</span>
       }
     }
   }
@@ -3838,11 +3838,11 @@ Supported schemes are HTTP authentication, an API key (either as a header or as 
 <pre class="nohighlight"><code>
 <span class="hljs-attr">type:</span> <span class="hljs-string">oauth2</span>
 <span class="hljs-attr">flows:</span> 
-<span class="hljs-attr">  implicit:</span>
-<span class="hljs-attr">    authorizationUrl:</span> <span class="hljs-attr">https://example.com/api/oauth/dialog</span>
-<span class="hljs-attr">    scopes:</span>
-<span class="hljs-attr">      write:</span><span class="hljs-attr">pets:</span> <span class="hljs-string">modify</span> <span class="hljs-string">pets</span> <span class="hljs-string">in</span> <span class="hljs-string">your</span> <span class="hljs-string">account</span>
-<span class="hljs-attr">      read:</span><span class="hljs-attr">pets:</span> <span class="hljs-string">read</span> <span class="hljs-string">your</span> <span class="hljs-string">pets</span>
+  <span class="hljs-attr">implicit:</span>
+    <span class="hljs-attr">authorizationUrl:</span> <span class="hljs-string">https://example.com/api/oauth/dialog</span>
+    <span class="hljs-attr">scopes:</span>
+      <span class="hljs-attr">write:pets:</span> <span class="hljs-string">modify</span> <span class="hljs-string">pets</span> <span class="hljs-string">in</span> <span class="hljs-string">your</span> <span class="hljs-string">account</span>
+      <span class="hljs-attr">read:pets:</span> <span class="hljs-string">read</span> <span class="hljs-string">your</span> <span class="hljs-string">pets</span>
 </code></pre>
 </section></section></section><section><h3><span id="oauthFlowsObject">OAuth Flows Object</span></h3>
 <p>Allows configuration of the supported OAuth Flows.</p>
@@ -3922,21 +3922,21 @@ Supported schemes are HTTP authentication, an API key (either as a header or as 
 </section><section><h4>OAuth Flow Object Examples</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"oauth2"</span>,
-  <span class="hljs-attr">"flows"</span>: {
-    <span class="hljs-attr">"implicit"</span>: {
-      <span class="hljs-attr">"authorizationUrl"</span>: <span class="hljs-string">"https://example.com/api/oauth/dialog"</span>,
-      <span class="hljs-attr">"scopes"</span>: {
-        <span class="hljs-attr">"write:pets"</span>: <span class="hljs-string">"modify pets in your account"</span>,
-        <span class="hljs-attr">"read:pets"</span>: <span class="hljs-string">"read your pets"</span>
+  <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;oauth2&quot;</span>,
+  <span class="hljs-attr">&quot;flows&quot;</span>: {
+    <span class="hljs-attr">&quot;implicit&quot;</span>: {
+      <span class="hljs-attr">&quot;authorizationUrl&quot;</span>: <span class="hljs-string">&quot;https://example.com/api/oauth/dialog&quot;</span>,
+      <span class="hljs-attr">&quot;scopes&quot;</span>: {
+        <span class="hljs-attr">&quot;write:pets&quot;</span>: <span class="hljs-string">&quot;modify pets in your account&quot;</span>,
+        <span class="hljs-attr">&quot;read:pets&quot;</span>: <span class="hljs-string">&quot;read your pets&quot;</span>
       }
     },
-    <span class="hljs-attr">"authorizationCode"</span>: {
-      <span class="hljs-attr">"authorizationUrl"</span>: <span class="hljs-string">"https://example.com/api/oauth/dialog"</span>,
-      <span class="hljs-attr">"tokenUrl"</span>: <span class="hljs-string">"https://example.com/api/oauth/token"</span>,
-      <span class="hljs-attr">"scopes"</span>: {
-        <span class="hljs-attr">"write:pets"</span>: <span class="hljs-string">"modify pets in your account"</span>,
-        <span class="hljs-attr">"read:pets"</span>: <span class="hljs-string">"read your pets"</span>
+    <span class="hljs-attr">&quot;authorizationCode&quot;</span>: {
+      <span class="hljs-attr">&quot;authorizationUrl&quot;</span>: <span class="hljs-string">&quot;https://example.com/api/oauth/dialog&quot;</span>,
+      <span class="hljs-attr">&quot;tokenUrl&quot;</span>: <span class="hljs-string">&quot;https://example.com/api/oauth/token&quot;</span>,
+      <span class="hljs-attr">&quot;scopes&quot;</span>: {
+        <span class="hljs-attr">&quot;write:pets&quot;</span>: <span class="hljs-string">&quot;modify pets in your account&quot;</span>,
+        <span class="hljs-attr">&quot;read:pets&quot;</span>: <span class="hljs-string">&quot;read your pets&quot;</span>
       }
     }
   }
@@ -3945,17 +3945,17 @@ Supported schemes are HTTP authentication, an API key (either as a header or as 
 <pre class="nohighlight"><code>
 <span class="hljs-attr">type:</span> <span class="hljs-string">oauth2</span>
 <span class="hljs-attr">flows:</span> 
-<span class="hljs-attr">  implicit:</span>
-<span class="hljs-attr">    authorizationUrl:</span> <span class="hljs-attr">https://example.com/api/oauth/dialog</span>
-<span class="hljs-attr">    scopes:</span>
-<span class="hljs-attr">      write:</span><span class="hljs-attr">pets:</span> <span class="hljs-string">modify</span> <span class="hljs-string">pets</span> <span class="hljs-string">in</span> <span class="hljs-string">your</span> <span class="hljs-string">account</span>
-<span class="hljs-attr">      read:</span><span class="hljs-attr">pets:</span> <span class="hljs-string">read</span> <span class="hljs-string">your</span> <span class="hljs-string">pets</span>
-<span class="hljs-attr">  authorizationCode:</span>
-<span class="hljs-attr">    authorizationUrl:</span> <span class="hljs-attr">https://example.com/api/oauth/dialog</span>
-<span class="hljs-attr">    tokenUrl:</span> <span class="hljs-attr">https://example.com/api/oauth/token</span>
-<span class="hljs-attr">    scopes:</span>
-<span class="hljs-attr">      write:</span><span class="hljs-attr">pets:</span> <span class="hljs-string">modify</span> <span class="hljs-string">pets</span> <span class="hljs-string">in</span> <span class="hljs-string">your</span> <span class="hljs-string">account</span>
-<span class="hljs-attr">      read:</span><span class="hljs-attr">pets:</span> <span class="hljs-string">read</span> <span class="hljs-string">your</span> <span class="hljs-string">pets</span> 
+  <span class="hljs-attr">implicit:</span>
+    <span class="hljs-attr">authorizationUrl:</span> <span class="hljs-string">https://example.com/api/oauth/dialog</span>
+    <span class="hljs-attr">scopes:</span>
+      <span class="hljs-attr">write:pets:</span> <span class="hljs-string">modify</span> <span class="hljs-string">pets</span> <span class="hljs-string">in</span> <span class="hljs-string">your</span> <span class="hljs-string">account</span>
+      <span class="hljs-attr">read:pets:</span> <span class="hljs-string">read</span> <span class="hljs-string">your</span> <span class="hljs-string">pets</span>
+  <span class="hljs-attr">authorizationCode:</span>
+    <span class="hljs-attr">authorizationUrl:</span> <span class="hljs-string">https://example.com/api/oauth/dialog</span>
+    <span class="hljs-attr">tokenUrl:</span> <span class="hljs-string">https://example.com/api/oauth/token</span>
+    <span class="hljs-attr">scopes:</span>
+      <span class="hljs-attr">write:pets:</span> <span class="hljs-string">modify</span> <span class="hljs-string">pets</span> <span class="hljs-string">in</span> <span class="hljs-string">your</span> <span class="hljs-string">account</span>
+      <span class="hljs-attr">read:pets:</span> <span class="hljs-string">read</span> <span class="hljs-string">your</span> <span class="hljs-string">pets</span> 
 </code></pre>
 </section></section><section><h3><span id="securityRequirementObject">Security Requirement Object</span></h3>
 <p>Lists the required security schemes to execute this operation.
@@ -3984,25 +3984,25 @@ This enables support for scenarios where multiple query parameters or HTTP heade
 <section><h5>Non-OAuth2 Security Requirement</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"api_key"</span>: []
+  <span class="hljs-attr">&quot;api_key&quot;</span>: []
 }
 </code></pre>
 <pre class="nohighlight"><code>
-<span class="hljs-attr">api_key:</span> <span class="hljs-string">[]</span>
+<span class="hljs-attr">api_key:</span> []
 </code></pre>
 </section><section><h5>OAuth2 Security Requirement</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"petstore_auth"</span>: [
-    <span class="hljs-string">"write:pets"</span>,
-    <span class="hljs-string">"read:pets"</span>
+  <span class="hljs-attr">&quot;petstore_auth&quot;</span>: [
+    <span class="hljs-string">&quot;write:pets&quot;</span>,
+    <span class="hljs-string">&quot;read:pets&quot;</span>
   ]
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">petstore_auth:</span>
-<span class="hljs-attr">- write:</span><span class="hljs-string">pets</span>
-<span class="hljs-attr">- read:</span><span class="hljs-string">pets</span>
+<span class="hljs-bullet">-</span> <span class="hljs-string">write:pets</span>
+<span class="hljs-bullet">-</span> <span class="hljs-string">read:pets</span>
 </code></pre>
 </section></section></section></section><section><h2><span id="specificationExtensions">Specification Extensions</span></h2>
 <p>While the OpenAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.</p>

--- a/oas/v3.0.1.html
+++ b/oas/v3.0.1.html
@@ -1,4 +1,4 @@
-<html><head><meta charset="UTF-8"><title>OpenAPI Specification</title><script src="https://mermade.github.io/static/respec21/respec-oai.js" class="remove"></script><script class="remove">var respecConfig = {"specStatus":"base","editors":[{"name":"Darrel Miller "},{"name":"Jeremy Whitlock "},{"name":"Marsh Gardiner "},{"name":"Mike Ralphson "},{"name":"Ron Ratovsky "},{"name":"Uri Sarid "}],"formerEditors":[{"name":"Jason Harmon "},{"name":"Tony Tam "}],"publishDate":"2017-12-06T00:00:00.000Z","subtitle":"Version 3.0.1","processVersion":2017,"edDraftURI":"http://github.com/OAI/openapi-specification/","github":{"repoURL":"https://github.com/OAI/openapi-specification/","branch":"master"},"shortName":"OAS","noTOC":false,"lint":false,"additionalCopyrightHolders":"the Linux Foundation","includePermalinks":true};</script><!-- Global site tag (gtag.js) - Google Analytics -->
+<html lang="en"><head><meta charset="UTF-8"><title>OpenAPI Specification</title><script src="https://spec.openapis.org/js/respec-oai.js" class="remove"></script><script class="remove">var respecConfig = {"specStatus":"base","editors":[{"name":"Darrel Miller "},{"name":"Jeremy Whitlock "},{"name":"Marsh Gardiner "},{"name":"Mike Ralphson "},{"name":"Ron Ratovsky "},{"name":"Uri Sarid "}],"formerEditors":[{"name":"Jason Harmon "},{"name":"Tony Tam "}],"publishDate":"2017-12-06T00:00:00.000Z","subtitle":"Version 3.0.1","processVersion":2017,"edDraftURI":"https://github.com/OAI/OpenAPI-Specification/","github":{"repoURL":"https://github.com/OAI/OpenAPI-Specification/","branch":"master"},"shortName":"OAS","noTOC":false,"lint":false,"additionalCopyrightHolders":"the Linux Foundation","includePermalinks":true};</script><!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=UA-831873-42"></script>
 <script>
  window.dataLayer = window.dataLayer || [];
@@ -50,7 +50,7 @@ The available status codes are defined by [[!RFC7231]] and registered status cod
 <p>For example, if a field has an array value, the JSON array representation will be used:</p>
 <pre class="nohighlight"><code>
 {
-   <span class="hljs-attr">"field"</span>: [ <span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span> ]
+   <span class="hljs-attr">&quot;field&quot;</span>: [ <span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span> ]
 }
 </code></pre>
 <p>All field names in the specification are <strong>case sensitive</strong>.</p>
@@ -267,32 +267,32 @@ The metadata MAY be used by the clients if needed, and MAY be presented in editi
 </section><section><h4>Info Object Example:</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"title"</span>: <span class="hljs-string">"Sample Pet Store App"</span>,
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"This is a sample server for a pet store."</span>,
-  <span class="hljs-attr">"termsOfService"</span>: <span class="hljs-string">"http://example.com/terms/"</span>,
-  <span class="hljs-attr">"contact"</span>: {
-    <span class="hljs-attr">"name"</span>: <span class="hljs-string">"API Support"</span>,
-    <span class="hljs-attr">"url"</span>: <span class="hljs-string">"http://www.example.com/support"</span>,
-    <span class="hljs-attr">"email"</span>: <span class="hljs-string">"support@example.com"</span>
+  <span class="hljs-attr">&quot;title&quot;</span>: <span class="hljs-string">&quot;Sample Pet Store App&quot;</span>,
+  <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;This is a sample server for a pet store.&quot;</span>,
+  <span class="hljs-attr">&quot;termsOfService&quot;</span>: <span class="hljs-string">&quot;http://example.com/terms/&quot;</span>,
+  <span class="hljs-attr">&quot;contact&quot;</span>: {
+    <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;API Support&quot;</span>,
+    <span class="hljs-attr">&quot;url&quot;</span>: <span class="hljs-string">&quot;http://www.example.com/support&quot;</span>,
+    <span class="hljs-attr">&quot;email&quot;</span>: <span class="hljs-string">&quot;support@example.com&quot;</span>
   },
-  <span class="hljs-attr">"license"</span>: {
-    <span class="hljs-attr">"name"</span>: <span class="hljs-string">"Apache 2.0"</span>,
-    <span class="hljs-attr">"url"</span>: <span class="hljs-string">"https://www.apache.org/licenses/LICENSE-2.0.html"</span>
+  <span class="hljs-attr">&quot;license&quot;</span>: {
+    <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;Apache 2.0&quot;</span>,
+    <span class="hljs-attr">&quot;url&quot;</span>: <span class="hljs-string">&quot;https://www.apache.org/licenses/LICENSE-2.0.html&quot;</span>
   },
-  <span class="hljs-attr">"version"</span>: <span class="hljs-string">"1.0.1"</span>
+  <span class="hljs-attr">&quot;version&quot;</span>: <span class="hljs-string">&quot;1.0.1&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">title:</span> <span class="hljs-string">Sample</span> <span class="hljs-string">Pet</span> <span class="hljs-string">Store</span> <span class="hljs-string">App</span>
 <span class="hljs-attr">description:</span> <span class="hljs-string">This</span> <span class="hljs-string">is</span> <span class="hljs-string">a</span> <span class="hljs-string">sample</span> <span class="hljs-string">server</span> <span class="hljs-string">for</span> <span class="hljs-string">a</span> <span class="hljs-string">pet</span> <span class="hljs-string">store.</span>
-<span class="hljs-attr">termsOfService:</span> <span class="hljs-attr">http://example.com/terms/</span>
+<span class="hljs-attr">termsOfService:</span> <span class="hljs-string">http://example.com/terms/</span>
 <span class="hljs-attr">contact:</span>
-<span class="hljs-attr">  name:</span> <span class="hljs-string">API</span> <span class="hljs-string">Support</span>
-<span class="hljs-attr">  url:</span> <span class="hljs-attr">http://www.example.com/support</span>
-<span class="hljs-attr">  email:</span> <span class="hljs-string">support@example.com</span>
+  <span class="hljs-attr">name:</span> <span class="hljs-string">API</span> <span class="hljs-string">Support</span>
+  <span class="hljs-attr">url:</span> <span class="hljs-string">http://www.example.com/support</span>
+  <span class="hljs-attr">email:</span> <span class="hljs-string">support@example.com</span>
 <span class="hljs-attr">license:</span>
-<span class="hljs-attr">  name:</span> <span class="hljs-string">Apache</span> <span class="hljs-number">2.0</span>
-<span class="hljs-attr">  url:</span> <span class="hljs-attr">https://www.apache.org/licenses/LICENSE-2.0.html</span>
+  <span class="hljs-attr">name:</span> <span class="hljs-string">Apache</span> <span class="hljs-number">2.0</span>
+  <span class="hljs-attr">url:</span> <span class="hljs-string">https://www.apache.org/licenses/LICENSE-2.0.html</span>
 <span class="hljs-attr">version:</span> <span class="hljs-number">1.0</span><span class="hljs-number">.1</span>
 </code></pre>
 </section></section><section><h3><span id="contactObject">Contact Object</span></h3>
@@ -328,14 +328,14 @@ The metadata MAY be used by the clients if needed, and MAY be presented in editi
 </section><section><h4>Contact Object Example:</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"name"</span>: <span class="hljs-string">"API Support"</span>,
-  <span class="hljs-attr">"url"</span>: <span class="hljs-string">"http://www.example.com/support"</span>,
-  <span class="hljs-attr">"email"</span>: <span class="hljs-string">"support@example.com"</span>
+  <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;API Support&quot;</span>,
+  <span class="hljs-attr">&quot;url&quot;</span>: <span class="hljs-string">&quot;http://www.example.com/support&quot;</span>,
+  <span class="hljs-attr">&quot;email&quot;</span>: <span class="hljs-string">&quot;support@example.com&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">name:</span> <span class="hljs-string">API</span> <span class="hljs-string">Support</span>
-<span class="hljs-attr">url:</span> <span class="hljs-attr">http://www.example.com/support</span>
+<span class="hljs-attr">url:</span> <span class="hljs-string">http://www.example.com/support</span>
 <span class="hljs-attr">email:</span> <span class="hljs-string">support@example.com</span>
 </code></pre>
 </section></section><section><h3><span id="licenseObject">License Object</span></h3>
@@ -366,13 +366,13 @@ The metadata MAY be used by the clients if needed, and MAY be presented in editi
 </section><section><h4>License Object Example:</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"name"</span>: <span class="hljs-string">"Apache 2.0"</span>,
-  <span class="hljs-attr">"url"</span>: <span class="hljs-string">"https://www.apache.org/licenses/LICENSE-2.0.html"</span>
+  <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;Apache 2.0&quot;</span>,
+  <span class="hljs-attr">&quot;url&quot;</span>: <span class="hljs-string">&quot;https://www.apache.org/licenses/LICENSE-2.0.html&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">name:</span> <span class="hljs-string">Apache</span> <span class="hljs-number">2.0</span>
-<span class="hljs-attr">url:</span> <span class="hljs-attr">https://www.apache.org/licenses/LICENSE-2.0.html</span>
+<span class="hljs-attr">url:</span> <span class="hljs-string">https://www.apache.org/licenses/LICENSE-2.0.html</span>
 </code></pre>
 </section></section><section><h3><span id="serverObject">Server Object</span></h3>
 <p>An object representing a Server.</p>
@@ -408,63 +408,63 @@ The metadata MAY be used by the clients if needed, and MAY be presented in editi
 <p>A single server would be described as:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"url"</span>: <span class="hljs-string">"https://development.gigantic-server.com/v1"</span>,
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Development server"</span>
+  <span class="hljs-attr">&quot;url&quot;</span>: <span class="hljs-string">&quot;https://development.gigantic-server.com/v1&quot;</span>,
+  <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;Development server&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
-<span class="hljs-attr">url:</span> <span class="hljs-attr">https://development.gigantic-server.com/v1</span>
+<span class="hljs-attr">url:</span> <span class="hljs-string">https://development.gigantic-server.com/v1</span>
 <span class="hljs-attr">description:</span> <span class="hljs-string">Development</span> <span class="hljs-string">server</span>
 </code></pre>
 <p>The following shows how multiple servers can be described, for example, at the OpenAPI Object’s <a href="#oasServers"><code>servers</code></a>:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"servers"</span>: [
+  <span class="hljs-attr">&quot;servers&quot;</span>: [
     {
-      <span class="hljs-attr">"url"</span>: <span class="hljs-string">"https://development.gigantic-server.com/v1"</span>,
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Development server"</span>
+      <span class="hljs-attr">&quot;url&quot;</span>: <span class="hljs-string">&quot;https://development.gigantic-server.com/v1&quot;</span>,
+      <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;Development server&quot;</span>
     },
     {
-      <span class="hljs-attr">"url"</span>: <span class="hljs-string">"https://staging.gigantic-server.com/v1"</span>,
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Staging server"</span>
+      <span class="hljs-attr">&quot;url&quot;</span>: <span class="hljs-string">&quot;https://staging.gigantic-server.com/v1&quot;</span>,
+      <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;Staging server&quot;</span>
     },
     {
-      <span class="hljs-attr">"url"</span>: <span class="hljs-string">"https://api.gigantic-server.com/v1"</span>,
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Production server"</span>
+      <span class="hljs-attr">&quot;url&quot;</span>: <span class="hljs-string">&quot;https://api.gigantic-server.com/v1&quot;</span>,
+      <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;Production server&quot;</span>
     }
   ]
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">servers:</span>
-<span class="hljs-attr">- url:</span> <span class="hljs-attr">https://development.gigantic-server.com/v1</span>
-<span class="hljs-attr">  description:</span> <span class="hljs-string">Development</span> <span class="hljs-string">server</span>
-<span class="hljs-attr">- url:</span> <span class="hljs-attr">https://staging.gigantic-server.com/v1</span>
-<span class="hljs-attr">  description:</span> <span class="hljs-string">Staging</span> <span class="hljs-string">server</span>
-<span class="hljs-attr">- url:</span> <span class="hljs-attr">https://api.gigantic-server.com/v1</span>
-<span class="hljs-attr">  description:</span> <span class="hljs-string">Production</span> <span class="hljs-string">server</span>
+<span class="hljs-bullet">-</span> <span class="hljs-attr">url:</span> <span class="hljs-string">https://development.gigantic-server.com/v1</span>
+  <span class="hljs-attr">description:</span> <span class="hljs-string">Development</span> <span class="hljs-string">server</span>
+<span class="hljs-bullet">-</span> <span class="hljs-attr">url:</span> <span class="hljs-string">https://staging.gigantic-server.com/v1</span>
+  <span class="hljs-attr">description:</span> <span class="hljs-string">Staging</span> <span class="hljs-string">server</span>
+<span class="hljs-bullet">-</span> <span class="hljs-attr">url:</span> <span class="hljs-string">https://api.gigantic-server.com/v1</span>
+  <span class="hljs-attr">description:</span> <span class="hljs-string">Production</span> <span class="hljs-string">server</span>
 </code></pre>
 <p>The following shows how variables can be used for a server configuration:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"servers"</span>: [
+  <span class="hljs-attr">&quot;servers&quot;</span>: [
     {
-      <span class="hljs-attr">"url"</span>: <span class="hljs-string">"https://{username}.gigantic-server.com:{port}/{basePath}"</span>,
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"The production API server"</span>,
-      <span class="hljs-attr">"variables"</span>: {
-        <span class="hljs-attr">"username"</span>: {
-          <span class="hljs-attr">"default"</span>: <span class="hljs-string">"demo"</span>,
-          <span class="hljs-attr">"description"</span>: <span class="hljs-string">"this value is assigned by the service provider, in this example `gigantic-server.com`"</span>
+      <span class="hljs-attr">&quot;url&quot;</span>: <span class="hljs-string">&quot;https://{username}.gigantic-server.com:{port}/{basePath}&quot;</span>,
+      <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;The production API server&quot;</span>,
+      <span class="hljs-attr">&quot;variables&quot;</span>: {
+        <span class="hljs-attr">&quot;username&quot;</span>: {
+          <span class="hljs-attr">&quot;default&quot;</span>: <span class="hljs-string">&quot;demo&quot;</span>,
+          <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;this value is assigned by the service provider, in this example `gigantic-server.com`&quot;</span>
         },
-        <span class="hljs-attr">"port"</span>: {
-          <span class="hljs-attr">"enum"</span>: [
-            <span class="hljs-string">"8443"</span>,
-            <span class="hljs-string">"443"</span>
+        <span class="hljs-attr">&quot;port&quot;</span>: {
+          <span class="hljs-attr">&quot;enum&quot;</span>: [
+            <span class="hljs-string">&quot;8443&quot;</span>,
+            <span class="hljs-string">&quot;443&quot;</span>
           ],
-          <span class="hljs-attr">"default"</span>: <span class="hljs-string">"8443"</span>
+          <span class="hljs-attr">&quot;default&quot;</span>: <span class="hljs-string">&quot;8443&quot;</span>
         },
-        <span class="hljs-attr">"basePath"</span>: {
-          <span class="hljs-attr">"default"</span>: <span class="hljs-string">"v2"</span>
+        <span class="hljs-attr">&quot;basePath&quot;</span>: {
+          <span class="hljs-attr">&quot;default&quot;</span>: <span class="hljs-string">&quot;v2&quot;</span>
         }
       }
     }
@@ -473,21 +473,21 @@ The metadata MAY be used by the clients if needed, and MAY be presented in editi
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">servers:</span>
-<span class="hljs-attr">- url:</span> <span class="hljs-attr">https://{username}.gigantic-server.com:{port}/{basePath}</span>
-<span class="hljs-attr">  description:</span> <span class="hljs-string">The</span> <span class="hljs-string">production</span> <span class="hljs-string">API</span> <span class="hljs-string">server</span>
-<span class="hljs-attr">  variables:</span>
-<span class="hljs-attr">    username:</span>
+<span class="hljs-bullet">-</span> <span class="hljs-attr">url:</span> <span class="hljs-string">https://{username}.gigantic-server.com:{port}/{basePath}</span>
+  <span class="hljs-attr">description:</span> <span class="hljs-string">The</span> <span class="hljs-string">production</span> <span class="hljs-string">API</span> <span class="hljs-string">server</span>
+  <span class="hljs-attr">variables:</span>
+    <span class="hljs-attr">username:</span>
       <span class="hljs-comment"># note! no enum here means it is an open value</span>
-<span class="hljs-attr">      default:</span> <span class="hljs-string">demo</span>
-<span class="hljs-attr">      description:</span> <span class="hljs-string">this</span> <span class="hljs-string">value</span> <span class="hljs-string">is</span> <span class="hljs-string">assigned</span> <span class="hljs-string">by</span> <span class="hljs-string">the</span> <span class="hljs-string">service</span> <span class="hljs-string">provider,</span> <span class="hljs-string">in</span> <span class="hljs-string">this</span> <span class="hljs-string">example</span> <span class="hljs-string">`gigantic-server.com`</span>
-<span class="hljs-attr">    port:</span>
-<span class="hljs-attr">      enum:</span>
-<span class="hljs-bullet">        -</span> <span class="hljs-string">'8443'</span>
-<span class="hljs-bullet">        -</span> <span class="hljs-string">'443'</span>
-<span class="hljs-attr">      default:</span> <span class="hljs-string">'8443'</span>
-<span class="hljs-attr">    basePath:</span>
+      <span class="hljs-attr">default:</span> <span class="hljs-string">demo</span>
+      <span class="hljs-attr">description:</span> <span class="hljs-string">this</span> <span class="hljs-string">value</span> <span class="hljs-string">is</span> <span class="hljs-string">assigned</span> <span class="hljs-string">by</span> <span class="hljs-string">the</span> <span class="hljs-string">service</span> <span class="hljs-string">provider,</span> <span class="hljs-string">in</span> <span class="hljs-string">this</span> <span class="hljs-string">example</span> <span class="hljs-string">`gigantic-server.com`</span>
+    <span class="hljs-attr">port:</span>
+      <span class="hljs-attr">enum:</span>
+        <span class="hljs-bullet">-</span> <span class="hljs-string">&#x27;8443&#x27;</span>
+        <span class="hljs-bullet">-</span> <span class="hljs-string">&#x27;443&#x27;</span>
+      <span class="hljs-attr">default:</span> <span class="hljs-string">&#x27;8443&#x27;</span>
+    <span class="hljs-attr">basePath:</span>
       <span class="hljs-comment"># open meaning there is the opportunity to use special base paths as assigned by the provider, default is `v2`</span>
-<span class="hljs-attr">      default:</span> <span class="hljs-string">v2</span>
+      <span class="hljs-attr">default:</span> <span class="hljs-string">v2</span>
 </code></pre>
 </section></section><section><h3><span id="serverVariableObject">Server Variable Object</span></h3>
 <p>An object representing a Server Variable for server URL template substitution.</p>
@@ -534,47 +534,47 @@ All objects defined within the components object will have no effect on the API 
 <tbody>
 <tr>
 <td><a id="componentsSchemas"> </a> schemas</td>
-<td style="text-align:left">Map[<code>string</code>, <a href="#schemaObject">Schema Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:left">Map[<code>string</code>, <a href="#schemaObject">Schema Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>An object to hold reusable <a href="#schemaObject">Schema Objects</a>.</td>
 </tr>
 <tr>
 <td><a id="componentsResponses"> </a> responses</td>
-<td style="text-align:left">Map[<code>string</code>, <a href="#responseObject">Response Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:left">Map[<code>string</code>, <a href="#responseObject">Response Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>An object to hold reusable <a href="#responseObject">Response Objects</a>.</td>
 </tr>
 <tr>
 <td><a id="componentsParameters"> </a> parameters</td>
-<td style="text-align:left">Map[<code>string</code>, <a href="#parameterObject">Parameter Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:left">Map[<code>string</code>, <a href="#parameterObject">Parameter Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>An object to hold reusable <a href="#parameterObject">Parameter Objects</a>.</td>
 </tr>
 <tr>
 <td><a id="componentsExamples"> </a> examples</td>
-<td style="text-align:left">Map[<code>string</code>, <a href="#exampleObject">Example Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:left">Map[<code>string</code>, <a href="#exampleObject">Example Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>An object to hold reusable <a href="#exampleObject">Example Objects</a>.</td>
 </tr>
 <tr>
 <td><a id="componentsRequestBodies"> </a> requestBodies</td>
-<td style="text-align:left">Map[<code>string</code>, <a href="#requestBodyObject">Request Body Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:left">Map[<code>string</code>, <a href="#requestBodyObject">Request Body Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>An object to hold reusable <a href="#requestBodyObject">Request Body Objects</a>.</td>
 </tr>
 <tr>
 <td><a id="componentsHeaders"> </a> headers</td>
-<td style="text-align:left">Map[<code>string</code>, <a href="#headerObject">Header Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:left">Map[<code>string</code>, <a href="#headerObject">Header Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>An object to hold reusable <a href="#headerObject">Header Objects</a>.</td>
 </tr>
 <tr>
 <td><a id="componentsSecuritySchemes"> </a> securitySchemes</td>
-<td style="text-align:left">Map[<code>string</code>, <a href="#securitySchemeObject">Security Scheme Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:left">Map[<code>string</code>, <a href="#securitySchemeObject">Security Scheme Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>An object to hold reusable <a href="#securitySchemeObject">Security Scheme Objects</a>.</td>
 </tr>
 <tr>
 <td><a id="componentsLinks"> </a> links</td>
-<td style="text-align:left">Map[<code>string</code>, <a href="#linkObject">Link Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:left">Map[<code>string</code>, <a href="#linkObject">Link Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>An object to hold reusable <a href="#linkObject">Link Objects</a>.</td>
 </tr>
 <tr>
 <td><a id="componentsCallbacks"> </a> callbacks</td>
-<td style="text-align:left">Map[<code>string</code>, <a href="#callbackObject">Callback Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:left">Map[<code>string</code>, <a href="#callbackObject">Callback Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>An object to hold reusable <a href="#callbackObject">Callback Objects</a>.</td>
 </tr>
 </tbody>
@@ -591,87 +591,87 @@ my.org.User
 </code></pre>
 </section><section><h4>Components Object Example</h4>
 <pre class="nohighlight"><code>
-<span class="hljs-string">"components"</span>: {
-  <span class="hljs-attr">"schemas"</span>: {
-    <span class="hljs-attr">"Category"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-      <span class="hljs-attr">"properties"</span>: {
-        <span class="hljs-attr">"id"</span>: {
-          <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>,
-          <span class="hljs-attr">"format"</span>: <span class="hljs-string">"int64"</span>
+&quot;components&quot;: {
+  &quot;schemas&quot;: {
+    &quot;Category&quot;: {
+      &quot;type&quot;: &quot;object&quot;,
+      &quot;properties&quot;: {
+        &quot;id&quot;: {
+          &quot;type&quot;: &quot;integer&quot;,
+          &quot;format&quot;: &quot;int64&quot;
         },
-        <span class="hljs-attr">"name"</span>: {
-          <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+        &quot;name&quot;: {
+          &quot;type&quot;: &quot;string&quot;
         }
       }
     },
-    <span class="hljs-attr">"Tag"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-      <span class="hljs-attr">"properties"</span>: {
-        <span class="hljs-attr">"id"</span>: {
-          <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>,
-          <span class="hljs-attr">"format"</span>: <span class="hljs-string">"int64"</span>
+    &quot;Tag&quot;: {
+      &quot;type&quot;: &quot;object&quot;,
+      &quot;properties&quot;: {
+        &quot;id&quot;: {
+          &quot;type&quot;: &quot;integer&quot;,
+          &quot;format&quot;: &quot;int64&quot;
         },
-        <span class="hljs-attr">"name"</span>: {
-          <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+        &quot;name&quot;: {
+          &quot;type&quot;: &quot;string&quot;
         }
       }
     }
   },
-  <span class="hljs-attr">"parameters"</span>: {
-    <span class="hljs-attr">"skipParam"</span>: {
-      <span class="hljs-attr">"name"</span>: <span class="hljs-string">"skip"</span>,
-      <span class="hljs-attr">"in"</span>: <span class="hljs-string">"query"</span>,
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"number of items to skip"</span>,
-      <span class="hljs-attr">"required"</span>: <span class="hljs-literal">true</span>,
-      <span class="hljs-attr">"schema"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>,
-        <span class="hljs-attr">"format"</span>: <span class="hljs-string">"int32"</span>
+  &quot;parameters&quot;: {
+    &quot;skipParam&quot;: {
+      &quot;name&quot;: &quot;skip&quot;,
+      &quot;in&quot;: &quot;query&quot;,
+      &quot;description&quot;: &quot;number of items to skip&quot;,
+      &quot;required&quot;: true,
+      &quot;schema&quot;: {
+        &quot;type&quot;: &quot;integer&quot;,
+        &quot;format&quot;: &quot;int32&quot;
       }
     },
-    <span class="hljs-attr">"limitParam"</span>: {
-      <span class="hljs-attr">"name"</span>: <span class="hljs-string">"limit"</span>,
-      <span class="hljs-attr">"in"</span>: <span class="hljs-string">"query"</span>,
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"max records to return"</span>,
-      <span class="hljs-attr">"required"</span>: <span class="hljs-literal">true</span>,
-      <span class="hljs-attr">"schema"</span> : {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>,
-        <span class="hljs-attr">"format"</span>: <span class="hljs-string">"int32"</span>
+    &quot;limitParam&quot;: {
+      &quot;name&quot;: &quot;limit&quot;,
+      &quot;in&quot;: &quot;query&quot;,
+      &quot;description&quot;: &quot;max records to return&quot;,
+      &quot;required&quot;: true,
+      &quot;schema&quot; : {
+        &quot;type&quot;: &quot;integer&quot;,
+        &quot;format&quot;: &quot;int32&quot;
       }
     }
   },
-  <span class="hljs-attr">"responses"</span>: {
-    <span class="hljs-attr">"NotFound"</span>: {
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Entity not found."</span>
+  &quot;responses&quot;: {
+    &quot;NotFound&quot;: {
+      &quot;description&quot;: &quot;Entity not found.&quot;
     },
-    <span class="hljs-attr">"IllegalInput"</span>: {
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Illegal input for operation."</span>
+    &quot;IllegalInput&quot;: {
+      &quot;description&quot;: &quot;Illegal input for operation.&quot;
     },
-    <span class="hljs-attr">"GeneralError"</span>: {
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"General Error"</span>,
-      <span class="hljs-attr">"content"</span>: {
-        <span class="hljs-attr">"application/json"</span>: {
-          <span class="hljs-attr">"schema"</span>: {
-            <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/GeneralError"</span>
+    &quot;GeneralError&quot;: {
+      &quot;description&quot;: &quot;General Error&quot;,
+      &quot;content&quot;: {
+        &quot;application/json&quot;: {
+          &quot;schema&quot;: {
+            &quot;$ref&quot;: &quot;#/components/schemas/GeneralError&quot;
           }
         }
       }
     }
   },
-  <span class="hljs-attr">"securitySchemes"</span>: {
-    <span class="hljs-attr">"api_key"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"apiKey"</span>,
-      <span class="hljs-attr">"name"</span>: <span class="hljs-string">"api_key"</span>,
-      <span class="hljs-attr">"in"</span>: <span class="hljs-string">"header"</span>
+  &quot;securitySchemes&quot;: {
+    &quot;api_key&quot;: {
+      &quot;type&quot;: &quot;apiKey&quot;,
+      &quot;name&quot;: &quot;api_key&quot;,
+      &quot;in&quot;: &quot;header&quot;
     },
-    <span class="hljs-attr">"petstore_auth"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"oauth2"</span>,
-      <span class="hljs-attr">"flows"</span>: {
-        <span class="hljs-attr">"implicit"</span>: {
-          <span class="hljs-attr">"authorizationUrl"</span>: <span class="hljs-string">"http://example.org/api/oauth/dialog"</span>,
-          <span class="hljs-attr">"scopes"</span>: {
-            <span class="hljs-attr">"write:pets"</span>: <span class="hljs-string">"modify pets in your account"</span>,
-            <span class="hljs-attr">"read:pets"</span>: <span class="hljs-string">"read your pets"</span>
+    &quot;petstore_auth&quot;: {
+      &quot;type&quot;: &quot;oauth2&quot;,
+      &quot;flows&quot;: {
+        &quot;implicit&quot;: {
+          &quot;authorizationUrl&quot;: &quot;http://example.org/api/oauth/dialog&quot;,
+          &quot;scopes&quot;: {
+            &quot;write:pets&quot;: &quot;modify pets in your account&quot;,
+            &quot;read:pets&quot;: &quot;read your pets&quot;
           }
         }
       }
@@ -681,64 +681,64 @@ my.org.User
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">components:</span>
-<span class="hljs-attr">  schemas:</span>
-<span class="hljs-attr">    Category:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">      properties:</span>
-<span class="hljs-attr">        id:</span>
-<span class="hljs-attr">          type:</span> <span class="hljs-string">integer</span>
-<span class="hljs-attr">          format:</span> <span class="hljs-string">int64</span>
-<span class="hljs-attr">        name:</span>
-<span class="hljs-attr">          type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">    Tag:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">      properties:</span>
-<span class="hljs-attr">        id:</span>
-<span class="hljs-attr">          type:</span> <span class="hljs-string">integer</span>
-<span class="hljs-attr">          format:</span> <span class="hljs-string">int64</span>
-<span class="hljs-attr">        name:</span>
-<span class="hljs-attr">          type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">  parameters:</span>
-<span class="hljs-attr">    skipParam:</span>
-<span class="hljs-attr">      name:</span> <span class="hljs-string">skip</span>
-<span class="hljs-attr">      in:</span> <span class="hljs-string">query</span>
-<span class="hljs-attr">      description:</span> <span class="hljs-string">number</span> <span class="hljs-string">of</span> <span class="hljs-string">items</span> <span class="hljs-string">to</span> <span class="hljs-string">skip</span>
-<span class="hljs-attr">      required:</span> <span class="hljs-literal">true</span>
-<span class="hljs-attr">      schema:</span>
-<span class="hljs-attr">        type:</span> <span class="hljs-string">integer</span>
-<span class="hljs-attr">        format:</span> <span class="hljs-string">int32</span>
-<span class="hljs-attr">    limitParam:</span>
-<span class="hljs-attr">      name:</span> <span class="hljs-string">limit</span>
-<span class="hljs-attr">      in:</span> <span class="hljs-string">query</span>
-<span class="hljs-attr">      description:</span> <span class="hljs-string">max</span> <span class="hljs-string">records</span> <span class="hljs-string">to</span> <span class="hljs-string">return</span>
-<span class="hljs-attr">      required:</span> <span class="hljs-literal">true</span>
-<span class="hljs-attr">      schema:</span>
-<span class="hljs-attr">        type:</span> <span class="hljs-string">integer</span>
-<span class="hljs-attr">        format:</span> <span class="hljs-string">int32</span>
-<span class="hljs-attr">  responses:</span>
-<span class="hljs-attr">    NotFound:</span>
-<span class="hljs-attr">      description:</span> <span class="hljs-string">Entity</span> <span class="hljs-string">not</span> <span class="hljs-string">found.</span>
-<span class="hljs-attr">    IllegalInput:</span>
-<span class="hljs-attr">      description:</span> <span class="hljs-string">Illegal</span> <span class="hljs-string">input</span> <span class="hljs-string">for</span> <span class="hljs-string">operation.</span>
-<span class="hljs-attr">    GeneralError:</span>
-<span class="hljs-attr">      description:</span> <span class="hljs-string">General</span> <span class="hljs-string">Error</span>
-<span class="hljs-attr">      content:</span>
-        <span class="hljs-string">application/json:</span>
-<span class="hljs-attr">          schema:</span>
-            <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/GeneralError'</span>
-<span class="hljs-attr">  securitySchemes:</span>
-<span class="hljs-attr">    api_key:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">apiKey</span>
-<span class="hljs-attr">      name:</span> <span class="hljs-string">api_key</span>
-<span class="hljs-attr">      in:</span> <span class="hljs-string">header</span>
-<span class="hljs-attr">    petstore_auth:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">oauth2</span>
-<span class="hljs-attr">      flows:</span> 
-<span class="hljs-attr">        implicit:</span>
-<span class="hljs-attr">          authorizationUrl:</span> <span class="hljs-attr">http://example.org/api/oauth/dialog</span>
-<span class="hljs-attr">          scopes:</span>
-<span class="hljs-attr">            write:</span><span class="hljs-attr">pets:</span> <span class="hljs-string">modify</span> <span class="hljs-string">pets</span> <span class="hljs-string">in</span> <span class="hljs-string">your</span> <span class="hljs-string">account</span>
-<span class="hljs-attr">            read:</span><span class="hljs-attr">pets:</span> <span class="hljs-string">read</span> <span class="hljs-string">your</span> <span class="hljs-string">pets</span>
+  <span class="hljs-attr">schemas:</span>
+    <span class="hljs-attr">Category:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+      <span class="hljs-attr">properties:</span>
+        <span class="hljs-attr">id:</span>
+          <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+          <span class="hljs-attr">format:</span> <span class="hljs-string">int64</span>
+        <span class="hljs-attr">name:</span>
+          <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+    <span class="hljs-attr">Tag:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+      <span class="hljs-attr">properties:</span>
+        <span class="hljs-attr">id:</span>
+          <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+          <span class="hljs-attr">format:</span> <span class="hljs-string">int64</span>
+        <span class="hljs-attr">name:</span>
+          <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">parameters:</span>
+    <span class="hljs-attr">skipParam:</span>
+      <span class="hljs-attr">name:</span> <span class="hljs-string">skip</span>
+      <span class="hljs-attr">in:</span> <span class="hljs-string">query</span>
+      <span class="hljs-attr">description:</span> <span class="hljs-string">number</span> <span class="hljs-string">of</span> <span class="hljs-string">items</span> <span class="hljs-string">to</span> <span class="hljs-string">skip</span>
+      <span class="hljs-attr">required:</span> <span class="hljs-literal">true</span>
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+        <span class="hljs-attr">format:</span> <span class="hljs-string">int32</span>
+    <span class="hljs-attr">limitParam:</span>
+      <span class="hljs-attr">name:</span> <span class="hljs-string">limit</span>
+      <span class="hljs-attr">in:</span> <span class="hljs-string">query</span>
+      <span class="hljs-attr">description:</span> <span class="hljs-string">max</span> <span class="hljs-string">records</span> <span class="hljs-string">to</span> <span class="hljs-string">return</span>
+      <span class="hljs-attr">required:</span> <span class="hljs-literal">true</span>
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+        <span class="hljs-attr">format:</span> <span class="hljs-string">int32</span>
+  <span class="hljs-attr">responses:</span>
+    <span class="hljs-attr">NotFound:</span>
+      <span class="hljs-attr">description:</span> <span class="hljs-string">Entity</span> <span class="hljs-string">not</span> <span class="hljs-string">found.</span>
+    <span class="hljs-attr">IllegalInput:</span>
+      <span class="hljs-attr">description:</span> <span class="hljs-string">Illegal</span> <span class="hljs-string">input</span> <span class="hljs-string">for</span> <span class="hljs-string">operation.</span>
+    <span class="hljs-attr">GeneralError:</span>
+      <span class="hljs-attr">description:</span> <span class="hljs-string">General</span> <span class="hljs-string">Error</span>
+      <span class="hljs-attr">content:</span>
+        <span class="hljs-attr">application/json:</span>
+          <span class="hljs-attr">schema:</span>
+            <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/GeneralError&#x27;</span>
+  <span class="hljs-attr">securitySchemes:</span>
+    <span class="hljs-attr">api_key:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">apiKey</span>
+      <span class="hljs-attr">name:</span> <span class="hljs-string">api_key</span>
+      <span class="hljs-attr">in:</span> <span class="hljs-string">header</span>
+    <span class="hljs-attr">petstore_auth:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">oauth2</span>
+      <span class="hljs-attr">flows:</span> 
+        <span class="hljs-attr">implicit:</span>
+          <span class="hljs-attr">authorizationUrl:</span> <span class="hljs-string">http://example.org/api/oauth/dialog</span>
+          <span class="hljs-attr">scopes:</span>
+            <span class="hljs-attr">write:pets:</span> <span class="hljs-string">modify</span> <span class="hljs-string">pets</span> <span class="hljs-string">in</span> <span class="hljs-string">your</span> <span class="hljs-string">account</span>
+            <span class="hljs-attr">read:pets:</span> <span class="hljs-string">read</span> <span class="hljs-string">your</span> <span class="hljs-string">pets</span>
 </code></pre>
 </section></section><section><h3><span id="pathsObject">Paths Object</span></h3>
 <p>Holds the relative paths to the individual endpoints and their operations.
@@ -756,7 +756,7 @@ The path is appended to the URL from the <a href="#serverObject"><code>Server Ob
 <tr>
 <td><a id="pathsPath"> </a>/{path}</td>
 <td style="text-align:center"><a href="#pathItemObject">Path Item Object</a></td>
-<td>A relative path to an individual endpoint. The field name MUST begin with a slash. The path is <strong>appended</strong> (no relative URL resolution) to the expanded URL from the <a href="#serverObject"><code>Server Object</code></a>'s <code>url</code> field in order to construct the full URL. <a href="#pathTemplating">Path templating</a> is allowed. When matching URLs, concrete (non-templated) paths would be matched before their templated counterparts. Templated paths with the same hierarchy but different templated names MUST NOT exist as they are identical. In case of ambiguous matching, it’s up to the tooling to decide which one to use.</td>
+<td>A relative path to an individual endpoint. The field name MUST begin with a slash. The path is <strong>appended</strong> (no relative URL resolution) to the expanded URL from the <a href="#serverObject"><code>Server Object</code></a>’s <code>url</code> field in order to construct the full URL. <a href="#pathTemplating">Path templating</a> is allowed. When matching URLs, concrete (non-templated) paths would be matched before their templated counterparts. Templated paths with the same hierarchy but different templated names MUST NOT exist as they are identical. In case of ambiguous matching, it’s up to the tooling to decide which one to use.</td>
 </tr>
 </tbody>
 </table>
@@ -780,18 +780,18 @@ The path is appended to the URL from the <a href="#serverObject"><code>Server Ob
 </section><section><h4>Paths Object Example</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"/pets"</span>: {
-    <span class="hljs-attr">"get"</span>: {
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Returns all pets from the system that the user has access to"</span>,
-      <span class="hljs-attr">"responses"</span>: {
-        <span class="hljs-attr">"200"</span>: {          
-          <span class="hljs-attr">"description"</span>: <span class="hljs-string">"A list of pets."</span>,
-          <span class="hljs-attr">"content"</span>: {
-            <span class="hljs-attr">"application/json"</span>: {
-              <span class="hljs-attr">"schema"</span>: {
-                <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-                <span class="hljs-attr">"items"</span>: {
-                  <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/pet"</span>
+  <span class="hljs-attr">&quot;/pets&quot;</span>: {
+    <span class="hljs-attr">&quot;get&quot;</span>: {
+      <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;Returns all pets from the system that the user has access to&quot;</span>,
+      <span class="hljs-attr">&quot;responses&quot;</span>: {
+        <span class="hljs-attr">&quot;200&quot;</span>: {          
+          <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;A list of pets.&quot;</span>,
+          <span class="hljs-attr">&quot;content&quot;</span>: {
+            <span class="hljs-attr">&quot;application/json&quot;</span>: {
+              <span class="hljs-attr">&quot;schema&quot;</span>: {
+                <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+                <span class="hljs-attr">&quot;items&quot;</span>: {
+                  <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/pet&quot;</span>
                 }
               }
             }
@@ -804,17 +804,17 @@ The path is appended to the URL from the <a href="#serverObject"><code>Server Ob
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-string">/pets:</span>
-<span class="hljs-attr">  get:</span>
-<span class="hljs-attr">    description:</span> <span class="hljs-string">Returns</span> <span class="hljs-string">all</span> <span class="hljs-string">pets</span> <span class="hljs-string">from</span> <span class="hljs-string">the</span> <span class="hljs-string">system</span> <span class="hljs-string">that</span> <span class="hljs-string">the</span> <span class="hljs-string">user</span> <span class="hljs-string">has</span> <span class="hljs-string">access</span> <span class="hljs-string">to</span>
-<span class="hljs-attr">    responses:</span>
-      <span class="hljs-string">'200'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">        description:</span> <span class="hljs-string">A</span> <span class="hljs-string">list</span> <span class="hljs-string">of</span> <span class="hljs-string">pets.</span>
-<span class="hljs-attr">        content:</span>
-          <span class="hljs-string">application/json:</span>
-<span class="hljs-attr">            schema:</span>
-<span class="hljs-attr">              type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">              items:</span>
-                <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/pet'</span>
+  <span class="hljs-attr">get:</span>
+    <span class="hljs-attr">description:</span> <span class="hljs-string">Returns</span> <span class="hljs-string">all</span> <span class="hljs-string">pets</span> <span class="hljs-string">from</span> <span class="hljs-string">the</span> <span class="hljs-string">system</span> <span class="hljs-string">that</span> <span class="hljs-string">the</span> <span class="hljs-string">user</span> <span class="hljs-string">has</span> <span class="hljs-string">access</span> <span class="hljs-string">to</span>
+    <span class="hljs-attr">responses:</span>
+      <span class="hljs-attr">&#x27;200&#x27;:</span>
+        <span class="hljs-attr">description:</span> <span class="hljs-string">A</span> <span class="hljs-string">list</span> <span class="hljs-string">of</span> <span class="hljs-string">pets.</span>
+        <span class="hljs-attr">content:</span>
+          <span class="hljs-attr">application/json:</span>
+            <span class="hljs-attr">schema:</span>
+              <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+              <span class="hljs-attr">items:</span>
+                <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/pet&#x27;</span>
 </code></pre>
 </section></section><section><h3><span id="pathItemObject">Path Item Object</span></h3>
 <p>Describes the operations available on a single path.
@@ -892,7 +892,7 @@ The path itself is still exposed to the documentation viewer but they will not k
 </tr>
 <tr>
 <td><a id="pathItemParameters"> </a>parameters</td>
-<td style="text-align:center">[<a href="#parameterObject">Parameter Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:center">[<a href="#parameterObject">Parameter Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>A list of parameters that are applicable for all the operations described under this path. These parameters can be overridden at the operation level, but cannot be removed there. The list MUST NOT include duplicated parameters. A unique parameter is defined by a combination of a <a href="#parameterName">name</a> and <a href="#parameterIn">location</a>. The list can use the <a href="#referenceObject">Reference Object</a> to link to parameters that are defined at the <a href="#componentsParameters">OpenAPI Object’s components/parameters</a>.</td>
 </tr>
 </tbody>
@@ -901,83 +901,83 @@ The path itself is still exposed to the documentation viewer but they will not k
 </section><section><h4>Path Item Object Example</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"get"</span>: {
-    <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Returns pets based on ID"</span>,
-    <span class="hljs-attr">"summary"</span>: <span class="hljs-string">"Find pets by ID"</span>,
-    <span class="hljs-attr">"operationId"</span>: <span class="hljs-string">"getPetsById"</span>,
-    <span class="hljs-attr">"responses"</span>: {
-      <span class="hljs-attr">"200"</span>: {
-        <span class="hljs-attr">"description"</span>: <span class="hljs-string">"pet response"</span>,
-        <span class="hljs-attr">"content"</span>: {
-          <span class="hljs-attr">"*/*"</span>: {
-            <span class="hljs-attr">"schema"</span>: {
-              <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-              <span class="hljs-attr">"items"</span>: {
-                <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/Pet"</span>
+  <span class="hljs-attr">&quot;get&quot;</span>: {
+    <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;Returns pets based on ID&quot;</span>,
+    <span class="hljs-attr">&quot;summary&quot;</span>: <span class="hljs-string">&quot;Find pets by ID&quot;</span>,
+    <span class="hljs-attr">&quot;operationId&quot;</span>: <span class="hljs-string">&quot;getPetsById&quot;</span>,
+    <span class="hljs-attr">&quot;responses&quot;</span>: {
+      <span class="hljs-attr">&quot;200&quot;</span>: {
+        <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;pet response&quot;</span>,
+        <span class="hljs-attr">&quot;content&quot;</span>: {
+          <span class="hljs-attr">&quot;*/*&quot;</span>: {
+            <span class="hljs-attr">&quot;schema&quot;</span>: {
+              <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+              <span class="hljs-attr">&quot;items&quot;</span>: {
+                <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/Pet&quot;</span>
               }
             }
           }
         }
       },
-      <span class="hljs-attr">"default"</span>: {
-        <span class="hljs-attr">"description"</span>: <span class="hljs-string">"error payload"</span>,
-        <span class="hljs-attr">"content"</span>: {
-          <span class="hljs-attr">"text/html"</span>: {
-            <span class="hljs-attr">"schema"</span>: {
-              <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/ErrorModel"</span>
+      <span class="hljs-attr">&quot;default&quot;</span>: {
+        <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;error payload&quot;</span>,
+        <span class="hljs-attr">&quot;content&quot;</span>: {
+          <span class="hljs-attr">&quot;text/html&quot;</span>: {
+            <span class="hljs-attr">&quot;schema&quot;</span>: {
+              <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/ErrorModel&quot;</span>
             }
           }
         }
       }
     }
   },
-  <span class="hljs-attr">"parameters"</span>: [
+  <span class="hljs-attr">&quot;parameters&quot;</span>: [
     {
-      <span class="hljs-attr">"name"</span>: <span class="hljs-string">"id"</span>,
-      <span class="hljs-attr">"in"</span>: <span class="hljs-string">"path"</span>,
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"ID of pet to use"</span>,
-      <span class="hljs-attr">"required"</span>: <span class="hljs-literal">true</span>,
-      <span class="hljs-attr">"schema"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-        <span class="hljs-attr">"items"</span>: {
-          <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+      <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;id&quot;</span>,
+      <span class="hljs-attr">&quot;in&quot;</span>: <span class="hljs-string">&quot;path&quot;</span>,
+      <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;ID of pet to use&quot;</span>,
+      <span class="hljs-attr">&quot;required&quot;</span>: <span class="hljs-literal">true</span>,
+      <span class="hljs-attr">&quot;schema&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+        <span class="hljs-attr">&quot;items&quot;</span>: {
+          <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
         }
       },
-      <span class="hljs-attr">"style"</span>: <span class="hljs-string">"simple"</span>
+      <span class="hljs-attr">&quot;style&quot;</span>: <span class="hljs-string">&quot;simple&quot;</span>
     }
   ]
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">get:</span>
-<span class="hljs-attr">  description:</span> <span class="hljs-string">Returns</span> <span class="hljs-string">pets</span> <span class="hljs-string">based</span> <span class="hljs-string">on</span> <span class="hljs-string">ID</span>
-<span class="hljs-attr">  summary:</span> <span class="hljs-string">Find</span> <span class="hljs-string">pets</span> <span class="hljs-string">by</span> <span class="hljs-string">ID</span>
-<span class="hljs-attr">  operationId:</span> <span class="hljs-string">getPetsById</span>
-<span class="hljs-attr">  responses:</span>
-    <span class="hljs-string">'200'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">      description:</span> <span class="hljs-string">pet</span> <span class="hljs-string">response</span>
-<span class="hljs-attr">      content:</span>
-        <span class="hljs-string">'*/*'</span> <span class="hljs-string">:</span>
-<span class="hljs-attr">          schema:</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">            items:</span>
-              <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Pet'</span>
-<span class="hljs-attr">    default:</span>
-<span class="hljs-attr">      description:</span> <span class="hljs-string">error</span> <span class="hljs-string">payload</span>
-<span class="hljs-attr">      content:</span>
-        <span class="hljs-string">'text/html'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">          schema:</span>
-            <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/ErrorModel'</span>
+  <span class="hljs-attr">description:</span> <span class="hljs-string">Returns</span> <span class="hljs-string">pets</span> <span class="hljs-string">based</span> <span class="hljs-string">on</span> <span class="hljs-string">ID</span>
+  <span class="hljs-attr">summary:</span> <span class="hljs-string">Find</span> <span class="hljs-string">pets</span> <span class="hljs-string">by</span> <span class="hljs-string">ID</span>
+  <span class="hljs-attr">operationId:</span> <span class="hljs-string">getPetsById</span>
+  <span class="hljs-attr">responses:</span>
+    <span class="hljs-attr">&#x27;200&#x27;:</span>
+      <span class="hljs-attr">description:</span> <span class="hljs-string">pet</span> <span class="hljs-string">response</span>
+      <span class="hljs-attr">content:</span>
+        <span class="hljs-string">&#x27;*/*&#x27;</span> <span class="hljs-string">:</span>
+          <span class="hljs-attr">schema:</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+            <span class="hljs-attr">items:</span>
+              <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/Pet&#x27;</span>
+    <span class="hljs-attr">default:</span>
+      <span class="hljs-attr">description:</span> <span class="hljs-string">error</span> <span class="hljs-string">payload</span>
+      <span class="hljs-attr">content:</span>
+        <span class="hljs-attr">&#x27;text/html&#x27;:</span>
+          <span class="hljs-attr">schema:</span>
+            <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/ErrorModel&#x27;</span>
 <span class="hljs-attr">parameters:</span>
-<span class="hljs-attr">- name:</span> <span class="hljs-string">id</span>
-<span class="hljs-attr">  in:</span> <span class="hljs-string">path</span>
-<span class="hljs-attr">  description:</span> <span class="hljs-string">ID</span> <span class="hljs-string">of</span> <span class="hljs-string">pet</span> <span class="hljs-string">to</span> <span class="hljs-string">use</span>
-<span class="hljs-attr">  required:</span> <span class="hljs-literal">true</span>
-<span class="hljs-attr">  schema:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">    style:</span> <span class="hljs-string">simple</span>
-<span class="hljs-attr">    items:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">string</span>  
+<span class="hljs-bullet">-</span> <span class="hljs-attr">name:</span> <span class="hljs-string">id</span>
+  <span class="hljs-attr">in:</span> <span class="hljs-string">path</span>
+  <span class="hljs-attr">description:</span> <span class="hljs-string">ID</span> <span class="hljs-string">of</span> <span class="hljs-string">pet</span> <span class="hljs-string">to</span> <span class="hljs-string">use</span>
+  <span class="hljs-attr">required:</span> <span class="hljs-literal">true</span>
+  <span class="hljs-attr">schema:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+    <span class="hljs-attr">style:</span> <span class="hljs-string">simple</span>
+    <span class="hljs-attr">items:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>  
 </code></pre>
 </section></section><section><h3><span id="operationObject">Operation Object</span></h3>
 <p>Describes a single API operation on a path.</p>
@@ -1018,12 +1018,12 @@ The path itself is still exposed to the documentation viewer but they will not k
 </tr>
 <tr>
 <td><a id="operationParameters"> </a>parameters</td>
-<td style="text-align:center">[<a href="#parameterObject">Parameter Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:center">[<a href="#parameterObject">Parameter Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>A list of parameters that are applicable for this operation. If a parameter is already defined at the <a href="#pathItemParameters">Path Item</a>, the new definition will override it but can never remove it. The list MUST NOT include duplicated parameters. A unique parameter is defined by a combination of a <a href="#parameterName">name</a> and <a href="#parameterIn">location</a>. The list can use the <a href="#referenceObject">Reference Object</a> to link to parameters that are defined at the <a href="#componentsParameters">OpenAPI Object’s components/parameters</a>.</td>
 </tr>
 <tr>
 <td><a id="operationRequestBody"> </a>requestBody</td>
-<td style="text-align:center"><a href="#requestBodyObject">Request Body Object</a> ¦ <a href="#referenceObject">Reference Object</a></td>
+<td style="text-align:center"><a href="#requestBodyObject">Request Body Object</a> | <a href="#referenceObject">Reference Object</a></td>
 <td>The request body applicable for this operation.  The <code>requestBody</code> is only supported in HTTP methods where the HTTP 1.1 specification [[!RFC7231]] has explicitly defined semantics for request bodies.  In other cases where the HTTP spec is vague, <code>requestBody</code> SHALL be ignored by consumers.</td>
 </tr>
 <tr>
@@ -1033,7 +1033,7 @@ The path itself is still exposed to the documentation viewer but they will not k
 </tr>
 <tr>
 <td><a id="operationCallbacks"> </a>callbacks</td>
-<td style="text-align:center">Map[<code>string</code>, <a href="#callbackObject">Callback Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:center">Map[<code>string</code>, <a href="#callbackObject">Callback Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>A map of possible out-of band callbacks related to the parent operation. The key is a unique identifier for the Callback Object. Each value in the map is a <a href="#callbackObject">Callback Object</a> that describes a request that may be initiated by the API provider and the expected responses. The key value used to identify the callback object is an expression, evaluated at runtime, that identifies a URL to use for the callback operation.</td>
 </tr>
 <tr>
@@ -1057,63 +1057,63 @@ The path itself is still exposed to the documentation viewer but they will not k
 </section><section><h4>Operation Object Example</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"tags"</span>: [
-    <span class="hljs-string">"pet"</span>
+  <span class="hljs-attr">&quot;tags&quot;</span>: [
+    <span class="hljs-string">&quot;pet&quot;</span>
   ],
-  <span class="hljs-attr">"summary"</span>: <span class="hljs-string">"Updates a pet in the store with form data"</span>,
-  <span class="hljs-attr">"operationId"</span>: <span class="hljs-string">"updatePetWithForm"</span>,
-  <span class="hljs-attr">"parameters"</span>: [
+  <span class="hljs-attr">&quot;summary&quot;</span>: <span class="hljs-string">&quot;Updates a pet in the store with form data&quot;</span>,
+  <span class="hljs-attr">&quot;operationId&quot;</span>: <span class="hljs-string">&quot;updatePetWithForm&quot;</span>,
+  <span class="hljs-attr">&quot;parameters&quot;</span>: [
     {
-      <span class="hljs-attr">"name"</span>: <span class="hljs-string">"petId"</span>,
-      <span class="hljs-attr">"in"</span>: <span class="hljs-string">"path"</span>,
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"ID of pet that needs to be updated"</span>,
-      <span class="hljs-attr">"required"</span>: <span class="hljs-literal">true</span>,
-      <span class="hljs-attr">"schema"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+      <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;petId&quot;</span>,
+      <span class="hljs-attr">&quot;in&quot;</span>: <span class="hljs-string">&quot;path&quot;</span>,
+      <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;ID of pet that needs to be updated&quot;</span>,
+      <span class="hljs-attr">&quot;required&quot;</span>: <span class="hljs-literal">true</span>,
+      <span class="hljs-attr">&quot;schema&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
       }
     }
   ],
-  <span class="hljs-attr">"requestBody"</span>: {
-    <span class="hljs-attr">"content"</span>: {
-      <span class="hljs-attr">"application/x-www-form-urlencoded"</span>: {
-        <span class="hljs-attr">"schema"</span>: {
-          <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-           <span class="hljs-attr">"properties"</span>: {
-              <span class="hljs-attr">"name"</span>: { 
-                <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Updated name of the pet"</span>,
-                <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+  <span class="hljs-attr">&quot;requestBody&quot;</span>: {
+    <span class="hljs-attr">&quot;content&quot;</span>: {
+      <span class="hljs-attr">&quot;application/x-www-form-urlencoded&quot;</span>: {
+        <span class="hljs-attr">&quot;schema&quot;</span>: {
+          <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+           <span class="hljs-attr">&quot;properties&quot;</span>: {
+              <span class="hljs-attr">&quot;name&quot;</span>: { 
+                <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;Updated name of the pet&quot;</span>,
+                <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
               },
-              <span class="hljs-attr">"status"</span>: {
-                <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Updated status of the pet"</span>,
-                <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+              <span class="hljs-attr">&quot;status&quot;</span>: {
+                <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;Updated status of the pet&quot;</span>,
+                <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
              }
            },
-        <span class="hljs-attr">"required"</span>: [<span class="hljs-string">"status"</span>] 
+        <span class="hljs-attr">&quot;required&quot;</span>: [<span class="hljs-string">&quot;status&quot;</span>] 
         }
       }
     }
   },
-  <span class="hljs-attr">"responses"</span>: {
-    <span class="hljs-attr">"200"</span>: {
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Pet updated."</span>,
-      <span class="hljs-attr">"content"</span>: {
-        <span class="hljs-attr">"application/json"</span>: {},
-        <span class="hljs-attr">"application/xml"</span>: {}
+  <span class="hljs-attr">&quot;responses&quot;</span>: {
+    <span class="hljs-attr">&quot;200&quot;</span>: {
+      <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;Pet updated.&quot;</span>,
+      <span class="hljs-attr">&quot;content&quot;</span>: {
+        <span class="hljs-attr">&quot;application/json&quot;</span>: {},
+        <span class="hljs-attr">&quot;application/xml&quot;</span>: {}
       }
     },
-    <span class="hljs-attr">"405"</span>: {
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Invalid input"</span>,
-      <span class="hljs-attr">"content"</span>: {
-        <span class="hljs-attr">"application/json"</span>: {},
-        <span class="hljs-attr">"application/xml"</span>: {}
+    <span class="hljs-attr">&quot;405&quot;</span>: {
+      <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;Invalid input&quot;</span>,
+      <span class="hljs-attr">&quot;content&quot;</span>: {
+        <span class="hljs-attr">&quot;application/json&quot;</span>: {},
+        <span class="hljs-attr">&quot;application/xml&quot;</span>: {}
       }
     }
   },
-  <span class="hljs-attr">"security"</span>: [
+  <span class="hljs-attr">&quot;security&quot;</span>: [
     {
-      <span class="hljs-attr">"petstore_auth"</span>: [
-        <span class="hljs-string">"write:pets"</span>,
-        <span class="hljs-string">"read:pets"</span>
+      <span class="hljs-attr">&quot;petstore_auth&quot;</span>: [
+        <span class="hljs-string">&quot;write:pets&quot;</span>,
+        <span class="hljs-string">&quot;read:pets&quot;</span>
       ]
     }
   ]
@@ -1125,40 +1125,40 @@ The path itself is still exposed to the documentation viewer but they will not k
 <span class="hljs-attr">summary:</span> <span class="hljs-string">Updates</span> <span class="hljs-string">a</span> <span class="hljs-string">pet</span> <span class="hljs-string">in</span> <span class="hljs-string">the</span> <span class="hljs-string">store</span> <span class="hljs-string">with</span> <span class="hljs-string">form</span> <span class="hljs-string">data</span>
 <span class="hljs-attr">operationId:</span> <span class="hljs-string">updatePetWithForm</span>
 <span class="hljs-attr">parameters:</span>
-<span class="hljs-attr">- name:</span> <span class="hljs-string">petId</span>
-<span class="hljs-attr">  in:</span> <span class="hljs-string">path</span>
-<span class="hljs-attr">  description:</span> <span class="hljs-string">ID</span> <span class="hljs-string">of</span> <span class="hljs-string">pet</span> <span class="hljs-string">that</span> <span class="hljs-string">needs</span> <span class="hljs-string">to</span> <span class="hljs-string">be</span> <span class="hljs-string">updated</span>
-<span class="hljs-attr">  required:</span> <span class="hljs-literal">true</span>
-<span class="hljs-attr">  schema:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">string</span>
+<span class="hljs-bullet">-</span> <span class="hljs-attr">name:</span> <span class="hljs-string">petId</span>
+  <span class="hljs-attr">in:</span> <span class="hljs-string">path</span>
+  <span class="hljs-attr">description:</span> <span class="hljs-string">ID</span> <span class="hljs-string">of</span> <span class="hljs-string">pet</span> <span class="hljs-string">that</span> <span class="hljs-string">needs</span> <span class="hljs-string">to</span> <span class="hljs-string">be</span> <span class="hljs-string">updated</span>
+  <span class="hljs-attr">required:</span> <span class="hljs-literal">true</span>
+  <span class="hljs-attr">schema:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
 <span class="hljs-attr">requestBody:</span>
-<span class="hljs-attr">  content:</span>
-    <span class="hljs-string">'application/x-www-form-urlencoded'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">      schema:</span>
-<span class="hljs-attr">       properties:</span>
-<span class="hljs-attr">          name:</span> 
-<span class="hljs-attr">            description:</span> <span class="hljs-string">Updated</span> <span class="hljs-string">name</span> <span class="hljs-string">of</span> <span class="hljs-string">the</span> <span class="hljs-string">pet</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">          status:</span>
-<span class="hljs-attr">            description:</span> <span class="hljs-string">Updated</span> <span class="hljs-string">status</span> <span class="hljs-string">of</span> <span class="hljs-string">the</span> <span class="hljs-string">pet</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">       required:</span>
-<span class="hljs-bullet">         -</span> <span class="hljs-string">status</span>
+  <span class="hljs-attr">content:</span>
+    <span class="hljs-attr">&#x27;application/x-www-form-urlencoded&#x27;:</span>
+      <span class="hljs-attr">schema:</span>
+       <span class="hljs-attr">properties:</span>
+          <span class="hljs-attr">name:</span> 
+            <span class="hljs-attr">description:</span> <span class="hljs-string">Updated</span> <span class="hljs-string">name</span> <span class="hljs-string">of</span> <span class="hljs-string">the</span> <span class="hljs-string">pet</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+          <span class="hljs-attr">status:</span>
+            <span class="hljs-attr">description:</span> <span class="hljs-string">Updated</span> <span class="hljs-string">status</span> <span class="hljs-string">of</span> <span class="hljs-string">the</span> <span class="hljs-string">pet</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+       <span class="hljs-attr">required:</span>
+         <span class="hljs-bullet">-</span> <span class="hljs-string">status</span>
 <span class="hljs-attr">responses:</span>
-  <span class="hljs-string">'200'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">    description:</span> <span class="hljs-string">Pet</span> <span class="hljs-string">updated.</span>
-<span class="hljs-attr">    content:</span> 
-      <span class="hljs-string">'application/json'</span><span class="hljs-string">:</span> <span class="hljs-string">{}</span>
-      <span class="hljs-string">'application/xml'</span><span class="hljs-string">:</span> <span class="hljs-string">{}</span>
-  <span class="hljs-string">'405'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">    description:</span> <span class="hljs-string">Invalid</span> <span class="hljs-string">input</span>
-<span class="hljs-attr">    content:</span> 
-      <span class="hljs-string">'application/json'</span><span class="hljs-string">:</span> <span class="hljs-string">{}</span>
-      <span class="hljs-string">'application/xml'</span><span class="hljs-string">:</span> <span class="hljs-string">{}</span>
+  <span class="hljs-attr">&#x27;200&#x27;:</span>
+    <span class="hljs-attr">description:</span> <span class="hljs-string">Pet</span> <span class="hljs-string">updated.</span>
+    <span class="hljs-attr">content:</span> 
+      <span class="hljs-attr">&#x27;application/json&#x27;:</span> {}
+      <span class="hljs-attr">&#x27;application/xml&#x27;:</span> {}
+  <span class="hljs-attr">&#x27;405&#x27;:</span>
+    <span class="hljs-attr">description:</span> <span class="hljs-string">Invalid</span> <span class="hljs-string">input</span>
+    <span class="hljs-attr">content:</span> 
+      <span class="hljs-attr">&#x27;application/json&#x27;:</span> {}
+      <span class="hljs-attr">&#x27;application/xml&#x27;:</span> {}
 <span class="hljs-attr">security:</span>
-<span class="hljs-attr">- petstore_auth:</span>
-<span class="hljs-attr">  - write:</span><span class="hljs-string">pets</span>
-<span class="hljs-attr">  - read:</span><span class="hljs-string">pets</span>
+<span class="hljs-bullet">-</span> <span class="hljs-attr">petstore_auth:</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-string">write:pets</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-string">read:pets</span>
 </code></pre>
 </section></section><section><h3><span id="externalDocumentationObject">External Documentation Object</span></h3>
 <p>Allows referencing an external resource for extended documentation.</p>
@@ -1188,13 +1188,13 @@ The path itself is still exposed to the documentation viewer but they will not k
 </section><section><h4>External Documentation Object Example</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Find more info here"</span>,
-  <span class="hljs-attr">"url"</span>: <span class="hljs-string">"https://example.com"</span>
+  <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;Find more info here&quot;</span>,
+  <span class="hljs-attr">&quot;url&quot;</span>: <span class="hljs-string">&quot;https://example.com&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">description:</span> <span class="hljs-string">Find</span> <span class="hljs-string">more</span> <span class="hljs-string">info</span> <span class="hljs-string">here</span>
-<span class="hljs-attr">url:</span> <span class="hljs-attr">https://example.com</span>
+<span class="hljs-attr">url:</span> <span class="hljs-string">https://example.com</span>
 </code></pre>
 </section></section><section><h3><span id="parameterObject">Parameter Object</span></h3>
 <p>Describes a single operation parameter.</p>
@@ -1277,7 +1277,7 @@ For simpler scenarios, a <a href="#parameterSchema"><code>schema</code></a> and 
 </tr>
 <tr>
 <td><a id="parameterSchema"> </a>schema</td>
-<td style="text-align:center"><a href="#schemaObject">Schema Object</a> ¦ <a href="#referenceObject">Reference Object</a></td>
+<td style="text-align:center"><a href="#schemaObject">Schema Object</a> | <a href="#referenceObject">Reference Object</a></td>
 <td>The schema defining the type used for the parameter.</td>
 </tr>
 <tr>
@@ -1287,7 +1287,7 @@ For simpler scenarios, a <a href="#parameterSchema"><code>schema</code></a> and 
 </tr>
 <tr>
 <td><a id="parameterExamples"> </a>examples</td>
-<td style="text-align:center">Map[ <code>string</code>, <a href="#exampleObject">Example Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:center">Map[ <code>string</code>, <a href="#exampleObject">Example Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>Examples of the media type.  Each example SHOULD contain a value in the correct format as specified in the parameter encoding.  The <code>examples</code> field is mutually exclusive of the <code>example</code> field.  Furthermore, if referencing a <code>schema</code> which contains an example, the <code>examples</code> value SHALL <em>override</em> the example provided by the schema.</td>
 </tr>
 </tbody>
@@ -1464,8 +1464,8 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 <td>false</td>
 <td>n/a</td>
 <td>n/a</td>
-<td>blue¦black¦brown</td>
-<td>R¦100¦G¦200</td>
+<td>blue|black|brown</td>
+<td>R|100|G|200</td>
 </tr>
 <tr>
 <td>deepObject</td>
@@ -1473,7 +1473,7 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 <td>n/a</td>
 <td>n/a</td>
 <td>n/a</td>
-<td>color\R=100&amp;color\G=200&amp;color\B=150</td>
+<td>color&#91;R&#93;=100&amp;color&#91;G&#93;=200&amp;color&#91;B&#93;=150</td>
 </tr>
 </tbody>
 </table>
@@ -1482,18 +1482,18 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 <p>A header parameter with an array of 64 bit integer numbers:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"name"</span>: <span class="hljs-string">"token"</span>,
-  <span class="hljs-attr">"in"</span>: <span class="hljs-string">"header"</span>,
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"token to be passed as a header"</span>,
-  <span class="hljs-attr">"required"</span>: <span class="hljs-literal">true</span>,
-  <span class="hljs-attr">"schema"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-    <span class="hljs-attr">"items"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>,
-      <span class="hljs-attr">"format"</span>: <span class="hljs-string">"int64"</span>
+  <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;token&quot;</span>,
+  <span class="hljs-attr">&quot;in&quot;</span>: <span class="hljs-string">&quot;header&quot;</span>,
+  <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;token to be passed as a header&quot;</span>,
+  <span class="hljs-attr">&quot;required&quot;</span>: <span class="hljs-literal">true</span>,
+  <span class="hljs-attr">&quot;schema&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+    <span class="hljs-attr">&quot;items&quot;</span>: {
+      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>,
+      <span class="hljs-attr">&quot;format&quot;</span>: <span class="hljs-string">&quot;int64&quot;</span>
     }
   },
-  <span class="hljs-attr">"style"</span>: <span class="hljs-string">"simple"</span>
+  <span class="hljs-attr">&quot;style&quot;</span>: <span class="hljs-string">&quot;simple&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -1502,21 +1502,21 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 <span class="hljs-attr">description:</span> <span class="hljs-string">token</span> <span class="hljs-string">to</span> <span class="hljs-string">be</span> <span class="hljs-string">passed</span> <span class="hljs-string">as</span> <span class="hljs-string">a</span> <span class="hljs-string">header</span>
 <span class="hljs-attr">required:</span> <span class="hljs-literal">true</span>
 <span class="hljs-attr">schema:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">  items:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">integer</span>
-<span class="hljs-attr">    format:</span> <span class="hljs-string">int64</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+  <span class="hljs-attr">items:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+    <span class="hljs-attr">format:</span> <span class="hljs-string">int64</span>
 <span class="hljs-attr">style:</span> <span class="hljs-string">simple</span>
 </code></pre>
 <p>A path parameter of a string value:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"name"</span>: <span class="hljs-string">"username"</span>,
-  <span class="hljs-attr">"in"</span>: <span class="hljs-string">"path"</span>,
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"username to fetch"</span>,
-  <span class="hljs-attr">"required"</span>: <span class="hljs-literal">true</span>,
-  <span class="hljs-attr">"schema"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+  <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;username&quot;</span>,
+  <span class="hljs-attr">&quot;in&quot;</span>: <span class="hljs-string">&quot;path&quot;</span>,
+  <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;username to fetch&quot;</span>,
+  <span class="hljs-attr">&quot;required&quot;</span>: <span class="hljs-literal">true</span>,
+  <span class="hljs-attr">&quot;schema&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
   }
 }
 </code></pre>
@@ -1526,23 +1526,23 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 <span class="hljs-attr">description:</span> <span class="hljs-string">username</span> <span class="hljs-string">to</span> <span class="hljs-string">fetch</span>
 <span class="hljs-attr">required:</span> <span class="hljs-literal">true</span>
 <span class="hljs-attr">schema:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
 </code></pre>
 <p>An optional query parameter of a string value, allowing multiple values by repeating the query parameter:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"name"</span>: <span class="hljs-string">"id"</span>,
-  <span class="hljs-attr">"in"</span>: <span class="hljs-string">"query"</span>,
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"ID of the object to fetch"</span>,
-  <span class="hljs-attr">"required"</span>: <span class="hljs-literal">false</span>,
-  <span class="hljs-attr">"schema"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-    <span class="hljs-attr">"items"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+  <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;id&quot;</span>,
+  <span class="hljs-attr">&quot;in&quot;</span>: <span class="hljs-string">&quot;query&quot;</span>,
+  <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;ID of the object to fetch&quot;</span>,
+  <span class="hljs-attr">&quot;required&quot;</span>: <span class="hljs-literal">false</span>,
+  <span class="hljs-attr">&quot;schema&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+    <span class="hljs-attr">&quot;items&quot;</span>: {
+      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
     }
   },
-  <span class="hljs-attr">"style"</span>: <span class="hljs-string">"form"</span>,
-  <span class="hljs-attr">"explode"</span>: <span class="hljs-literal">true</span>
+  <span class="hljs-attr">&quot;style&quot;</span>: <span class="hljs-string">&quot;form&quot;</span>,
+  <span class="hljs-attr">&quot;explode&quot;</span>: <span class="hljs-literal">true</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -1551,54 +1551,54 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 <span class="hljs-attr">description:</span> <span class="hljs-string">ID</span> <span class="hljs-string">of</span> <span class="hljs-string">the</span> <span class="hljs-string">object</span> <span class="hljs-string">to</span> <span class="hljs-string">fetch</span>
 <span class="hljs-attr">required:</span> <span class="hljs-literal">false</span>
 <span class="hljs-attr">schema:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">  items:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+  <span class="hljs-attr">items:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
 <span class="hljs-attr">style:</span> <span class="hljs-string">form</span>
 <span class="hljs-attr">explode:</span> <span class="hljs-literal">true</span>
 </code></pre>
 <p>A free-form query parameter, allowing undefined parameters of a specific type:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"in"</span>: <span class="hljs-string">"query"</span>,
-  <span class="hljs-attr">"name"</span>: <span class="hljs-string">"freeForm"</span>,
-  <span class="hljs-attr">"schema"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-    <span class="hljs-attr">"additionalProperties"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>
+  <span class="hljs-attr">&quot;in&quot;</span>: <span class="hljs-string">&quot;query&quot;</span>,
+  <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;freeForm&quot;</span>,
+  <span class="hljs-attr">&quot;schema&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+    <span class="hljs-attr">&quot;additionalProperties&quot;</span>: {
+      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>
     },
   },
-  <span class="hljs-attr">"style"</span>: <span class="hljs-string">"form"</span>
+  <span class="hljs-attr">&quot;style&quot;</span>: <span class="hljs-string">&quot;form&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">in:</span> <span class="hljs-string">query</span>
 <span class="hljs-attr">name:</span> <span class="hljs-string">freeForm</span>
 <span class="hljs-attr">schema:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">  additionalProperties:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">integer</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+  <span class="hljs-attr">additionalProperties:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
 <span class="hljs-attr">style:</span> <span class="hljs-string">form</span>
 </code></pre>
 <p>A complex parameter using <code>content</code> to define serialization:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"in"</span>: <span class="hljs-string">"query"</span>,
-  <span class="hljs-attr">"name"</span>: <span class="hljs-string">"coordinates"</span>,
-  <span class="hljs-attr">"content"</span>: {
-    <span class="hljs-attr">"application/json"</span>: {
-      <span class="hljs-attr">"schema"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-        <span class="hljs-attr">"required"</span>: [
-          <span class="hljs-string">"lat"</span>,
-          <span class="hljs-string">"long"</span>
+  <span class="hljs-attr">&quot;in&quot;</span>: <span class="hljs-string">&quot;query&quot;</span>,
+  <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;coordinates&quot;</span>,
+  <span class="hljs-attr">&quot;content&quot;</span>: {
+    <span class="hljs-attr">&quot;application/json&quot;</span>: {
+      <span class="hljs-attr">&quot;schema&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+        <span class="hljs-attr">&quot;required&quot;</span>: [
+          <span class="hljs-string">&quot;lat&quot;</span>,
+          <span class="hljs-string">&quot;long&quot;</span>
         ],
-        <span class="hljs-attr">"properties"</span>: {
-          <span class="hljs-attr">"lat"</span>: {
-            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"number"</span>
+        <span class="hljs-attr">&quot;properties&quot;</span>: {
+          <span class="hljs-attr">&quot;lat&quot;</span>: {
+            <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;number&quot;</span>
           },
-          <span class="hljs-attr">"long"</span>: {
-            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"number"</span>
+          <span class="hljs-attr">&quot;long&quot;</span>: {
+            <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;number&quot;</span>
           }
         }
       }
@@ -1610,17 +1610,17 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 <span class="hljs-attr">in:</span> <span class="hljs-string">query</span>
 <span class="hljs-attr">name:</span> <span class="hljs-string">coordinates</span>
 <span class="hljs-attr">content:</span>
-  <span class="hljs-string">application/json:</span>
-<span class="hljs-attr">    schema:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">      required:</span>
-<span class="hljs-bullet">        -</span> <span class="hljs-string">lat</span>
-<span class="hljs-bullet">        -</span> <span class="hljs-string">long</span>
-<span class="hljs-attr">      properties:</span>
-<span class="hljs-attr">        lat:</span>
-<span class="hljs-attr">          type:</span> <span class="hljs-string">number</span>
-<span class="hljs-attr">        long:</span>
-<span class="hljs-attr">          type:</span> <span class="hljs-string">number</span>
+  <span class="hljs-attr">application/json:</span>
+    <span class="hljs-attr">schema:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+      <span class="hljs-attr">required:</span>
+        <span class="hljs-bullet">-</span> <span class="hljs-string">lat</span>
+        <span class="hljs-bullet">-</span> <span class="hljs-string">long</span>
+      <span class="hljs-attr">properties:</span>
+        <span class="hljs-attr">lat:</span>
+          <span class="hljs-attr">type:</span> <span class="hljs-string">number</span>
+        <span class="hljs-attr">long:</span>
+          <span class="hljs-attr">type:</span> <span class="hljs-string">number</span>
 </code></pre>
 </section></section><section><h3><span id="requestBodyObject">Request Body Object</span></h3>
 <p>Describes a single request body.</p>
@@ -1656,43 +1656,43 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 <p>A request body with a referenced model definition.</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"user to add to the system"</span>,
-  <span class="hljs-attr">"content"</span>: {
-    <span class="hljs-attr">"application/json"</span>: {
-      <span class="hljs-attr">"schema"</span>: {
-        <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/User"</span>
+  <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;user to add to the system&quot;</span>,
+  <span class="hljs-attr">&quot;content&quot;</span>: {
+    <span class="hljs-attr">&quot;application/json&quot;</span>: {
+      <span class="hljs-attr">&quot;schema&quot;</span>: {
+        <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/User&quot;</span>
       },
-      <span class="hljs-attr">"examples"</span>: {
-          <span class="hljs-attr">"user"</span> : {
-            <span class="hljs-attr">"summary"</span>: <span class="hljs-string">"User Example"</span>, 
-            <span class="hljs-attr">"externalValue"</span>: <span class="hljs-string">"http://foo.bar/examples/user-example.json"</span>
+      <span class="hljs-attr">&quot;examples&quot;</span>: {
+          <span class="hljs-attr">&quot;user&quot;</span> : {
+            <span class="hljs-attr">&quot;summary&quot;</span>: <span class="hljs-string">&quot;User Example&quot;</span>, 
+            <span class="hljs-attr">&quot;externalValue&quot;</span>: <span class="hljs-string">&quot;http://foo.bar/examples/user-example.json&quot;</span>
           } 
         }
     },
-    <span class="hljs-attr">"application/xml"</span>: {
-      <span class="hljs-attr">"schema"</span>: {
-        <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/User"</span>
+    <span class="hljs-attr">&quot;application/xml&quot;</span>: {
+      <span class="hljs-attr">&quot;schema&quot;</span>: {
+        <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/User&quot;</span>
       },
-      <span class="hljs-attr">"examples"</span>: {
-          <span class="hljs-attr">"user"</span> : {
-            <span class="hljs-attr">"summary"</span>: <span class="hljs-string">"User example in XML"</span>,
-            <span class="hljs-attr">"externalValue"</span>: <span class="hljs-string">"http://foo.bar/examples/user-example.xml"</span>
+      <span class="hljs-attr">&quot;examples&quot;</span>: {
+          <span class="hljs-attr">&quot;user&quot;</span> : {
+            <span class="hljs-attr">&quot;summary&quot;</span>: <span class="hljs-string">&quot;User example in XML&quot;</span>,
+            <span class="hljs-attr">&quot;externalValue&quot;</span>: <span class="hljs-string">&quot;http://foo.bar/examples/user-example.xml&quot;</span>
           }
         }
     },
-    <span class="hljs-attr">"text/plain"</span>: {
-      <span class="hljs-attr">"examples"</span>: {
-        <span class="hljs-attr">"user"</span> : {
-            <span class="hljs-attr">"summary"</span>: <span class="hljs-string">"User example in Plain text"</span>,
-            <span class="hljs-attr">"externalValue"</span>: <span class="hljs-string">"http://foo.bar/examples/user-example.txt"</span> 
+    <span class="hljs-attr">&quot;text/plain&quot;</span>: {
+      <span class="hljs-attr">&quot;examples&quot;</span>: {
+        <span class="hljs-attr">&quot;user&quot;</span> : {
+            <span class="hljs-attr">&quot;summary&quot;</span>: <span class="hljs-string">&quot;User example in Plain text&quot;</span>,
+            <span class="hljs-attr">&quot;externalValue&quot;</span>: <span class="hljs-string">&quot;http://foo.bar/examples/user-example.txt&quot;</span> 
         }
       } 
     },
-    <span class="hljs-attr">"*/*"</span>: {
-      <span class="hljs-attr">"examples"</span>: {
-        <span class="hljs-attr">"user"</span> : {
-            <span class="hljs-attr">"summary"</span>: <span class="hljs-string">"User example in other format"</span>,
-            <span class="hljs-attr">"externalValue"</span>: <span class="hljs-string">"http://foo.bar/examples/user-example.whatever"</span>
+    <span class="hljs-attr">&quot;*/*&quot;</span>: {
+      <span class="hljs-attr">&quot;examples&quot;</span>: {
+        <span class="hljs-attr">&quot;user&quot;</span> : {
+            <span class="hljs-attr">&quot;summary&quot;</span>: <span class="hljs-string">&quot;User example in other format&quot;</span>,
+            <span class="hljs-attr">&quot;externalValue&quot;</span>: <span class="hljs-string">&quot;http://foo.bar/examples/user-example.whatever&quot;</span>
         }
       }
     }
@@ -1702,41 +1702,41 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 <pre class="nohighlight"><code>
 <span class="hljs-attr">description:</span> <span class="hljs-string">user</span> <span class="hljs-string">to</span> <span class="hljs-string">add</span> <span class="hljs-string">to</span> <span class="hljs-string">the</span> <span class="hljs-string">system</span>
 <span class="hljs-attr">content:</span> 
-  <span class="hljs-string">'application/json'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">    schema:</span>
-      <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/User'</span>
-<span class="hljs-attr">    examples:</span>
-<span class="hljs-attr">      user:</span>
-<span class="hljs-attr">        summary:</span> <span class="hljs-string">User</span> <span class="hljs-string">Example</span>
-<span class="hljs-attr">        externalValue:</span> <span class="hljs-string">'http://foo.bar/examples/user-example.json'</span>
-  <span class="hljs-string">'application/xml'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">    schema:</span>
-      <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/User'</span>
-<span class="hljs-attr">    examples:</span>
-<span class="hljs-attr">      user:</span>
-<span class="hljs-attr">        summary:</span> <span class="hljs-string">User</span> <span class="hljs-string">Example</span> <span class="hljs-string">in</span> <span class="hljs-string">XML</span>
-<span class="hljs-attr">        externalValue:</span> <span class="hljs-string">'http://foo.bar/examples/user-example.xml'</span>
-  <span class="hljs-string">'text/plain'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">    examples:</span>
-<span class="hljs-attr">      user:</span>
-<span class="hljs-attr">        summary:</span> <span class="hljs-string">User</span> <span class="hljs-string">example</span> <span class="hljs-string">in</span> <span class="hljs-string">text</span> <span class="hljs-string">plain</span> <span class="hljs-string">format</span>
-<span class="hljs-attr">        externalValue:</span> <span class="hljs-string">'http://foo.bar/examples/user-example.txt'</span>
-  <span class="hljs-string">'*/*'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">    examples:</span>
-<span class="hljs-attr">      user:</span> 
-<span class="hljs-attr">        summary:</span> <span class="hljs-string">User</span> <span class="hljs-string">example</span> <span class="hljs-string">in</span> <span class="hljs-string">other</span> <span class="hljs-string">format</span>
-<span class="hljs-attr">        externalValue:</span> <span class="hljs-string">'http://foo.bar/examples/user-example.whatever'</span>
+  <span class="hljs-attr">&#x27;application/json&#x27;:</span>
+    <span class="hljs-attr">schema:</span>
+      <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/User&#x27;</span>
+    <span class="hljs-attr">examples:</span>
+      <span class="hljs-attr">user:</span>
+        <span class="hljs-attr">summary:</span> <span class="hljs-string">User</span> <span class="hljs-string">Example</span>
+        <span class="hljs-attr">externalValue:</span> <span class="hljs-string">&#x27;http://foo.bar/examples/user-example.json&#x27;</span>
+  <span class="hljs-attr">&#x27;application/xml&#x27;:</span>
+    <span class="hljs-attr">schema:</span>
+      <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/User&#x27;</span>
+    <span class="hljs-attr">examples:</span>
+      <span class="hljs-attr">user:</span>
+        <span class="hljs-attr">summary:</span> <span class="hljs-string">User</span> <span class="hljs-string">Example</span> <span class="hljs-string">in</span> <span class="hljs-string">XML</span>
+        <span class="hljs-attr">externalValue:</span> <span class="hljs-string">&#x27;http://foo.bar/examples/user-example.xml&#x27;</span>
+  <span class="hljs-attr">&#x27;text/plain&#x27;:</span>
+    <span class="hljs-attr">examples:</span>
+      <span class="hljs-attr">user:</span>
+        <span class="hljs-attr">summary:</span> <span class="hljs-string">User</span> <span class="hljs-string">example</span> <span class="hljs-string">in</span> <span class="hljs-string">text</span> <span class="hljs-string">plain</span> <span class="hljs-string">format</span>
+        <span class="hljs-attr">externalValue:</span> <span class="hljs-string">&#x27;http://foo.bar/examples/user-example.txt&#x27;</span>
+  <span class="hljs-string">&#x27;*/*&#x27;</span><span class="hljs-string">:</span>
+    <span class="hljs-attr">examples:</span>
+      <span class="hljs-attr">user:</span> 
+        <span class="hljs-attr">summary:</span> <span class="hljs-string">User</span> <span class="hljs-string">example</span> <span class="hljs-string">in</span> <span class="hljs-string">other</span> <span class="hljs-string">format</span>
+        <span class="hljs-attr">externalValue:</span> <span class="hljs-string">&#x27;http://foo.bar/examples/user-example.whatever&#x27;</span>
 </code></pre>
 <p>A body parameter that is an array of string values:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"user to add to the system"</span>,
-  <span class="hljs-attr">"content"</span>: {
-    <span class="hljs-attr">"text/plain"</span>: {
-      <span class="hljs-attr">"schema"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-        <span class="hljs-attr">"items"</span>: {
-          <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+  <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;user to add to the system&quot;</span>,
+  <span class="hljs-attr">&quot;content&quot;</span>: {
+    <span class="hljs-attr">&quot;text/plain&quot;</span>: {
+      <span class="hljs-attr">&quot;schema&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+        <span class="hljs-attr">&quot;items&quot;</span>: {
+          <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
         }
       }
     }
@@ -1747,11 +1747,11 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 <span class="hljs-attr">description:</span> <span class="hljs-string">user</span> <span class="hljs-string">to</span> <span class="hljs-string">add</span> <span class="hljs-string">to</span> <span class="hljs-string">the</span> <span class="hljs-string">system</span>
 <span class="hljs-attr">required:</span> <span class="hljs-literal">true</span>
 <span class="hljs-attr">content:</span>
-  <span class="hljs-string">text/plain:</span>
-<span class="hljs-attr">    schema:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">      items:</span>
-<span class="hljs-attr">        type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">text/plain:</span>
+    <span class="hljs-attr">schema:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+      <span class="hljs-attr">items:</span>
+        <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
 </code></pre>
 </section></section><section><h3><span id="mediaTypeObject">Media Type Object</span></h3>
 <p>Each Media Type Object provides schema and examples for the media type identified by its key.</p>
@@ -1767,7 +1767,7 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 <tbody>
 <tr>
 <td><a id="mediaTypeSchema"> </a>schema</td>
-<td style="text-align:center"><a href="#schemaObject">Schema Object</a> ¦ <a href="#referenceObject">Reference Object</a></td>
+<td style="text-align:center"><a href="#schemaObject">Schema Object</a> | <a href="#referenceObject">Reference Object</a></td>
 <td>The schema defining the type used for the request body.</td>
 </tr>
 <tr>
@@ -1777,7 +1777,7 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 </tr>
 <tr>
 <td><a id="mediaTypeExamples"> </a>examples</td>
-<td style="text-align:center">Map[ <code>string</code>, <a href="#exampleObject">Example Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:center">Map[ <code>string</code>, <a href="#exampleObject">Example Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>Examples of the media type.  Each example object SHOULD  match the media type and specified schema if present.  The <code>examples</code> field is mutually exclusive of the <code>example</code> field.  Furthermore, if referencing a <code>schema</code> which contains an example, the <code>examples</code> value SHALL <em>override</em> the example provided by the schema.</td>
 </tr>
 <tr>
@@ -1791,33 +1791,33 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 </section><section><h4>Media Type Examples</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-string">"application/json"</span>: {
-    <span class="hljs-string">"schema"</span>: {
-         <span class="hljs-string">"$ref"</span>: <span class="hljs-string">"#/components/schemas/Pet"</span>
+  <span class="hljs-string">&quot;application/json&quot;</span>: {
+    <span class="hljs-string">&quot;schema&quot;</span>: {
+         <span class="hljs-string">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/Pet&quot;</span>
     },
-    <span class="hljs-string">"examples"</span>: {
-      <span class="hljs-string">"cat"</span> : {
-        <span class="hljs-string">"summary"</span>: <span class="hljs-string">"An example of a cat"</span>,
-        <span class="hljs-string">"value"</span>: 
+    <span class="hljs-string">&quot;examples&quot;</span>: {
+      <span class="hljs-string">&quot;cat&quot;</span> : {
+        <span class="hljs-string">&quot;summary&quot;</span>: <span class="hljs-string">&quot;An example of a cat&quot;</span>,
+        <span class="hljs-string">&quot;value&quot;</span>: 
           {
-            <span class="hljs-string">"name"</span>: <span class="hljs-string">"Fluffy"</span>,
-            <span class="hljs-string">"petType"</span>: <span class="hljs-string">"Cat"</span>,
-            <span class="hljs-string">"color"</span>: <span class="hljs-string">"White"</span>,
-            <span class="hljs-string">"gender"</span>: <span class="hljs-string">"male"</span>,
-            <span class="hljs-string">"breed"</span>: <span class="hljs-string">"Persian"</span>
+            <span class="hljs-string">&quot;name&quot;</span>: <span class="hljs-string">&quot;Fluffy&quot;</span>,
+            <span class="hljs-string">&quot;petType&quot;</span>: <span class="hljs-string">&quot;Cat&quot;</span>,
+            <span class="hljs-string">&quot;color&quot;</span>: <span class="hljs-string">&quot;White&quot;</span>,
+            <span class="hljs-string">&quot;gender&quot;</span>: <span class="hljs-string">&quot;male&quot;</span>,
+            <span class="hljs-string">&quot;breed&quot;</span>: <span class="hljs-string">&quot;Persian&quot;</span>
           }
       },
-      <span class="hljs-string">"dog"</span>: {
-        <span class="hljs-string">"summary"</span>: <span class="hljs-string">"An example of a dog with a cat's name"</span>,
-        <span class="hljs-string">"value"</span> :  { 
-          <span class="hljs-string">"name"</span>: <span class="hljs-string">"Puma"</span>,
-          <span class="hljs-string">"petType"</span>: <span class="hljs-string">"Dog"</span>,
-          <span class="hljs-string">"color"</span>: <span class="hljs-string">"Black"</span>,
-          <span class="hljs-string">"gender"</span>: <span class="hljs-string">"Female"</span>,
-          <span class="hljs-string">"breed"</span>: <span class="hljs-string">"Mixed"</span>
+      <span class="hljs-string">&quot;dog&quot;</span>: {
+        <span class="hljs-string">&quot;summary&quot;</span>: <span class="hljs-string">&quot;An example of a dog with a cat&#x27;s name&quot;</span>,
+        <span class="hljs-string">&quot;value&quot;</span> :  { 
+          <span class="hljs-string">&quot;name&quot;</span>: <span class="hljs-string">&quot;Puma&quot;</span>,
+          <span class="hljs-string">&quot;petType&quot;</span>: <span class="hljs-string">&quot;Dog&quot;</span>,
+          <span class="hljs-string">&quot;color&quot;</span>: <span class="hljs-string">&quot;Black&quot;</span>,
+          <span class="hljs-string">&quot;gender&quot;</span>: <span class="hljs-string">&quot;Female&quot;</span>,
+          <span class="hljs-string">&quot;breed&quot;</span>: <span class="hljs-string">&quot;Mixed&quot;</span>
         },
-      <span class="hljs-string">"frog"</span>: {
-          <span class="hljs-string">"$ref"</span>: <span class="hljs-string">"#/components/examples/frog-example"</span>
+      <span class="hljs-string">&quot;frog&quot;</span>: {
+          <span class="hljs-string">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/examples/frog-example&quot;</span>
         }
       }
     }
@@ -1825,83 +1825,83 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 }
 </code></pre>
 <pre class="nohighlight"><code>
-<span class="hljs-string">application/json:</span> 
-<span class="hljs-attr">  schema:</span>
-    <span class="hljs-string">$ref:</span> <span class="hljs-string">"#/components/schemas/Pet"</span>
-<span class="hljs-attr">  examples:</span>
-<span class="hljs-attr">    cat:</span>
-<span class="hljs-attr">      summary:</span> <span class="hljs-string">An</span> <span class="hljs-string">example</span> <span class="hljs-string">of</span> <span class="hljs-string">a</span> <span class="hljs-string">cat</span>
-<span class="hljs-attr">      value:</span>
-<span class="hljs-attr">        name:</span> <span class="hljs-string">Fluffy</span>
-<span class="hljs-attr">        petType:</span> <span class="hljs-string">Cat</span>
-<span class="hljs-attr">        color:</span> <span class="hljs-string">White</span>
-<span class="hljs-attr">        gender:</span> <span class="hljs-string">male</span>
-<span class="hljs-attr">        breed:</span> <span class="hljs-string">Persian</span>
-<span class="hljs-attr">    dog:</span>
-<span class="hljs-attr">      summary:</span> <span class="hljs-string">An</span> <span class="hljs-string">example</span> <span class="hljs-string">of</span> <span class="hljs-string">a</span> <span class="hljs-string">dog</span> <span class="hljs-string">with</span> <span class="hljs-string">a</span> <span class="hljs-string">cat's</span> <span class="hljs-string">name</span>
-<span class="hljs-attr">      value:</span>
-<span class="hljs-attr">        name:</span> <span class="hljs-string">Puma</span>
-<span class="hljs-attr">        petType:</span> <span class="hljs-string">Dog</span>
-<span class="hljs-attr">        color:</span> <span class="hljs-string">Black</span>
-<span class="hljs-attr">        gender:</span> <span class="hljs-string">Female</span>
-<span class="hljs-attr">        breed:</span> <span class="hljs-string">Mixed</span>
-<span class="hljs-attr">    frog:</span>
-      <span class="hljs-string">$ref:</span> <span class="hljs-string">"#/components/examples/frog-example"</span>
+<span class="hljs-attr">application/json:</span> 
+  <span class="hljs-attr">schema:</span>
+    <span class="hljs-string">$ref:</span> <span class="hljs-string">&quot;#/components/schemas/Pet&quot;</span>
+  <span class="hljs-attr">examples:</span>
+    <span class="hljs-attr">cat:</span>
+      <span class="hljs-attr">summary:</span> <span class="hljs-string">An</span> <span class="hljs-string">example</span> <span class="hljs-string">of</span> <span class="hljs-string">a</span> <span class="hljs-string">cat</span>
+      <span class="hljs-attr">value:</span>
+        <span class="hljs-attr">name:</span> <span class="hljs-string">Fluffy</span>
+        <span class="hljs-attr">petType:</span> <span class="hljs-string">Cat</span>
+        <span class="hljs-attr">color:</span> <span class="hljs-string">White</span>
+        <span class="hljs-attr">gender:</span> <span class="hljs-string">male</span>
+        <span class="hljs-attr">breed:</span> <span class="hljs-string">Persian</span>
+    <span class="hljs-attr">dog:</span>
+      <span class="hljs-attr">summary:</span> <span class="hljs-string">An</span> <span class="hljs-string">example</span> <span class="hljs-string">of</span> <span class="hljs-string">a</span> <span class="hljs-string">dog</span> <span class="hljs-string">with</span> <span class="hljs-string">a</span> <span class="hljs-string">cat&#x27;s</span> <span class="hljs-string">name</span>
+      <span class="hljs-attr">value:</span>
+        <span class="hljs-attr">name:</span> <span class="hljs-string">Puma</span>
+        <span class="hljs-attr">petType:</span> <span class="hljs-string">Dog</span>
+        <span class="hljs-attr">color:</span> <span class="hljs-string">Black</span>
+        <span class="hljs-attr">gender:</span> <span class="hljs-string">Female</span>
+        <span class="hljs-attr">breed:</span> <span class="hljs-string">Mixed</span>
+    <span class="hljs-attr">frog:</span>
+      <span class="hljs-string">$ref:</span> <span class="hljs-string">&quot;#/components/examples/frog-example&quot;</span>
 </code></pre>
 </section><section><h4>Considerations for File Uploads</h4>
 <p>In contrast with the 2.0 specification, <code>file</code> input/output content in OpenAPI is described with the same semantics as any other schema type. Specifically:</p>
 <pre class="nohighlight"><code>
 <span class="hljs-comment"># content transferred with base64 encoding</span>
 <span class="hljs-attr">schema:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">  format:</span> <span class="hljs-string">base64</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">format:</span> <span class="hljs-string">base64</span>
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-comment"># content transferred in binary (octet-stream):</span>
 <span class="hljs-attr">schema:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">  format:</span> <span class="hljs-string">binary</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">format:</span> <span class="hljs-string">binary</span>
 </code></pre>
 <p>These examples apply to either input payloads of file uploads or response payloads.</p>
 <p>A <code>requestBody</code> for submitting a file in a <code>POST</code> operation may look like the following example:</p>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">requestBody:</span>
-<span class="hljs-attr">  content:</span>
-    <span class="hljs-string">application/octet-stream:</span>
+  <span class="hljs-attr">content:</span>
+    <span class="hljs-attr">application/octet-stream:</span>
       <span class="hljs-comment"># any media type is accepted, functionally equivalent to `*/*`</span>
-<span class="hljs-attr">      schema:</span>
+      <span class="hljs-attr">schema:</span>
         <span class="hljs-comment"># a binary file of any type</span>
-<span class="hljs-attr">        type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">        format:</span> <span class="hljs-string">binary</span>
+        <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+        <span class="hljs-attr">format:</span> <span class="hljs-string">binary</span>
 </code></pre>
 <p>In addition, specific media types MAY be specified:</p>
 <pre class="nohighlight"><code>
 <span class="hljs-comment"># multiple, specific media types may be specified:</span>
 <span class="hljs-attr">requestBody:</span>
-<span class="hljs-attr">  content:</span>
+  <span class="hljs-attr">content:</span>
       <span class="hljs-comment"># a binary file of type png or jpeg</span>
-    <span class="hljs-string">'image/jpeg'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">      schema:</span>
-<span class="hljs-attr">        type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">        format:</span> <span class="hljs-string">binary</span>
-    <span class="hljs-string">'image/png'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">      schema:</span>
-<span class="hljs-attr">        type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">        format:</span> <span class="hljs-string">binary</span>        
+    <span class="hljs-attr">&#x27;image/jpeg&#x27;:</span>
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+        <span class="hljs-attr">format:</span> <span class="hljs-string">binary</span>
+    <span class="hljs-attr">&#x27;image/png&#x27;:</span>
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+        <span class="hljs-attr">format:</span> <span class="hljs-string">binary</span>        
 </code></pre>
 <p>To upload multiple files, a <code>multipart</code> media type MUST be used:</p>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">requestBody:</span>
-<span class="hljs-attr">  content:</span>
-    <span class="hljs-string">multipart/form-data:</span>
-<span class="hljs-attr">      schema:</span>
-<span class="hljs-attr">        properties:</span>
-          <span class="hljs-comment"># The property name 'file' will be used for all files.</span>
-<span class="hljs-attr">          file:</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">            items:</span>
-<span class="hljs-attr">              type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">              format:</span> <span class="hljs-string">binary</span>
+  <span class="hljs-attr">content:</span>
+    <span class="hljs-attr">multipart/form-data:</span>
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-attr">properties:</span>
+          <span class="hljs-comment"># The property name &#x27;file&#x27; will be used for all files.</span>
+          <span class="hljs-attr">file:</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+            <span class="hljs-attr">items:</span>
+              <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+              <span class="hljs-attr">format:</span> <span class="hljs-string">binary</span>
 
 </code></pre>
 </section><section><h4>Support for x-www-form-urlencoded Request Bodies</h4>
@@ -1909,21 +1909,21 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 definition may be used:</p>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">requestBody:</span>
-<span class="hljs-attr">  content:</span>
-    <span class="hljs-string">application/x-www-form-urlencoded:</span>
-<span class="hljs-attr">      schema:</span>
-<span class="hljs-attr">        type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">        properties:</span>
-<span class="hljs-attr">          id:</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">            format:</span> <span class="hljs-string">uuid</span>
-<span class="hljs-attr">          address:</span>
+  <span class="hljs-attr">content:</span>
+    <span class="hljs-attr">application/x-www-form-urlencoded:</span>
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+        <span class="hljs-attr">properties:</span>
+          <span class="hljs-attr">id:</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+            <span class="hljs-attr">format:</span> <span class="hljs-string">uuid</span>
+          <span class="hljs-attr">address:</span>
             <span class="hljs-comment"># complex types are stringified to support RFC 1866</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">            properties:</span> <span class="hljs-string">{}</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+            <span class="hljs-attr">properties:</span> {}
 </code></pre>
 <p>In this example, the contents in the <code>requestBody</code> MUST be stringified per [[!RFC1866]] when passed to the server.  In addition, the <code>address</code> field complex object will be stringified.</p>
-<p>When passing complex objects in the <code>application/x-www-form-urlencoded</code> content type, the default serialization strategy of such properties is described in the <a href="#encodingObject"><code>Encoding Object</code></a>'s <a href="#encodingStyle"><code>style</code></a> property as <code>form</code>.</p>
+<p>When passing complex objects in the <code>application/x-www-form-urlencoded</code> content type, the default serialization strategy of such properties is described in the <a href="#encodingObject"><code>Encoding Object</code></a>’s <a href="#encodingStyle"><code>style</code></a> property as <code>form</code>.</p>
 </section><section><h4>Special Considerations for <code>multipart</code> Content</h4>
 <p>It is common to use <code>multipart/form-data</code> as a <code>Content-Type</code> when transferring request bodies to operations.  In contrast to 2.0, a <code>schema</code> is REQUIRED to define the input parameters to the operation when using <code>multipart</code> content.  This supports complex structures as well as supporting mechanisms for multiple file uploads.</p>
 <p>When passing in <code>multipart</code> types, boundaries MAY be used to separate sections of the content being transferred — thus, the following default <code>Content-Type</code>s are defined for <code>multipart</code>:</p>
@@ -1935,32 +1935,32 @@ definition may be used:</p>
 <p>Examples:</p>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">requestBody:</span>
-<span class="hljs-attr">  content:</span>
-    <span class="hljs-string">multipart/form-data:</span>
-<span class="hljs-attr">      schema:</span>
-<span class="hljs-attr">        type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">        properties:</span>
-<span class="hljs-attr">          id:</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">            format:</span> <span class="hljs-string">uuid</span>
-<span class="hljs-attr">          address:</span>
+  <span class="hljs-attr">content:</span>
+    <span class="hljs-attr">multipart/form-data:</span>
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+        <span class="hljs-attr">properties:</span>
+          <span class="hljs-attr">id:</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+            <span class="hljs-attr">format:</span> <span class="hljs-string">uuid</span>
+          <span class="hljs-attr">address:</span>
             <span class="hljs-comment"># default Content-Type for objects is `application/json`</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">            properties:</span> <span class="hljs-string">{}</span>
-<span class="hljs-attr">          profileImage:</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+            <span class="hljs-attr">properties:</span> {}
+          <span class="hljs-attr">profileImage:</span>
             <span class="hljs-comment"># default Content-Type for string/binary is `application/octet-stream`</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">            format:</span> <span class="hljs-string">binary</span>
-<span class="hljs-attr">          children:</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+            <span class="hljs-attr">format:</span> <span class="hljs-string">binary</span>
+          <span class="hljs-attr">children:</span>
             <span class="hljs-comment"># default Content-Type for arrays is based on the `inner` type (text/plain here)</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">            items:</span>
-<span class="hljs-attr">              type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">          addresses:</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+            <span class="hljs-attr">items:</span>
+              <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+          <span class="hljs-attr">addresses:</span>
             <span class="hljs-comment"># default Content-Type for arrays is based on the `inner` type (object shown, so `application/json` in this example)</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">            items:</span>
-<span class="hljs-attr">              type:</span> <span class="hljs-string">'#/components/schemas/Address'</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+            <span class="hljs-attr">items:</span>
+              <span class="hljs-attr">type:</span> <span class="hljs-string">&#x27;#/components/schemas/Address&#x27;</span>
 </code></pre>
 <p>An <code>encoding</code> attribute is introduced to give you control over the serialization of parts of <code>multipart</code> request bodies.  This attribute is <em>only</em> applicable to <code>multipart</code> and <code>application/x-www-form-urlencoded</code> request bodies.</p>
 </section></section><section><h3><span id="encodingObject">Encoding Object</span></h3>
@@ -1982,7 +1982,7 @@ definition may be used:</p>
 </tr>
 <tr>
 <td><a id="encodingHeaders"> </a>headers</td>
-<td style="text-align:center">Map[<code>string</code>, <a href="#headerObject">Header Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:center">Map[<code>string</code>, <a href="#headerObject">Header Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>A map allowing additional information to be provided as headers, for example <code>Content-Disposition</code>.  <code>Content-Type</code> is described separately and SHALL be ignored in this section. This property SHALL be ignored if the request body media type is not a <code>multipart</code>.</td>
 </tr>
 <tr>
@@ -2006,40 +2006,40 @@ definition may be used:</p>
 </section><section><h4>Encoding Object Example</h4>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">requestBody:</span>
-<span class="hljs-attr">  content:</span>
-    <span class="hljs-string">multipart/mixed:</span>
-<span class="hljs-attr">      schema:</span>
-<span class="hljs-attr">        type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">        properties:</span>
-<span class="hljs-attr">          id:</span>
+  <span class="hljs-attr">content:</span>
+    <span class="hljs-attr">multipart/mixed:</span>
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+        <span class="hljs-attr">properties:</span>
+          <span class="hljs-attr">id:</span>
             <span class="hljs-comment"># default is text/plain</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">            format:</span> <span class="hljs-string">uuid</span>
-<span class="hljs-attr">          address:</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+            <span class="hljs-attr">format:</span> <span class="hljs-string">uuid</span>
+          <span class="hljs-attr">address:</span>
             <span class="hljs-comment"># default is application/json</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">            properties:</span> <span class="hljs-string">{}</span>
-<span class="hljs-attr">          historyMetadata:</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+            <span class="hljs-attr">properties:</span> {}
+          <span class="hljs-attr">historyMetadata:</span>
             <span class="hljs-comment"># need to declare XML format!</span>
-<span class="hljs-attr">            description:</span> <span class="hljs-string">metadata</span> <span class="hljs-string">in</span> <span class="hljs-string">XML</span> <span class="hljs-string">format</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">            properties:</span> <span class="hljs-string">{}</span>
-<span class="hljs-attr">          profileImage:</span>
+            <span class="hljs-attr">description:</span> <span class="hljs-string">metadata</span> <span class="hljs-string">in</span> <span class="hljs-string">XML</span> <span class="hljs-string">format</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+            <span class="hljs-attr">properties:</span> {}
+          <span class="hljs-attr">profileImage:</span>
             <span class="hljs-comment"># default is application/octet-stream, need to declare an image type only!</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">            format:</span> <span class="hljs-string">binary</span>
-<span class="hljs-attr">      encoding:</span>
-<span class="hljs-attr">        historyMetadata:</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+            <span class="hljs-attr">format:</span> <span class="hljs-string">binary</span>
+      <span class="hljs-attr">encoding:</span>
+        <span class="hljs-attr">historyMetadata:</span>
           <span class="hljs-comment"># require XML Content-Type in utf-8 encoding</span>
-<span class="hljs-attr">          contentType:</span> <span class="hljs-string">application/xml;</span> <span class="hljs-string">charset=utf-8</span>
-<span class="hljs-attr">        profileImage:</span>
+          <span class="hljs-attr">contentType:</span> <span class="hljs-string">application/xml;</span> <span class="hljs-string">charset=utf-8</span>
+        <span class="hljs-attr">profileImage:</span>
           <span class="hljs-comment"># only accept png/jpeg</span>
-<span class="hljs-attr">          contentType:</span> <span class="hljs-string">image/png,</span> <span class="hljs-string">image/jpeg</span>
-<span class="hljs-attr">          headers:</span>
-<span class="hljs-attr">            X-Rate-Limit-Limit:</span>
-<span class="hljs-attr">              description:</span> <span class="hljs-string">The</span> <span class="hljs-string">number</span> <span class="hljs-string">of</span> <span class="hljs-string">allowed</span> <span class="hljs-string">requests</span> <span class="hljs-string">in</span> <span class="hljs-string">the</span> <span class="hljs-string">current</span> <span class="hljs-string">period</span>
-<span class="hljs-attr">              schema:</span>
-<span class="hljs-attr">                type:</span> <span class="hljs-string">integer</span>
+          <span class="hljs-attr">contentType:</span> <span class="hljs-string">image/png,</span> <span class="hljs-string">image/jpeg</span>
+          <span class="hljs-attr">headers:</span>
+            <span class="hljs-attr">X-Rate-Limit-Limit:</span>
+              <span class="hljs-attr">description:</span> <span class="hljs-string">The</span> <span class="hljs-string">number</span> <span class="hljs-string">of</span> <span class="hljs-string">allowed</span> <span class="hljs-string">requests</span> <span class="hljs-string">in</span> <span class="hljs-string">the</span> <span class="hljs-string">current</span> <span class="hljs-string">period</span>
+              <span class="hljs-attr">schema:</span>
+                <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
 </code></pre>
 </section></section><section><h3><span id="responsesObject">Responses Object</span></h3>
 <p>A container for the expected responses of an operation.
@@ -2062,7 +2062,7 @@ SHOULD be the response for a successful operation call.</p>
 <tbody>
 <tr>
 <td><a id="responsesDefault"> </a>default</td>
-<td style="text-align:center"><a href="#responseObject">Response Object</a> ¦ <a href="#referenceObject">Reference Object</a></td>
+<td style="text-align:center"><a href="#responseObject">Response Object</a> | <a href="#referenceObject">Reference Object</a></td>
 <td>The documentation of responses other than the ones declared for specific HTTP response codes. Use this field to cover undeclared responses. A <a href="#referenceObject">Reference Object</a> can link to a response that the <a href="#componentsResponses">OpenAPI Object’s components/responses</a> section defines.</td>
 </tr>
 </tbody>
@@ -2079,7 +2079,7 @@ SHOULD be the response for a successful operation call.</p>
 <tbody>
 <tr>
 <td><a id="responsesCode"> </a><a href="#httpCodes">HTTP Status Code</a></td>
-<td style="text-align:center"><a href="#responseObject">Response Object</a> ¦ <a href="#referenceObject">Reference Object</a></td>
+<td style="text-align:center"><a href="#responseObject">Response Object</a> | <a href="#referenceObject">Reference Object</a></td>
 <td>Any <a href="#httpCodes">HTTP status code</a> can be used as the property name, but only one property per code, to describe the expected response for that HTTP status code.  A <a href="#referenceObject">Reference Object</a> can link to a response that is defined in the <a href="#componentsResponses">OpenAPI Object’s components/responses</a> section. This field MUST be enclosed in quotation marks (for example, “200”) for compatibility between JSON and YAML. To define a range of response codes, this field MAY contain the uppercase wildcard character <code>X</code>. For example, <code>2XX</code> represents all response codes between <code>[200-299]</code>. The following range definitions are allowed: <code>1XX</code>, <code>2XX</code>, <code>3XX</code>, <code>4XX</code>, and <code>5XX</code>. If a response range is defined using an explicit code, the explicit code definition takes precedence over the range definition for that code.</td>
 </tr>
 </tbody>
@@ -2089,22 +2089,22 @@ SHOULD be the response for a successful operation call.</p>
 <p>A 200 response for a successful operation and a default response for others (implying an error):</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"200"</span>: {
-    <span class="hljs-attr">"description"</span>: <span class="hljs-string">"a pet to be returned"</span>,
-    <span class="hljs-attr">"content"</span>: {
-      <span class="hljs-attr">"application/json"</span>: {
-        <span class="hljs-attr">"schema"</span>: {
-          <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/Pet"</span>
+  <span class="hljs-attr">&quot;200&quot;</span>: {
+    <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;a pet to be returned&quot;</span>,
+    <span class="hljs-attr">&quot;content&quot;</span>: {
+      <span class="hljs-attr">&quot;application/json&quot;</span>: {
+        <span class="hljs-attr">&quot;schema&quot;</span>: {
+          <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/Pet&quot;</span>
         }
       }
     }
   },
-  <span class="hljs-attr">"default"</span>: {
-    <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Unexpected error"</span>,
-    <span class="hljs-attr">"content"</span>: {
-      <span class="hljs-attr">"application/json"</span>: {
-        <span class="hljs-attr">"schema"</span>: {
-          <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/ErrorModel"</span>
+  <span class="hljs-attr">&quot;default&quot;</span>: {
+    <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;Unexpected error&quot;</span>,
+    <span class="hljs-attr">&quot;content&quot;</span>: {
+      <span class="hljs-attr">&quot;application/json&quot;</span>: {
+        <span class="hljs-attr">&quot;schema&quot;</span>: {
+          <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/ErrorModel&quot;</span>
         }
       }
     }
@@ -2112,18 +2112,18 @@ SHOULD be the response for a successful operation call.</p>
 }
 </code></pre>
 <pre class="nohighlight"><code>
-<span class="hljs-string">'200'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">  description:</span> <span class="hljs-string">a</span> <span class="hljs-string">pet</span> <span class="hljs-string">to</span> <span class="hljs-string">be</span> <span class="hljs-string">returned</span>
-<span class="hljs-attr">  content:</span> 
-    <span class="hljs-string">application/json:</span>
-<span class="hljs-attr">      schema:</span>
-        <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Pet'</span>
+<span class="hljs-attr">&#x27;200&#x27;:</span>
+  <span class="hljs-attr">description:</span> <span class="hljs-string">a</span> <span class="hljs-string">pet</span> <span class="hljs-string">to</span> <span class="hljs-string">be</span> <span class="hljs-string">returned</span>
+  <span class="hljs-attr">content:</span> 
+    <span class="hljs-attr">application/json:</span>
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/Pet&#x27;</span>
 <span class="hljs-attr">default:</span>
-<span class="hljs-attr">  description:</span> <span class="hljs-string">Unexpected</span> <span class="hljs-string">error</span>
-<span class="hljs-attr">  content:</span>
-    <span class="hljs-string">application/json:</span>
-<span class="hljs-attr">      schema:</span>
-        <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/ErrorModel'</span>
+  <span class="hljs-attr">description:</span> <span class="hljs-string">Unexpected</span> <span class="hljs-string">error</span>
+  <span class="hljs-attr">content:</span>
+    <span class="hljs-attr">application/json:</span>
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/ErrorModel&#x27;</span>
 </code></pre>
 </section></section><section><h3><span id="responseObject">Response Object</span></h3>
 <p>Describes a single response from an API Operation, including design-time, static
@@ -2145,7 +2145,7 @@ SHOULD be the response for a successful operation call.</p>
 </tr>
 <tr>
 <td><a id="responseHeaders"> </a>headers</td>
-<td style="text-align:center">Map[<code>string</code>, <a href="#headerObject">Header Object</a>  ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:center">Map[<code>string</code>, <a href="#headerObject">Header Object</a>  | <a href="#referenceObject">Reference Object</a>]</td>
 <td>Maps a header name to its definition. [[!RFC7230]] states header names are case insensitive. If a response header is defined with the name <code>&quot;Content-Type&quot;</code>, it SHALL be ignored.</td>
 </tr>
 <tr>
@@ -2155,7 +2155,7 @@ SHOULD be the response for a successful operation call.</p>
 </tr>
 <tr>
 <td><a id="responseLinks"> </a>links</td>
-<td style="text-align:center">Map[<code>string</code>, <a href="#linkObject">Link Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:center">Map[<code>string</code>, <a href="#linkObject">Link Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>A map of operations links that can be followed from the response. The key of the map is a short name for the link, following the naming constraints of the names for <a href="#componentsObject">Component Objects</a>.</td>
 </tr>
 </tbody>
@@ -2165,13 +2165,13 @@ SHOULD be the response for a successful operation call.</p>
 <p>Response of an array of a complex type:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"A complex object array response"</span>,
-  <span class="hljs-attr">"content"</span>: {
-    <span class="hljs-attr">"application/json"</span>: {
-      <span class="hljs-attr">"schema"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-        <span class="hljs-attr">"items"</span>: {
-          <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/VeryComplexType"</span>
+  <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;A complex object array response&quot;</span>,
+  <span class="hljs-attr">&quot;content&quot;</span>: {
+    <span class="hljs-attr">&quot;application/json&quot;</span>: {
+      <span class="hljs-attr">&quot;schema&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+        <span class="hljs-attr">&quot;items&quot;</span>: {
+          <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/VeryComplexType&quot;</span>
         }
       }
     }
@@ -2181,20 +2181,20 @@ SHOULD be the response for a successful operation call.</p>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">description:</span> <span class="hljs-string">A</span> <span class="hljs-string">complex</span> <span class="hljs-string">object</span> <span class="hljs-string">array</span> <span class="hljs-string">response</span>
 <span class="hljs-attr">content:</span> 
-  <span class="hljs-string">application/json:</span>
-<span class="hljs-attr">    schema:</span> 
-<span class="hljs-attr">      type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">      items:</span>
-        <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/VeryComplexType'</span>
+  <span class="hljs-attr">application/json:</span>
+    <span class="hljs-attr">schema:</span> 
+      <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+      <span class="hljs-attr">items:</span>
+        <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/VeryComplexType&#x27;</span>
 </code></pre>
 <p>Response with a string type:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"A simple string response"</span>,
-  <span class="hljs-attr">"content"</span>: {
-    <span class="hljs-attr">"text/plain"</span>: {
-      <span class="hljs-attr">"schema"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+  <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;A simple string response&quot;</span>,
+  <span class="hljs-attr">&quot;content&quot;</span>: {
+    <span class="hljs-attr">&quot;text/plain&quot;</span>: {
+      <span class="hljs-attr">&quot;schema&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
       }
     }
   }
@@ -2204,38 +2204,38 @@ SHOULD be the response for a successful operation call.</p>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">description:</span> <span class="hljs-string">A</span> <span class="hljs-string">simple</span> <span class="hljs-string">string</span> <span class="hljs-string">response</span>
 <span class="hljs-attr">content:</span>
-  <span class="hljs-string">text/plain:</span>
-<span class="hljs-attr">    schema:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">text/plain:</span>
+    <span class="hljs-attr">schema:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
 </code></pre>
 <p>Plain text response with headers:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"A simple string response"</span>,
-  <span class="hljs-attr">"content"</span>: {
-    <span class="hljs-attr">"text/plain"</span>: {
-      <span class="hljs-attr">"schema"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+  <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;A simple string response&quot;</span>,
+  <span class="hljs-attr">&quot;content&quot;</span>: {
+    <span class="hljs-attr">&quot;text/plain&quot;</span>: {
+      <span class="hljs-attr">&quot;schema&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
       }
     }
   },
-  <span class="hljs-attr">"headers"</span>: {
-    <span class="hljs-attr">"X-Rate-Limit-Limit"</span>: {
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"The number of allowed requests in the current period"</span>,
-      <span class="hljs-attr">"schema"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>
+  <span class="hljs-attr">&quot;headers&quot;</span>: {
+    <span class="hljs-attr">&quot;X-Rate-Limit-Limit&quot;</span>: {
+      <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;The number of allowed requests in the current period&quot;</span>,
+      <span class="hljs-attr">&quot;schema&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>
       }
     },
-    <span class="hljs-attr">"X-Rate-Limit-Remaining"</span>: {
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"The number of remaining requests in the current period"</span>,
-      <span class="hljs-attr">"schema"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>
+    <span class="hljs-attr">&quot;X-Rate-Limit-Remaining&quot;</span>: {
+      <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;The number of remaining requests in the current period&quot;</span>,
+      <span class="hljs-attr">&quot;schema&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>
       }
     },
-    <span class="hljs-attr">"X-Rate-Limit-Reset"</span>: {
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"The number of seconds left in the current period"</span>,
-      <span class="hljs-attr">"schema"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>
+    <span class="hljs-attr">&quot;X-Rate-Limit-Reset&quot;</span>: {
+      <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;The number of seconds left in the current period&quot;</span>,
+      <span class="hljs-attr">&quot;schema&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>
       }
     }
   }
@@ -2244,28 +2244,28 @@ SHOULD be the response for a successful operation call.</p>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">description:</span> <span class="hljs-string">A</span> <span class="hljs-string">simple</span> <span class="hljs-string">string</span> <span class="hljs-string">response</span>
 <span class="hljs-attr">content:</span>
-  <span class="hljs-string">text/plain:</span>
-<span class="hljs-attr">    schema:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">    example:</span> <span class="hljs-string">'whoa!'</span>
+  <span class="hljs-attr">text/plain:</span>
+    <span class="hljs-attr">schema:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+    <span class="hljs-attr">example:</span> <span class="hljs-string">&#x27;whoa!&#x27;</span>
 <span class="hljs-attr">headers:</span>
-<span class="hljs-attr">  X-Rate-Limit-Limit:</span>
-<span class="hljs-attr">    description:</span> <span class="hljs-string">The</span> <span class="hljs-string">number</span> <span class="hljs-string">of</span> <span class="hljs-string">allowed</span> <span class="hljs-string">requests</span> <span class="hljs-string">in</span> <span class="hljs-string">the</span> <span class="hljs-string">current</span> <span class="hljs-string">period</span>
-<span class="hljs-attr">    schema:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">integer</span>
-<span class="hljs-attr">  X-Rate-Limit-Remaining:</span>
-<span class="hljs-attr">    description:</span> <span class="hljs-string">The</span> <span class="hljs-string">number</span> <span class="hljs-string">of</span> <span class="hljs-string">remaining</span> <span class="hljs-string">requests</span> <span class="hljs-string">in</span> <span class="hljs-string">the</span> <span class="hljs-string">current</span> <span class="hljs-string">period</span>
-<span class="hljs-attr">    schema:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">integer</span>
-<span class="hljs-attr">  X-Rate-Limit-Reset:</span>
-<span class="hljs-attr">    description:</span> <span class="hljs-string">The</span> <span class="hljs-string">number</span> <span class="hljs-string">of</span> <span class="hljs-string">seconds</span> <span class="hljs-string">left</span> <span class="hljs-string">in</span> <span class="hljs-string">the</span> <span class="hljs-string">current</span> <span class="hljs-string">period</span>
-<span class="hljs-attr">    schema:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">integer</span>
+  <span class="hljs-attr">X-Rate-Limit-Limit:</span>
+    <span class="hljs-attr">description:</span> <span class="hljs-string">The</span> <span class="hljs-string">number</span> <span class="hljs-string">of</span> <span class="hljs-string">allowed</span> <span class="hljs-string">requests</span> <span class="hljs-string">in</span> <span class="hljs-string">the</span> <span class="hljs-string">current</span> <span class="hljs-string">period</span>
+    <span class="hljs-attr">schema:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+  <span class="hljs-attr">X-Rate-Limit-Remaining:</span>
+    <span class="hljs-attr">description:</span> <span class="hljs-string">The</span> <span class="hljs-string">number</span> <span class="hljs-string">of</span> <span class="hljs-string">remaining</span> <span class="hljs-string">requests</span> <span class="hljs-string">in</span> <span class="hljs-string">the</span> <span class="hljs-string">current</span> <span class="hljs-string">period</span>
+    <span class="hljs-attr">schema:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+  <span class="hljs-attr">X-Rate-Limit-Reset:</span>
+    <span class="hljs-attr">description:</span> <span class="hljs-string">The</span> <span class="hljs-string">number</span> <span class="hljs-string">of</span> <span class="hljs-string">seconds</span> <span class="hljs-string">left</span> <span class="hljs-string">in</span> <span class="hljs-string">the</span> <span class="hljs-string">current</span> <span class="hljs-string">period</span>
+    <span class="hljs-attr">schema:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
 </code></pre>
 <p>Response with no return value:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"object created"</span>
+  <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;object created&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -2288,7 +2288,7 @@ The key value used to identify the callback object is an expression, evaluated a
 <tr>
 <td><a id="callbackExpression"> </a>{expression}</td>
 <td style="text-align:center"><a href="#pathItemObject">Path Item Object</a></td>
-<td>A Path Item Object used to define a callback request and expected responses.  A <a href="../examples/v3.0/callback-example.yaml">complete example</a> is available.</td>
+<td>A Path Item Object used to define a callback request and expected responses.  A <a href="https://github.com/OAI/OpenAPI-Specification/tree/master/examples/v3.0/callback-example.yaml">complete example</a> is available.</td>
 </tr>
 </tbody>
 </table>
@@ -2300,22 +2300,22 @@ However, using a <a href="#runtimeExpression">runtime expression</a> the complet
 This includes accessing any part of a body that a JSON Pointer [[!RFC6901]] can reference.</p>
 <p>For example, given the following HTTP request:</p>
 <pre class="nohighlight"><code>
-<span class="hljs-keyword">POST</span> <span class="hljs-string">/subscribe/myevent?queryUrl=http://clientdomain.com/stillrunning</span> HTTP/1.1
-<span class="hljs-attribute">Host</span>: example.org
-<span class="hljs-attribute">Content-Type</span>: application/json
-<span class="hljs-attribute">Content-Length</span>: 187
+<span class="hljs-keyword">POST</span> <span class="hljs-string">/subscribe/myevent?queryUrl=http://clientdomain.com/stillrunning</span> <span class="hljs-meta">HTTP/1.1</span>
+<span class="hljs-attribute">Host</span><span class="hljs-punctuation">: </span>example.org
+<span class="hljs-attribute">Content-Type</span><span class="hljs-punctuation">: </span>application/json
+<span class="hljs-attribute">Content-Length</span><span class="hljs-punctuation">: </span>187
 
-<span class="groovy">{
-  <span class="hljs-string">"failedUrl"</span> : <span class="hljs-string">"http://clientdomain.com/failed"</span>,
-  <span class="hljs-string">"successUrls"</span> : [
-    <span class="hljs-string">"http://clientdomain.com/fast"</span>,
-    <span class="hljs-string">"http://clientdomain.com/medium"</span>,
-    <span class="hljs-string">"http://clientdomain.com/slow"</span>
+<span class="awk">{
+  <span class="hljs-string">&quot;failedUrl&quot;</span> : <span class="hljs-string">&quot;http://clientdomain.com/failed&quot;</span>,
+  <span class="hljs-string">&quot;successUrls&quot;</span> : [
+    <span class="hljs-string">&quot;http://clientdomain.com/fast&quot;</span>,
+    <span class="hljs-string">&quot;http://clientdomain.com/medium&quot;</span>,
+    <span class="hljs-string">&quot;http://clientdomain.com/slow&quot;</span>
   ] 
 }
 
 <span class="hljs-number">201</span> Created
-<span class="hljs-string">Location:</span> <span class="hljs-string">http:</span><span class="hljs-comment">//example.org/subscription/1</span>
+Location: http:<span class="hljs-regexp">//</span>example.org<span class="hljs-regexp">/subscription/</span><span class="hljs-number">1</span>
 </span></code></pre>
 <p>The following examples show how the various expressions evaluate, assuming the callback operation has a path parameter named <code>eventType</code> and a query parameter named <code>queryUrl</code>.</p>
 <table>
@@ -2364,17 +2364,17 @@ This includes accessing any part of a body that a JSON Pointer [[!RFC6901]] can 
 <p>The following example shows a callback to the URL specified by the <code>id</code> and <code>email</code> property in the request body.</p>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">myWebhook:</span>
-  <span class="hljs-string">'http://notificationServer.com?transactionId={$request.body#/id}&amp;email={$request.body#/email}'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">    post:</span>
-<span class="hljs-attr">      requestBody:</span>
-<span class="hljs-attr">        description:</span> <span class="hljs-string">Callback</span> <span class="hljs-string">payload</span>
-<span class="hljs-attr">        content:</span> 
-          <span class="hljs-string">'application/json'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">            schema:</span>
-              <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/SomePayload'</span>
-<span class="hljs-attr">      responses:</span>
-        <span class="hljs-string">'200'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">          description:</span> <span class="hljs-string">webhook</span> <span class="hljs-string">successfully</span> <span class="hljs-string">processed</span> <span class="hljs-string">and</span> <span class="hljs-literal">no</span> <span class="hljs-string">retries</span> <span class="hljs-string">will</span> <span class="hljs-string">be</span> <span class="hljs-string">performed</span>
+  <span class="hljs-string">&#x27;http://notificationServer.com?transactionId={$request.body#/id}&amp;email={$request.body#/email}&#x27;</span><span class="hljs-string">:</span>
+    <span class="hljs-attr">post:</span>
+      <span class="hljs-attr">requestBody:</span>
+        <span class="hljs-attr">description:</span> <span class="hljs-string">Callback</span> <span class="hljs-string">payload</span>
+        <span class="hljs-attr">content:</span> 
+          <span class="hljs-attr">&#x27;application/json&#x27;:</span>
+            <span class="hljs-attr">schema:</span>
+              <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/SomePayload&#x27;</span>
+      <span class="hljs-attr">responses:</span>
+        <span class="hljs-attr">&#x27;200&#x27;:</span>
+          <span class="hljs-attr">description:</span> <span class="hljs-string">webhook</span> <span class="hljs-string">successfully</span> <span class="hljs-string">processed</span> <span class="hljs-string">and</span> <span class="hljs-literal">no</span> <span class="hljs-string">retries</span> <span class="hljs-string">will</span> <span class="hljs-string">be</span> <span class="hljs-string">performed</span>
 </code></pre>
 </section></section><section><h3><span id="exampleObject">Example Object</span></h3>
 <section><h4>Fixed Fields</h4>
@@ -2417,60 +2417,60 @@ validate compatibility automatically, and reject the example value(s) if incompa
 <pre class="nohighlight"><code>
 <span class="hljs-comment"># in a model</span>
 <span class="hljs-attr">schemas:</span>
-<span class="hljs-attr">  properties:</span>
-<span class="hljs-attr">    name:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">      examples:</span>
-<span class="hljs-attr">        name:</span>
-          <span class="hljs-string">$ref:</span> <span class="hljs-attr">http://example.org/petapi-examples/openapi.json#/components/examples/name-example</span>
+  <span class="hljs-attr">properties:</span>
+    <span class="hljs-attr">name:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+      <span class="hljs-attr">examples:</span>
+        <span class="hljs-attr">name:</span>
+          <span class="hljs-string">$ref:</span> <span class="hljs-string">http://example.org/petapi-examples/openapi.json#/components/examples/name-example</span>
 
 <span class="hljs-comment"># in a request body:</span>
-<span class="hljs-attr">  requestBody:</span>
-<span class="hljs-attr">    content:</span>
-      <span class="hljs-string">'application/json'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">        schema:</span>
-          <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Address'</span>
-<span class="hljs-attr">        examples:</span> 
-<span class="hljs-attr">          foo:</span>
-<span class="hljs-attr">            summary:</span> <span class="hljs-string">A</span> <span class="hljs-string">foo</span> <span class="hljs-string">example</span>
-<span class="hljs-attr">            value:</span> <span class="hljs-string">{"foo":</span> <span class="hljs-string">"bar"</span><span class="hljs-string">}</span>
-<span class="hljs-attr">          bar:</span>
-<span class="hljs-attr">            summary:</span> <span class="hljs-string">A</span> <span class="hljs-string">bar</span> <span class="hljs-string">example</span>
-<span class="hljs-attr">            value:</span> <span class="hljs-string">{"bar":</span> <span class="hljs-string">"baz"</span><span class="hljs-string">}</span>
-      <span class="hljs-string">'application/xml'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">        examples:</span> 
-<span class="hljs-attr">          xmlExample:</span>
-<span class="hljs-attr">            summary:</span> <span class="hljs-string">This</span> <span class="hljs-string">is</span> <span class="hljs-string">an</span> <span class="hljs-string">example</span> <span class="hljs-string">in</span> <span class="hljs-string">XML</span>
-<span class="hljs-attr">            externalValue:</span> <span class="hljs-string">'http://example.org/examples/address-example.xml'</span>
-      <span class="hljs-string">'text/plain'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">        examples:</span>
-<span class="hljs-attr">          textExample:</span> 
-<span class="hljs-attr">            summary:</span> <span class="hljs-string">This</span> <span class="hljs-string">is</span> <span class="hljs-string">a</span> <span class="hljs-string">text</span> <span class="hljs-string">example</span>
-<span class="hljs-attr">            externalValue:</span> <span class="hljs-string">'http://foo.bar/examples/address-example.txt'</span> 
+  <span class="hljs-attr">requestBody:</span>
+    <span class="hljs-attr">content:</span>
+      <span class="hljs-attr">&#x27;application/json&#x27;:</span>
+        <span class="hljs-attr">schema:</span>
+          <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/Address&#x27;</span>
+        <span class="hljs-attr">examples:</span> 
+          <span class="hljs-attr">foo:</span>
+            <span class="hljs-attr">summary:</span> <span class="hljs-string">A</span> <span class="hljs-string">foo</span> <span class="hljs-string">example</span>
+            <span class="hljs-attr">value:</span> {<span class="hljs-attr">&quot;foo&quot;:</span> <span class="hljs-string">&quot;bar&quot;</span>}
+          <span class="hljs-attr">bar:</span>
+            <span class="hljs-attr">summary:</span> <span class="hljs-string">A</span> <span class="hljs-string">bar</span> <span class="hljs-string">example</span>
+            <span class="hljs-attr">value:</span> {<span class="hljs-attr">&quot;bar&quot;:</span> <span class="hljs-string">&quot;baz&quot;</span>}
+      <span class="hljs-attr">&#x27;application/xml&#x27;:</span>
+        <span class="hljs-attr">examples:</span> 
+          <span class="hljs-attr">xmlExample:</span>
+            <span class="hljs-attr">summary:</span> <span class="hljs-string">This</span> <span class="hljs-string">is</span> <span class="hljs-string">an</span> <span class="hljs-string">example</span> <span class="hljs-string">in</span> <span class="hljs-string">XML</span>
+            <span class="hljs-attr">externalValue:</span> <span class="hljs-string">&#x27;http://example.org/examples/address-example.xml&#x27;</span>
+      <span class="hljs-attr">&#x27;text/plain&#x27;:</span>
+        <span class="hljs-attr">examples:</span>
+          <span class="hljs-attr">textExample:</span> 
+            <span class="hljs-attr">summary:</span> <span class="hljs-string">This</span> <span class="hljs-string">is</span> <span class="hljs-string">a</span> <span class="hljs-string">text</span> <span class="hljs-string">example</span>
+            <span class="hljs-attr">externalValue:</span> <span class="hljs-string">&#x27;http://foo.bar/examples/address-example.txt&#x27;</span> 
 
 
 <span class="hljs-comment"># in a parameter</span>
-<span class="hljs-attr">  parameters:</span>
-<span class="hljs-attr">    - name:</span> <span class="hljs-string">'zipCode'</span>
-<span class="hljs-attr">      in:</span> <span class="hljs-string">'query'</span>
-<span class="hljs-attr">      schema:</span>
-<span class="hljs-attr">        type:</span> <span class="hljs-string">'string'</span>
-<span class="hljs-attr">        format:</span> <span class="hljs-string">'zip-code'</span>
-<span class="hljs-attr">        examples:</span>
-<span class="hljs-attr">          zip-example:</span> 
-            <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/examples/zip-example'</span>
+  <span class="hljs-attr">parameters:</span>
+    <span class="hljs-bullet">-</span> <span class="hljs-attr">name:</span> <span class="hljs-string">&#x27;zipCode&#x27;</span>
+      <span class="hljs-attr">in:</span> <span class="hljs-string">&#x27;query&#x27;</span>
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-attr">type:</span> <span class="hljs-string">&#x27;string&#x27;</span>
+        <span class="hljs-attr">format:</span> <span class="hljs-string">&#x27;zip-code&#x27;</span>
+        <span class="hljs-attr">examples:</span>
+          <span class="hljs-attr">zip-example:</span> 
+            <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/examples/zip-example&#x27;</span>
 
 <span class="hljs-comment"># in a response</span>
-<span class="hljs-attr">  responses:</span>
-    <span class="hljs-string">'200'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">      description:</span> <span class="hljs-string">your</span> <span class="hljs-string">car</span> <span class="hljs-string">appointment</span> <span class="hljs-string">has</span> <span class="hljs-string">been</span> <span class="hljs-string">booked</span>
-<span class="hljs-attr">      content:</span> 
-        <span class="hljs-string">application/json:</span>
-<span class="hljs-attr">          schema:</span>
-            <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/SuccessResponse'</span>
-<span class="hljs-attr">          examples:</span>
-<span class="hljs-attr">            confirmation-success:</span>
-              <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/examples/confirmation-success'</span>
+  <span class="hljs-attr">responses:</span>
+    <span class="hljs-attr">&#x27;200&#x27;:</span>
+      <span class="hljs-attr">description:</span> <span class="hljs-string">your</span> <span class="hljs-string">car</span> <span class="hljs-string">appointment</span> <span class="hljs-string">has</span> <span class="hljs-string">been</span> <span class="hljs-string">booked</span>
+      <span class="hljs-attr">content:</span> 
+        <span class="hljs-attr">application/json:</span>
+          <span class="hljs-attr">schema:</span>
+            <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/SuccessResponse&#x27;</span>
+          <span class="hljs-attr">examples:</span>
+            <span class="hljs-attr">confirmation-success:</span>
+              <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/examples/confirmation-success&#x27;</span>
 </code></pre>
 </section></section><section><h3><span id="linkObject">Link Object</span></h3>
 <p>The <code>Link object</code> represents a possible design-time link for a response.
@@ -2499,12 +2499,12 @@ The presence of a link does not guarantee the caller’s ability to successfully
 </tr>
 <tr>
 <td><a id="linkParameters"> </a>parameters</td>
-<td style="text-align:center">Map[<code>string</code>, Any ¦ <a href="#runtimeExpression">{expression}</a>]</td>
+<td style="text-align:center">Map[<code>string</code>, Any | <a href="#runtimeExpression">{expression}</a>]</td>
 <td>A map representing parameters to pass to an operation as specified with <code>operationId</code> or identified via <code>operationRef</code>. The key is the parameter name to be used, whereas the value can be a constant or an expression to be evaluated and passed to the linked operation.  The parameter name can be qualified using the <a href="#parameterIn">parameter location</a> <code>[{in}.]{name}</code> for operations that use the same parameter name in different locations (e.g. <a href="http://path.id">path.id</a>).</td>
 </tr>
 <tr>
 <td><a id="linkRequestBody"> </a>requestBody</td>
-<td style="text-align:center">Any ¦ <a href="#runtimeExpression">{expression}</a></td>
+<td style="text-align:center">Any | <a href="#runtimeExpression">{expression}</a></td>
 <td>A literal value or <a href="#runtimeExpression">{expression}</a> to use as a request body when calling the target operation.</td>
 </tr>
 <tr>
@@ -2529,57 +2529,57 @@ for specifications with external references.</p>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">paths:</span>
   <span class="hljs-string">/users/{id}:</span>
-<span class="hljs-attr">    parameters:</span>
-<span class="hljs-attr">    - name:</span> <span class="hljs-string">id</span>
-<span class="hljs-attr">      in:</span> <span class="hljs-string">path</span>
-<span class="hljs-attr">      required:</span> <span class="hljs-literal">true</span>
-<span class="hljs-attr">      description:</span> <span class="hljs-string">the</span> <span class="hljs-string">user</span> <span class="hljs-string">identifier,</span> <span class="hljs-string">as</span> <span class="hljs-string">userId</span> 
-<span class="hljs-attr">      schema:</span>
-<span class="hljs-attr">        type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">    get:</span>
-<span class="hljs-attr">      responses:</span>
-        <span class="hljs-string">'200'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">          description:</span> <span class="hljs-string">the</span> <span class="hljs-string">user</span> <span class="hljs-string">being</span> <span class="hljs-string">returned</span>
-<span class="hljs-attr">          content:</span>
-            <span class="hljs-string">application/json:</span>
-<span class="hljs-attr">              schema:</span>
-<span class="hljs-attr">                type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">                properties:</span>
-<span class="hljs-attr">                  uuid:</span> <span class="hljs-comment"># the unique user id</span>
-<span class="hljs-attr">                    type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">                    format:</span> <span class="hljs-string">uuid</span>
-<span class="hljs-attr">          links:</span>
-<span class="hljs-attr">            address:</span>
+    <span class="hljs-attr">parameters:</span>
+    <span class="hljs-bullet">-</span> <span class="hljs-attr">name:</span> <span class="hljs-string">id</span>
+      <span class="hljs-attr">in:</span> <span class="hljs-string">path</span>
+      <span class="hljs-attr">required:</span> <span class="hljs-literal">true</span>
+      <span class="hljs-attr">description:</span> <span class="hljs-string">the</span> <span class="hljs-string">user</span> <span class="hljs-string">identifier,</span> <span class="hljs-string">as</span> <span class="hljs-string">userId</span> 
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+    <span class="hljs-attr">get:</span>
+      <span class="hljs-attr">responses:</span>
+        <span class="hljs-attr">&#x27;200&#x27;:</span>
+          <span class="hljs-attr">description:</span> <span class="hljs-string">the</span> <span class="hljs-string">user</span> <span class="hljs-string">being</span> <span class="hljs-string">returned</span>
+          <span class="hljs-attr">content:</span>
+            <span class="hljs-attr">application/json:</span>
+              <span class="hljs-attr">schema:</span>
+                <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+                <span class="hljs-attr">properties:</span>
+                  <span class="hljs-attr">uuid:</span> <span class="hljs-comment"># the unique user id</span>
+                    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+                    <span class="hljs-attr">format:</span> <span class="hljs-string">uuid</span>
+          <span class="hljs-attr">links:</span>
+            <span class="hljs-attr">address:</span>
               <span class="hljs-comment"># the target link operationId</span>
-<span class="hljs-attr">              operationId:</span> <span class="hljs-string">getUserAddress</span>
-<span class="hljs-attr">              parameters:</span>
+              <span class="hljs-attr">operationId:</span> <span class="hljs-string">getUserAddress</span>
+              <span class="hljs-attr">parameters:</span>
                 <span class="hljs-comment"># get the `id` field from the request path parameter named `id`</span>
-<span class="hljs-attr">                userId:</span> <span class="hljs-string">$request.path.id</span>
+                <span class="hljs-attr">userId:</span> <span class="hljs-string">$request.path.id</span>
   <span class="hljs-comment"># the path item of the linked operation</span>
   <span class="hljs-string">/users/{userid}/address:</span>
-<span class="hljs-attr">    parameters:</span>
-<span class="hljs-attr">    - name:</span> <span class="hljs-string">userid</span>
-<span class="hljs-attr">      in:</span> <span class="hljs-string">path</span>
-<span class="hljs-attr">      required:</span> <span class="hljs-literal">true</span>
-<span class="hljs-attr">      description:</span> <span class="hljs-string">the</span> <span class="hljs-string">user</span> <span class="hljs-string">identifier,</span> <span class="hljs-string">as</span> <span class="hljs-string">userId</span> 
-<span class="hljs-attr">      schema:</span>
-<span class="hljs-attr">        type:</span> <span class="hljs-string">string</span>
+    <span class="hljs-attr">parameters:</span>
+    <span class="hljs-bullet">-</span> <span class="hljs-attr">name:</span> <span class="hljs-string">userid</span>
+      <span class="hljs-attr">in:</span> <span class="hljs-string">path</span>
+      <span class="hljs-attr">required:</span> <span class="hljs-literal">true</span>
+      <span class="hljs-attr">description:</span> <span class="hljs-string">the</span> <span class="hljs-string">user</span> <span class="hljs-string">identifier,</span> <span class="hljs-string">as</span> <span class="hljs-string">userId</span> 
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
     <span class="hljs-comment"># linked operation</span>
-<span class="hljs-attr">    get:</span>
-<span class="hljs-attr">      operationId:</span> <span class="hljs-string">getUserAddress</span>
-<span class="hljs-attr">      responses:</span>
-        <span class="hljs-string">'200'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">          description:</span> <span class="hljs-string">the</span> <span class="hljs-string">user's</span> <span class="hljs-string">address</span>
+    <span class="hljs-attr">get:</span>
+      <span class="hljs-attr">operationId:</span> <span class="hljs-string">getUserAddress</span>
+      <span class="hljs-attr">responses:</span>
+        <span class="hljs-attr">&#x27;200&#x27;:</span>
+          <span class="hljs-attr">description:</span> <span class="hljs-string">the</span> <span class="hljs-string">user&#x27;s</span> <span class="hljs-string">address</span>
 </code></pre>
 <p>When a runtime expression fails to evaluate, no parameter value is passed to the target operation.</p>
 <p>Values from the response body can be used to drive a linked operation.</p>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">links:</span>
-<span class="hljs-attr">  address:</span>
-<span class="hljs-attr">    operationId:</span> <span class="hljs-string">getUserAddressByUUID</span>
-<span class="hljs-attr">    parameters:</span>
+  <span class="hljs-attr">address:</span>
+    <span class="hljs-attr">operationId:</span> <span class="hljs-string">getUserAddressByUUID</span>
+    <span class="hljs-attr">parameters:</span>
       <span class="hljs-comment"># get the `uuid` field from the `uuid` field in the response body</span>
-<span class="hljs-attr">      userUuid:</span> <span class="hljs-string">$response.body#/uuid</span>
+      <span class="hljs-attr">userUuid:</span> <span class="hljs-string">$response.body#/uuid</span>
 </code></pre>
 <p>Clients follow all links at their discretion.
 Neither permissions, nor the capability to make a successful call to that link, is guaranteed
@@ -2589,27 +2589,27 @@ solely by the existence of a relationship.</p>
 value), references MAY also be made through a relative <code>operationRef</code>:</p>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">links:</span>
-<span class="hljs-attr">  UserRepositories:</span>
-    <span class="hljs-comment"># returns array of '#/components/schemas/repository'</span>
-<span class="hljs-attr">    operationRef:</span> <span class="hljs-string">'#/paths/~12.0~1repositories~1{username}/get'</span>
-<span class="hljs-attr">    parameters:</span>
-<span class="hljs-attr">      username:</span> <span class="hljs-string">$response.body#/username</span>
+  <span class="hljs-attr">UserRepositories:</span>
+    <span class="hljs-comment"># returns array of &#x27;#/components/schemas/repository&#x27;</span>
+    <span class="hljs-attr">operationRef:</span> <span class="hljs-string">&#x27;#/paths/~12.0~1repositories~1{username}/get&#x27;</span>
+    <span class="hljs-attr">parameters:</span>
+      <span class="hljs-attr">username:</span> <span class="hljs-string">$response.body#/username</span>
 </code></pre>
 <p>or an absolute <code>operationRef</code>:</p>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">links:</span>
-<span class="hljs-attr">  UserRepositories:</span>
-    <span class="hljs-comment"># returns array of '#/components/schemas/repository'</span>
-<span class="hljs-attr">    operationRef:</span> <span class="hljs-string">'https://na2.gigantic-server.com/#/paths/~12.0~1repositories~1{username}/get'</span>
-<span class="hljs-attr">    parameters:</span>
-<span class="hljs-attr">      username:</span> <span class="hljs-string">$response.body#/username</span>
+  <span class="hljs-attr">UserRepositories:</span>
+    <span class="hljs-comment"># returns array of &#x27;#/components/schemas/repository&#x27;</span>
+    <span class="hljs-attr">operationRef:</span> <span class="hljs-string">&#x27;https://na2.gigantic-server.com/#/paths/~12.0~1repositories~1{username}/get&#x27;</span>
+    <span class="hljs-attr">parameters:</span>
+      <span class="hljs-attr">username:</span> <span class="hljs-string">$response.body#/username</span>
 </code></pre>
 <p>Note that in the use of <code>operationRef</code>, the <em>escaped forward-slash</em> is necessary when
 using JSON references.</p>
 </section><section><h4><span id="runtimeExpression">Runtime Expressions</span></h4>
 <p>Runtime expressions allow defining values based on information that will only be available within the HTTP message in an actual API call.
 This mechanism is used by <a href="#linkObject">Link Objects</a> and <a href="#callbackObject">Callback Objects</a>.</p>
-<p>The runtime expression is defined by the following [Augmented Backus-Naur Form] syntax</p>
+<p>The runtime expression is defined by the following [ABNF] syntax</p>
 <pre class="highlight "><code>
       expression = ( &quot;$url&quot; | &quot;$method&quot; | &quot;$statusCode&quot; | &quot;$request.&quot; source | &quot;$response.&quot; source )
       source = ( header-reference | query-reference | path-reference | body-reference )  
@@ -2684,16 +2684,16 @@ Expressions can be embedded into string values by surrounding the expression wit
 <p>A simple header of type <code>integer</code>:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"The number of allowed requests in the current period"</span>,
-  <span class="hljs-attr">"schema"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>
+  <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;The number of allowed requests in the current period&quot;</span>,
+  <span class="hljs-attr">&quot;schema&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>
   }
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">description:</span> <span class="hljs-string">The</span> <span class="hljs-string">number</span> <span class="hljs-string">of</span> <span class="hljs-string">allowed</span> <span class="hljs-string">requests</span> <span class="hljs-string">in</span> <span class="hljs-string">the</span> <span class="hljs-string">current</span> <span class="hljs-string">period</span>
 <span class="hljs-attr">schema:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">integer</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
 </code></pre>
 </section></section><section><h3><span id="tagObject">Tag Object</span></h3>
 <p>Adds metadata to a single tag that is used by the <a href="#operationObject">Operation Object</a>.
@@ -2729,8 +2729,8 @@ It is not mandatory to have a Tag Object per tag defined in the Operation Object
 </section><section><h4>Tag Object Example</h4>
 <pre class="nohighlight"><code>
 {
-	<span class="hljs-attr">"name"</span>: <span class="hljs-string">"pet"</span>,
-	<span class="hljs-attr">"description"</span>: <span class="hljs-string">"Pets operations"</span>
+	<span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;pet&quot;</span>,
+	<span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;Pets operations&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -2762,16 +2762,16 @@ It is not mandatory to have a Tag Object per tag defined in the Operation Object
 </section><section><h4>Reference Object Example</h4>
 <pre class="nohighlight"><code>
 {
-	<span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/Pet"</span>
+	<span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/Pet&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
-<span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Pet'</span>
+<span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/Pet&#x27;</span>
 </code></pre>
 </section><section><h4>Relative Schema Document Example</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"Pet.json"</span>
+  <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;Pet.json&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -2780,7 +2780,7 @@ It is not mandatory to have a Tag Object per tag defined in the Operation Object
 </section><section><h4>Relative Documents With Embedded Schema Example</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"definitions.json#/Pet"</span>
+  <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;definitions.json#/Pet&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -2902,8 +2902,8 @@ The <a href="#xmlObject">XML Object</a> contains additional information about th
 <section><h5>Primitive Sample</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
-  <span class="hljs-attr">"format"</span>: <span class="hljs-string">"email"</span>
+  <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>,
+  <span class="hljs-attr">&quot;format&quot;</span>: <span class="hljs-string">&quot;email&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -2913,21 +2913,21 @@ The <a href="#xmlObject">XML Object</a> contains additional information about th
 </section><section><h5>Simple Model</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-  <span class="hljs-attr">"required"</span>: [
-    <span class="hljs-string">"name"</span>
+  <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+  <span class="hljs-attr">&quot;required&quot;</span>: [
+    <span class="hljs-string">&quot;name&quot;</span>
   ],
-  <span class="hljs-attr">"properties"</span>: {
-    <span class="hljs-attr">"name"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+  <span class="hljs-attr">&quot;properties&quot;</span>: {
+    <span class="hljs-attr">&quot;name&quot;</span>: {
+      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
     },
-    <span class="hljs-attr">"address"</span>: {
-      <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/Address"</span>
+    <span class="hljs-attr">&quot;address&quot;</span>: {
+      <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/Address&quot;</span>
     },
-    <span class="hljs-attr">"age"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>,
-      <span class="hljs-attr">"format"</span>: <span class="hljs-string">"int32"</span>,
-      <span class="hljs-attr">"minimum"</span>: <span class="hljs-number">0</span>
+    <span class="hljs-attr">&quot;age&quot;</span>: {
+      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>,
+      <span class="hljs-attr">&quot;format&quot;</span>: <span class="hljs-string">&quot;int32&quot;</span>,
+      <span class="hljs-attr">&quot;minimum&quot;</span>: <span class="hljs-number">0</span>
     }
   }
 }
@@ -2937,115 +2937,115 @@ The <a href="#xmlObject">XML Object</a> contains additional information about th
 <span class="hljs-attr">required:</span>
 <span class="hljs-bullet">-</span> <span class="hljs-string">name</span>
 <span class="hljs-attr">properties:</span>
-<span class="hljs-attr">  name:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">  address:</span>
-    <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Address'</span>
-<span class="hljs-attr">  age:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">integer</span>
-<span class="hljs-attr">    format:</span> <span class="hljs-string">int32</span>
-<span class="hljs-attr">    minimum:</span> <span class="hljs-number">0</span>
+  <span class="hljs-attr">name:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">address:</span>
+    <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/Address&#x27;</span>
+  <span class="hljs-attr">age:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+    <span class="hljs-attr">format:</span> <span class="hljs-string">int32</span>
+    <span class="hljs-attr">minimum:</span> <span class="hljs-number">0</span>
 </code></pre>
 </section><section><h5>Model with Map/Dictionary Properties</h5>
 <p>For a simple string to string mapping:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-  <span class="hljs-attr">"additionalProperties"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+  <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+  <span class="hljs-attr">&quot;additionalProperties&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
   }
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
 <span class="hljs-attr">additionalProperties:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
 </code></pre>
 <p>For a string to model mapping:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-  <span class="hljs-attr">"additionalProperties"</span>: {
-    <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/ComplexModel"</span>
+  <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+  <span class="hljs-attr">&quot;additionalProperties&quot;</span>: {
+    <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/ComplexModel&quot;</span>
   }
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
 <span class="hljs-attr">additionalProperties:</span>
-  <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/ComplexModel'</span>
+  <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/ComplexModel&#x27;</span>
 </code></pre>
 </section><section><h5>Model with Example</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-  <span class="hljs-attr">"properties"</span>: {
-    <span class="hljs-attr">"id"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>,
-      <span class="hljs-attr">"format"</span>: <span class="hljs-string">"int64"</span>
+  <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+  <span class="hljs-attr">&quot;properties&quot;</span>: {
+    <span class="hljs-attr">&quot;id&quot;</span>: {
+      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>,
+      <span class="hljs-attr">&quot;format&quot;</span>: <span class="hljs-string">&quot;int64&quot;</span>
     },
-    <span class="hljs-attr">"name"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+    <span class="hljs-attr">&quot;name&quot;</span>: {
+      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
     }
   },
-  <span class="hljs-attr">"required"</span>: [
-    <span class="hljs-string">"name"</span>
+  <span class="hljs-attr">&quot;required&quot;</span>: [
+    <span class="hljs-string">&quot;name&quot;</span>
   ],
-  <span class="hljs-attr">"example"</span>: {
-    <span class="hljs-attr">"name"</span>: <span class="hljs-string">"Puma"</span>,
-    <span class="hljs-attr">"id"</span>: <span class="hljs-number">1</span>
+  <span class="hljs-attr">&quot;example&quot;</span>: {
+    <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;Puma&quot;</span>,
+    <span class="hljs-attr">&quot;id&quot;</span>: <span class="hljs-number">1</span>
   }
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
 <span class="hljs-attr">properties:</span>
-<span class="hljs-attr">  id:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">integer</span>
-<span class="hljs-attr">    format:</span> <span class="hljs-string">int64</span>
-<span class="hljs-attr">  name:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">id:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+    <span class="hljs-attr">format:</span> <span class="hljs-string">int64</span>
+  <span class="hljs-attr">name:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
 <span class="hljs-attr">required:</span>
 <span class="hljs-bullet">-</span> <span class="hljs-string">name</span>
 <span class="hljs-attr">example:</span>
-<span class="hljs-attr">  name:</span> <span class="hljs-string">Puma</span>
-<span class="hljs-attr">  id:</span> <span class="hljs-number">1</span>
+  <span class="hljs-attr">name:</span> <span class="hljs-string">Puma</span>
+  <span class="hljs-attr">id:</span> <span class="hljs-number">1</span>
 </code></pre>
 </section><section><h5>Models with Composition</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"components"</span>: {
-    <span class="hljs-attr">"schemas"</span>: {
-      <span class="hljs-attr">"ErrorModel"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-        <span class="hljs-attr">"required"</span>: [
-          <span class="hljs-string">"message"</span>,
-          <span class="hljs-string">"code"</span>
+  <span class="hljs-attr">&quot;components&quot;</span>: {
+    <span class="hljs-attr">&quot;schemas&quot;</span>: {
+      <span class="hljs-attr">&quot;ErrorModel&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+        <span class="hljs-attr">&quot;required&quot;</span>: [
+          <span class="hljs-string">&quot;message&quot;</span>,
+          <span class="hljs-string">&quot;code&quot;</span>
         ],
-        <span class="hljs-attr">"properties"</span>: {
-          <span class="hljs-attr">"message"</span>: {
-            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+        <span class="hljs-attr">&quot;properties&quot;</span>: {
+          <span class="hljs-attr">&quot;message&quot;</span>: {
+            <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
           },
-          <span class="hljs-attr">"code"</span>: {
-            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>,
-            <span class="hljs-attr">"minimum"</span>: <span class="hljs-number">100</span>,
-            <span class="hljs-attr">"maximum"</span>: <span class="hljs-number">600</span>
+          <span class="hljs-attr">&quot;code&quot;</span>: {
+            <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>,
+            <span class="hljs-attr">&quot;minimum&quot;</span>: <span class="hljs-number">100</span>,
+            <span class="hljs-attr">&quot;maximum&quot;</span>: <span class="hljs-number">600</span>
           }
         }
       },
-      <span class="hljs-attr">"ExtendedErrorModel"</span>: {
-        <span class="hljs-attr">"allOf"</span>: [
+      <span class="hljs-attr">&quot;ExtendedErrorModel&quot;</span>: {
+        <span class="hljs-attr">&quot;allOf&quot;</span>: [
           {
-            <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/ErrorModel"</span>
+            <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/ErrorModel&quot;</span>
           },
           {
-            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-            <span class="hljs-attr">"required"</span>: [
-              <span class="hljs-string">"rootCause"</span>
+            <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+            <span class="hljs-attr">&quot;required&quot;</span>: [
+              <span class="hljs-string">&quot;rootCause&quot;</span>
             ],
-            <span class="hljs-attr">"properties"</span>: {
-              <span class="hljs-attr">"rootCause"</span>: {
-                <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+            <span class="hljs-attr">&quot;properties&quot;</span>: {
+              <span class="hljs-attr">&quot;rootCause&quot;</span>: {
+                <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
               }
             }
           }
@@ -3057,98 +3057,98 @@ The <a href="#xmlObject">XML Object</a> contains additional information about th
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">components:</span>
-<span class="hljs-attr">  schemas:</span>
-<span class="hljs-attr">    ErrorModel:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">      required:</span>
-<span class="hljs-bullet">      -</span> <span class="hljs-string">message</span>
-<span class="hljs-bullet">      -</span> <span class="hljs-string">code</span>
-<span class="hljs-attr">      properties:</span>
-<span class="hljs-attr">        message:</span>
-<span class="hljs-attr">          type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">        code:</span>
-<span class="hljs-attr">          type:</span> <span class="hljs-string">integer</span>
-<span class="hljs-attr">          minimum:</span> <span class="hljs-number">100</span>
-<span class="hljs-attr">          maximum:</span> <span class="hljs-number">600</span>
-<span class="hljs-attr">    ExtendedErrorModel:</span>
-<span class="hljs-attr">      allOf:</span>
-<span class="hljs-bullet">      -</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/ErrorModel'</span>
-<span class="hljs-attr">      - type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">        required:</span>
-<span class="hljs-bullet">        -</span> <span class="hljs-string">rootCause</span>
-<span class="hljs-attr">        properties:</span>
-<span class="hljs-attr">          rootCause:</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">schemas:</span>
+    <span class="hljs-attr">ErrorModel:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+      <span class="hljs-attr">required:</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-string">message</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-string">code</span>
+      <span class="hljs-attr">properties:</span>
+        <span class="hljs-attr">message:</span>
+          <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+        <span class="hljs-attr">code:</span>
+          <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+          <span class="hljs-attr">minimum:</span> <span class="hljs-number">100</span>
+          <span class="hljs-attr">maximum:</span> <span class="hljs-number">600</span>
+    <span class="hljs-attr">ExtendedErrorModel:</span>
+      <span class="hljs-attr">allOf:</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/ErrorModel&#x27;</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+        <span class="hljs-attr">required:</span>
+        <span class="hljs-bullet">-</span> <span class="hljs-string">rootCause</span>
+        <span class="hljs-attr">properties:</span>
+          <span class="hljs-attr">rootCause:</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
 </code></pre>
 </section><section><h5>Models with Polymorphism Support</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"components"</span>: {
-    <span class="hljs-attr">"schemas"</span>: {
-      <span class="hljs-attr">"Pet"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-        <span class="hljs-attr">"discriminator"</span>: {
-          <span class="hljs-attr">"propertyName"</span>: <span class="hljs-string">"petType"</span>
+  <span class="hljs-attr">&quot;components&quot;</span>: {
+    <span class="hljs-attr">&quot;schemas&quot;</span>: {
+      <span class="hljs-attr">&quot;Pet&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+        <span class="hljs-attr">&quot;discriminator&quot;</span>: {
+          <span class="hljs-attr">&quot;propertyName&quot;</span>: <span class="hljs-string">&quot;petType&quot;</span>
         },
-        <span class="hljs-attr">"properties"</span>: {
-          <span class="hljs-attr">"name"</span>: {
-            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+        <span class="hljs-attr">&quot;properties&quot;</span>: {
+          <span class="hljs-attr">&quot;name&quot;</span>: {
+            <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
           },
-          <span class="hljs-attr">"petType"</span>: {
-            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+          <span class="hljs-attr">&quot;petType&quot;</span>: {
+            <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
           }
         },
-        <span class="hljs-attr">"required"</span>: [
-          <span class="hljs-string">"name"</span>,
-          <span class="hljs-string">"petType"</span>
+        <span class="hljs-attr">&quot;required&quot;</span>: [
+          <span class="hljs-string">&quot;name&quot;</span>,
+          <span class="hljs-string">&quot;petType&quot;</span>
         ]
       },
-      <span class="hljs-attr">"Cat"</span>: {
-        <span class="hljs-attr">"description"</span>: <span class="hljs-string">"A representation of a cat. Note that `Cat` will be used as the discriminator value."</span>,
-        <span class="hljs-attr">"allOf"</span>: [
+      <span class="hljs-attr">&quot;Cat&quot;</span>: {
+        <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;A representation of a cat. Note that `Cat` will be used as the discriminator value.&quot;</span>,
+        <span class="hljs-attr">&quot;allOf&quot;</span>: [
           {
-            <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/Pet"</span>
+            <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/Pet&quot;</span>
           },
           {
-            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-            <span class="hljs-attr">"properties"</span>: {
-              <span class="hljs-attr">"huntingSkill"</span>: {
-                <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
-                <span class="hljs-attr">"description"</span>: <span class="hljs-string">"The measured skill for hunting"</span>,
-                <span class="hljs-attr">"default"</span>: <span class="hljs-string">"lazy"</span>,
-                <span class="hljs-attr">"enum"</span>: [
-                  <span class="hljs-string">"clueless"</span>,
-                  <span class="hljs-string">"lazy"</span>,
-                  <span class="hljs-string">"adventurous"</span>,
-                  <span class="hljs-string">"aggressive"</span>
+            <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+            <span class="hljs-attr">&quot;properties&quot;</span>: {
+              <span class="hljs-attr">&quot;huntingSkill&quot;</span>: {
+                <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>,
+                <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;The measured skill for hunting&quot;</span>,
+                <span class="hljs-attr">&quot;default&quot;</span>: <span class="hljs-string">&quot;lazy&quot;</span>,
+                <span class="hljs-attr">&quot;enum&quot;</span>: [
+                  <span class="hljs-string">&quot;clueless&quot;</span>,
+                  <span class="hljs-string">&quot;lazy&quot;</span>,
+                  <span class="hljs-string">&quot;adventurous&quot;</span>,
+                  <span class="hljs-string">&quot;aggressive&quot;</span>
                 ]
               }
             },
-            <span class="hljs-attr">"required"</span>: [
-              <span class="hljs-string">"huntingSkill"</span>
+            <span class="hljs-attr">&quot;required&quot;</span>: [
+              <span class="hljs-string">&quot;huntingSkill&quot;</span>
             ]
           }
         ]
       },
-      <span class="hljs-attr">"Dog"</span>: {
-        <span class="hljs-attr">"description"</span>: <span class="hljs-string">"A representation of a dog. Note that `Dog` will be used as the discriminator value."</span>,
-        <span class="hljs-attr">"allOf"</span>: [
+      <span class="hljs-attr">&quot;Dog&quot;</span>: {
+        <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;A representation of a dog. Note that `Dog` will be used as the discriminator value.&quot;</span>,
+        <span class="hljs-attr">&quot;allOf&quot;</span>: [
           {
-            <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/Pet"</span>
+            <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/Pet&quot;</span>
           },
           {
-            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-            <span class="hljs-attr">"properties"</span>: {
-              <span class="hljs-attr">"packSize"</span>: {
-                <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>,
-                <span class="hljs-attr">"format"</span>: <span class="hljs-string">"int32"</span>,
-                <span class="hljs-attr">"description"</span>: <span class="hljs-string">"the size of the pack the dog is from"</span>,
-                <span class="hljs-attr">"default"</span>: <span class="hljs-number">0</span>,
-                <span class="hljs-attr">"minimum"</span>: <span class="hljs-number">0</span>
+            <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+            <span class="hljs-attr">&quot;properties&quot;</span>: {
+              <span class="hljs-attr">&quot;packSize&quot;</span>: {
+                <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>,
+                <span class="hljs-attr">&quot;format&quot;</span>: <span class="hljs-string">&quot;int32&quot;</span>,
+                <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;the size of the pack the dog is from&quot;</span>,
+                <span class="hljs-attr">&quot;default&quot;</span>: <span class="hljs-number">0</span>,
+                <span class="hljs-attr">&quot;minimum&quot;</span>: <span class="hljs-number">0</span>
               }
             },
-            <span class="hljs-attr">"required"</span>: [
-              <span class="hljs-string">"packSize"</span>
+            <span class="hljs-attr">&quot;required&quot;</span>: [
+              <span class="hljs-string">&quot;packSize&quot;</span>
             ]
           }
         ]
@@ -3159,49 +3159,49 @@ The <a href="#xmlObject">XML Object</a> contains additional information about th
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">components:</span>
-<span class="hljs-attr">  schemas:</span>
-<span class="hljs-attr">    Pet:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">      discriminator:</span>
-<span class="hljs-attr">        propertyName:</span> <span class="hljs-string">petType</span>
-<span class="hljs-attr">      properties:</span>
-<span class="hljs-attr">        name:</span>
-<span class="hljs-attr">          type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">        petType:</span>
-<span class="hljs-attr">          type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">      required:</span>
-<span class="hljs-bullet">      -</span> <span class="hljs-string">name</span>
-<span class="hljs-bullet">      -</span> <span class="hljs-string">petType</span>
-<span class="hljs-attr">    Cat:</span>  <span class="hljs-comment">## "Cat" will be used as the discriminator value</span>
-<span class="hljs-attr">      description:</span> <span class="hljs-string">A</span> <span class="hljs-string">representation</span> <span class="hljs-string">of</span> <span class="hljs-string">a</span> <span class="hljs-string">cat</span>
-<span class="hljs-attr">      allOf:</span>
-<span class="hljs-bullet">      -</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Pet'</span>
-<span class="hljs-attr">      - type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">        properties:</span>
-<span class="hljs-attr">          huntingSkill:</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">            description:</span> <span class="hljs-string">The</span> <span class="hljs-string">measured</span> <span class="hljs-string">skill</span> <span class="hljs-string">for</span> <span class="hljs-string">hunting</span>
-<span class="hljs-attr">            enum:</span>
-<span class="hljs-bullet">            -</span> <span class="hljs-string">clueless</span>
-<span class="hljs-bullet">            -</span> <span class="hljs-string">lazy</span>
-<span class="hljs-bullet">            -</span> <span class="hljs-string">adventurous</span>
-<span class="hljs-bullet">            -</span> <span class="hljs-string">aggressive</span>
-<span class="hljs-attr">        required:</span>
-<span class="hljs-bullet">        -</span> <span class="hljs-string">huntingSkill</span>
-<span class="hljs-attr">    Dog:</span>  <span class="hljs-comment">## "Dog" will be used as the discriminator value</span>
-<span class="hljs-attr">      description:</span> <span class="hljs-string">A</span> <span class="hljs-string">representation</span> <span class="hljs-string">of</span> <span class="hljs-string">a</span> <span class="hljs-string">dog</span>
-<span class="hljs-attr">      allOf:</span>
-<span class="hljs-bullet">      -</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Pet'</span>
-<span class="hljs-attr">      - type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">        properties:</span>
-<span class="hljs-attr">          packSize:</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">integer</span>
-<span class="hljs-attr">            format:</span> <span class="hljs-string">int32</span>
-<span class="hljs-attr">            description:</span> <span class="hljs-string">the</span> <span class="hljs-string">size</span> <span class="hljs-string">of</span> <span class="hljs-string">the</span> <span class="hljs-string">pack</span> <span class="hljs-string">the</span> <span class="hljs-string">dog</span> <span class="hljs-string">is</span> <span class="hljs-string">from</span>
-<span class="hljs-attr">            default:</span> <span class="hljs-number">0</span>
-<span class="hljs-attr">            minimum:</span> <span class="hljs-number">0</span>
-<span class="hljs-attr">        required:</span>
-<span class="hljs-bullet">        -</span> <span class="hljs-string">packSize</span>
+  <span class="hljs-attr">schemas:</span>
+    <span class="hljs-attr">Pet:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+      <span class="hljs-attr">discriminator:</span>
+        <span class="hljs-attr">propertyName:</span> <span class="hljs-string">petType</span>
+      <span class="hljs-attr">properties:</span>
+        <span class="hljs-attr">name:</span>
+          <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+        <span class="hljs-attr">petType:</span>
+          <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+      <span class="hljs-attr">required:</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-string">name</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-string">petType</span>
+    <span class="hljs-attr">Cat:</span>  <span class="hljs-comment">## &quot;Cat&quot; will be used as the discriminator value</span>
+      <span class="hljs-attr">description:</span> <span class="hljs-string">A</span> <span class="hljs-string">representation</span> <span class="hljs-string">of</span> <span class="hljs-string">a</span> <span class="hljs-string">cat</span>
+      <span class="hljs-attr">allOf:</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/Pet&#x27;</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+        <span class="hljs-attr">properties:</span>
+          <span class="hljs-attr">huntingSkill:</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+            <span class="hljs-attr">description:</span> <span class="hljs-string">The</span> <span class="hljs-string">measured</span> <span class="hljs-string">skill</span> <span class="hljs-string">for</span> <span class="hljs-string">hunting</span>
+            <span class="hljs-attr">enum:</span>
+            <span class="hljs-bullet">-</span> <span class="hljs-string">clueless</span>
+            <span class="hljs-bullet">-</span> <span class="hljs-string">lazy</span>
+            <span class="hljs-bullet">-</span> <span class="hljs-string">adventurous</span>
+            <span class="hljs-bullet">-</span> <span class="hljs-string">aggressive</span>
+        <span class="hljs-attr">required:</span>
+        <span class="hljs-bullet">-</span> <span class="hljs-string">huntingSkill</span>
+    <span class="hljs-attr">Dog:</span>  <span class="hljs-comment">## &quot;Dog&quot; will be used as the discriminator value</span>
+      <span class="hljs-attr">description:</span> <span class="hljs-string">A</span> <span class="hljs-string">representation</span> <span class="hljs-string">of</span> <span class="hljs-string">a</span> <span class="hljs-string">dog</span>
+      <span class="hljs-attr">allOf:</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/Pet&#x27;</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+        <span class="hljs-attr">properties:</span>
+          <span class="hljs-attr">packSize:</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+            <span class="hljs-attr">format:</span> <span class="hljs-string">int32</span>
+            <span class="hljs-attr">description:</span> <span class="hljs-string">the</span> <span class="hljs-string">size</span> <span class="hljs-string">of</span> <span class="hljs-string">the</span> <span class="hljs-string">pack</span> <span class="hljs-string">the</span> <span class="hljs-string">dog</span> <span class="hljs-string">is</span> <span class="hljs-string">from</span>
+            <span class="hljs-attr">default:</span> <span class="hljs-number">0</span>
+            <span class="hljs-attr">minimum:</span> <span class="hljs-number">0</span>
+        <span class="hljs-attr">required:</span>
+        <span class="hljs-bullet">-</span> <span class="hljs-string">packSize</span>
 </code></pre>
 </section></section></section><section><h3><span id="discriminatorObject">Discriminator Object</span></h3>
 <p>When request bodies or response payloads may be one of a number of different schemas, a <code>discriminator</code> object can be used to aid in serialization, deserialization, and validation.  The discriminator is a specific object in a schema which is used to inform the consumer of the specification of an alternative schema based on the value associated with it.</p>
@@ -3375,14 +3375,14 @@ See examples for expected behavior.</p>
 <p>Basic string property:</p>
 <pre class="nohighlight"><code>
 {
-    <span class="hljs-attr">"animals"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+    <span class="hljs-attr">&quot;animals&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
     }
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">animals:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-tag">&lt;<span class="hljs-name">animals</span>&gt;</span>...<span class="hljs-tag">&lt;/<span class="hljs-name">animals</span>&gt;</span>
@@ -3390,19 +3390,19 @@ See examples for expected behavior.</p>
 <p>Basic string array property (<a href="#xmlWrapped"><code>wrapped</code></a> is <code>false</code> by default):</p>
 <pre class="nohighlight"><code>
 {
-    <span class="hljs-attr">"animals"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-        <span class="hljs-attr">"items"</span>: {
-            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+    <span class="hljs-attr">&quot;animals&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+        <span class="hljs-attr">&quot;items&quot;</span>: {
+            <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
         }
     }
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">animals:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">  items:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+  <span class="hljs-attr">items:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-tag">&lt;<span class="hljs-name">animals</span>&gt;</span>...<span class="hljs-tag">&lt;/<span class="hljs-name">animals</span>&gt;</span>
@@ -3412,19 +3412,19 @@ See examples for expected behavior.</p>
 </section><section><h5>XML Name Replacement</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"animals"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
-    <span class="hljs-attr">"xml"</span>: {
-      <span class="hljs-attr">"name"</span>: <span class="hljs-string">"animal"</span>
+  <span class="hljs-attr">&quot;animals&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>,
+    <span class="hljs-attr">&quot;xml&quot;</span>: {
+      <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;animal&quot;</span>
     }
   }
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">animals:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">  xml:</span>
-<span class="hljs-attr">    name:</span> <span class="hljs-string">animal</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">xml:</span>
+    <span class="hljs-attr">name:</span> <span class="hljs-string">animal</span>
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-tag">&lt;<span class="hljs-name">animal</span>&gt;</span>...<span class="hljs-tag">&lt;/<span class="hljs-name">animal</span>&gt;</span>
@@ -3433,21 +3433,21 @@ See examples for expected behavior.</p>
 <p>In this example, a full model definition is shown.</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"Person"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-    <span class="hljs-attr">"properties"</span>: {
-      <span class="hljs-attr">"id"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>,
-        <span class="hljs-attr">"format"</span>: <span class="hljs-string">"int32"</span>,
-        <span class="hljs-attr">"xml"</span>: {
-          <span class="hljs-attr">"attribute"</span>: <span class="hljs-literal">true</span>
+  <span class="hljs-attr">&quot;Person&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+    <span class="hljs-attr">&quot;properties&quot;</span>: {
+      <span class="hljs-attr">&quot;id&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>,
+        <span class="hljs-attr">&quot;format&quot;</span>: <span class="hljs-string">&quot;int32&quot;</span>,
+        <span class="hljs-attr">&quot;xml&quot;</span>: {
+          <span class="hljs-attr">&quot;attribute&quot;</span>: <span class="hljs-literal">true</span>
         }
       },
-      <span class="hljs-attr">"name"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
-        <span class="hljs-attr">"xml"</span>: {
-          <span class="hljs-attr">"namespace"</span>: <span class="hljs-string">"http://example.com/schema/sample"</span>,
-          <span class="hljs-attr">"prefix"</span>: <span class="hljs-string">"sample"</span>
+      <span class="hljs-attr">&quot;name&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>,
+        <span class="hljs-attr">&quot;xml&quot;</span>: {
+          <span class="hljs-attr">&quot;namespace&quot;</span>: <span class="hljs-string">&quot;http://example.com/schema/sample&quot;</span>,
+          <span class="hljs-attr">&quot;prefix&quot;</span>: <span class="hljs-string">&quot;sample&quot;</span>
         }
       }
     }
@@ -3456,34 +3456,34 @@ See examples for expected behavior.</p>
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">Person:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">  properties:</span>
-<span class="hljs-attr">    id:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">integer</span>
-<span class="hljs-attr">      format:</span> <span class="hljs-string">int32</span>
-<span class="hljs-attr">      xml:</span>
-<span class="hljs-attr">        attribute:</span> <span class="hljs-literal">true</span>
-<span class="hljs-attr">    name:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">      xml:</span>
-<span class="hljs-attr">        namespace:</span> <span class="hljs-attr">http://example.com/schema/sample</span>
-<span class="hljs-attr">        prefix:</span> <span class="hljs-string">sample</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+  <span class="hljs-attr">properties:</span>
+    <span class="hljs-attr">id:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+      <span class="hljs-attr">format:</span> <span class="hljs-string">int32</span>
+      <span class="hljs-attr">xml:</span>
+        <span class="hljs-attr">attribute:</span> <span class="hljs-literal">true</span>
+    <span class="hljs-attr">name:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+      <span class="hljs-attr">xml:</span>
+        <span class="hljs-attr">namespace:</span> <span class="hljs-string">http://example.com/schema/sample</span>
+        <span class="hljs-attr">prefix:</span> <span class="hljs-string">sample</span>
 </code></pre>
 <pre class="nohighlight"><code>
-<span class="hljs-tag">&lt;<span class="hljs-name">Person</span> <span class="hljs-attr">id</span>=<span class="hljs-string">"123"</span>&gt;</span>
-    <span class="hljs-tag">&lt;<span class="hljs-name">sample:name</span> <span class="hljs-attr">xmlns:sample</span>=<span class="hljs-string">"http://example.com/schema/sample"</span>&gt;</span>example<span class="hljs-tag">&lt;/<span class="hljs-name">sample:name</span>&gt;</span>
+<span class="hljs-tag">&lt;<span class="hljs-name">Person</span> <span class="hljs-attr">id</span>=<span class="hljs-string">&quot;123&quot;</span>&gt;</span>
+    <span class="hljs-tag">&lt;<span class="hljs-name">sample:name</span> <span class="hljs-attr">xmlns:sample</span>=<span class="hljs-string">&quot;http://example.com/schema/sample&quot;</span>&gt;</span>example<span class="hljs-tag">&lt;/<span class="hljs-name">sample:name</span>&gt;</span>
 <span class="hljs-tag">&lt;/<span class="hljs-name">Person</span>&gt;</span>
 </code></pre>
 </section><section><h5>XML Arrays</h5>
 <p>Changing the element names:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"animals"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-    <span class="hljs-attr">"items"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
-      <span class="hljs-attr">"xml"</span>: {
-        <span class="hljs-attr">"name"</span>: <span class="hljs-string">"animal"</span>
+  <span class="hljs-attr">&quot;animals&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+    <span class="hljs-attr">&quot;items&quot;</span>: {
+      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>,
+      <span class="hljs-attr">&quot;xml&quot;</span>: {
+        <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;animal&quot;</span>
       }
     }
   }
@@ -3491,11 +3491,11 @@ See examples for expected behavior.</p>
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">animals:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">  items:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">    xml:</span>
-<span class="hljs-attr">      name:</span> <span class="hljs-string">animal</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+  <span class="hljs-attr">items:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+    <span class="hljs-attr">xml:</span>
+      <span class="hljs-attr">name:</span> <span class="hljs-string">animal</span>
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-tag">&lt;<span class="hljs-name">animal</span>&gt;</span>value<span class="hljs-tag">&lt;/<span class="hljs-name">animal</span>&gt;</span>
@@ -3504,29 +3504,29 @@ See examples for expected behavior.</p>
 <p>The external <code>name</code> property has no effect on the XML:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"animals"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-    <span class="hljs-attr">"items"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
-      <span class="hljs-attr">"xml"</span>: {
-        <span class="hljs-attr">"name"</span>: <span class="hljs-string">"animal"</span>
+  <span class="hljs-attr">&quot;animals&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+    <span class="hljs-attr">&quot;items&quot;</span>: {
+      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>,
+      <span class="hljs-attr">&quot;xml&quot;</span>: {
+        <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;animal&quot;</span>
       }
     },
-    <span class="hljs-attr">"xml"</span>: {
-      <span class="hljs-attr">"name"</span>: <span class="hljs-string">"aliens"</span>
+    <span class="hljs-attr">&quot;xml&quot;</span>: {
+      <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;aliens&quot;</span>
     }
   }
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">animals:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">  items:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">    xml:</span>
-<span class="hljs-attr">      name:</span> <span class="hljs-string">animal</span>
-<span class="hljs-attr">  xml:</span>
-<span class="hljs-attr">    name:</span> <span class="hljs-string">aliens</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+  <span class="hljs-attr">items:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+    <span class="hljs-attr">xml:</span>
+      <span class="hljs-attr">name:</span> <span class="hljs-string">animal</span>
+  <span class="hljs-attr">xml:</span>
+    <span class="hljs-attr">name:</span> <span class="hljs-string">aliens</span>
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-tag">&lt;<span class="hljs-name">animal</span>&gt;</span>value<span class="hljs-tag">&lt;/<span class="hljs-name">animal</span>&gt;</span>
@@ -3535,24 +3535,24 @@ See examples for expected behavior.</p>
 <p>Even when the array is wrapped, if a name is not explicitly defined, the same name will be used both internally and externally:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"animals"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-    <span class="hljs-attr">"items"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+  <span class="hljs-attr">&quot;animals&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+    <span class="hljs-attr">&quot;items&quot;</span>: {
+      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
     },
-    <span class="hljs-attr">"xml"</span>: {
-      <span class="hljs-attr">"wrapped"</span>: <span class="hljs-literal">true</span>
+    <span class="hljs-attr">&quot;xml&quot;</span>: {
+      <span class="hljs-attr">&quot;wrapped&quot;</span>: <span class="hljs-literal">true</span>
     }
   }
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">animals:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">  items:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">  xml:</span>
-<span class="hljs-attr">    wrapped:</span> <span class="hljs-literal">true</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+  <span class="hljs-attr">items:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">xml:</span>
+    <span class="hljs-attr">wrapped:</span> <span class="hljs-literal">true</span>
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-tag">&lt;<span class="hljs-name">animals</span>&gt;</span>
@@ -3563,29 +3563,29 @@ See examples for expected behavior.</p>
 <p>To overcome the naming problem in the example above, the following definition can be used:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"animals"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-    <span class="hljs-attr">"items"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
-      <span class="hljs-attr">"xml"</span>: {
-        <span class="hljs-attr">"name"</span>: <span class="hljs-string">"animal"</span>
+  <span class="hljs-attr">&quot;animals&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+    <span class="hljs-attr">&quot;items&quot;</span>: {
+      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>,
+      <span class="hljs-attr">&quot;xml&quot;</span>: {
+        <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;animal&quot;</span>
       }
     },
-    <span class="hljs-attr">"xml"</span>: {
-      <span class="hljs-attr">"wrapped"</span>: <span class="hljs-literal">true</span>
+    <span class="hljs-attr">&quot;xml&quot;</span>: {
+      <span class="hljs-attr">&quot;wrapped&quot;</span>: <span class="hljs-literal">true</span>
     }
   }
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">animals:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">  items:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">    xml:</span>
-<span class="hljs-attr">      name:</span> <span class="hljs-string">animal</span>
-<span class="hljs-attr">  xml:</span>
-<span class="hljs-attr">    wrapped:</span> <span class="hljs-literal">true</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+  <span class="hljs-attr">items:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+    <span class="hljs-attr">xml:</span>
+      <span class="hljs-attr">name:</span> <span class="hljs-string">animal</span>
+  <span class="hljs-attr">xml:</span>
+    <span class="hljs-attr">wrapped:</span> <span class="hljs-literal">true</span>
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-tag">&lt;<span class="hljs-name">animals</span>&gt;</span>
@@ -3596,31 +3596,31 @@ See examples for expected behavior.</p>
 <p>Affecting both internal and external names:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"animals"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-    <span class="hljs-attr">"items"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
-      <span class="hljs-attr">"xml"</span>: {
-        <span class="hljs-attr">"name"</span>: <span class="hljs-string">"animal"</span>
+  <span class="hljs-attr">&quot;animals&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+    <span class="hljs-attr">&quot;items&quot;</span>: {
+      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>,
+      <span class="hljs-attr">&quot;xml&quot;</span>: {
+        <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;animal&quot;</span>
       }
     },
-    <span class="hljs-attr">"xml"</span>: {
-      <span class="hljs-attr">"name"</span>: <span class="hljs-string">"aliens"</span>,
-      <span class="hljs-attr">"wrapped"</span>: <span class="hljs-literal">true</span>
+    <span class="hljs-attr">&quot;xml&quot;</span>: {
+      <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;aliens&quot;</span>,
+      <span class="hljs-attr">&quot;wrapped&quot;</span>: <span class="hljs-literal">true</span>
     }
   }
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">animals:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">  items:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">    xml:</span>
-<span class="hljs-attr">      name:</span> <span class="hljs-string">animal</span>
-<span class="hljs-attr">  xml:</span>
-<span class="hljs-attr">    name:</span> <span class="hljs-string">aliens</span>
-<span class="hljs-attr">    wrapped:</span> <span class="hljs-literal">true</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+  <span class="hljs-attr">items:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+    <span class="hljs-attr">xml:</span>
+      <span class="hljs-attr">name:</span> <span class="hljs-string">animal</span>
+  <span class="hljs-attr">xml:</span>
+    <span class="hljs-attr">name:</span> <span class="hljs-string">aliens</span>
+    <span class="hljs-attr">wrapped:</span> <span class="hljs-literal">true</span>
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-tag">&lt;<span class="hljs-name">aliens</span>&gt;</span>
@@ -3631,26 +3631,26 @@ See examples for expected behavior.</p>
 <p>If we change the external element but not the internal ones:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"animals"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-    <span class="hljs-attr">"items"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+  <span class="hljs-attr">&quot;animals&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+    <span class="hljs-attr">&quot;items&quot;</span>: {
+      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
     },
-    <span class="hljs-attr">"xml"</span>: {
-      <span class="hljs-attr">"name"</span>: <span class="hljs-string">"aliens"</span>,
-      <span class="hljs-attr">"wrapped"</span>: <span class="hljs-literal">true</span>
+    <span class="hljs-attr">&quot;xml&quot;</span>: {
+      <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;aliens&quot;</span>,
+      <span class="hljs-attr">&quot;wrapped&quot;</span>: <span class="hljs-literal">true</span>
     }
   }
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">animals:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">  items:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">  xml:</span>
-<span class="hljs-attr">    name:</span> <span class="hljs-string">aliens</span>
-<span class="hljs-attr">    wrapped:</span> <span class="hljs-literal">true</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+  <span class="hljs-attr">items:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">xml:</span>
+    <span class="hljs-attr">name:</span> <span class="hljs-string">aliens</span>
+    <span class="hljs-attr">wrapped:</span> <span class="hljs-literal">true</span>
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-tag">&lt;<span class="hljs-name">aliens</span>&gt;</span>
@@ -3727,8 +3727,8 @@ Supported schemes are HTTP authentication, an API key (either as a header or as 
 <section><h5>Basic Authentication Sample</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"http"</span>,
-  <span class="hljs-attr">"scheme"</span>: <span class="hljs-string">"basic"</span>
+  <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;http&quot;</span>,
+  <span class="hljs-attr">&quot;scheme&quot;</span>: <span class="hljs-string">&quot;basic&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -3738,9 +3738,9 @@ Supported schemes are HTTP authentication, an API key (either as a header or as 
 </section><section><h5>API Key Sample</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"apiKey"</span>,
-  <span class="hljs-attr">"name"</span>: <span class="hljs-string">"api_key"</span>,
-  <span class="hljs-attr">"in"</span>: <span class="hljs-string">"header"</span>
+  <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;apiKey&quot;</span>,
+  <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;api_key&quot;</span>,
+  <span class="hljs-attr">&quot;in&quot;</span>: <span class="hljs-string">&quot;header&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -3751,9 +3751,9 @@ Supported schemes are HTTP authentication, an API key (either as a header or as 
 </section><section><h5>JWT Bearer Sample</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"http"</span>,
-  <span class="hljs-attr">"scheme"</span>: <span class="hljs-string">"bearer"</span>,
-  <span class="hljs-attr">"bearerFormat"</span>: <span class="hljs-string">"JWT"</span>,
+  <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;http&quot;</span>,
+  <span class="hljs-attr">&quot;scheme&quot;</span>: <span class="hljs-string">&quot;bearer&quot;</span>,
+  <span class="hljs-attr">&quot;bearerFormat&quot;</span>: <span class="hljs-string">&quot;JWT&quot;</span>,
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -3764,13 +3764,13 @@ Supported schemes are HTTP authentication, an API key (either as a header or as 
 </section><section><h5>Implicit OAuth2 Sample</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"oauth2"</span>,
-  <span class="hljs-attr">"flows"</span>: {
-    <span class="hljs-attr">"implicit"</span>: {
-      <span class="hljs-attr">"authorizationUrl"</span>: <span class="hljs-string">"https://example.com/api/oauth/dialog"</span>,
-      <span class="hljs-attr">"scopes"</span>: {
-        <span class="hljs-attr">"write:pets"</span>: <span class="hljs-string">"modify pets in your account"</span>,
-        <span class="hljs-attr">"read:pets"</span>: <span class="hljs-string">"read your pets"</span>
+  <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;oauth2&quot;</span>,
+  <span class="hljs-attr">&quot;flows&quot;</span>: {
+    <span class="hljs-attr">&quot;implicit&quot;</span>: {
+      <span class="hljs-attr">&quot;authorizationUrl&quot;</span>: <span class="hljs-string">&quot;https://example.com/api/oauth/dialog&quot;</span>,
+      <span class="hljs-attr">&quot;scopes&quot;</span>: {
+        <span class="hljs-attr">&quot;write:pets&quot;</span>: <span class="hljs-string">&quot;modify pets in your account&quot;</span>,
+        <span class="hljs-attr">&quot;read:pets&quot;</span>: <span class="hljs-string">&quot;read your pets&quot;</span>
       }
     }
   }
@@ -3779,11 +3779,11 @@ Supported schemes are HTTP authentication, an API key (either as a header or as 
 <pre class="nohighlight"><code>
 <span class="hljs-attr">type:</span> <span class="hljs-string">oauth2</span>
 <span class="hljs-attr">flows:</span> 
-<span class="hljs-attr">  implicit:</span>
-<span class="hljs-attr">    authorizationUrl:</span> <span class="hljs-attr">https://example.com/api/oauth/dialog</span>
-<span class="hljs-attr">    scopes:</span>
-<span class="hljs-attr">      write:</span><span class="hljs-attr">pets:</span> <span class="hljs-string">modify</span> <span class="hljs-string">pets</span> <span class="hljs-string">in</span> <span class="hljs-string">your</span> <span class="hljs-string">account</span>
-<span class="hljs-attr">      read:</span><span class="hljs-attr">pets:</span> <span class="hljs-string">read</span> <span class="hljs-string">your</span> <span class="hljs-string">pets</span>
+  <span class="hljs-attr">implicit:</span>
+    <span class="hljs-attr">authorizationUrl:</span> <span class="hljs-string">https://example.com/api/oauth/dialog</span>
+    <span class="hljs-attr">scopes:</span>
+      <span class="hljs-attr">write:pets:</span> <span class="hljs-string">modify</span> <span class="hljs-string">pets</span> <span class="hljs-string">in</span> <span class="hljs-string">your</span> <span class="hljs-string">account</span>
+      <span class="hljs-attr">read:pets:</span> <span class="hljs-string">read</span> <span class="hljs-string">your</span> <span class="hljs-string">pets</span>
 </code></pre>
 </section></section></section><section><h3><span id="oauthFlowsObject">OAuth Flows Object</span></h3>
 <p>Allows configuration of the supported OAuth Flows.</p>
@@ -3863,21 +3863,21 @@ Supported schemes are HTTP authentication, an API key (either as a header or as 
 </section><section><h4>OAuth Flow Object Examples</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"oauth2"</span>,
-  <span class="hljs-attr">"flows"</span>: {
-    <span class="hljs-attr">"implicit"</span>: {
-      <span class="hljs-attr">"authorizationUrl"</span>: <span class="hljs-string">"https://example.com/api/oauth/dialog"</span>,
-      <span class="hljs-attr">"scopes"</span>: {
-        <span class="hljs-attr">"write:pets"</span>: <span class="hljs-string">"modify pets in your account"</span>,
-        <span class="hljs-attr">"read:pets"</span>: <span class="hljs-string">"read your pets"</span>
+  <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;oauth2&quot;</span>,
+  <span class="hljs-attr">&quot;flows&quot;</span>: {
+    <span class="hljs-attr">&quot;implicit&quot;</span>: {
+      <span class="hljs-attr">&quot;authorizationUrl&quot;</span>: <span class="hljs-string">&quot;https://example.com/api/oauth/dialog&quot;</span>,
+      <span class="hljs-attr">&quot;scopes&quot;</span>: {
+        <span class="hljs-attr">&quot;write:pets&quot;</span>: <span class="hljs-string">&quot;modify pets in your account&quot;</span>,
+        <span class="hljs-attr">&quot;read:pets&quot;</span>: <span class="hljs-string">&quot;read your pets&quot;</span>
       }
     },
-    <span class="hljs-attr">"authorizationCode"</span>: {
-      <span class="hljs-attr">"authorizationUrl"</span>: <span class="hljs-string">"https://example.com/api/oauth/dialog"</span>,
-      <span class="hljs-attr">"tokenUrl"</span>: <span class="hljs-string">"https://example.com/api/oauth/token"</span>,
-      <span class="hljs-attr">"scopes"</span>: {
-        <span class="hljs-attr">"write:pets"</span>: <span class="hljs-string">"modify pets in your account"</span>,
-        <span class="hljs-attr">"read:pets"</span>: <span class="hljs-string">"read your pets"</span>
+    <span class="hljs-attr">&quot;authorizationCode&quot;</span>: {
+      <span class="hljs-attr">&quot;authorizationUrl&quot;</span>: <span class="hljs-string">&quot;https://example.com/api/oauth/dialog&quot;</span>,
+      <span class="hljs-attr">&quot;tokenUrl&quot;</span>: <span class="hljs-string">&quot;https://example.com/api/oauth/token&quot;</span>,
+      <span class="hljs-attr">&quot;scopes&quot;</span>: {
+        <span class="hljs-attr">&quot;write:pets&quot;</span>: <span class="hljs-string">&quot;modify pets in your account&quot;</span>,
+        <span class="hljs-attr">&quot;read:pets&quot;</span>: <span class="hljs-string">&quot;read your pets&quot;</span>
       }
     }
   }
@@ -3886,17 +3886,17 @@ Supported schemes are HTTP authentication, an API key (either as a header or as 
 <pre class="nohighlight"><code>
 <span class="hljs-attr">type:</span> <span class="hljs-string">oauth2</span>
 <span class="hljs-attr">flows:</span> 
-<span class="hljs-attr">  implicit:</span>
-<span class="hljs-attr">    authorizationUrl:</span> <span class="hljs-attr">https://example.com/api/oauth/dialog</span>
-<span class="hljs-attr">    scopes:</span>
-<span class="hljs-attr">      write:</span><span class="hljs-attr">pets:</span> <span class="hljs-string">modify</span> <span class="hljs-string">pets</span> <span class="hljs-string">in</span> <span class="hljs-string">your</span> <span class="hljs-string">account</span>
-<span class="hljs-attr">      read:</span><span class="hljs-attr">pets:</span> <span class="hljs-string">read</span> <span class="hljs-string">your</span> <span class="hljs-string">pets</span>
-<span class="hljs-attr">  authorizationCode:</span>
-<span class="hljs-attr">    authorizationUrl:</span> <span class="hljs-attr">https://example.com/api/oauth/dialog</span>
-<span class="hljs-attr">    tokenUrl:</span> <span class="hljs-attr">https://example.com/api/oauth/token</span>
-<span class="hljs-attr">    scopes:</span>
-<span class="hljs-attr">      write:</span><span class="hljs-attr">pets:</span> <span class="hljs-string">modify</span> <span class="hljs-string">pets</span> <span class="hljs-string">in</span> <span class="hljs-string">your</span> <span class="hljs-string">account</span>
-<span class="hljs-attr">      read:</span><span class="hljs-attr">pets:</span> <span class="hljs-string">read</span> <span class="hljs-string">your</span> <span class="hljs-string">pets</span> 
+  <span class="hljs-attr">implicit:</span>
+    <span class="hljs-attr">authorizationUrl:</span> <span class="hljs-string">https://example.com/api/oauth/dialog</span>
+    <span class="hljs-attr">scopes:</span>
+      <span class="hljs-attr">write:pets:</span> <span class="hljs-string">modify</span> <span class="hljs-string">pets</span> <span class="hljs-string">in</span> <span class="hljs-string">your</span> <span class="hljs-string">account</span>
+      <span class="hljs-attr">read:pets:</span> <span class="hljs-string">read</span> <span class="hljs-string">your</span> <span class="hljs-string">pets</span>
+  <span class="hljs-attr">authorizationCode:</span>
+    <span class="hljs-attr">authorizationUrl:</span> <span class="hljs-string">https://example.com/api/oauth/dialog</span>
+    <span class="hljs-attr">tokenUrl:</span> <span class="hljs-string">https://example.com/api/oauth/token</span>
+    <span class="hljs-attr">scopes:</span>
+      <span class="hljs-attr">write:pets:</span> <span class="hljs-string">modify</span> <span class="hljs-string">pets</span> <span class="hljs-string">in</span> <span class="hljs-string">your</span> <span class="hljs-string">account</span>
+      <span class="hljs-attr">read:pets:</span> <span class="hljs-string">read</span> <span class="hljs-string">your</span> <span class="hljs-string">pets</span> 
 </code></pre>
 </section></section><section><h3><span id="securityRequirementObject">Security Requirement Object</span></h3>
 <p>Lists the required security schemes to execute this operation.
@@ -3925,25 +3925,25 @@ This enables support for scenarios where multiple query parameters or HTTP heade
 <section><h5>Non-OAuth2 Security Requirement</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"api_key"</span>: []
+  <span class="hljs-attr">&quot;api_key&quot;</span>: []
 }
 </code></pre>
 <pre class="nohighlight"><code>
-<span class="hljs-attr">api_key:</span> <span class="hljs-string">[]</span>
+<span class="hljs-attr">api_key:</span> []
 </code></pre>
 </section><section><h5>OAuth2 Security Requirement</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"petstore_auth"</span>: [
-    <span class="hljs-string">"write:pets"</span>,
-    <span class="hljs-string">"read:pets"</span>
+  <span class="hljs-attr">&quot;petstore_auth&quot;</span>: [
+    <span class="hljs-string">&quot;write:pets&quot;</span>,
+    <span class="hljs-string">&quot;read:pets&quot;</span>
   ]
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">petstore_auth:</span>
-<span class="hljs-attr">- write:</span><span class="hljs-string">pets</span>
-<span class="hljs-attr">- read:</span><span class="hljs-string">pets</span>
+<span class="hljs-bullet">-</span> <span class="hljs-string">write:pets</span>
+<span class="hljs-bullet">-</span> <span class="hljs-string">read:pets</span>
 </code></pre>
 </section></section></section></section><section><h2><span id="specificationExtensions">Specification Extensions</span></h2>
 <p>While the OpenAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.</p>

--- a/oas/v3.0.2.html
+++ b/oas/v3.0.2.html
@@ -1,4 +1,4 @@
-<html><head><meta charset="UTF-8"><title>OpenAPI Specification</title><script src="https://mermade.github.io/static/respec21/respec-oai.js" class="remove"></script><script class="remove">var respecConfig = {"specStatus":"base","editors":[{"name":"Darrel Miller "},{"name":"Jeremy Whitlock "},{"name":"Marsh Gardiner "},{"name":"Mike Ralphson "},{"name":"Ron Ratovsky "},{"name":"Uri Sarid "}],"formerEditors":[{"name":"Jason Harmon "},{"name":"Tony Tam "}],"publishDate":"2018-10-08T00:00:00.000Z","subtitle":"Version 3.0.2","processVersion":2017,"edDraftURI":"http://github.com/OAI/openapi-specification/","github":{"repoURL":"https://github.com/OAI/openapi-specification/","branch":"master"},"shortName":"OAS","noTOC":false,"lint":false,"additionalCopyrightHolders":"the Linux Foundation","includePermalinks":true};</script><!-- Global site tag (gtag.js) - Google Analytics -->
+<html lang="en"><head><meta charset="UTF-8"><title>OpenAPI Specification</title><script src="https://spec.openapis.org/js/respec-oai.js" class="remove"></script><script class="remove">var respecConfig = {"specStatus":"base","editors":[{"name":"Darrel Miller "},{"name":"Jeremy Whitlock "},{"name":"Marsh Gardiner "},{"name":"Mike Ralphson "},{"name":"Ron Ratovsky "},{"name":"Uri Sarid "}],"formerEditors":[{"name":"Jason Harmon "},{"name":"Tony Tam "}],"publishDate":"2018-10-08T00:00:00.000Z","subtitle":"Version 3.0.2","processVersion":2017,"edDraftURI":"https://github.com/OAI/OpenAPI-Specification/","github":{"repoURL":"https://github.com/OAI/OpenAPI-Specification/","branch":"master"},"shortName":"OAS","noTOC":false,"lint":false,"additionalCopyrightHolders":"the Linux Foundation","includePermalinks":true};</script><!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=UA-831873-42"></script>
 <script>
  window.dataLayer = window.dataLayer || [];
@@ -50,7 +50,7 @@ The available status codes are defined by [[!RFC7231]] and registered status cod
 <p>For example, if a field has an array value, the JSON array representation will be used:</p>
 <pre class="nohighlight"><code>
 {
-   <span class="hljs-attr">"field"</span>: [ <span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span> ]
+   <span class="hljs-attr">&quot;field&quot;</span>: [ <span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span> ]
 }
 </code></pre>
 <p>All field names in the specification are <strong>case sensitive</strong>.
@@ -256,32 +256,32 @@ The metadata MAY be used by the clients if needed, and MAY be presented in editi
 </section><section><h4>Info Object Example</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"title"</span>: <span class="hljs-string">"Sample Pet Store App"</span>,
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"This is a sample server for a pet store."</span>,
-  <span class="hljs-attr">"termsOfService"</span>: <span class="hljs-string">"http://example.com/terms/"</span>,
-  <span class="hljs-attr">"contact"</span>: {
-    <span class="hljs-attr">"name"</span>: <span class="hljs-string">"API Support"</span>,
-    <span class="hljs-attr">"url"</span>: <span class="hljs-string">"http://www.example.com/support"</span>,
-    <span class="hljs-attr">"email"</span>: <span class="hljs-string">"support@example.com"</span>
+  <span class="hljs-attr">&quot;title&quot;</span>: <span class="hljs-string">&quot;Sample Pet Store App&quot;</span>,
+  <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;This is a sample server for a pet store.&quot;</span>,
+  <span class="hljs-attr">&quot;termsOfService&quot;</span>: <span class="hljs-string">&quot;http://example.com/terms/&quot;</span>,
+  <span class="hljs-attr">&quot;contact&quot;</span>: {
+    <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;API Support&quot;</span>,
+    <span class="hljs-attr">&quot;url&quot;</span>: <span class="hljs-string">&quot;http://www.example.com/support&quot;</span>,
+    <span class="hljs-attr">&quot;email&quot;</span>: <span class="hljs-string">&quot;support@example.com&quot;</span>
   },
-  <span class="hljs-attr">"license"</span>: {
-    <span class="hljs-attr">"name"</span>: <span class="hljs-string">"Apache 2.0"</span>,
-    <span class="hljs-attr">"url"</span>: <span class="hljs-string">"https://www.apache.org/licenses/LICENSE-2.0.html"</span>
+  <span class="hljs-attr">&quot;license&quot;</span>: {
+    <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;Apache 2.0&quot;</span>,
+    <span class="hljs-attr">&quot;url&quot;</span>: <span class="hljs-string">&quot;https://www.apache.org/licenses/LICENSE-2.0.html&quot;</span>
   },
-  <span class="hljs-attr">"version"</span>: <span class="hljs-string">"1.0.1"</span>
+  <span class="hljs-attr">&quot;version&quot;</span>: <span class="hljs-string">&quot;1.0.1&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">title:</span> <span class="hljs-string">Sample</span> <span class="hljs-string">Pet</span> <span class="hljs-string">Store</span> <span class="hljs-string">App</span>
 <span class="hljs-attr">description:</span> <span class="hljs-string">This</span> <span class="hljs-string">is</span> <span class="hljs-string">a</span> <span class="hljs-string">sample</span> <span class="hljs-string">server</span> <span class="hljs-string">for</span> <span class="hljs-string">a</span> <span class="hljs-string">pet</span> <span class="hljs-string">store.</span>
-<span class="hljs-attr">termsOfService:</span> <span class="hljs-attr">http://example.com/terms/</span>
+<span class="hljs-attr">termsOfService:</span> <span class="hljs-string">http://example.com/terms/</span>
 <span class="hljs-attr">contact:</span>
-<span class="hljs-attr">  name:</span> <span class="hljs-string">API</span> <span class="hljs-string">Support</span>
-<span class="hljs-attr">  url:</span> <span class="hljs-attr">http://www.example.com/support</span>
-<span class="hljs-attr">  email:</span> <span class="hljs-string">support@example.com</span>
+  <span class="hljs-attr">name:</span> <span class="hljs-string">API</span> <span class="hljs-string">Support</span>
+  <span class="hljs-attr">url:</span> <span class="hljs-string">http://www.example.com/support</span>
+  <span class="hljs-attr">email:</span> <span class="hljs-string">support@example.com</span>
 <span class="hljs-attr">license:</span>
-<span class="hljs-attr">  name:</span> <span class="hljs-string">Apache</span> <span class="hljs-number">2.0</span>
-<span class="hljs-attr">  url:</span> <span class="hljs-attr">https://www.apache.org/licenses/LICENSE-2.0.html</span>
+  <span class="hljs-attr">name:</span> <span class="hljs-string">Apache</span> <span class="hljs-number">2.0</span>
+  <span class="hljs-attr">url:</span> <span class="hljs-string">https://www.apache.org/licenses/LICENSE-2.0.html</span>
 <span class="hljs-attr">version:</span> <span class="hljs-number">1.0</span><span class="hljs-number">.1</span>
 </code></pre>
 </section></section><section><h3><span id="contactObject">Contact Object</span></h3>
@@ -317,14 +317,14 @@ The metadata MAY be used by the clients if needed, and MAY be presented in editi
 </section><section><h4>Contact Object Example</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"name"</span>: <span class="hljs-string">"API Support"</span>,
-  <span class="hljs-attr">"url"</span>: <span class="hljs-string">"http://www.example.com/support"</span>,
-  <span class="hljs-attr">"email"</span>: <span class="hljs-string">"support@example.com"</span>
+  <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;API Support&quot;</span>,
+  <span class="hljs-attr">&quot;url&quot;</span>: <span class="hljs-string">&quot;http://www.example.com/support&quot;</span>,
+  <span class="hljs-attr">&quot;email&quot;</span>: <span class="hljs-string">&quot;support@example.com&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">name:</span> <span class="hljs-string">API</span> <span class="hljs-string">Support</span>
-<span class="hljs-attr">url:</span> <span class="hljs-attr">http://www.example.com/support</span>
+<span class="hljs-attr">url:</span> <span class="hljs-string">http://www.example.com/support</span>
 <span class="hljs-attr">email:</span> <span class="hljs-string">support@example.com</span>
 </code></pre>
 </section></section><section><h3><span id="licenseObject">License Object</span></h3>
@@ -355,13 +355,13 @@ The metadata MAY be used by the clients if needed, and MAY be presented in editi
 </section><section><h4>License Object Example</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"name"</span>: <span class="hljs-string">"Apache 2.0"</span>,
-  <span class="hljs-attr">"url"</span>: <span class="hljs-string">"https://www.apache.org/licenses/LICENSE-2.0.html"</span>
+  <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;Apache 2.0&quot;</span>,
+  <span class="hljs-attr">&quot;url&quot;</span>: <span class="hljs-string">&quot;https://www.apache.org/licenses/LICENSE-2.0.html&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">name:</span> <span class="hljs-string">Apache</span> <span class="hljs-number">2.0</span>
-<span class="hljs-attr">url:</span> <span class="hljs-attr">https://www.apache.org/licenses/LICENSE-2.0.html</span>
+<span class="hljs-attr">url:</span> <span class="hljs-string">https://www.apache.org/licenses/LICENSE-2.0.html</span>
 </code></pre>
 </section></section><section><h3><span id="serverObject">Server Object</span></h3>
 <p>An object representing a Server.</p>
@@ -397,63 +397,63 @@ The metadata MAY be used by the clients if needed, and MAY be presented in editi
 <p>A single server would be described as:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"url"</span>: <span class="hljs-string">"https://development.gigantic-server.com/v1"</span>,
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Development server"</span>
+  <span class="hljs-attr">&quot;url&quot;</span>: <span class="hljs-string">&quot;https://development.gigantic-server.com/v1&quot;</span>,
+  <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;Development server&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
-<span class="hljs-attr">url:</span> <span class="hljs-attr">https://development.gigantic-server.com/v1</span>
+<span class="hljs-attr">url:</span> <span class="hljs-string">https://development.gigantic-server.com/v1</span>
 <span class="hljs-attr">description:</span> <span class="hljs-string">Development</span> <span class="hljs-string">server</span>
 </code></pre>
 <p>The following shows how multiple servers can be described, for example, at the OpenAPI Object’s <a href="#oasServers"><code>servers</code></a>:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"servers"</span>: [
+  <span class="hljs-attr">&quot;servers&quot;</span>: [
     {
-      <span class="hljs-attr">"url"</span>: <span class="hljs-string">"https://development.gigantic-server.com/v1"</span>,
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Development server"</span>
+      <span class="hljs-attr">&quot;url&quot;</span>: <span class="hljs-string">&quot;https://development.gigantic-server.com/v1&quot;</span>,
+      <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;Development server&quot;</span>
     },
     {
-      <span class="hljs-attr">"url"</span>: <span class="hljs-string">"https://staging.gigantic-server.com/v1"</span>,
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Staging server"</span>
+      <span class="hljs-attr">&quot;url&quot;</span>: <span class="hljs-string">&quot;https://staging.gigantic-server.com/v1&quot;</span>,
+      <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;Staging server&quot;</span>
     },
     {
-      <span class="hljs-attr">"url"</span>: <span class="hljs-string">"https://api.gigantic-server.com/v1"</span>,
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Production server"</span>
+      <span class="hljs-attr">&quot;url&quot;</span>: <span class="hljs-string">&quot;https://api.gigantic-server.com/v1&quot;</span>,
+      <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;Production server&quot;</span>
     }
   ]
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">servers:</span>
-<span class="hljs-attr">- url:</span> <span class="hljs-attr">https://development.gigantic-server.com/v1</span>
-<span class="hljs-attr">  description:</span> <span class="hljs-string">Development</span> <span class="hljs-string">server</span>
-<span class="hljs-attr">- url:</span> <span class="hljs-attr">https://staging.gigantic-server.com/v1</span>
-<span class="hljs-attr">  description:</span> <span class="hljs-string">Staging</span> <span class="hljs-string">server</span>
-<span class="hljs-attr">- url:</span> <span class="hljs-attr">https://api.gigantic-server.com/v1</span>
-<span class="hljs-attr">  description:</span> <span class="hljs-string">Production</span> <span class="hljs-string">server</span>
+<span class="hljs-bullet">-</span> <span class="hljs-attr">url:</span> <span class="hljs-string">https://development.gigantic-server.com/v1</span>
+  <span class="hljs-attr">description:</span> <span class="hljs-string">Development</span> <span class="hljs-string">server</span>
+<span class="hljs-bullet">-</span> <span class="hljs-attr">url:</span> <span class="hljs-string">https://staging.gigantic-server.com/v1</span>
+  <span class="hljs-attr">description:</span> <span class="hljs-string">Staging</span> <span class="hljs-string">server</span>
+<span class="hljs-bullet">-</span> <span class="hljs-attr">url:</span> <span class="hljs-string">https://api.gigantic-server.com/v1</span>
+  <span class="hljs-attr">description:</span> <span class="hljs-string">Production</span> <span class="hljs-string">server</span>
 </code></pre>
 <p>The following shows how variables can be used for a server configuration:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"servers"</span>: [
+  <span class="hljs-attr">&quot;servers&quot;</span>: [
     {
-      <span class="hljs-attr">"url"</span>: <span class="hljs-string">"https://{username}.gigantic-server.com:{port}/{basePath}"</span>,
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"The production API server"</span>,
-      <span class="hljs-attr">"variables"</span>: {
-        <span class="hljs-attr">"username"</span>: {
-          <span class="hljs-attr">"default"</span>: <span class="hljs-string">"demo"</span>,
-          <span class="hljs-attr">"description"</span>: <span class="hljs-string">"this value is assigned by the service provider, in this example `gigantic-server.com`"</span>
+      <span class="hljs-attr">&quot;url&quot;</span>: <span class="hljs-string">&quot;https://{username}.gigantic-server.com:{port}/{basePath}&quot;</span>,
+      <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;The production API server&quot;</span>,
+      <span class="hljs-attr">&quot;variables&quot;</span>: {
+        <span class="hljs-attr">&quot;username&quot;</span>: {
+          <span class="hljs-attr">&quot;default&quot;</span>: <span class="hljs-string">&quot;demo&quot;</span>,
+          <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;this value is assigned by the service provider, in this example `gigantic-server.com`&quot;</span>
         },
-        <span class="hljs-attr">"port"</span>: {
-          <span class="hljs-attr">"enum"</span>: [
-            <span class="hljs-string">"8443"</span>,
-            <span class="hljs-string">"443"</span>
+        <span class="hljs-attr">&quot;port&quot;</span>: {
+          <span class="hljs-attr">&quot;enum&quot;</span>: [
+            <span class="hljs-string">&quot;8443&quot;</span>,
+            <span class="hljs-string">&quot;443&quot;</span>
           ],
-          <span class="hljs-attr">"default"</span>: <span class="hljs-string">"8443"</span>
+          <span class="hljs-attr">&quot;default&quot;</span>: <span class="hljs-string">&quot;8443&quot;</span>
         },
-        <span class="hljs-attr">"basePath"</span>: {
-          <span class="hljs-attr">"default"</span>: <span class="hljs-string">"v2"</span>
+        <span class="hljs-attr">&quot;basePath&quot;</span>: {
+          <span class="hljs-attr">&quot;default&quot;</span>: <span class="hljs-string">&quot;v2&quot;</span>
         }
       }
     }
@@ -462,21 +462,21 @@ The metadata MAY be used by the clients if needed, and MAY be presented in editi
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">servers:</span>
-<span class="hljs-attr">- url:</span> <span class="hljs-attr">https://{username}.gigantic-server.com:{port}/{basePath}</span>
-<span class="hljs-attr">  description:</span> <span class="hljs-string">The</span> <span class="hljs-string">production</span> <span class="hljs-string">API</span> <span class="hljs-string">server</span>
-<span class="hljs-attr">  variables:</span>
-<span class="hljs-attr">    username:</span>
+<span class="hljs-bullet">-</span> <span class="hljs-attr">url:</span> <span class="hljs-string">https://{username}.gigantic-server.com:{port}/{basePath}</span>
+  <span class="hljs-attr">description:</span> <span class="hljs-string">The</span> <span class="hljs-string">production</span> <span class="hljs-string">API</span> <span class="hljs-string">server</span>
+  <span class="hljs-attr">variables:</span>
+    <span class="hljs-attr">username:</span>
       <span class="hljs-comment"># note! no enum here means it is an open value</span>
-<span class="hljs-attr">      default:</span> <span class="hljs-string">demo</span>
-<span class="hljs-attr">      description:</span> <span class="hljs-string">this</span> <span class="hljs-string">value</span> <span class="hljs-string">is</span> <span class="hljs-string">assigned</span> <span class="hljs-string">by</span> <span class="hljs-string">the</span> <span class="hljs-string">service</span> <span class="hljs-string">provider,</span> <span class="hljs-string">in</span> <span class="hljs-string">this</span> <span class="hljs-string">example</span> <span class="hljs-string">`gigantic-server.com`</span>
-<span class="hljs-attr">    port:</span>
-<span class="hljs-attr">      enum:</span>
-<span class="hljs-bullet">        -</span> <span class="hljs-string">'8443'</span>
-<span class="hljs-bullet">        -</span> <span class="hljs-string">'443'</span>
-<span class="hljs-attr">      default:</span> <span class="hljs-string">'8443'</span>
-<span class="hljs-attr">    basePath:</span>
+      <span class="hljs-attr">default:</span> <span class="hljs-string">demo</span>
+      <span class="hljs-attr">description:</span> <span class="hljs-string">this</span> <span class="hljs-string">value</span> <span class="hljs-string">is</span> <span class="hljs-string">assigned</span> <span class="hljs-string">by</span> <span class="hljs-string">the</span> <span class="hljs-string">service</span> <span class="hljs-string">provider,</span> <span class="hljs-string">in</span> <span class="hljs-string">this</span> <span class="hljs-string">example</span> <span class="hljs-string">`gigantic-server.com`</span>
+    <span class="hljs-attr">port:</span>
+      <span class="hljs-attr">enum:</span>
+        <span class="hljs-bullet">-</span> <span class="hljs-string">&#x27;8443&#x27;</span>
+        <span class="hljs-bullet">-</span> <span class="hljs-string">&#x27;443&#x27;</span>
+      <span class="hljs-attr">default:</span> <span class="hljs-string">&#x27;8443&#x27;</span>
+    <span class="hljs-attr">basePath:</span>
       <span class="hljs-comment"># open meaning there is the opportunity to use special base paths as assigned by the provider, default is `v2`</span>
-<span class="hljs-attr">      default:</span> <span class="hljs-string">v2</span>
+      <span class="hljs-attr">default:</span> <span class="hljs-string">v2</span>
 </code></pre>
 </section></section><section><h3><span id="serverVariableObject">Server Variable Object</span></h3>
 <p>An object representing a Server Variable for server URL template substitution.</p>
@@ -523,47 +523,47 @@ All objects defined within the components object will have no effect on the API 
 <tbody>
 <tr>
 <td><a id="componentsSchemas"> </a> schemas</td>
-<td style="text-align:left">Map[<code>string</code>, <a href="#schemaObject">Schema Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:left">Map[<code>string</code>, <a href="#schemaObject">Schema Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>An object to hold reusable <a href="#schemaObject">Schema Objects</a>.</td>
 </tr>
 <tr>
 <td><a id="componentsResponses"> </a> responses</td>
-<td style="text-align:left">Map[<code>string</code>, <a href="#responseObject">Response Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:left">Map[<code>string</code>, <a href="#responseObject">Response Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>An object to hold reusable <a href="#responseObject">Response Objects</a>.</td>
 </tr>
 <tr>
 <td><a id="componentsParameters"> </a> parameters</td>
-<td style="text-align:left">Map[<code>string</code>, <a href="#parameterObject">Parameter Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:left">Map[<code>string</code>, <a href="#parameterObject">Parameter Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>An object to hold reusable <a href="#parameterObject">Parameter Objects</a>.</td>
 </tr>
 <tr>
 <td><a id="componentsExamples"> </a> examples</td>
-<td style="text-align:left">Map[<code>string</code>, <a href="#exampleObject">Example Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:left">Map[<code>string</code>, <a href="#exampleObject">Example Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>An object to hold reusable <a href="#exampleObject">Example Objects</a>.</td>
 </tr>
 <tr>
 <td><a id="componentsRequestBodies"> </a> requestBodies</td>
-<td style="text-align:left">Map[<code>string</code>, <a href="#requestBodyObject">Request Body Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:left">Map[<code>string</code>, <a href="#requestBodyObject">Request Body Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>An object to hold reusable <a href="#requestBodyObject">Request Body Objects</a>.</td>
 </tr>
 <tr>
 <td><a id="componentsHeaders"> </a> headers</td>
-<td style="text-align:left">Map[<code>string</code>, <a href="#headerObject">Header Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:left">Map[<code>string</code>, <a href="#headerObject">Header Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>An object to hold reusable <a href="#headerObject">Header Objects</a>.</td>
 </tr>
 <tr>
 <td><a id="componentsSecuritySchemes"> </a> securitySchemes</td>
-<td style="text-align:left">Map[<code>string</code>, <a href="#securitySchemeObject">Security Scheme Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:left">Map[<code>string</code>, <a href="#securitySchemeObject">Security Scheme Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>An object to hold reusable <a href="#securitySchemeObject">Security Scheme Objects</a>.</td>
 </tr>
 <tr>
 <td><a id="componentsLinks"> </a> links</td>
-<td style="text-align:left">Map[<code>string</code>, <a href="#linkObject">Link Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:left">Map[<code>string</code>, <a href="#linkObject">Link Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>An object to hold reusable <a href="#linkObject">Link Objects</a>.</td>
 </tr>
 <tr>
 <td><a id="componentsCallbacks"> </a> callbacks</td>
-<td style="text-align:left">Map[<code>string</code>, <a href="#callbackObject">Callback Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:left">Map[<code>string</code>, <a href="#callbackObject">Callback Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>An object to hold reusable <a href="#callbackObject">Callback Objects</a>.</td>
 </tr>
 </tbody>
@@ -580,99 +580,99 @@ my.org.User
 </code></pre>
 </section><section><h4>Components Object Example</h4>
 <pre class="nohighlight"><code>
-<span class="hljs-string">"components"</span>: {
-  <span class="hljs-attr">"schemas"</span>: {
-    <span class="hljs-attr">"GeneralError"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-      <span class="hljs-attr">"properties"</span>: {
-        <span class="hljs-attr">"code"</span>: {
-          <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>,
-          <span class="hljs-attr">"format"</span>: <span class="hljs-string">"int32"</span>
+&quot;components&quot;: {
+  &quot;schemas&quot;: {
+    &quot;GeneralError&quot;: {
+      &quot;type&quot;: &quot;object&quot;,
+      &quot;properties&quot;: {
+        &quot;code&quot;: {
+          &quot;type&quot;: &quot;integer&quot;,
+          &quot;format&quot;: &quot;int32&quot;
         },
-        <span class="hljs-attr">"message"</span>: {
-          <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+        &quot;message&quot;: {
+          &quot;type&quot;: &quot;string&quot;
         }
       }
     },
-    <span class="hljs-attr">"Category"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-      <span class="hljs-attr">"properties"</span>: {
-        <span class="hljs-attr">"id"</span>: {
-          <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>,
-          <span class="hljs-attr">"format"</span>: <span class="hljs-string">"int64"</span>
+    &quot;Category&quot;: {
+      &quot;type&quot;: &quot;object&quot;,
+      &quot;properties&quot;: {
+        &quot;id&quot;: {
+          &quot;type&quot;: &quot;integer&quot;,
+          &quot;format&quot;: &quot;int64&quot;
         },
-        <span class="hljs-attr">"name"</span>: {
-          <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+        &quot;name&quot;: {
+          &quot;type&quot;: &quot;string&quot;
         }
       }
     },
-    <span class="hljs-attr">"Tag"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-      <span class="hljs-attr">"properties"</span>: {
-        <span class="hljs-attr">"id"</span>: {
-          <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>,
-          <span class="hljs-attr">"format"</span>: <span class="hljs-string">"int64"</span>
+    &quot;Tag&quot;: {
+      &quot;type&quot;: &quot;object&quot;,
+      &quot;properties&quot;: {
+        &quot;id&quot;: {
+          &quot;type&quot;: &quot;integer&quot;,
+          &quot;format&quot;: &quot;int64&quot;
         },
-        <span class="hljs-attr">"name"</span>: {
-          <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+        &quot;name&quot;: {
+          &quot;type&quot;: &quot;string&quot;
         }
       }
     }
   },
-  <span class="hljs-attr">"parameters"</span>: {
-    <span class="hljs-attr">"skipParam"</span>: {
-      <span class="hljs-attr">"name"</span>: <span class="hljs-string">"skip"</span>,
-      <span class="hljs-attr">"in"</span>: <span class="hljs-string">"query"</span>,
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"number of items to skip"</span>,
-      <span class="hljs-attr">"required"</span>: <span class="hljs-literal">true</span>,
-      <span class="hljs-attr">"schema"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>,
-        <span class="hljs-attr">"format"</span>: <span class="hljs-string">"int32"</span>
+  &quot;parameters&quot;: {
+    &quot;skipParam&quot;: {
+      &quot;name&quot;: &quot;skip&quot;,
+      &quot;in&quot;: &quot;query&quot;,
+      &quot;description&quot;: &quot;number of items to skip&quot;,
+      &quot;required&quot;: true,
+      &quot;schema&quot;: {
+        &quot;type&quot;: &quot;integer&quot;,
+        &quot;format&quot;: &quot;int32&quot;
       }
     },
-    <span class="hljs-attr">"limitParam"</span>: {
-      <span class="hljs-attr">"name"</span>: <span class="hljs-string">"limit"</span>,
-      <span class="hljs-attr">"in"</span>: <span class="hljs-string">"query"</span>,
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"max records to return"</span>,
-      <span class="hljs-attr">"required"</span>: <span class="hljs-literal">true</span>,
-      <span class="hljs-attr">"schema"</span> : {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>,
-        <span class="hljs-attr">"format"</span>: <span class="hljs-string">"int32"</span>
+    &quot;limitParam&quot;: {
+      &quot;name&quot;: &quot;limit&quot;,
+      &quot;in&quot;: &quot;query&quot;,
+      &quot;description&quot;: &quot;max records to return&quot;,
+      &quot;required&quot;: true,
+      &quot;schema&quot; : {
+        &quot;type&quot;: &quot;integer&quot;,
+        &quot;format&quot;: &quot;int32&quot;
       }
     }
   },
-  <span class="hljs-attr">"responses"</span>: {
-    <span class="hljs-attr">"NotFound"</span>: {
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Entity not found."</span>
+  &quot;responses&quot;: {
+    &quot;NotFound&quot;: {
+      &quot;description&quot;: &quot;Entity not found.&quot;
     },
-    <span class="hljs-attr">"IllegalInput"</span>: {
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Illegal input for operation."</span>
+    &quot;IllegalInput&quot;: {
+      &quot;description&quot;: &quot;Illegal input for operation.&quot;
     },
-    <span class="hljs-attr">"GeneralError"</span>: {
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"General Error"</span>,
-      <span class="hljs-attr">"content"</span>: {
-        <span class="hljs-attr">"application/json"</span>: {
-          <span class="hljs-attr">"schema"</span>: {
-            <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/GeneralError"</span>
+    &quot;GeneralError&quot;: {
+      &quot;description&quot;: &quot;General Error&quot;,
+      &quot;content&quot;: {
+        &quot;application/json&quot;: {
+          &quot;schema&quot;: {
+            &quot;$ref&quot;: &quot;#/components/schemas/GeneralError&quot;
           }
         }
       }
     }
   },
-  <span class="hljs-attr">"securitySchemes"</span>: {
-    <span class="hljs-attr">"api_key"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"apiKey"</span>,
-      <span class="hljs-attr">"name"</span>: <span class="hljs-string">"api_key"</span>,
-      <span class="hljs-attr">"in"</span>: <span class="hljs-string">"header"</span>
+  &quot;securitySchemes&quot;: {
+    &quot;api_key&quot;: {
+      &quot;type&quot;: &quot;apiKey&quot;,
+      &quot;name&quot;: &quot;api_key&quot;,
+      &quot;in&quot;: &quot;header&quot;
     },
-    <span class="hljs-attr">"petstore_auth"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"oauth2"</span>,
-      <span class="hljs-attr">"flows"</span>: {
-        <span class="hljs-attr">"implicit"</span>: {
-          <span class="hljs-attr">"authorizationUrl"</span>: <span class="hljs-string">"http://example.org/api/oauth/dialog"</span>,
-          <span class="hljs-attr">"scopes"</span>: {
-            <span class="hljs-attr">"write:pets"</span>: <span class="hljs-string">"modify pets in your account"</span>,
-            <span class="hljs-attr">"read:pets"</span>: <span class="hljs-string">"read your pets"</span>
+    &quot;petstore_auth&quot;: {
+      &quot;type&quot;: &quot;oauth2&quot;,
+      &quot;flows&quot;: {
+        &quot;implicit&quot;: {
+          &quot;authorizationUrl&quot;: &quot;http://example.org/api/oauth/dialog&quot;,
+          &quot;scopes&quot;: {
+            &quot;write:pets&quot;: &quot;modify pets in your account&quot;,
+            &quot;read:pets&quot;: &quot;read your pets&quot;
           }
         }
       }
@@ -682,72 +682,72 @@ my.org.User
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">components:</span>
-<span class="hljs-attr">  schemas:</span>
-<span class="hljs-attr">    GeneralError:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">      properties:</span>
-<span class="hljs-attr">        code:</span>
-<span class="hljs-attr">          type:</span> <span class="hljs-string">integer</span>
-<span class="hljs-attr">          format:</span> <span class="hljs-string">int32</span>
-<span class="hljs-attr">        message:</span>
-<span class="hljs-attr">          type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">    Category:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">      properties:</span>
-<span class="hljs-attr">        id:</span>
-<span class="hljs-attr">          type:</span> <span class="hljs-string">integer</span>
-<span class="hljs-attr">          format:</span> <span class="hljs-string">int64</span>
-<span class="hljs-attr">        name:</span>
-<span class="hljs-attr">          type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">    Tag:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">      properties:</span>
-<span class="hljs-attr">        id:</span>
-<span class="hljs-attr">          type:</span> <span class="hljs-string">integer</span>
-<span class="hljs-attr">          format:</span> <span class="hljs-string">int64</span>
-<span class="hljs-attr">        name:</span>
-<span class="hljs-attr">          type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">  parameters:</span>
-<span class="hljs-attr">    skipParam:</span>
-<span class="hljs-attr">      name:</span> <span class="hljs-string">skip</span>
-<span class="hljs-attr">      in:</span> <span class="hljs-string">query</span>
-<span class="hljs-attr">      description:</span> <span class="hljs-string">number</span> <span class="hljs-string">of</span> <span class="hljs-string">items</span> <span class="hljs-string">to</span> <span class="hljs-string">skip</span>
-<span class="hljs-attr">      required:</span> <span class="hljs-literal">true</span>
-<span class="hljs-attr">      schema:</span>
-<span class="hljs-attr">        type:</span> <span class="hljs-string">integer</span>
-<span class="hljs-attr">        format:</span> <span class="hljs-string">int32</span>
-<span class="hljs-attr">    limitParam:</span>
-<span class="hljs-attr">      name:</span> <span class="hljs-string">limit</span>
-<span class="hljs-attr">      in:</span> <span class="hljs-string">query</span>
-<span class="hljs-attr">      description:</span> <span class="hljs-string">max</span> <span class="hljs-string">records</span> <span class="hljs-string">to</span> <span class="hljs-string">return</span>
-<span class="hljs-attr">      required:</span> <span class="hljs-literal">true</span>
-<span class="hljs-attr">      schema:</span>
-<span class="hljs-attr">        type:</span> <span class="hljs-string">integer</span>
-<span class="hljs-attr">        format:</span> <span class="hljs-string">int32</span>
-<span class="hljs-attr">  responses:</span>
-<span class="hljs-attr">    NotFound:</span>
-<span class="hljs-attr">      description:</span> <span class="hljs-string">Entity</span> <span class="hljs-string">not</span> <span class="hljs-string">found.</span>
-<span class="hljs-attr">    IllegalInput:</span>
-<span class="hljs-attr">      description:</span> <span class="hljs-string">Illegal</span> <span class="hljs-string">input</span> <span class="hljs-string">for</span> <span class="hljs-string">operation.</span>
-<span class="hljs-attr">    GeneralError:</span>
-<span class="hljs-attr">      description:</span> <span class="hljs-string">General</span> <span class="hljs-string">Error</span>
-<span class="hljs-attr">      content:</span>
-        <span class="hljs-string">application/json:</span>
-<span class="hljs-attr">          schema:</span>
-            <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/GeneralError'</span>
-<span class="hljs-attr">  securitySchemes:</span>
-<span class="hljs-attr">    api_key:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">apiKey</span>
-<span class="hljs-attr">      name:</span> <span class="hljs-string">api_key</span>
-<span class="hljs-attr">      in:</span> <span class="hljs-string">header</span>
-<span class="hljs-attr">    petstore_auth:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">oauth2</span>
-<span class="hljs-attr">      flows:</span> 
-<span class="hljs-attr">        implicit:</span>
-<span class="hljs-attr">          authorizationUrl:</span> <span class="hljs-attr">http://example.org/api/oauth/dialog</span>
-<span class="hljs-attr">          scopes:</span>
-<span class="hljs-attr">            write:</span><span class="hljs-attr">pets:</span> <span class="hljs-string">modify</span> <span class="hljs-string">pets</span> <span class="hljs-string">in</span> <span class="hljs-string">your</span> <span class="hljs-string">account</span>
-<span class="hljs-attr">            read:</span><span class="hljs-attr">pets:</span> <span class="hljs-string">read</span> <span class="hljs-string">your</span> <span class="hljs-string">pets</span>
+  <span class="hljs-attr">schemas:</span>
+    <span class="hljs-attr">GeneralError:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+      <span class="hljs-attr">properties:</span>
+        <span class="hljs-attr">code:</span>
+          <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+          <span class="hljs-attr">format:</span> <span class="hljs-string">int32</span>
+        <span class="hljs-attr">message:</span>
+          <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+    <span class="hljs-attr">Category:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+      <span class="hljs-attr">properties:</span>
+        <span class="hljs-attr">id:</span>
+          <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+          <span class="hljs-attr">format:</span> <span class="hljs-string">int64</span>
+        <span class="hljs-attr">name:</span>
+          <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+    <span class="hljs-attr">Tag:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+      <span class="hljs-attr">properties:</span>
+        <span class="hljs-attr">id:</span>
+          <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+          <span class="hljs-attr">format:</span> <span class="hljs-string">int64</span>
+        <span class="hljs-attr">name:</span>
+          <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">parameters:</span>
+    <span class="hljs-attr">skipParam:</span>
+      <span class="hljs-attr">name:</span> <span class="hljs-string">skip</span>
+      <span class="hljs-attr">in:</span> <span class="hljs-string">query</span>
+      <span class="hljs-attr">description:</span> <span class="hljs-string">number</span> <span class="hljs-string">of</span> <span class="hljs-string">items</span> <span class="hljs-string">to</span> <span class="hljs-string">skip</span>
+      <span class="hljs-attr">required:</span> <span class="hljs-literal">true</span>
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+        <span class="hljs-attr">format:</span> <span class="hljs-string">int32</span>
+    <span class="hljs-attr">limitParam:</span>
+      <span class="hljs-attr">name:</span> <span class="hljs-string">limit</span>
+      <span class="hljs-attr">in:</span> <span class="hljs-string">query</span>
+      <span class="hljs-attr">description:</span> <span class="hljs-string">max</span> <span class="hljs-string">records</span> <span class="hljs-string">to</span> <span class="hljs-string">return</span>
+      <span class="hljs-attr">required:</span> <span class="hljs-literal">true</span>
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+        <span class="hljs-attr">format:</span> <span class="hljs-string">int32</span>
+  <span class="hljs-attr">responses:</span>
+    <span class="hljs-attr">NotFound:</span>
+      <span class="hljs-attr">description:</span> <span class="hljs-string">Entity</span> <span class="hljs-string">not</span> <span class="hljs-string">found.</span>
+    <span class="hljs-attr">IllegalInput:</span>
+      <span class="hljs-attr">description:</span> <span class="hljs-string">Illegal</span> <span class="hljs-string">input</span> <span class="hljs-string">for</span> <span class="hljs-string">operation.</span>
+    <span class="hljs-attr">GeneralError:</span>
+      <span class="hljs-attr">description:</span> <span class="hljs-string">General</span> <span class="hljs-string">Error</span>
+      <span class="hljs-attr">content:</span>
+        <span class="hljs-attr">application/json:</span>
+          <span class="hljs-attr">schema:</span>
+            <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/GeneralError&#x27;</span>
+  <span class="hljs-attr">securitySchemes:</span>
+    <span class="hljs-attr">api_key:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">apiKey</span>
+      <span class="hljs-attr">name:</span> <span class="hljs-string">api_key</span>
+      <span class="hljs-attr">in:</span> <span class="hljs-string">header</span>
+    <span class="hljs-attr">petstore_auth:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">oauth2</span>
+      <span class="hljs-attr">flows:</span> 
+        <span class="hljs-attr">implicit:</span>
+          <span class="hljs-attr">authorizationUrl:</span> <span class="hljs-string">http://example.org/api/oauth/dialog</span>
+          <span class="hljs-attr">scopes:</span>
+            <span class="hljs-attr">write:pets:</span> <span class="hljs-string">modify</span> <span class="hljs-string">pets</span> <span class="hljs-string">in</span> <span class="hljs-string">your</span> <span class="hljs-string">account</span>
+            <span class="hljs-attr">read:pets:</span> <span class="hljs-string">read</span> <span class="hljs-string">your</span> <span class="hljs-string">pets</span>
 </code></pre>
 </section></section><section><h3><span id="pathsObject">Paths Object</span></h3>
 <p>Holds the relative paths to the individual endpoints and their operations.
@@ -765,7 +765,7 @@ The path is appended to the URL from the <a href="#serverObject"><code>Server Ob
 <tr>
 <td><a id="pathsPath"> </a>/{path}</td>
 <td style="text-align:center"><a href="#pathItemObject">Path Item Object</a></td>
-<td>A relative path to an individual endpoint. The field name MUST begin with a slash. The path is <strong>appended</strong> (no relative URL resolution) to the expanded URL from the <a href="#serverObject"><code>Server Object</code></a>'s <code>url</code> field in order to construct the full URL. <a href="#pathTemplating">Path templating</a> is allowed. When matching URLs, concrete (non-templated) paths would be matched before their templated counterparts. Templated paths with the same hierarchy but different templated names MUST NOT exist as they are identical. In case of ambiguous matching, it’s up to the tooling to decide which one to use.</td>
+<td>A relative path to an individual endpoint. The field name MUST begin with a slash. The path is <strong>appended</strong> (no relative URL resolution) to the expanded URL from the <a href="#serverObject"><code>Server Object</code></a>’s <code>url</code> field in order to construct the full URL. <a href="#pathTemplating">Path templating</a> is allowed. When matching URLs, concrete (non-templated) paths would be matched before their templated counterparts. Templated paths with the same hierarchy but different templated names MUST NOT exist as they are identical. In case of ambiguous matching, it’s up to the tooling to decide which one to use.</td>
 </tr>
 </tbody>
 </table>
@@ -789,18 +789,18 @@ The path is appended to the URL from the <a href="#serverObject"><code>Server Ob
 </section><section><h4>Paths Object Example</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"/pets"</span>: {
-    <span class="hljs-attr">"get"</span>: {
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Returns all pets from the system that the user has access to"</span>,
-      <span class="hljs-attr">"responses"</span>: {
-        <span class="hljs-attr">"200"</span>: {          
-          <span class="hljs-attr">"description"</span>: <span class="hljs-string">"A list of pets."</span>,
-          <span class="hljs-attr">"content"</span>: {
-            <span class="hljs-attr">"application/json"</span>: {
-              <span class="hljs-attr">"schema"</span>: {
-                <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-                <span class="hljs-attr">"items"</span>: {
-                  <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/pet"</span>
+  <span class="hljs-attr">&quot;/pets&quot;</span>: {
+    <span class="hljs-attr">&quot;get&quot;</span>: {
+      <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;Returns all pets from the system that the user has access to&quot;</span>,
+      <span class="hljs-attr">&quot;responses&quot;</span>: {
+        <span class="hljs-attr">&quot;200&quot;</span>: {          
+          <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;A list of pets.&quot;</span>,
+          <span class="hljs-attr">&quot;content&quot;</span>: {
+            <span class="hljs-attr">&quot;application/json&quot;</span>: {
+              <span class="hljs-attr">&quot;schema&quot;</span>: {
+                <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+                <span class="hljs-attr">&quot;items&quot;</span>: {
+                  <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/pet&quot;</span>
                 }
               }
             }
@@ -813,17 +813,17 @@ The path is appended to the URL from the <a href="#serverObject"><code>Server Ob
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-string">/pets:</span>
-<span class="hljs-attr">  get:</span>
-<span class="hljs-attr">    description:</span> <span class="hljs-string">Returns</span> <span class="hljs-string">all</span> <span class="hljs-string">pets</span> <span class="hljs-string">from</span> <span class="hljs-string">the</span> <span class="hljs-string">system</span> <span class="hljs-string">that</span> <span class="hljs-string">the</span> <span class="hljs-string">user</span> <span class="hljs-string">has</span> <span class="hljs-string">access</span> <span class="hljs-string">to</span>
-<span class="hljs-attr">    responses:</span>
-      <span class="hljs-string">'200'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">        description:</span> <span class="hljs-string">A</span> <span class="hljs-string">list</span> <span class="hljs-string">of</span> <span class="hljs-string">pets.</span>
-<span class="hljs-attr">        content:</span>
-          <span class="hljs-string">application/json:</span>
-<span class="hljs-attr">            schema:</span>
-<span class="hljs-attr">              type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">              items:</span>
-                <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/pet'</span>
+  <span class="hljs-attr">get:</span>
+    <span class="hljs-attr">description:</span> <span class="hljs-string">Returns</span> <span class="hljs-string">all</span> <span class="hljs-string">pets</span> <span class="hljs-string">from</span> <span class="hljs-string">the</span> <span class="hljs-string">system</span> <span class="hljs-string">that</span> <span class="hljs-string">the</span> <span class="hljs-string">user</span> <span class="hljs-string">has</span> <span class="hljs-string">access</span> <span class="hljs-string">to</span>
+    <span class="hljs-attr">responses:</span>
+      <span class="hljs-attr">&#x27;200&#x27;:</span>
+        <span class="hljs-attr">description:</span> <span class="hljs-string">A</span> <span class="hljs-string">list</span> <span class="hljs-string">of</span> <span class="hljs-string">pets.</span>
+        <span class="hljs-attr">content:</span>
+          <span class="hljs-attr">application/json:</span>
+            <span class="hljs-attr">schema:</span>
+              <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+              <span class="hljs-attr">items:</span>
+                <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/pet&#x27;</span>
 </code></pre>
 </section></section><section><h3><span id="pathItemObject">Path Item Object</span></h3>
 <p>Describes the operations available on a single path.
@@ -901,7 +901,7 @@ The path itself is still exposed to the documentation viewer but they will not k
 </tr>
 <tr>
 <td><a id="pathItemParameters"> </a>parameters</td>
-<td style="text-align:center">[<a href="#parameterObject">Parameter Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:center">[<a href="#parameterObject">Parameter Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>A list of parameters that are applicable for all the operations described under this path. These parameters can be overridden at the operation level, but cannot be removed there. The list MUST NOT include duplicated parameters. A unique parameter is defined by a combination of a <a href="#parameterName">name</a> and <a href="#parameterIn">location</a>. The list can use the <a href="#referenceObject">Reference Object</a> to link to parameters that are defined at the <a href="#componentsParameters">OpenAPI Object’s components/parameters</a>.</td>
 </tr>
 </tbody>
@@ -910,83 +910,83 @@ The path itself is still exposed to the documentation viewer but they will not k
 </section><section><h4>Path Item Object Example</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"get"</span>: {
-    <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Returns pets based on ID"</span>,
-    <span class="hljs-attr">"summary"</span>: <span class="hljs-string">"Find pets by ID"</span>,
-    <span class="hljs-attr">"operationId"</span>: <span class="hljs-string">"getPetsById"</span>,
-    <span class="hljs-attr">"responses"</span>: {
-      <span class="hljs-attr">"200"</span>: {
-        <span class="hljs-attr">"description"</span>: <span class="hljs-string">"pet response"</span>,
-        <span class="hljs-attr">"content"</span>: {
-          <span class="hljs-attr">"*/*"</span>: {
-            <span class="hljs-attr">"schema"</span>: {
-              <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-              <span class="hljs-attr">"items"</span>: {
-                <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/Pet"</span>
+  <span class="hljs-attr">&quot;get&quot;</span>: {
+    <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;Returns pets based on ID&quot;</span>,
+    <span class="hljs-attr">&quot;summary&quot;</span>: <span class="hljs-string">&quot;Find pets by ID&quot;</span>,
+    <span class="hljs-attr">&quot;operationId&quot;</span>: <span class="hljs-string">&quot;getPetsById&quot;</span>,
+    <span class="hljs-attr">&quot;responses&quot;</span>: {
+      <span class="hljs-attr">&quot;200&quot;</span>: {
+        <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;pet response&quot;</span>,
+        <span class="hljs-attr">&quot;content&quot;</span>: {
+          <span class="hljs-attr">&quot;*/*&quot;</span>: {
+            <span class="hljs-attr">&quot;schema&quot;</span>: {
+              <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+              <span class="hljs-attr">&quot;items&quot;</span>: {
+                <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/Pet&quot;</span>
               }
             }
           }
         }
       },
-      <span class="hljs-attr">"default"</span>: {
-        <span class="hljs-attr">"description"</span>: <span class="hljs-string">"error payload"</span>,
-        <span class="hljs-attr">"content"</span>: {
-          <span class="hljs-attr">"text/html"</span>: {
-            <span class="hljs-attr">"schema"</span>: {
-              <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/ErrorModel"</span>
+      <span class="hljs-attr">&quot;default&quot;</span>: {
+        <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;error payload&quot;</span>,
+        <span class="hljs-attr">&quot;content&quot;</span>: {
+          <span class="hljs-attr">&quot;text/html&quot;</span>: {
+            <span class="hljs-attr">&quot;schema&quot;</span>: {
+              <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/ErrorModel&quot;</span>
             }
           }
         }
       }
     }
   },
-  <span class="hljs-attr">"parameters"</span>: [
+  <span class="hljs-attr">&quot;parameters&quot;</span>: [
     {
-      <span class="hljs-attr">"name"</span>: <span class="hljs-string">"id"</span>,
-      <span class="hljs-attr">"in"</span>: <span class="hljs-string">"path"</span>,
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"ID of pet to use"</span>,
-      <span class="hljs-attr">"required"</span>: <span class="hljs-literal">true</span>,
-      <span class="hljs-attr">"schema"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-        <span class="hljs-attr">"items"</span>: {
-          <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+      <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;id&quot;</span>,
+      <span class="hljs-attr">&quot;in&quot;</span>: <span class="hljs-string">&quot;path&quot;</span>,
+      <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;ID of pet to use&quot;</span>,
+      <span class="hljs-attr">&quot;required&quot;</span>: <span class="hljs-literal">true</span>,
+      <span class="hljs-attr">&quot;schema&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+        <span class="hljs-attr">&quot;items&quot;</span>: {
+          <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
         }
       },
-      <span class="hljs-attr">"style"</span>: <span class="hljs-string">"simple"</span>
+      <span class="hljs-attr">&quot;style&quot;</span>: <span class="hljs-string">&quot;simple&quot;</span>
     }
   ]
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">get:</span>
-<span class="hljs-attr">  description:</span> <span class="hljs-string">Returns</span> <span class="hljs-string">pets</span> <span class="hljs-string">based</span> <span class="hljs-string">on</span> <span class="hljs-string">ID</span>
-<span class="hljs-attr">  summary:</span> <span class="hljs-string">Find</span> <span class="hljs-string">pets</span> <span class="hljs-string">by</span> <span class="hljs-string">ID</span>
-<span class="hljs-attr">  operationId:</span> <span class="hljs-string">getPetsById</span>
-<span class="hljs-attr">  responses:</span>
-    <span class="hljs-string">'200'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">      description:</span> <span class="hljs-string">pet</span> <span class="hljs-string">response</span>
-<span class="hljs-attr">      content:</span>
-        <span class="hljs-string">'*/*'</span> <span class="hljs-string">:</span>
-<span class="hljs-attr">          schema:</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">            items:</span>
-              <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Pet'</span>
-<span class="hljs-attr">    default:</span>
-<span class="hljs-attr">      description:</span> <span class="hljs-string">error</span> <span class="hljs-string">payload</span>
-<span class="hljs-attr">      content:</span>
-        <span class="hljs-string">'text/html'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">          schema:</span>
-            <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/ErrorModel'</span>
+  <span class="hljs-attr">description:</span> <span class="hljs-string">Returns</span> <span class="hljs-string">pets</span> <span class="hljs-string">based</span> <span class="hljs-string">on</span> <span class="hljs-string">ID</span>
+  <span class="hljs-attr">summary:</span> <span class="hljs-string">Find</span> <span class="hljs-string">pets</span> <span class="hljs-string">by</span> <span class="hljs-string">ID</span>
+  <span class="hljs-attr">operationId:</span> <span class="hljs-string">getPetsById</span>
+  <span class="hljs-attr">responses:</span>
+    <span class="hljs-attr">&#x27;200&#x27;:</span>
+      <span class="hljs-attr">description:</span> <span class="hljs-string">pet</span> <span class="hljs-string">response</span>
+      <span class="hljs-attr">content:</span>
+        <span class="hljs-string">&#x27;*/*&#x27;</span> <span class="hljs-string">:</span>
+          <span class="hljs-attr">schema:</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+            <span class="hljs-attr">items:</span>
+              <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/Pet&#x27;</span>
+    <span class="hljs-attr">default:</span>
+      <span class="hljs-attr">description:</span> <span class="hljs-string">error</span> <span class="hljs-string">payload</span>
+      <span class="hljs-attr">content:</span>
+        <span class="hljs-attr">&#x27;text/html&#x27;:</span>
+          <span class="hljs-attr">schema:</span>
+            <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/ErrorModel&#x27;</span>
 <span class="hljs-attr">parameters:</span>
-<span class="hljs-attr">- name:</span> <span class="hljs-string">id</span>
-<span class="hljs-attr">  in:</span> <span class="hljs-string">path</span>
-<span class="hljs-attr">  description:</span> <span class="hljs-string">ID</span> <span class="hljs-string">of</span> <span class="hljs-string">pet</span> <span class="hljs-string">to</span> <span class="hljs-string">use</span>
-<span class="hljs-attr">  required:</span> <span class="hljs-literal">true</span>
-<span class="hljs-attr">  schema:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">    style:</span> <span class="hljs-string">simple</span>
-<span class="hljs-attr">    items:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">string</span>  
+<span class="hljs-bullet">-</span> <span class="hljs-attr">name:</span> <span class="hljs-string">id</span>
+  <span class="hljs-attr">in:</span> <span class="hljs-string">path</span>
+  <span class="hljs-attr">description:</span> <span class="hljs-string">ID</span> <span class="hljs-string">of</span> <span class="hljs-string">pet</span> <span class="hljs-string">to</span> <span class="hljs-string">use</span>
+  <span class="hljs-attr">required:</span> <span class="hljs-literal">true</span>
+  <span class="hljs-attr">schema:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+    <span class="hljs-attr">style:</span> <span class="hljs-string">simple</span>
+    <span class="hljs-attr">items:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>  
 </code></pre>
 </section></section><section><h3><span id="operationObject">Operation Object</span></h3>
 <p>Describes a single API operation on a path.</p>
@@ -1027,12 +1027,12 @@ The path itself is still exposed to the documentation viewer but they will not k
 </tr>
 <tr>
 <td><a id="operationParameters"> </a>parameters</td>
-<td style="text-align:center">[<a href="#parameterObject">Parameter Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:center">[<a href="#parameterObject">Parameter Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>A list of parameters that are applicable for this operation. If a parameter is already defined at the <a href="#pathItemParameters">Path Item</a>, the new definition will override it but can never remove it. The list MUST NOT include duplicated parameters. A unique parameter is defined by a combination of a <a href="#parameterName">name</a> and <a href="#parameterIn">location</a>. The list can use the <a href="#referenceObject">Reference Object</a> to link to parameters that are defined at the <a href="#componentsParameters">OpenAPI Object’s components/parameters</a>.</td>
 </tr>
 <tr>
 <td><a id="operationRequestBody"> </a>requestBody</td>
-<td style="text-align:center"><a href="#requestBodyObject">Request Body Object</a> ¦ <a href="#referenceObject">Reference Object</a></td>
+<td style="text-align:center"><a href="#requestBodyObject">Request Body Object</a> | <a href="#referenceObject">Reference Object</a></td>
 <td>The request body applicable for this operation.  The <code>requestBody</code> is only supported in HTTP methods where the HTTP 1.1 specification [[!RFC7231]] has explicitly defined semantics for request bodies.  In other cases where the HTTP spec is vague, <code>requestBody</code> SHALL be ignored by consumers.</td>
 </tr>
 <tr>
@@ -1042,7 +1042,7 @@ The path itself is still exposed to the documentation viewer but they will not k
 </tr>
 <tr>
 <td><a id="operationCallbacks"> </a>callbacks</td>
-<td style="text-align:center">Map[<code>string</code>, <a href="#callbackObject">Callback Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:center">Map[<code>string</code>, <a href="#callbackObject">Callback Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>A map of possible out-of band callbacks related to the parent operation. The key is a unique identifier for the Callback Object. Each value in the map is a <a href="#callbackObject">Callback Object</a> that describes a request that may be initiated by the API provider and the expected responses. The key value used to identify the callback object is an expression, evaluated at runtime, that identifies a URL to use for the callback operation.</td>
 </tr>
 <tr>
@@ -1066,63 +1066,63 @@ The path itself is still exposed to the documentation viewer but they will not k
 </section><section><h4>Operation Object Example</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"tags"</span>: [
-    <span class="hljs-string">"pet"</span>
+  <span class="hljs-attr">&quot;tags&quot;</span>: [
+    <span class="hljs-string">&quot;pet&quot;</span>
   ],
-  <span class="hljs-attr">"summary"</span>: <span class="hljs-string">"Updates a pet in the store with form data"</span>,
-  <span class="hljs-attr">"operationId"</span>: <span class="hljs-string">"updatePetWithForm"</span>,
-  <span class="hljs-attr">"parameters"</span>: [
+  <span class="hljs-attr">&quot;summary&quot;</span>: <span class="hljs-string">&quot;Updates a pet in the store with form data&quot;</span>,
+  <span class="hljs-attr">&quot;operationId&quot;</span>: <span class="hljs-string">&quot;updatePetWithForm&quot;</span>,
+  <span class="hljs-attr">&quot;parameters&quot;</span>: [
     {
-      <span class="hljs-attr">"name"</span>: <span class="hljs-string">"petId"</span>,
-      <span class="hljs-attr">"in"</span>: <span class="hljs-string">"path"</span>,
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"ID of pet that needs to be updated"</span>,
-      <span class="hljs-attr">"required"</span>: <span class="hljs-literal">true</span>,
-      <span class="hljs-attr">"schema"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+      <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;petId&quot;</span>,
+      <span class="hljs-attr">&quot;in&quot;</span>: <span class="hljs-string">&quot;path&quot;</span>,
+      <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;ID of pet that needs to be updated&quot;</span>,
+      <span class="hljs-attr">&quot;required&quot;</span>: <span class="hljs-literal">true</span>,
+      <span class="hljs-attr">&quot;schema&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
       }
     }
   ],
-  <span class="hljs-attr">"requestBody"</span>: {
-    <span class="hljs-attr">"content"</span>: {
-      <span class="hljs-attr">"application/x-www-form-urlencoded"</span>: {
-        <span class="hljs-attr">"schema"</span>: {
-          <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-           <span class="hljs-attr">"properties"</span>: {
-              <span class="hljs-attr">"name"</span>: { 
-                <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Updated name of the pet"</span>,
-                <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+  <span class="hljs-attr">&quot;requestBody&quot;</span>: {
+    <span class="hljs-attr">&quot;content&quot;</span>: {
+      <span class="hljs-attr">&quot;application/x-www-form-urlencoded&quot;</span>: {
+        <span class="hljs-attr">&quot;schema&quot;</span>: {
+          <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+           <span class="hljs-attr">&quot;properties&quot;</span>: {
+              <span class="hljs-attr">&quot;name&quot;</span>: { 
+                <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;Updated name of the pet&quot;</span>,
+                <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
               },
-              <span class="hljs-attr">"status"</span>: {
-                <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Updated status of the pet"</span>,
-                <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+              <span class="hljs-attr">&quot;status&quot;</span>: {
+                <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;Updated status of the pet&quot;</span>,
+                <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
              }
            },
-        <span class="hljs-attr">"required"</span>: [<span class="hljs-string">"status"</span>] 
+        <span class="hljs-attr">&quot;required&quot;</span>: [<span class="hljs-string">&quot;status&quot;</span>] 
         }
       }
     }
   },
-  <span class="hljs-attr">"responses"</span>: {
-    <span class="hljs-attr">"200"</span>: {
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Pet updated."</span>,
-      <span class="hljs-attr">"content"</span>: {
-        <span class="hljs-attr">"application/json"</span>: {},
-        <span class="hljs-attr">"application/xml"</span>: {}
+  <span class="hljs-attr">&quot;responses&quot;</span>: {
+    <span class="hljs-attr">&quot;200&quot;</span>: {
+      <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;Pet updated.&quot;</span>,
+      <span class="hljs-attr">&quot;content&quot;</span>: {
+        <span class="hljs-attr">&quot;application/json&quot;</span>: {},
+        <span class="hljs-attr">&quot;application/xml&quot;</span>: {}
       }
     },
-    <span class="hljs-attr">"405"</span>: {
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Method Not Allowed"</span>,
-      <span class="hljs-attr">"content"</span>: {
-        <span class="hljs-attr">"application/json"</span>: {},
-        <span class="hljs-attr">"application/xml"</span>: {}
+    <span class="hljs-attr">&quot;405&quot;</span>: {
+      <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;Method Not Allowed&quot;</span>,
+      <span class="hljs-attr">&quot;content&quot;</span>: {
+        <span class="hljs-attr">&quot;application/json&quot;</span>: {},
+        <span class="hljs-attr">&quot;application/xml&quot;</span>: {}
       }
     }
   },
-  <span class="hljs-attr">"security"</span>: [
+  <span class="hljs-attr">&quot;security&quot;</span>: [
     {
-      <span class="hljs-attr">"petstore_auth"</span>: [
-        <span class="hljs-string">"write:pets"</span>,
-        <span class="hljs-string">"read:pets"</span>
+      <span class="hljs-attr">&quot;petstore_auth&quot;</span>: [
+        <span class="hljs-string">&quot;write:pets&quot;</span>,
+        <span class="hljs-string">&quot;read:pets&quot;</span>
       ]
     }
   ]
@@ -1134,40 +1134,40 @@ The path itself is still exposed to the documentation viewer but they will not k
 <span class="hljs-attr">summary:</span> <span class="hljs-string">Updates</span> <span class="hljs-string">a</span> <span class="hljs-string">pet</span> <span class="hljs-string">in</span> <span class="hljs-string">the</span> <span class="hljs-string">store</span> <span class="hljs-string">with</span> <span class="hljs-string">form</span> <span class="hljs-string">data</span>
 <span class="hljs-attr">operationId:</span> <span class="hljs-string">updatePetWithForm</span>
 <span class="hljs-attr">parameters:</span>
-<span class="hljs-attr">- name:</span> <span class="hljs-string">petId</span>
-<span class="hljs-attr">  in:</span> <span class="hljs-string">path</span>
-<span class="hljs-attr">  description:</span> <span class="hljs-string">ID</span> <span class="hljs-string">of</span> <span class="hljs-string">pet</span> <span class="hljs-string">that</span> <span class="hljs-string">needs</span> <span class="hljs-string">to</span> <span class="hljs-string">be</span> <span class="hljs-string">updated</span>
-<span class="hljs-attr">  required:</span> <span class="hljs-literal">true</span>
-<span class="hljs-attr">  schema:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">string</span>
+<span class="hljs-bullet">-</span> <span class="hljs-attr">name:</span> <span class="hljs-string">petId</span>
+  <span class="hljs-attr">in:</span> <span class="hljs-string">path</span>
+  <span class="hljs-attr">description:</span> <span class="hljs-string">ID</span> <span class="hljs-string">of</span> <span class="hljs-string">pet</span> <span class="hljs-string">that</span> <span class="hljs-string">needs</span> <span class="hljs-string">to</span> <span class="hljs-string">be</span> <span class="hljs-string">updated</span>
+  <span class="hljs-attr">required:</span> <span class="hljs-literal">true</span>
+  <span class="hljs-attr">schema:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
 <span class="hljs-attr">requestBody:</span>
-<span class="hljs-attr">  content:</span>
-    <span class="hljs-string">'application/x-www-form-urlencoded'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">      schema:</span>
-<span class="hljs-attr">       properties:</span>
-<span class="hljs-attr">          name:</span> 
-<span class="hljs-attr">            description:</span> <span class="hljs-string">Updated</span> <span class="hljs-string">name</span> <span class="hljs-string">of</span> <span class="hljs-string">the</span> <span class="hljs-string">pet</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">          status:</span>
-<span class="hljs-attr">            description:</span> <span class="hljs-string">Updated</span> <span class="hljs-string">status</span> <span class="hljs-string">of</span> <span class="hljs-string">the</span> <span class="hljs-string">pet</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">       required:</span>
-<span class="hljs-bullet">         -</span> <span class="hljs-string">status</span>
+  <span class="hljs-attr">content:</span>
+    <span class="hljs-attr">&#x27;application/x-www-form-urlencoded&#x27;:</span>
+      <span class="hljs-attr">schema:</span>
+       <span class="hljs-attr">properties:</span>
+          <span class="hljs-attr">name:</span> 
+            <span class="hljs-attr">description:</span> <span class="hljs-string">Updated</span> <span class="hljs-string">name</span> <span class="hljs-string">of</span> <span class="hljs-string">the</span> <span class="hljs-string">pet</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+          <span class="hljs-attr">status:</span>
+            <span class="hljs-attr">description:</span> <span class="hljs-string">Updated</span> <span class="hljs-string">status</span> <span class="hljs-string">of</span> <span class="hljs-string">the</span> <span class="hljs-string">pet</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+       <span class="hljs-attr">required:</span>
+         <span class="hljs-bullet">-</span> <span class="hljs-string">status</span>
 <span class="hljs-attr">responses:</span>
-  <span class="hljs-string">'200'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">    description:</span> <span class="hljs-string">Pet</span> <span class="hljs-string">updated.</span>
-<span class="hljs-attr">    content:</span> 
-      <span class="hljs-string">'application/json'</span><span class="hljs-string">:</span> <span class="hljs-string">{}</span>
-      <span class="hljs-string">'application/xml'</span><span class="hljs-string">:</span> <span class="hljs-string">{}</span>
-  <span class="hljs-string">'405'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">    description:</span> <span class="hljs-string">Method</span> <span class="hljs-string">Not</span> <span class="hljs-string">Allowed</span>
-<span class="hljs-attr">    content:</span> 
-      <span class="hljs-string">'application/json'</span><span class="hljs-string">:</span> <span class="hljs-string">{}</span>
-      <span class="hljs-string">'application/xml'</span><span class="hljs-string">:</span> <span class="hljs-string">{}</span>
+  <span class="hljs-attr">&#x27;200&#x27;:</span>
+    <span class="hljs-attr">description:</span> <span class="hljs-string">Pet</span> <span class="hljs-string">updated.</span>
+    <span class="hljs-attr">content:</span> 
+      <span class="hljs-attr">&#x27;application/json&#x27;:</span> {}
+      <span class="hljs-attr">&#x27;application/xml&#x27;:</span> {}
+  <span class="hljs-attr">&#x27;405&#x27;:</span>
+    <span class="hljs-attr">description:</span> <span class="hljs-string">Method</span> <span class="hljs-string">Not</span> <span class="hljs-string">Allowed</span>
+    <span class="hljs-attr">content:</span> 
+      <span class="hljs-attr">&#x27;application/json&#x27;:</span> {}
+      <span class="hljs-attr">&#x27;application/xml&#x27;:</span> {}
 <span class="hljs-attr">security:</span>
-<span class="hljs-attr">- petstore_auth:</span>
-<span class="hljs-attr">  - write:</span><span class="hljs-string">pets</span>
-<span class="hljs-attr">  - read:</span><span class="hljs-string">pets</span>
+<span class="hljs-bullet">-</span> <span class="hljs-attr">petstore_auth:</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-string">write:pets</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-string">read:pets</span>
 </code></pre>
 </section></section><section><h3><span id="externalDocumentationObject">External Documentation Object</span></h3>
 <p>Allows referencing an external resource for extended documentation.</p>
@@ -1197,13 +1197,13 @@ The path itself is still exposed to the documentation viewer but they will not k
 </section><section><h4>External Documentation Object Example</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Find more info here"</span>,
-  <span class="hljs-attr">"url"</span>: <span class="hljs-string">"https://example.com"</span>
+  <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;Find more info here&quot;</span>,
+  <span class="hljs-attr">&quot;url&quot;</span>: <span class="hljs-string">&quot;https://example.com&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">description:</span> <span class="hljs-string">Find</span> <span class="hljs-string">more</span> <span class="hljs-string">info</span> <span class="hljs-string">here</span>
-<span class="hljs-attr">url:</span> <span class="hljs-attr">https://example.com</span>
+<span class="hljs-attr">url:</span> <span class="hljs-string">https://example.com</span>
 </code></pre>
 </section></section><section><h3><span id="parameterObject">Parameter Object</span></h3>
 <p>Describes a single operation parameter.</p>
@@ -1286,7 +1286,7 @@ For simpler scenarios, a <a href="#parameterSchema"><code>schema</code></a> and 
 </tr>
 <tr>
 <td><a id="parameterSchema"> </a>schema</td>
-<td style="text-align:center"><a href="#schemaObject">Schema Object</a> ¦ <a href="#referenceObject">Reference Object</a></td>
+<td style="text-align:center"><a href="#schemaObject">Schema Object</a> | <a href="#referenceObject">Reference Object</a></td>
 <td>The schema defining the type used for the parameter.</td>
 </tr>
 <tr>
@@ -1296,7 +1296,7 @@ For simpler scenarios, a <a href="#parameterSchema"><code>schema</code></a> and 
 </tr>
 <tr>
 <td><a id="parameterExamples"> </a>examples</td>
-<td style="text-align:center">Map[ <code>string</code>, <a href="#exampleObject">Example Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:center">Map[ <code>string</code>, <a href="#exampleObject">Example Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>Examples of the media type.  Each example SHOULD contain a value in the correct format as specified in the parameter encoding.  The <code>examples</code> field is mutually exclusive of the <code>example</code> field.  Furthermore, if referencing a <code>schema</code> which contains an example, the <code>examples</code> value SHALL <em>override</em> the example provided by the schema.</td>
 </tr>
 </tbody>
@@ -1473,8 +1473,8 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 <td>false</td>
 <td>n/a</td>
 <td>n/a</td>
-<td>blue¦black¦brown</td>
-<td>R¦100¦G¦200</td>
+<td>blue|black|brown</td>
+<td>R|100|G|200</td>
 </tr>
 <tr>
 <td>deepObject</td>
@@ -1482,7 +1482,7 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 <td>n/a</td>
 <td>n/a</td>
 <td>n/a</td>
-<td>color\R=100&amp;color\G=200&amp;color\B=150</td>
+<td>color&#91;R&#93;=100&amp;color&#91;G&#93;=200&amp;color&#91;B&#93;=150</td>
 </tr>
 </tbody>
 </table>
@@ -1491,18 +1491,18 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 <p>A header parameter with an array of 64 bit integer numbers:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"name"</span>: <span class="hljs-string">"token"</span>,
-  <span class="hljs-attr">"in"</span>: <span class="hljs-string">"header"</span>,
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"token to be passed as a header"</span>,
-  <span class="hljs-attr">"required"</span>: <span class="hljs-literal">true</span>,
-  <span class="hljs-attr">"schema"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-    <span class="hljs-attr">"items"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>,
-      <span class="hljs-attr">"format"</span>: <span class="hljs-string">"int64"</span>
+  <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;token&quot;</span>,
+  <span class="hljs-attr">&quot;in&quot;</span>: <span class="hljs-string">&quot;header&quot;</span>,
+  <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;token to be passed as a header&quot;</span>,
+  <span class="hljs-attr">&quot;required&quot;</span>: <span class="hljs-literal">true</span>,
+  <span class="hljs-attr">&quot;schema&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+    <span class="hljs-attr">&quot;items&quot;</span>: {
+      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>,
+      <span class="hljs-attr">&quot;format&quot;</span>: <span class="hljs-string">&quot;int64&quot;</span>
     }
   },
-  <span class="hljs-attr">"style"</span>: <span class="hljs-string">"simple"</span>
+  <span class="hljs-attr">&quot;style&quot;</span>: <span class="hljs-string">&quot;simple&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -1511,21 +1511,21 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 <span class="hljs-attr">description:</span> <span class="hljs-string">token</span> <span class="hljs-string">to</span> <span class="hljs-string">be</span> <span class="hljs-string">passed</span> <span class="hljs-string">as</span> <span class="hljs-string">a</span> <span class="hljs-string">header</span>
 <span class="hljs-attr">required:</span> <span class="hljs-literal">true</span>
 <span class="hljs-attr">schema:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">  items:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">integer</span>
-<span class="hljs-attr">    format:</span> <span class="hljs-string">int64</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+  <span class="hljs-attr">items:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+    <span class="hljs-attr">format:</span> <span class="hljs-string">int64</span>
 <span class="hljs-attr">style:</span> <span class="hljs-string">simple</span>
 </code></pre>
 <p>A path parameter of a string value:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"name"</span>: <span class="hljs-string">"username"</span>,
-  <span class="hljs-attr">"in"</span>: <span class="hljs-string">"path"</span>,
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"username to fetch"</span>,
-  <span class="hljs-attr">"required"</span>: <span class="hljs-literal">true</span>,
-  <span class="hljs-attr">"schema"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+  <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;username&quot;</span>,
+  <span class="hljs-attr">&quot;in&quot;</span>: <span class="hljs-string">&quot;path&quot;</span>,
+  <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;username to fetch&quot;</span>,
+  <span class="hljs-attr">&quot;required&quot;</span>: <span class="hljs-literal">true</span>,
+  <span class="hljs-attr">&quot;schema&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
   }
 }
 </code></pre>
@@ -1535,23 +1535,23 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 <span class="hljs-attr">description:</span> <span class="hljs-string">username</span> <span class="hljs-string">to</span> <span class="hljs-string">fetch</span>
 <span class="hljs-attr">required:</span> <span class="hljs-literal">true</span>
 <span class="hljs-attr">schema:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
 </code></pre>
 <p>An optional query parameter of a string value, allowing multiple values by repeating the query parameter:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"name"</span>: <span class="hljs-string">"id"</span>,
-  <span class="hljs-attr">"in"</span>: <span class="hljs-string">"query"</span>,
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"ID of the object to fetch"</span>,
-  <span class="hljs-attr">"required"</span>: <span class="hljs-literal">false</span>,
-  <span class="hljs-attr">"schema"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-    <span class="hljs-attr">"items"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+  <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;id&quot;</span>,
+  <span class="hljs-attr">&quot;in&quot;</span>: <span class="hljs-string">&quot;query&quot;</span>,
+  <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;ID of the object to fetch&quot;</span>,
+  <span class="hljs-attr">&quot;required&quot;</span>: <span class="hljs-literal">false</span>,
+  <span class="hljs-attr">&quot;schema&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+    <span class="hljs-attr">&quot;items&quot;</span>: {
+      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
     }
   },
-  <span class="hljs-attr">"style"</span>: <span class="hljs-string">"form"</span>,
-  <span class="hljs-attr">"explode"</span>: <span class="hljs-literal">true</span>
+  <span class="hljs-attr">&quot;style&quot;</span>: <span class="hljs-string">&quot;form&quot;</span>,
+  <span class="hljs-attr">&quot;explode&quot;</span>: <span class="hljs-literal">true</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -1560,54 +1560,54 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 <span class="hljs-attr">description:</span> <span class="hljs-string">ID</span> <span class="hljs-string">of</span> <span class="hljs-string">the</span> <span class="hljs-string">object</span> <span class="hljs-string">to</span> <span class="hljs-string">fetch</span>
 <span class="hljs-attr">required:</span> <span class="hljs-literal">false</span>
 <span class="hljs-attr">schema:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">  items:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+  <span class="hljs-attr">items:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
 <span class="hljs-attr">style:</span> <span class="hljs-string">form</span>
 <span class="hljs-attr">explode:</span> <span class="hljs-literal">true</span>
 </code></pre>
 <p>A free-form query parameter, allowing undefined parameters of a specific type:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"in"</span>: <span class="hljs-string">"query"</span>,
-  <span class="hljs-attr">"name"</span>: <span class="hljs-string">"freeForm"</span>,
-  <span class="hljs-attr">"schema"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-    <span class="hljs-attr">"additionalProperties"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>
+  <span class="hljs-attr">&quot;in&quot;</span>: <span class="hljs-string">&quot;query&quot;</span>,
+  <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;freeForm&quot;</span>,
+  <span class="hljs-attr">&quot;schema&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+    <span class="hljs-attr">&quot;additionalProperties&quot;</span>: {
+      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>
     },
   },
-  <span class="hljs-attr">"style"</span>: <span class="hljs-string">"form"</span>
+  <span class="hljs-attr">&quot;style&quot;</span>: <span class="hljs-string">&quot;form&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">in:</span> <span class="hljs-string">query</span>
 <span class="hljs-attr">name:</span> <span class="hljs-string">freeForm</span>
 <span class="hljs-attr">schema:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">  additionalProperties:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">integer</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+  <span class="hljs-attr">additionalProperties:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
 <span class="hljs-attr">style:</span> <span class="hljs-string">form</span>
 </code></pre>
 <p>A complex parameter using <code>content</code> to define serialization:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"in"</span>: <span class="hljs-string">"query"</span>,
-  <span class="hljs-attr">"name"</span>: <span class="hljs-string">"coordinates"</span>,
-  <span class="hljs-attr">"content"</span>: {
-    <span class="hljs-attr">"application/json"</span>: {
-      <span class="hljs-attr">"schema"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-        <span class="hljs-attr">"required"</span>: [
-          <span class="hljs-string">"lat"</span>,
-          <span class="hljs-string">"long"</span>
+  <span class="hljs-attr">&quot;in&quot;</span>: <span class="hljs-string">&quot;query&quot;</span>,
+  <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;coordinates&quot;</span>,
+  <span class="hljs-attr">&quot;content&quot;</span>: {
+    <span class="hljs-attr">&quot;application/json&quot;</span>: {
+      <span class="hljs-attr">&quot;schema&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+        <span class="hljs-attr">&quot;required&quot;</span>: [
+          <span class="hljs-string">&quot;lat&quot;</span>,
+          <span class="hljs-string">&quot;long&quot;</span>
         ],
-        <span class="hljs-attr">"properties"</span>: {
-          <span class="hljs-attr">"lat"</span>: {
-            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"number"</span>
+        <span class="hljs-attr">&quot;properties&quot;</span>: {
+          <span class="hljs-attr">&quot;lat&quot;</span>: {
+            <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;number&quot;</span>
           },
-          <span class="hljs-attr">"long"</span>: {
-            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"number"</span>
+          <span class="hljs-attr">&quot;long&quot;</span>: {
+            <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;number&quot;</span>
           }
         }
       }
@@ -1619,17 +1619,17 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 <span class="hljs-attr">in:</span> <span class="hljs-string">query</span>
 <span class="hljs-attr">name:</span> <span class="hljs-string">coordinates</span>
 <span class="hljs-attr">content:</span>
-  <span class="hljs-string">application/json:</span>
-<span class="hljs-attr">    schema:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">      required:</span>
-<span class="hljs-bullet">        -</span> <span class="hljs-string">lat</span>
-<span class="hljs-bullet">        -</span> <span class="hljs-string">long</span>
-<span class="hljs-attr">      properties:</span>
-<span class="hljs-attr">        lat:</span>
-<span class="hljs-attr">          type:</span> <span class="hljs-string">number</span>
-<span class="hljs-attr">        long:</span>
-<span class="hljs-attr">          type:</span> <span class="hljs-string">number</span>
+  <span class="hljs-attr">application/json:</span>
+    <span class="hljs-attr">schema:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+      <span class="hljs-attr">required:</span>
+        <span class="hljs-bullet">-</span> <span class="hljs-string">lat</span>
+        <span class="hljs-bullet">-</span> <span class="hljs-string">long</span>
+      <span class="hljs-attr">properties:</span>
+        <span class="hljs-attr">lat:</span>
+          <span class="hljs-attr">type:</span> <span class="hljs-string">number</span>
+        <span class="hljs-attr">long:</span>
+          <span class="hljs-attr">type:</span> <span class="hljs-string">number</span>
 </code></pre>
 </section></section><section><h3><span id="requestBodyObject">Request Body Object</span></h3>
 <p>Describes a single request body.</p>
@@ -1665,43 +1665,43 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 <p>A request body with a referenced model definition.</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"user to add to the system"</span>,
-  <span class="hljs-attr">"content"</span>: {
-    <span class="hljs-attr">"application/json"</span>: {
-      <span class="hljs-attr">"schema"</span>: {
-        <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/User"</span>
+  <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;user to add to the system&quot;</span>,
+  <span class="hljs-attr">&quot;content&quot;</span>: {
+    <span class="hljs-attr">&quot;application/json&quot;</span>: {
+      <span class="hljs-attr">&quot;schema&quot;</span>: {
+        <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/User&quot;</span>
       },
-      <span class="hljs-attr">"examples"</span>: {
-          <span class="hljs-attr">"user"</span> : {
-            <span class="hljs-attr">"summary"</span>: <span class="hljs-string">"User Example"</span>, 
-            <span class="hljs-attr">"externalValue"</span>: <span class="hljs-string">"http://foo.bar/examples/user-example.json"</span>
+      <span class="hljs-attr">&quot;examples&quot;</span>: {
+          <span class="hljs-attr">&quot;user&quot;</span> : {
+            <span class="hljs-attr">&quot;summary&quot;</span>: <span class="hljs-string">&quot;User Example&quot;</span>, 
+            <span class="hljs-attr">&quot;externalValue&quot;</span>: <span class="hljs-string">&quot;http://foo.bar/examples/user-example.json&quot;</span>
           } 
         }
     },
-    <span class="hljs-attr">"application/xml"</span>: {
-      <span class="hljs-attr">"schema"</span>: {
-        <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/User"</span>
+    <span class="hljs-attr">&quot;application/xml&quot;</span>: {
+      <span class="hljs-attr">&quot;schema&quot;</span>: {
+        <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/User&quot;</span>
       },
-      <span class="hljs-attr">"examples"</span>: {
-          <span class="hljs-attr">"user"</span> : {
-            <span class="hljs-attr">"summary"</span>: <span class="hljs-string">"User example in XML"</span>,
-            <span class="hljs-attr">"externalValue"</span>: <span class="hljs-string">"http://foo.bar/examples/user-example.xml"</span>
+      <span class="hljs-attr">&quot;examples&quot;</span>: {
+          <span class="hljs-attr">&quot;user&quot;</span> : {
+            <span class="hljs-attr">&quot;summary&quot;</span>: <span class="hljs-string">&quot;User example in XML&quot;</span>,
+            <span class="hljs-attr">&quot;externalValue&quot;</span>: <span class="hljs-string">&quot;http://foo.bar/examples/user-example.xml&quot;</span>
           }
         }
     },
-    <span class="hljs-attr">"text/plain"</span>: {
-      <span class="hljs-attr">"examples"</span>: {
-        <span class="hljs-attr">"user"</span> : {
-            <span class="hljs-attr">"summary"</span>: <span class="hljs-string">"User example in Plain text"</span>,
-            <span class="hljs-attr">"externalValue"</span>: <span class="hljs-string">"http://foo.bar/examples/user-example.txt"</span> 
+    <span class="hljs-attr">&quot;text/plain&quot;</span>: {
+      <span class="hljs-attr">&quot;examples&quot;</span>: {
+        <span class="hljs-attr">&quot;user&quot;</span> : {
+            <span class="hljs-attr">&quot;summary&quot;</span>: <span class="hljs-string">&quot;User example in Plain text&quot;</span>,
+            <span class="hljs-attr">&quot;externalValue&quot;</span>: <span class="hljs-string">&quot;http://foo.bar/examples/user-example.txt&quot;</span> 
         }
       } 
     },
-    <span class="hljs-attr">"*/*"</span>: {
-      <span class="hljs-attr">"examples"</span>: {
-        <span class="hljs-attr">"user"</span> : {
-            <span class="hljs-attr">"summary"</span>: <span class="hljs-string">"User example in other format"</span>,
-            <span class="hljs-attr">"externalValue"</span>: <span class="hljs-string">"http://foo.bar/examples/user-example.whatever"</span>
+    <span class="hljs-attr">&quot;*/*&quot;</span>: {
+      <span class="hljs-attr">&quot;examples&quot;</span>: {
+        <span class="hljs-attr">&quot;user&quot;</span> : {
+            <span class="hljs-attr">&quot;summary&quot;</span>: <span class="hljs-string">&quot;User example in other format&quot;</span>,
+            <span class="hljs-attr">&quot;externalValue&quot;</span>: <span class="hljs-string">&quot;http://foo.bar/examples/user-example.whatever&quot;</span>
         }
       }
     }
@@ -1711,41 +1711,41 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 <pre class="nohighlight"><code>
 <span class="hljs-attr">description:</span> <span class="hljs-string">user</span> <span class="hljs-string">to</span> <span class="hljs-string">add</span> <span class="hljs-string">to</span> <span class="hljs-string">the</span> <span class="hljs-string">system</span>
 <span class="hljs-attr">content:</span> 
-  <span class="hljs-string">'application/json'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">    schema:</span>
-      <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/User'</span>
-<span class="hljs-attr">    examples:</span>
-<span class="hljs-attr">      user:</span>
-<span class="hljs-attr">        summary:</span> <span class="hljs-string">User</span> <span class="hljs-string">Example</span>
-<span class="hljs-attr">        externalValue:</span> <span class="hljs-string">'http://foo.bar/examples/user-example.json'</span>
-  <span class="hljs-string">'application/xml'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">    schema:</span>
-      <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/User'</span>
-<span class="hljs-attr">    examples:</span>
-<span class="hljs-attr">      user:</span>
-<span class="hljs-attr">        summary:</span> <span class="hljs-string">User</span> <span class="hljs-string">Example</span> <span class="hljs-string">in</span> <span class="hljs-string">XML</span>
-<span class="hljs-attr">        externalValue:</span> <span class="hljs-string">'http://foo.bar/examples/user-example.xml'</span>
-  <span class="hljs-string">'text/plain'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">    examples:</span>
-<span class="hljs-attr">      user:</span>
-<span class="hljs-attr">        summary:</span> <span class="hljs-string">User</span> <span class="hljs-string">example</span> <span class="hljs-string">in</span> <span class="hljs-string">text</span> <span class="hljs-string">plain</span> <span class="hljs-string">format</span>
-<span class="hljs-attr">        externalValue:</span> <span class="hljs-string">'http://foo.bar/examples/user-example.txt'</span>
-  <span class="hljs-string">'*/*'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">    examples:</span>
-<span class="hljs-attr">      user:</span> 
-<span class="hljs-attr">        summary:</span> <span class="hljs-string">User</span> <span class="hljs-string">example</span> <span class="hljs-string">in</span> <span class="hljs-string">other</span> <span class="hljs-string">format</span>
-<span class="hljs-attr">        externalValue:</span> <span class="hljs-string">'http://foo.bar/examples/user-example.whatever'</span>
+  <span class="hljs-attr">&#x27;application/json&#x27;:</span>
+    <span class="hljs-attr">schema:</span>
+      <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/User&#x27;</span>
+    <span class="hljs-attr">examples:</span>
+      <span class="hljs-attr">user:</span>
+        <span class="hljs-attr">summary:</span> <span class="hljs-string">User</span> <span class="hljs-string">Example</span>
+        <span class="hljs-attr">externalValue:</span> <span class="hljs-string">&#x27;http://foo.bar/examples/user-example.json&#x27;</span>
+  <span class="hljs-attr">&#x27;application/xml&#x27;:</span>
+    <span class="hljs-attr">schema:</span>
+      <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/User&#x27;</span>
+    <span class="hljs-attr">examples:</span>
+      <span class="hljs-attr">user:</span>
+        <span class="hljs-attr">summary:</span> <span class="hljs-string">User</span> <span class="hljs-string">Example</span> <span class="hljs-string">in</span> <span class="hljs-string">XML</span>
+        <span class="hljs-attr">externalValue:</span> <span class="hljs-string">&#x27;http://foo.bar/examples/user-example.xml&#x27;</span>
+  <span class="hljs-attr">&#x27;text/plain&#x27;:</span>
+    <span class="hljs-attr">examples:</span>
+      <span class="hljs-attr">user:</span>
+        <span class="hljs-attr">summary:</span> <span class="hljs-string">User</span> <span class="hljs-string">example</span> <span class="hljs-string">in</span> <span class="hljs-string">text</span> <span class="hljs-string">plain</span> <span class="hljs-string">format</span>
+        <span class="hljs-attr">externalValue:</span> <span class="hljs-string">&#x27;http://foo.bar/examples/user-example.txt&#x27;</span>
+  <span class="hljs-string">&#x27;*/*&#x27;</span><span class="hljs-string">:</span>
+    <span class="hljs-attr">examples:</span>
+      <span class="hljs-attr">user:</span> 
+        <span class="hljs-attr">summary:</span> <span class="hljs-string">User</span> <span class="hljs-string">example</span> <span class="hljs-string">in</span> <span class="hljs-string">other</span> <span class="hljs-string">format</span>
+        <span class="hljs-attr">externalValue:</span> <span class="hljs-string">&#x27;http://foo.bar/examples/user-example.whatever&#x27;</span>
 </code></pre>
 <p>A body parameter that is an array of string values:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"user to add to the system"</span>,
-  <span class="hljs-attr">"content"</span>: {
-    <span class="hljs-attr">"text/plain"</span>: {
-      <span class="hljs-attr">"schema"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-        <span class="hljs-attr">"items"</span>: {
-          <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+  <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;user to add to the system&quot;</span>,
+  <span class="hljs-attr">&quot;content&quot;</span>: {
+    <span class="hljs-attr">&quot;text/plain&quot;</span>: {
+      <span class="hljs-attr">&quot;schema&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+        <span class="hljs-attr">&quot;items&quot;</span>: {
+          <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
         }
       }
     }
@@ -1756,11 +1756,11 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 <span class="hljs-attr">description:</span> <span class="hljs-string">user</span> <span class="hljs-string">to</span> <span class="hljs-string">add</span> <span class="hljs-string">to</span> <span class="hljs-string">the</span> <span class="hljs-string">system</span>
 <span class="hljs-attr">required:</span> <span class="hljs-literal">true</span>
 <span class="hljs-attr">content:</span>
-  <span class="hljs-string">text/plain:</span>
-<span class="hljs-attr">    schema:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">      items:</span>
-<span class="hljs-attr">        type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">text/plain:</span>
+    <span class="hljs-attr">schema:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+      <span class="hljs-attr">items:</span>
+        <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
 </code></pre>
 </section></section><section><h3><span id="mediaTypeObject">Media Type Object</span></h3>
 <p>Each Media Type Object provides schema and examples for the media type identified by its key.</p>
@@ -1776,7 +1776,7 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 <tbody>
 <tr>
 <td><a id="mediaTypeSchema"> </a>schema</td>
-<td style="text-align:center"><a href="#schemaObject">Schema Object</a> ¦ <a href="#referenceObject">Reference Object</a></td>
+<td style="text-align:center"><a href="#schemaObject">Schema Object</a> | <a href="#referenceObject">Reference Object</a></td>
 <td>The schema defining the content of the request, response, or parameter.</td>
 </tr>
 <tr>
@@ -1786,7 +1786,7 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 </tr>
 <tr>
 <td><a id="mediaTypeExamples"> </a>examples</td>
-<td style="text-align:center">Map[ <code>string</code>, <a href="#exampleObject">Example Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:center">Map[ <code>string</code>, <a href="#exampleObject">Example Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>Examples of the media type.  Each example object SHOULD  match the media type and specified schema if present.  The <code>examples</code> field is mutually exclusive of the <code>example</code> field.  Furthermore, if referencing a <code>schema</code> which contains an example, the <code>examples</code> value SHALL <em>override</em> the example provided by the schema.</td>
 </tr>
 <tr>
@@ -1800,33 +1800,33 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 </section><section><h4>Media Type Examples</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"application/json"</span>: {
-    <span class="hljs-attr">"schema"</span>: {
-         <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/Pet"</span>
+  <span class="hljs-attr">&quot;application/json&quot;</span>: {
+    <span class="hljs-attr">&quot;schema&quot;</span>: {
+         <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/Pet&quot;</span>
     },
-    <span class="hljs-attr">"examples"</span>: {
-      <span class="hljs-attr">"cat"</span> : {
-        <span class="hljs-attr">"summary"</span>: <span class="hljs-string">"An example of a cat"</span>,
-        <span class="hljs-attr">"value"</span>: 
+    <span class="hljs-attr">&quot;examples&quot;</span>: {
+      <span class="hljs-attr">&quot;cat&quot;</span> : {
+        <span class="hljs-attr">&quot;summary&quot;</span>: <span class="hljs-string">&quot;An example of a cat&quot;</span>,
+        <span class="hljs-attr">&quot;value&quot;</span>: 
           {
-            <span class="hljs-attr">"name"</span>: <span class="hljs-string">"Fluffy"</span>,
-            <span class="hljs-attr">"petType"</span>: <span class="hljs-string">"Cat"</span>,
-            <span class="hljs-attr">"color"</span>: <span class="hljs-string">"White"</span>,
-            <span class="hljs-attr">"gender"</span>: <span class="hljs-string">"male"</span>,
-            <span class="hljs-attr">"breed"</span>: <span class="hljs-string">"Persian"</span>
+            <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;Fluffy&quot;</span>,
+            <span class="hljs-attr">&quot;petType&quot;</span>: <span class="hljs-string">&quot;Cat&quot;</span>,
+            <span class="hljs-attr">&quot;color&quot;</span>: <span class="hljs-string">&quot;White&quot;</span>,
+            <span class="hljs-attr">&quot;gender&quot;</span>: <span class="hljs-string">&quot;male&quot;</span>,
+            <span class="hljs-attr">&quot;breed&quot;</span>: <span class="hljs-string">&quot;Persian&quot;</span>
           }
       },
-      <span class="hljs-attr">"dog"</span>: {
-        <span class="hljs-attr">"summary"</span>: <span class="hljs-string">"An example of a dog with a cat's name"</span>,
-        <span class="hljs-attr">"value"</span> :  { 
-          <span class="hljs-attr">"name"</span>: <span class="hljs-string">"Puma"</span>,
-          <span class="hljs-attr">"petType"</span>: <span class="hljs-string">"Dog"</span>,
-          <span class="hljs-attr">"color"</span>: <span class="hljs-string">"Black"</span>,
-          <span class="hljs-attr">"gender"</span>: <span class="hljs-string">"Female"</span>,
-          <span class="hljs-attr">"breed"</span>: <span class="hljs-string">"Mixed"</span>
+      <span class="hljs-attr">&quot;dog&quot;</span>: {
+        <span class="hljs-attr">&quot;summary&quot;</span>: <span class="hljs-string">&quot;An example of a dog with a cat&#x27;s name&quot;</span>,
+        <span class="hljs-attr">&quot;value&quot;</span> :  { 
+          <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;Puma&quot;</span>,
+          <span class="hljs-attr">&quot;petType&quot;</span>: <span class="hljs-string">&quot;Dog&quot;</span>,
+          <span class="hljs-attr">&quot;color&quot;</span>: <span class="hljs-string">&quot;Black&quot;</span>,
+          <span class="hljs-attr">&quot;gender&quot;</span>: <span class="hljs-string">&quot;Female&quot;</span>,
+          <span class="hljs-attr">&quot;breed&quot;</span>: <span class="hljs-string">&quot;Mixed&quot;</span>
         },
-      <span class="hljs-attr">"frog"</span>: {
-          <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/examples/frog-example"</span>
+      <span class="hljs-attr">&quot;frog&quot;</span>: {
+          <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/examples/frog-example&quot;</span>
         }
       }
     }
@@ -1834,83 +1834,83 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 }
 </code></pre>
 <pre class="nohighlight"><code>
-<span class="hljs-string">application/json:</span> 
-<span class="hljs-attr">  schema:</span>
-    <span class="hljs-string">$ref:</span> <span class="hljs-string">"#/components/schemas/Pet"</span>
-<span class="hljs-attr">  examples:</span>
-<span class="hljs-attr">    cat:</span>
-<span class="hljs-attr">      summary:</span> <span class="hljs-string">An</span> <span class="hljs-string">example</span> <span class="hljs-string">of</span> <span class="hljs-string">a</span> <span class="hljs-string">cat</span>
-<span class="hljs-attr">      value:</span>
-<span class="hljs-attr">        name:</span> <span class="hljs-string">Fluffy</span>
-<span class="hljs-attr">        petType:</span> <span class="hljs-string">Cat</span>
-<span class="hljs-attr">        color:</span> <span class="hljs-string">White</span>
-<span class="hljs-attr">        gender:</span> <span class="hljs-string">male</span>
-<span class="hljs-attr">        breed:</span> <span class="hljs-string">Persian</span>
-<span class="hljs-attr">    dog:</span>
-<span class="hljs-attr">      summary:</span> <span class="hljs-string">An</span> <span class="hljs-string">example</span> <span class="hljs-string">of</span> <span class="hljs-string">a</span> <span class="hljs-string">dog</span> <span class="hljs-string">with</span> <span class="hljs-string">a</span> <span class="hljs-string">cat's</span> <span class="hljs-string">name</span>
-<span class="hljs-attr">      value:</span>
-<span class="hljs-attr">        name:</span> <span class="hljs-string">Puma</span>
-<span class="hljs-attr">        petType:</span> <span class="hljs-string">Dog</span>
-<span class="hljs-attr">        color:</span> <span class="hljs-string">Black</span>
-<span class="hljs-attr">        gender:</span> <span class="hljs-string">Female</span>
-<span class="hljs-attr">        breed:</span> <span class="hljs-string">Mixed</span>
-<span class="hljs-attr">    frog:</span>
-      <span class="hljs-string">$ref:</span> <span class="hljs-string">"#/components/examples/frog-example"</span>
+<span class="hljs-attr">application/json:</span> 
+  <span class="hljs-attr">schema:</span>
+    <span class="hljs-string">$ref:</span> <span class="hljs-string">&quot;#/components/schemas/Pet&quot;</span>
+  <span class="hljs-attr">examples:</span>
+    <span class="hljs-attr">cat:</span>
+      <span class="hljs-attr">summary:</span> <span class="hljs-string">An</span> <span class="hljs-string">example</span> <span class="hljs-string">of</span> <span class="hljs-string">a</span> <span class="hljs-string">cat</span>
+      <span class="hljs-attr">value:</span>
+        <span class="hljs-attr">name:</span> <span class="hljs-string">Fluffy</span>
+        <span class="hljs-attr">petType:</span> <span class="hljs-string">Cat</span>
+        <span class="hljs-attr">color:</span> <span class="hljs-string">White</span>
+        <span class="hljs-attr">gender:</span> <span class="hljs-string">male</span>
+        <span class="hljs-attr">breed:</span> <span class="hljs-string">Persian</span>
+    <span class="hljs-attr">dog:</span>
+      <span class="hljs-attr">summary:</span> <span class="hljs-string">An</span> <span class="hljs-string">example</span> <span class="hljs-string">of</span> <span class="hljs-string">a</span> <span class="hljs-string">dog</span> <span class="hljs-string">with</span> <span class="hljs-string">a</span> <span class="hljs-string">cat&#x27;s</span> <span class="hljs-string">name</span>
+      <span class="hljs-attr">value:</span>
+        <span class="hljs-attr">name:</span> <span class="hljs-string">Puma</span>
+        <span class="hljs-attr">petType:</span> <span class="hljs-string">Dog</span>
+        <span class="hljs-attr">color:</span> <span class="hljs-string">Black</span>
+        <span class="hljs-attr">gender:</span> <span class="hljs-string">Female</span>
+        <span class="hljs-attr">breed:</span> <span class="hljs-string">Mixed</span>
+    <span class="hljs-attr">frog:</span>
+      <span class="hljs-string">$ref:</span> <span class="hljs-string">&quot;#/components/examples/frog-example&quot;</span>
 </code></pre>
 </section><section><h4>Considerations for File Uploads</h4>
 <p>In contrast with the 2.0 specification, <code>file</code> input/output content in OpenAPI is described with the same semantics as any other schema type. Specifically:</p>
 <pre class="nohighlight"><code>
 <span class="hljs-comment"># content transferred with base64 encoding</span>
 <span class="hljs-attr">schema:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">  format:</span> <span class="hljs-string">base64</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">format:</span> <span class="hljs-string">base64</span>
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-comment"># content transferred in binary (octet-stream):</span>
 <span class="hljs-attr">schema:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">  format:</span> <span class="hljs-string">binary</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">format:</span> <span class="hljs-string">binary</span>
 </code></pre>
 <p>These examples apply to either input payloads of file uploads or response payloads.</p>
 <p>A <code>requestBody</code> for submitting a file in a <code>POST</code> operation may look like the following example:</p>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">requestBody:</span>
-<span class="hljs-attr">  content:</span>
-    <span class="hljs-string">application/octet-stream:</span>
+  <span class="hljs-attr">content:</span>
+    <span class="hljs-attr">application/octet-stream:</span>
       <span class="hljs-comment"># any media type is accepted, functionally equivalent to `*/*`</span>
-<span class="hljs-attr">      schema:</span>
+      <span class="hljs-attr">schema:</span>
         <span class="hljs-comment"># a binary file of any type</span>
-<span class="hljs-attr">        type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">        format:</span> <span class="hljs-string">binary</span>
+        <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+        <span class="hljs-attr">format:</span> <span class="hljs-string">binary</span>
 </code></pre>
 <p>In addition, specific media types MAY be specified:</p>
 <pre class="nohighlight"><code>
 <span class="hljs-comment"># multiple, specific media types may be specified:</span>
 <span class="hljs-attr">requestBody:</span>
-<span class="hljs-attr">  content:</span>
+  <span class="hljs-attr">content:</span>
       <span class="hljs-comment"># a binary file of type png or jpeg</span>
-    <span class="hljs-string">'image/jpeg'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">      schema:</span>
-<span class="hljs-attr">        type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">        format:</span> <span class="hljs-string">binary</span>
-    <span class="hljs-string">'image/png'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">      schema:</span>
-<span class="hljs-attr">        type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">        format:</span> <span class="hljs-string">binary</span>        
+    <span class="hljs-attr">&#x27;image/jpeg&#x27;:</span>
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+        <span class="hljs-attr">format:</span> <span class="hljs-string">binary</span>
+    <span class="hljs-attr">&#x27;image/png&#x27;:</span>
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+        <span class="hljs-attr">format:</span> <span class="hljs-string">binary</span>        
 </code></pre>
 <p>To upload multiple files, a <code>multipart</code> media type MUST be used:</p>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">requestBody:</span>
-<span class="hljs-attr">  content:</span>
-    <span class="hljs-string">multipart/form-data:</span>
-<span class="hljs-attr">      schema:</span>
-<span class="hljs-attr">        properties:</span>
-          <span class="hljs-comment"># The property name 'file' will be used for all files.</span>
-<span class="hljs-attr">          file:</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">            items:</span>
-<span class="hljs-attr">              type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">              format:</span> <span class="hljs-string">binary</span>
+  <span class="hljs-attr">content:</span>
+    <span class="hljs-attr">multipart/form-data:</span>
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-attr">properties:</span>
+          <span class="hljs-comment"># The property name &#x27;file&#x27; will be used for all files.</span>
+          <span class="hljs-attr">file:</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+            <span class="hljs-attr">items:</span>
+              <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+              <span class="hljs-attr">format:</span> <span class="hljs-string">binary</span>
 
 </code></pre>
 </section><section><h4>Support for x-www-form-urlencoded Request Bodies</h4>
@@ -1918,21 +1918,21 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 definition may be used:</p>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">requestBody:</span>
-<span class="hljs-attr">  content:</span>
-    <span class="hljs-string">application/x-www-form-urlencoded:</span>
-<span class="hljs-attr">      schema:</span>
-<span class="hljs-attr">        type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">        properties:</span>
-<span class="hljs-attr">          id:</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">            format:</span> <span class="hljs-string">uuid</span>
-<span class="hljs-attr">          address:</span>
+  <span class="hljs-attr">content:</span>
+    <span class="hljs-attr">application/x-www-form-urlencoded:</span>
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+        <span class="hljs-attr">properties:</span>
+          <span class="hljs-attr">id:</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+            <span class="hljs-attr">format:</span> <span class="hljs-string">uuid</span>
+          <span class="hljs-attr">address:</span>
             <span class="hljs-comment"># complex types are stringified to support RFC 1866</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">            properties:</span> <span class="hljs-string">{}</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+            <span class="hljs-attr">properties:</span> {}
 </code></pre>
 <p>In this example, the contents in the <code>requestBody</code> MUST be stringified per [[!RFC1866]] when passed to the server.  In addition, the <code>address</code> field complex object will be stringified.</p>
-<p>When passing complex objects in the <code>application/x-www-form-urlencoded</code> content type, the default serialization strategy of such properties is described in the <a href="#encodingObject"><code>Encoding Object</code></a>'s <a href="#encodingStyle"><code>style</code></a> property as <code>form</code>.</p>
+<p>When passing complex objects in the <code>application/x-www-form-urlencoded</code> content type, the default serialization strategy of such properties is described in the <a href="#encodingObject"><code>Encoding Object</code></a>’s <a href="#encodingStyle"><code>style</code></a> property as <code>form</code>.</p>
 </section><section><h4>Special Considerations for <code>multipart</code> Content</h4>
 <p>It is common to use <code>multipart/form-data</code> as a <code>Content-Type</code> when transferring request bodies to operations.  In contrast to 2.0, a <code>schema</code> is REQUIRED to define the input parameters to the operation when using <code>multipart</code> content.  This supports complex structures as well as supporting mechanisms for multiple file uploads.</p>
 <p>When passing in <code>multipart</code> types, boundaries MAY be used to separate sections of the content being transferred — thus, the following default <code>Content-Type</code>s are defined for <code>multipart</code>:</p>
@@ -1944,32 +1944,32 @@ definition may be used:</p>
 <p>Examples:</p>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">requestBody:</span>
-<span class="hljs-attr">  content:</span>
-    <span class="hljs-string">multipart/form-data:</span>
-<span class="hljs-attr">      schema:</span>
-<span class="hljs-attr">        type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">        properties:</span>
-<span class="hljs-attr">          id:</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">            format:</span> <span class="hljs-string">uuid</span>
-<span class="hljs-attr">          address:</span>
+  <span class="hljs-attr">content:</span>
+    <span class="hljs-attr">multipart/form-data:</span>
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+        <span class="hljs-attr">properties:</span>
+          <span class="hljs-attr">id:</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+            <span class="hljs-attr">format:</span> <span class="hljs-string">uuid</span>
+          <span class="hljs-attr">address:</span>
             <span class="hljs-comment"># default Content-Type for objects is `application/json`</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">            properties:</span> <span class="hljs-string">{}</span>
-<span class="hljs-attr">          profileImage:</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+            <span class="hljs-attr">properties:</span> {}
+          <span class="hljs-attr">profileImage:</span>
             <span class="hljs-comment"># default Content-Type for string/binary is `application/octet-stream`</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">            format:</span> <span class="hljs-string">binary</span>
-<span class="hljs-attr">          children:</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+            <span class="hljs-attr">format:</span> <span class="hljs-string">binary</span>
+          <span class="hljs-attr">children:</span>
             <span class="hljs-comment"># default Content-Type for arrays is based on the `inner` type (text/plain here)</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">            items:</span>
-<span class="hljs-attr">              type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">          addresses:</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+            <span class="hljs-attr">items:</span>
+              <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+          <span class="hljs-attr">addresses:</span>
             <span class="hljs-comment"># default Content-Type for arrays is based on the `inner` type (object shown, so `application/json` in this example)</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">            items:</span>
-<span class="hljs-attr">              type:</span> <span class="hljs-string">'#/components/schemas/Address'</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+            <span class="hljs-attr">items:</span>
+              <span class="hljs-attr">type:</span> <span class="hljs-string">&#x27;#/components/schemas/Address&#x27;</span>
 </code></pre>
 <p>An <code>encoding</code> attribute is introduced to give you control over the serialization of parts of <code>multipart</code> request bodies.  This attribute is <em>only</em> applicable to <code>multipart</code> and <code>application/x-www-form-urlencoded</code> request bodies.</p>
 </section></section><section><h3><span id="encodingObject">Encoding Object</span></h3>
@@ -1991,7 +1991,7 @@ definition may be used:</p>
 </tr>
 <tr>
 <td><a id="encodingHeaders"> </a>headers</td>
-<td style="text-align:center">Map[<code>string</code>, <a href="#headerObject">Header Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:center">Map[<code>string</code>, <a href="#headerObject">Header Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>A map allowing additional information to be provided as headers, for example <code>Content-Disposition</code>.  <code>Content-Type</code> is described separately and SHALL be ignored in this section. This property SHALL be ignored if the request body media type is not a <code>multipart</code>.</td>
 </tr>
 <tr>
@@ -2015,40 +2015,40 @@ definition may be used:</p>
 </section><section><h4>Encoding Object Example</h4>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">requestBody:</span>
-<span class="hljs-attr">  content:</span>
-    <span class="hljs-string">multipart/mixed:</span>
-<span class="hljs-attr">      schema:</span>
-<span class="hljs-attr">        type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">        properties:</span>
-<span class="hljs-attr">          id:</span>
+  <span class="hljs-attr">content:</span>
+    <span class="hljs-attr">multipart/mixed:</span>
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+        <span class="hljs-attr">properties:</span>
+          <span class="hljs-attr">id:</span>
             <span class="hljs-comment"># default is text/plain</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">            format:</span> <span class="hljs-string">uuid</span>
-<span class="hljs-attr">          address:</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+            <span class="hljs-attr">format:</span> <span class="hljs-string">uuid</span>
+          <span class="hljs-attr">address:</span>
             <span class="hljs-comment"># default is application/json</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">            properties:</span> <span class="hljs-string">{}</span>
-<span class="hljs-attr">          historyMetadata:</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+            <span class="hljs-attr">properties:</span> {}
+          <span class="hljs-attr">historyMetadata:</span>
             <span class="hljs-comment"># need to declare XML format!</span>
-<span class="hljs-attr">            description:</span> <span class="hljs-string">metadata</span> <span class="hljs-string">in</span> <span class="hljs-string">XML</span> <span class="hljs-string">format</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">            properties:</span> <span class="hljs-string">{}</span>
-<span class="hljs-attr">          profileImage:</span>
+            <span class="hljs-attr">description:</span> <span class="hljs-string">metadata</span> <span class="hljs-string">in</span> <span class="hljs-string">XML</span> <span class="hljs-string">format</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+            <span class="hljs-attr">properties:</span> {}
+          <span class="hljs-attr">profileImage:</span>
             <span class="hljs-comment"># default is application/octet-stream, need to declare an image type only!</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">            format:</span> <span class="hljs-string">binary</span>
-<span class="hljs-attr">      encoding:</span>
-<span class="hljs-attr">        historyMetadata:</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+            <span class="hljs-attr">format:</span> <span class="hljs-string">binary</span>
+      <span class="hljs-attr">encoding:</span>
+        <span class="hljs-attr">historyMetadata:</span>
           <span class="hljs-comment"># require XML Content-Type in utf-8 encoding</span>
-<span class="hljs-attr">          contentType:</span> <span class="hljs-string">application/xml;</span> <span class="hljs-string">charset=utf-8</span>
-<span class="hljs-attr">        profileImage:</span>
+          <span class="hljs-attr">contentType:</span> <span class="hljs-string">application/xml;</span> <span class="hljs-string">charset=utf-8</span>
+        <span class="hljs-attr">profileImage:</span>
           <span class="hljs-comment"># only accept png/jpeg</span>
-<span class="hljs-attr">          contentType:</span> <span class="hljs-string">image/png,</span> <span class="hljs-string">image/jpeg</span>
-<span class="hljs-attr">          headers:</span>
-<span class="hljs-attr">            X-Rate-Limit-Limit:</span>
-<span class="hljs-attr">              description:</span> <span class="hljs-string">The</span> <span class="hljs-string">number</span> <span class="hljs-string">of</span> <span class="hljs-string">allowed</span> <span class="hljs-string">requests</span> <span class="hljs-string">in</span> <span class="hljs-string">the</span> <span class="hljs-string">current</span> <span class="hljs-string">period</span>
-<span class="hljs-attr">              schema:</span>
-<span class="hljs-attr">                type:</span> <span class="hljs-string">integer</span>
+          <span class="hljs-attr">contentType:</span> <span class="hljs-string">image/png,</span> <span class="hljs-string">image/jpeg</span>
+          <span class="hljs-attr">headers:</span>
+            <span class="hljs-attr">X-Rate-Limit-Limit:</span>
+              <span class="hljs-attr">description:</span> <span class="hljs-string">The</span> <span class="hljs-string">number</span> <span class="hljs-string">of</span> <span class="hljs-string">allowed</span> <span class="hljs-string">requests</span> <span class="hljs-string">in</span> <span class="hljs-string">the</span> <span class="hljs-string">current</span> <span class="hljs-string">period</span>
+              <span class="hljs-attr">schema:</span>
+                <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
 </code></pre>
 </section></section><section><h3><span id="responsesObject">Responses Object</span></h3>
 <p>A container for the expected responses of an operation.
@@ -2071,7 +2071,7 @@ SHOULD be the response for a successful operation call.</p>
 <tbody>
 <tr>
 <td><a id="responsesDefault"> </a>default</td>
-<td style="text-align:center"><a href="#responseObject">Response Object</a> ¦ <a href="#referenceObject">Reference Object</a></td>
+<td style="text-align:center"><a href="#responseObject">Response Object</a> | <a href="#referenceObject">Reference Object</a></td>
 <td>The documentation of responses other than the ones declared for specific HTTP response codes. Use this field to cover undeclared responses. A <a href="#referenceObject">Reference Object</a> can link to a response that the <a href="#componentsResponses">OpenAPI Object’s components/responses</a> section defines.</td>
 </tr>
 </tbody>
@@ -2088,7 +2088,7 @@ SHOULD be the response for a successful operation call.</p>
 <tbody>
 <tr>
 <td><a id="responsesCode"> </a><a href="#httpCodes">HTTP Status Code</a></td>
-<td style="text-align:center"><a href="#responseObject">Response Object</a> ¦ <a href="#referenceObject">Reference Object</a></td>
+<td style="text-align:center"><a href="#responseObject">Response Object</a> | <a href="#referenceObject">Reference Object</a></td>
 <td>Any <a href="#httpCodes">HTTP status code</a> can be used as the property name, but only one property per code, to describe the expected response for that HTTP status code.  A <a href="#referenceObject">Reference Object</a> can link to a response that is defined in the <a href="#componentsResponses">OpenAPI Object’s components/responses</a> section. This field MUST be enclosed in quotation marks (for example, “200”) for compatibility between JSON and YAML. To define a range of response codes, this field MAY contain the uppercase wildcard character <code>X</code>. For example, <code>2XX</code> represents all response codes between <code>[200-299]</code>. Only the following range definitions are allowed: <code>1XX</code>, <code>2XX</code>, <code>3XX</code>, <code>4XX</code>, and <code>5XX</code>. If a response is defined using an explicit code, the explicit code definition takes precedence over the range definition for that code.</td>
 </tr>
 </tbody>
@@ -2098,22 +2098,22 @@ SHOULD be the response for a successful operation call.</p>
 <p>A 200 response for a successful operation and a default response for others (implying an error):</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"200"</span>: {
-    <span class="hljs-attr">"description"</span>: <span class="hljs-string">"a pet to be returned"</span>,
-    <span class="hljs-attr">"content"</span>: {
-      <span class="hljs-attr">"application/json"</span>: {
-        <span class="hljs-attr">"schema"</span>: {
-          <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/Pet"</span>
+  <span class="hljs-attr">&quot;200&quot;</span>: {
+    <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;a pet to be returned&quot;</span>,
+    <span class="hljs-attr">&quot;content&quot;</span>: {
+      <span class="hljs-attr">&quot;application/json&quot;</span>: {
+        <span class="hljs-attr">&quot;schema&quot;</span>: {
+          <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/Pet&quot;</span>
         }
       }
     }
   },
-  <span class="hljs-attr">"default"</span>: {
-    <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Unexpected error"</span>,
-    <span class="hljs-attr">"content"</span>: {
-      <span class="hljs-attr">"application/json"</span>: {
-        <span class="hljs-attr">"schema"</span>: {
-          <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/ErrorModel"</span>
+  <span class="hljs-attr">&quot;default&quot;</span>: {
+    <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;Unexpected error&quot;</span>,
+    <span class="hljs-attr">&quot;content&quot;</span>: {
+      <span class="hljs-attr">&quot;application/json&quot;</span>: {
+        <span class="hljs-attr">&quot;schema&quot;</span>: {
+          <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/ErrorModel&quot;</span>
         }
       }
     }
@@ -2121,18 +2121,18 @@ SHOULD be the response for a successful operation call.</p>
 }
 </code></pre>
 <pre class="nohighlight"><code>
-<span class="hljs-string">'200'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">  description:</span> <span class="hljs-string">a</span> <span class="hljs-string">pet</span> <span class="hljs-string">to</span> <span class="hljs-string">be</span> <span class="hljs-string">returned</span>
-<span class="hljs-attr">  content:</span> 
-    <span class="hljs-string">application/json:</span>
-<span class="hljs-attr">      schema:</span>
-        <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Pet'</span>
+<span class="hljs-attr">&#x27;200&#x27;:</span>
+  <span class="hljs-attr">description:</span> <span class="hljs-string">a</span> <span class="hljs-string">pet</span> <span class="hljs-string">to</span> <span class="hljs-string">be</span> <span class="hljs-string">returned</span>
+  <span class="hljs-attr">content:</span> 
+    <span class="hljs-attr">application/json:</span>
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/Pet&#x27;</span>
 <span class="hljs-attr">default:</span>
-<span class="hljs-attr">  description:</span> <span class="hljs-string">Unexpected</span> <span class="hljs-string">error</span>
-<span class="hljs-attr">  content:</span>
-    <span class="hljs-string">application/json:</span>
-<span class="hljs-attr">      schema:</span>
-        <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/ErrorModel'</span>
+  <span class="hljs-attr">description:</span> <span class="hljs-string">Unexpected</span> <span class="hljs-string">error</span>
+  <span class="hljs-attr">content:</span>
+    <span class="hljs-attr">application/json:</span>
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/ErrorModel&#x27;</span>
 </code></pre>
 </section></section><section><h3><span id="responseObject">Response Object</span></h3>
 <p>Describes a single response from an API Operation, including design-time, static
@@ -2154,7 +2154,7 @@ SHOULD be the response for a successful operation call.</p>
 </tr>
 <tr>
 <td><a id="responseHeaders"> </a>headers</td>
-<td style="text-align:center">Map[<code>string</code>, <a href="#headerObject">Header Object</a>  ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:center">Map[<code>string</code>, <a href="#headerObject">Header Object</a>  | <a href="#referenceObject">Reference Object</a>]</td>
 <td>Maps a header name to its definition. [[!RFC7230]] states header names are case insensitive. If a response header is defined with the name <code>&quot;Content-Type&quot;</code>, it SHALL be ignored.</td>
 </tr>
 <tr>
@@ -2164,7 +2164,7 @@ SHOULD be the response for a successful operation call.</p>
 </tr>
 <tr>
 <td><a id="responseLinks"> </a>links</td>
-<td style="text-align:center">Map[<code>string</code>, <a href="#linkObject">Link Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:center">Map[<code>string</code>, <a href="#linkObject">Link Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>A map of operations links that can be followed from the response. The key of the map is a short name for the link, following the naming constraints of the names for <a href="#componentsObject">Component Objects</a>.</td>
 </tr>
 </tbody>
@@ -2174,13 +2174,13 @@ SHOULD be the response for a successful operation call.</p>
 <p>Response of an array of a complex type:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"A complex object array response"</span>,
-  <span class="hljs-attr">"content"</span>: {
-    <span class="hljs-attr">"application/json"</span>: {
-      <span class="hljs-attr">"schema"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-        <span class="hljs-attr">"items"</span>: {
-          <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/VeryComplexType"</span>
+  <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;A complex object array response&quot;</span>,
+  <span class="hljs-attr">&quot;content&quot;</span>: {
+    <span class="hljs-attr">&quot;application/json&quot;</span>: {
+      <span class="hljs-attr">&quot;schema&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+        <span class="hljs-attr">&quot;items&quot;</span>: {
+          <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/VeryComplexType&quot;</span>
         }
       }
     }
@@ -2190,20 +2190,20 @@ SHOULD be the response for a successful operation call.</p>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">description:</span> <span class="hljs-string">A</span> <span class="hljs-string">complex</span> <span class="hljs-string">object</span> <span class="hljs-string">array</span> <span class="hljs-string">response</span>
 <span class="hljs-attr">content:</span> 
-  <span class="hljs-string">application/json:</span>
-<span class="hljs-attr">    schema:</span> 
-<span class="hljs-attr">      type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">      items:</span>
-        <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/VeryComplexType'</span>
+  <span class="hljs-attr">application/json:</span>
+    <span class="hljs-attr">schema:</span> 
+      <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+      <span class="hljs-attr">items:</span>
+        <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/VeryComplexType&#x27;</span>
 </code></pre>
 <p>Response with a string type:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"A simple string response"</span>,
-  <span class="hljs-attr">"content"</span>: {
-    <span class="hljs-attr">"text/plain"</span>: {
-      <span class="hljs-attr">"schema"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+  <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;A simple string response&quot;</span>,
+  <span class="hljs-attr">&quot;content&quot;</span>: {
+    <span class="hljs-attr">&quot;text/plain&quot;</span>: {
+      <span class="hljs-attr">&quot;schema&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
       }
     }
   }
@@ -2213,38 +2213,38 @@ SHOULD be the response for a successful operation call.</p>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">description:</span> <span class="hljs-string">A</span> <span class="hljs-string">simple</span> <span class="hljs-string">string</span> <span class="hljs-string">response</span>
 <span class="hljs-attr">content:</span>
-  <span class="hljs-string">text/plain:</span>
-<span class="hljs-attr">    schema:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">text/plain:</span>
+    <span class="hljs-attr">schema:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
 </code></pre>
 <p>Plain text response with headers:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"A simple string response"</span>,
-  <span class="hljs-attr">"content"</span>: {
-    <span class="hljs-attr">"text/plain"</span>: {
-      <span class="hljs-attr">"schema"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+  <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;A simple string response&quot;</span>,
+  <span class="hljs-attr">&quot;content&quot;</span>: {
+    <span class="hljs-attr">&quot;text/plain&quot;</span>: {
+      <span class="hljs-attr">&quot;schema&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
       }
     }
   },
-  <span class="hljs-attr">"headers"</span>: {
-    <span class="hljs-attr">"X-Rate-Limit-Limit"</span>: {
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"The number of allowed requests in the current period"</span>,
-      <span class="hljs-attr">"schema"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>
+  <span class="hljs-attr">&quot;headers&quot;</span>: {
+    <span class="hljs-attr">&quot;X-Rate-Limit-Limit&quot;</span>: {
+      <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;The number of allowed requests in the current period&quot;</span>,
+      <span class="hljs-attr">&quot;schema&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>
       }
     },
-    <span class="hljs-attr">"X-Rate-Limit-Remaining"</span>: {
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"The number of remaining requests in the current period"</span>,
-      <span class="hljs-attr">"schema"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>
+    <span class="hljs-attr">&quot;X-Rate-Limit-Remaining&quot;</span>: {
+      <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;The number of remaining requests in the current period&quot;</span>,
+      <span class="hljs-attr">&quot;schema&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>
       }
     },
-    <span class="hljs-attr">"X-Rate-Limit-Reset"</span>: {
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"The number of seconds left in the current period"</span>,
-      <span class="hljs-attr">"schema"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>
+    <span class="hljs-attr">&quot;X-Rate-Limit-Reset&quot;</span>: {
+      <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;The number of seconds left in the current period&quot;</span>,
+      <span class="hljs-attr">&quot;schema&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>
       }
     }
   }
@@ -2253,28 +2253,28 @@ SHOULD be the response for a successful operation call.</p>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">description:</span> <span class="hljs-string">A</span> <span class="hljs-string">simple</span> <span class="hljs-string">string</span> <span class="hljs-string">response</span>
 <span class="hljs-attr">content:</span>
-  <span class="hljs-string">text/plain:</span>
-<span class="hljs-attr">    schema:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">    example:</span> <span class="hljs-string">'whoa!'</span>
+  <span class="hljs-attr">text/plain:</span>
+    <span class="hljs-attr">schema:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+    <span class="hljs-attr">example:</span> <span class="hljs-string">&#x27;whoa!&#x27;</span>
 <span class="hljs-attr">headers:</span>
-<span class="hljs-attr">  X-Rate-Limit-Limit:</span>
-<span class="hljs-attr">    description:</span> <span class="hljs-string">The</span> <span class="hljs-string">number</span> <span class="hljs-string">of</span> <span class="hljs-string">allowed</span> <span class="hljs-string">requests</span> <span class="hljs-string">in</span> <span class="hljs-string">the</span> <span class="hljs-string">current</span> <span class="hljs-string">period</span>
-<span class="hljs-attr">    schema:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">integer</span>
-<span class="hljs-attr">  X-Rate-Limit-Remaining:</span>
-<span class="hljs-attr">    description:</span> <span class="hljs-string">The</span> <span class="hljs-string">number</span> <span class="hljs-string">of</span> <span class="hljs-string">remaining</span> <span class="hljs-string">requests</span> <span class="hljs-string">in</span> <span class="hljs-string">the</span> <span class="hljs-string">current</span> <span class="hljs-string">period</span>
-<span class="hljs-attr">    schema:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">integer</span>
-<span class="hljs-attr">  X-Rate-Limit-Reset:</span>
-<span class="hljs-attr">    description:</span> <span class="hljs-string">The</span> <span class="hljs-string">number</span> <span class="hljs-string">of</span> <span class="hljs-string">seconds</span> <span class="hljs-string">left</span> <span class="hljs-string">in</span> <span class="hljs-string">the</span> <span class="hljs-string">current</span> <span class="hljs-string">period</span>
-<span class="hljs-attr">    schema:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">integer</span>
+  <span class="hljs-attr">X-Rate-Limit-Limit:</span>
+    <span class="hljs-attr">description:</span> <span class="hljs-string">The</span> <span class="hljs-string">number</span> <span class="hljs-string">of</span> <span class="hljs-string">allowed</span> <span class="hljs-string">requests</span> <span class="hljs-string">in</span> <span class="hljs-string">the</span> <span class="hljs-string">current</span> <span class="hljs-string">period</span>
+    <span class="hljs-attr">schema:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+  <span class="hljs-attr">X-Rate-Limit-Remaining:</span>
+    <span class="hljs-attr">description:</span> <span class="hljs-string">The</span> <span class="hljs-string">number</span> <span class="hljs-string">of</span> <span class="hljs-string">remaining</span> <span class="hljs-string">requests</span> <span class="hljs-string">in</span> <span class="hljs-string">the</span> <span class="hljs-string">current</span> <span class="hljs-string">period</span>
+    <span class="hljs-attr">schema:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+  <span class="hljs-attr">X-Rate-Limit-Reset:</span>
+    <span class="hljs-attr">description:</span> <span class="hljs-string">The</span> <span class="hljs-string">number</span> <span class="hljs-string">of</span> <span class="hljs-string">seconds</span> <span class="hljs-string">left</span> <span class="hljs-string">in</span> <span class="hljs-string">the</span> <span class="hljs-string">current</span> <span class="hljs-string">period</span>
+    <span class="hljs-attr">schema:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
 </code></pre>
 <p>Response with no return value:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"object created"</span>
+  <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;object created&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -2297,7 +2297,7 @@ The key value used to identify the callback object is an expression, evaluated a
 <tr>
 <td><a id="callbackExpression"> </a>{expression}</td>
 <td style="text-align:center"><a href="#pathItemObject">Path Item Object</a></td>
-<td>A Path Item Object used to define a callback request and expected responses.  A <a href="../examples/v3.0/callback-example.yaml">complete example</a> is available.</td>
+<td>A Path Item Object used to define a callback request and expected responses.  A <a href="https://github.com/OAI/OpenAPI-Specification/tree/master/examples/v3.0/callback-example.yaml">complete example</a> is available.</td>
 </tr>
 </tbody>
 </table>
@@ -2309,22 +2309,22 @@ However, using a <a href="#runtimeExpression">runtime expression</a> the complet
 This includes accessing any part of a body that a JSON Pointer [[!RFC6901]] can reference.</p>
 <p>For example, given the following HTTP request:</p>
 <pre class="nohighlight"><code>
-<span class="hljs-keyword">POST</span> <span class="hljs-string">/subscribe/myevent?queryUrl=http://clientdomain.com/stillrunning</span> HTTP/1.1
-<span class="hljs-attribute">Host</span>: example.org
-<span class="hljs-attribute">Content-Type</span>: application/json
-<span class="hljs-attribute">Content-Length</span>: 187
+<span class="hljs-keyword">POST</span> <span class="hljs-string">/subscribe/myevent?queryUrl=http://clientdomain.com/stillrunning</span> <span class="hljs-meta">HTTP/1.1</span>
+<span class="hljs-attribute">Host</span><span class="hljs-punctuation">: </span>example.org
+<span class="hljs-attribute">Content-Type</span><span class="hljs-punctuation">: </span>application/json
+<span class="hljs-attribute">Content-Length</span><span class="hljs-punctuation">: </span>187
 
-<span class="groovy">{
-  <span class="hljs-string">"failedUrl"</span> : <span class="hljs-string">"http://clientdomain.com/failed"</span>,
-  <span class="hljs-string">"successUrls"</span> : [
-    <span class="hljs-string">"http://clientdomain.com/fast"</span>,
-    <span class="hljs-string">"http://clientdomain.com/medium"</span>,
-    <span class="hljs-string">"http://clientdomain.com/slow"</span>
+<span class="awk">{
+  <span class="hljs-string">&quot;failedUrl&quot;</span> : <span class="hljs-string">&quot;http://clientdomain.com/failed&quot;</span>,
+  <span class="hljs-string">&quot;successUrls&quot;</span> : [
+    <span class="hljs-string">&quot;http://clientdomain.com/fast&quot;</span>,
+    <span class="hljs-string">&quot;http://clientdomain.com/medium&quot;</span>,
+    <span class="hljs-string">&quot;http://clientdomain.com/slow&quot;</span>
   ] 
 }
 
 <span class="hljs-number">201</span> Created
-<span class="hljs-string">Location:</span> <span class="hljs-string">http:</span><span class="hljs-comment">//example.org/subscription/1</span>
+Location: http:<span class="hljs-regexp">//</span>example.org<span class="hljs-regexp">/subscription/</span><span class="hljs-number">1</span>
 </span></code></pre>
 <p>The following examples show how the various expressions evaluate, assuming the callback operation has a path parameter named <code>eventType</code> and a query parameter named <code>queryUrl</code>.</p>
 <table>
@@ -2373,17 +2373,17 @@ This includes accessing any part of a body that a JSON Pointer [[!RFC6901]] can 
 <p>The following example shows a callback to the URL specified by the <code>id</code> and <code>email</code> property in the request body.</p>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">myWebhook:</span>
-  <span class="hljs-string">'http://notificationServer.com?transactionId={$request.body#/id}&amp;email={$request.body#/email}'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">    post:</span>
-<span class="hljs-attr">      requestBody:</span>
-<span class="hljs-attr">        description:</span> <span class="hljs-string">Callback</span> <span class="hljs-string">payload</span>
-<span class="hljs-attr">        content:</span> 
-          <span class="hljs-string">'application/json'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">            schema:</span>
-              <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/SomePayload'</span>
-<span class="hljs-attr">      responses:</span>
-        <span class="hljs-string">'200'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">          description:</span> <span class="hljs-string">webhook</span> <span class="hljs-string">successfully</span> <span class="hljs-string">processed</span> <span class="hljs-string">and</span> <span class="hljs-literal">no</span> <span class="hljs-string">retries</span> <span class="hljs-string">will</span> <span class="hljs-string">be</span> <span class="hljs-string">performed</span>
+  <span class="hljs-string">&#x27;http://notificationServer.com?transactionId={$request.body#/id}&amp;email={$request.body#/email}&#x27;</span><span class="hljs-string">:</span>
+    <span class="hljs-attr">post:</span>
+      <span class="hljs-attr">requestBody:</span>
+        <span class="hljs-attr">description:</span> <span class="hljs-string">Callback</span> <span class="hljs-string">payload</span>
+        <span class="hljs-attr">content:</span> 
+          <span class="hljs-attr">&#x27;application/json&#x27;:</span>
+            <span class="hljs-attr">schema:</span>
+              <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/SomePayload&#x27;</span>
+      <span class="hljs-attr">responses:</span>
+        <span class="hljs-attr">&#x27;200&#x27;:</span>
+          <span class="hljs-attr">description:</span> <span class="hljs-string">webhook</span> <span class="hljs-string">successfully</span> <span class="hljs-string">processed</span> <span class="hljs-string">and</span> <span class="hljs-literal">no</span> <span class="hljs-string">retries</span> <span class="hljs-string">will</span> <span class="hljs-string">be</span> <span class="hljs-string">performed</span>
 </code></pre>
 </section></section><section><h3><span id="exampleObject">Example Object</span></h3>
 <section><h4>Fixed Fields</h4>
@@ -2426,62 +2426,62 @@ validate compatibility automatically, and reject the example value(s) if incompa
 <p>In a model:</p>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">schemas:</span>
-<span class="hljs-attr">  properties:</span>
-<span class="hljs-attr">    name:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">      examples:</span>
-<span class="hljs-attr">        name:</span>
-          <span class="hljs-string">$ref:</span> <span class="hljs-attr">http://example.org/petapi-examples/openapi.json#/components/examples/name-example</span>
+  <span class="hljs-attr">properties:</span>
+    <span class="hljs-attr">name:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+      <span class="hljs-attr">examples:</span>
+        <span class="hljs-attr">name:</span>
+          <span class="hljs-string">$ref:</span> <span class="hljs-string">http://example.org/petapi-examples/openapi.json#/components/examples/name-example</span>
 </code></pre>
 <p>In a request body:</p>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">requestBody:</span>
-<span class="hljs-attr">  content:</span>
-    <span class="hljs-string">'application/json'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">      schema:</span>
-        <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Address'</span>
-<span class="hljs-attr">      examples:</span> 
-<span class="hljs-attr">        foo:</span>
-<span class="hljs-attr">          summary:</span> <span class="hljs-string">A</span> <span class="hljs-string">foo</span> <span class="hljs-string">example</span>
-<span class="hljs-attr">          value:</span> <span class="hljs-string">{"foo":</span> <span class="hljs-string">"bar"</span><span class="hljs-string">}</span>
-<span class="hljs-attr">        bar:</span>
-<span class="hljs-attr">          summary:</span> <span class="hljs-string">A</span> <span class="hljs-string">bar</span> <span class="hljs-string">example</span>
-<span class="hljs-attr">          value:</span> <span class="hljs-string">{"bar":</span> <span class="hljs-string">"baz"</span><span class="hljs-string">}</span>
-    <span class="hljs-string">'application/xml'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">      examples:</span> 
-<span class="hljs-attr">        xmlExample:</span>
-<span class="hljs-attr">          summary:</span> <span class="hljs-string">This</span> <span class="hljs-string">is</span> <span class="hljs-string">an</span> <span class="hljs-string">example</span> <span class="hljs-string">in</span> <span class="hljs-string">XML</span>
-<span class="hljs-attr">          externalValue:</span> <span class="hljs-string">'http://example.org/examples/address-example.xml'</span>
-    <span class="hljs-string">'text/plain'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">      examples:</span>
-<span class="hljs-attr">        textExample:</span> 
-<span class="hljs-attr">          summary:</span> <span class="hljs-string">This</span> <span class="hljs-string">is</span> <span class="hljs-string">a</span> <span class="hljs-string">text</span> <span class="hljs-string">example</span>
-<span class="hljs-attr">          externalValue:</span> <span class="hljs-string">'http://foo.bar/examples/address-example.txt'</span>
+  <span class="hljs-attr">content:</span>
+    <span class="hljs-attr">&#x27;application/json&#x27;:</span>
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/Address&#x27;</span>
+      <span class="hljs-attr">examples:</span> 
+        <span class="hljs-attr">foo:</span>
+          <span class="hljs-attr">summary:</span> <span class="hljs-string">A</span> <span class="hljs-string">foo</span> <span class="hljs-string">example</span>
+          <span class="hljs-attr">value:</span> {<span class="hljs-attr">&quot;foo&quot;:</span> <span class="hljs-string">&quot;bar&quot;</span>}
+        <span class="hljs-attr">bar:</span>
+          <span class="hljs-attr">summary:</span> <span class="hljs-string">A</span> <span class="hljs-string">bar</span> <span class="hljs-string">example</span>
+          <span class="hljs-attr">value:</span> {<span class="hljs-attr">&quot;bar&quot;:</span> <span class="hljs-string">&quot;baz&quot;</span>}
+    <span class="hljs-attr">&#x27;application/xml&#x27;:</span>
+      <span class="hljs-attr">examples:</span> 
+        <span class="hljs-attr">xmlExample:</span>
+          <span class="hljs-attr">summary:</span> <span class="hljs-string">This</span> <span class="hljs-string">is</span> <span class="hljs-string">an</span> <span class="hljs-string">example</span> <span class="hljs-string">in</span> <span class="hljs-string">XML</span>
+          <span class="hljs-attr">externalValue:</span> <span class="hljs-string">&#x27;http://example.org/examples/address-example.xml&#x27;</span>
+    <span class="hljs-attr">&#x27;text/plain&#x27;:</span>
+      <span class="hljs-attr">examples:</span>
+        <span class="hljs-attr">textExample:</span> 
+          <span class="hljs-attr">summary:</span> <span class="hljs-string">This</span> <span class="hljs-string">is</span> <span class="hljs-string">a</span> <span class="hljs-string">text</span> <span class="hljs-string">example</span>
+          <span class="hljs-attr">externalValue:</span> <span class="hljs-string">&#x27;http://foo.bar/examples/address-example.txt&#x27;</span>
 </code></pre>
 <p>In a parameter:</p>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">parameters:</span>
-<span class="hljs-attr">  - name:</span> <span class="hljs-string">'zipCode'</span>
-<span class="hljs-attr">    in:</span> <span class="hljs-string">'query'</span>
-<span class="hljs-attr">    schema:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">'string'</span>
-<span class="hljs-attr">      format:</span> <span class="hljs-string">'zip-code'</span>
-<span class="hljs-attr">      examples:</span>
-<span class="hljs-attr">        zip-example:</span> 
-          <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/examples/zip-example'</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-attr">name:</span> <span class="hljs-string">&#x27;zipCode&#x27;</span>
+    <span class="hljs-attr">in:</span> <span class="hljs-string">&#x27;query&#x27;</span>
+    <span class="hljs-attr">schema:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">&#x27;string&#x27;</span>
+      <span class="hljs-attr">format:</span> <span class="hljs-string">&#x27;zip-code&#x27;</span>
+      <span class="hljs-attr">examples:</span>
+        <span class="hljs-attr">zip-example:</span> 
+          <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/examples/zip-example&#x27;</span>
 </code></pre>
 <p>In a response:</p>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">responses:</span>
-  <span class="hljs-string">'200'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">    description:</span> <span class="hljs-string">your</span> <span class="hljs-string">car</span> <span class="hljs-string">appointment</span> <span class="hljs-string">has</span> <span class="hljs-string">been</span> <span class="hljs-string">booked</span>
-<span class="hljs-attr">    content:</span> 
-      <span class="hljs-string">application/json:</span>
-<span class="hljs-attr">        schema:</span>
-          <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/SuccessResponse'</span>
-<span class="hljs-attr">        examples:</span>
-<span class="hljs-attr">          confirmation-success:</span>
-            <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/examples/confirmation-success'</span>
+  <span class="hljs-attr">&#x27;200&#x27;:</span>
+    <span class="hljs-attr">description:</span> <span class="hljs-string">your</span> <span class="hljs-string">car</span> <span class="hljs-string">appointment</span> <span class="hljs-string">has</span> <span class="hljs-string">been</span> <span class="hljs-string">booked</span>
+    <span class="hljs-attr">content:</span> 
+      <span class="hljs-attr">application/json:</span>
+        <span class="hljs-attr">schema:</span>
+          <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/SuccessResponse&#x27;</span>
+        <span class="hljs-attr">examples:</span>
+          <span class="hljs-attr">confirmation-success:</span>
+            <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/examples/confirmation-success&#x27;</span>
 </code></pre>
 </section></section><section><h3><span id="linkObject">Link Object</span></h3>
 <p>The <code>Link object</code> represents a possible design-time link for a response.
@@ -2510,12 +2510,12 @@ The presence of a link does not guarantee the caller’s ability to successfully
 </tr>
 <tr>
 <td><a id="linkParameters"> </a>parameters</td>
-<td style="text-align:center">Map[<code>string</code>, Any ¦ <a href="#runtimeExpression">{expression}</a>]</td>
+<td style="text-align:center">Map[<code>string</code>, Any | <a href="#runtimeExpression">{expression}</a>]</td>
 <td>A map representing parameters to pass to an operation as specified with <code>operationId</code> or identified via <code>operationRef</code>. The key is the parameter name to be used, whereas the value can be a constant or an expression to be evaluated and passed to the linked operation.  The parameter name can be qualified using the <a href="#parameterIn">parameter location</a> <code>[{in}.]{name}</code> for operations that use the same parameter name in different locations (e.g. <a href="http://path.id">path.id</a>).</td>
 </tr>
 <tr>
 <td><a id="linkRequestBody"> </a>requestBody</td>
-<td style="text-align:center">Any ¦ <a href="#runtimeExpression">{expression}</a></td>
+<td style="text-align:center">Any | <a href="#runtimeExpression">{expression}</a></td>
 <td>A literal value or <a href="#runtimeExpression">{expression}</a> to use as a request body when calling the target operation.</td>
 </tr>
 <tr>
@@ -2540,57 +2540,57 @@ for specifications with external references.</p>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">paths:</span>
   <span class="hljs-string">/users/{id}:</span>
-<span class="hljs-attr">    parameters:</span>
-<span class="hljs-attr">    - name:</span> <span class="hljs-string">id</span>
-<span class="hljs-attr">      in:</span> <span class="hljs-string">path</span>
-<span class="hljs-attr">      required:</span> <span class="hljs-literal">true</span>
-<span class="hljs-attr">      description:</span> <span class="hljs-string">the</span> <span class="hljs-string">user</span> <span class="hljs-string">identifier,</span> <span class="hljs-string">as</span> <span class="hljs-string">userId</span> 
-<span class="hljs-attr">      schema:</span>
-<span class="hljs-attr">        type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">    get:</span>
-<span class="hljs-attr">      responses:</span>
-        <span class="hljs-string">'200'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">          description:</span> <span class="hljs-string">the</span> <span class="hljs-string">user</span> <span class="hljs-string">being</span> <span class="hljs-string">returned</span>
-<span class="hljs-attr">          content:</span>
-            <span class="hljs-string">application/json:</span>
-<span class="hljs-attr">              schema:</span>
-<span class="hljs-attr">                type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">                properties:</span>
-<span class="hljs-attr">                  uuid:</span> <span class="hljs-comment"># the unique user id</span>
-<span class="hljs-attr">                    type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">                    format:</span> <span class="hljs-string">uuid</span>
-<span class="hljs-attr">          links:</span>
-<span class="hljs-attr">            address:</span>
+    <span class="hljs-attr">parameters:</span>
+    <span class="hljs-bullet">-</span> <span class="hljs-attr">name:</span> <span class="hljs-string">id</span>
+      <span class="hljs-attr">in:</span> <span class="hljs-string">path</span>
+      <span class="hljs-attr">required:</span> <span class="hljs-literal">true</span>
+      <span class="hljs-attr">description:</span> <span class="hljs-string">the</span> <span class="hljs-string">user</span> <span class="hljs-string">identifier,</span> <span class="hljs-string">as</span> <span class="hljs-string">userId</span> 
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+    <span class="hljs-attr">get:</span>
+      <span class="hljs-attr">responses:</span>
+        <span class="hljs-attr">&#x27;200&#x27;:</span>
+          <span class="hljs-attr">description:</span> <span class="hljs-string">the</span> <span class="hljs-string">user</span> <span class="hljs-string">being</span> <span class="hljs-string">returned</span>
+          <span class="hljs-attr">content:</span>
+            <span class="hljs-attr">application/json:</span>
+              <span class="hljs-attr">schema:</span>
+                <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+                <span class="hljs-attr">properties:</span>
+                  <span class="hljs-attr">uuid:</span> <span class="hljs-comment"># the unique user id</span>
+                    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+                    <span class="hljs-attr">format:</span> <span class="hljs-string">uuid</span>
+          <span class="hljs-attr">links:</span>
+            <span class="hljs-attr">address:</span>
               <span class="hljs-comment"># the target link operationId</span>
-<span class="hljs-attr">              operationId:</span> <span class="hljs-string">getUserAddress</span>
-<span class="hljs-attr">              parameters:</span>
+              <span class="hljs-attr">operationId:</span> <span class="hljs-string">getUserAddress</span>
+              <span class="hljs-attr">parameters:</span>
                 <span class="hljs-comment"># get the `id` field from the request path parameter named `id`</span>
-<span class="hljs-attr">                userId:</span> <span class="hljs-string">$request.path.id</span>
+                <span class="hljs-attr">userId:</span> <span class="hljs-string">$request.path.id</span>
   <span class="hljs-comment"># the path item of the linked operation</span>
   <span class="hljs-string">/users/{userid}/address:</span>
-<span class="hljs-attr">    parameters:</span>
-<span class="hljs-attr">    - name:</span> <span class="hljs-string">userid</span>
-<span class="hljs-attr">      in:</span> <span class="hljs-string">path</span>
-<span class="hljs-attr">      required:</span> <span class="hljs-literal">true</span>
-<span class="hljs-attr">      description:</span> <span class="hljs-string">the</span> <span class="hljs-string">user</span> <span class="hljs-string">identifier,</span> <span class="hljs-string">as</span> <span class="hljs-string">userId</span> 
-<span class="hljs-attr">      schema:</span>
-<span class="hljs-attr">        type:</span> <span class="hljs-string">string</span>
+    <span class="hljs-attr">parameters:</span>
+    <span class="hljs-bullet">-</span> <span class="hljs-attr">name:</span> <span class="hljs-string">userid</span>
+      <span class="hljs-attr">in:</span> <span class="hljs-string">path</span>
+      <span class="hljs-attr">required:</span> <span class="hljs-literal">true</span>
+      <span class="hljs-attr">description:</span> <span class="hljs-string">the</span> <span class="hljs-string">user</span> <span class="hljs-string">identifier,</span> <span class="hljs-string">as</span> <span class="hljs-string">userId</span> 
+      <span class="hljs-attr">schema:</span>
+        <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
     <span class="hljs-comment"># linked operation</span>
-<span class="hljs-attr">    get:</span>
-<span class="hljs-attr">      operationId:</span> <span class="hljs-string">getUserAddress</span>
-<span class="hljs-attr">      responses:</span>
-        <span class="hljs-string">'200'</span><span class="hljs-string">:</span>
-<span class="hljs-attr">          description:</span> <span class="hljs-string">the</span> <span class="hljs-string">user's</span> <span class="hljs-string">address</span>
+    <span class="hljs-attr">get:</span>
+      <span class="hljs-attr">operationId:</span> <span class="hljs-string">getUserAddress</span>
+      <span class="hljs-attr">responses:</span>
+        <span class="hljs-attr">&#x27;200&#x27;:</span>
+          <span class="hljs-attr">description:</span> <span class="hljs-string">the</span> <span class="hljs-string">user&#x27;s</span> <span class="hljs-string">address</span>
 </code></pre>
 <p>When a runtime expression fails to evaluate, no parameter value is passed to the target operation.</p>
 <p>Values from the response body can be used to drive a linked operation.</p>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">links:</span>
-<span class="hljs-attr">  address:</span>
-<span class="hljs-attr">    operationId:</span> <span class="hljs-string">getUserAddressByUUID</span>
-<span class="hljs-attr">    parameters:</span>
+  <span class="hljs-attr">address:</span>
+    <span class="hljs-attr">operationId:</span> <span class="hljs-string">getUserAddressByUUID</span>
+    <span class="hljs-attr">parameters:</span>
       <span class="hljs-comment"># get the `uuid` field from the `uuid` field in the response body</span>
-<span class="hljs-attr">      userUuid:</span> <span class="hljs-string">$response.body#/uuid</span>
+      <span class="hljs-attr">userUuid:</span> <span class="hljs-string">$response.body#/uuid</span>
 </code></pre>
 <p>Clients follow all links at their discretion.
 Neither permissions, nor the capability to make a successful call to that link, is guaranteed
@@ -2600,27 +2600,27 @@ solely by the existence of a relationship.</p>
 value), references MAY also be made through a relative <code>operationRef</code>:</p>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">links:</span>
-<span class="hljs-attr">  UserRepositories:</span>
-    <span class="hljs-comment"># returns array of '#/components/schemas/repository'</span>
-<span class="hljs-attr">    operationRef:</span> <span class="hljs-string">'#/paths/~12.0~1repositories~1{username}/get'</span>
-<span class="hljs-attr">    parameters:</span>
-<span class="hljs-attr">      username:</span> <span class="hljs-string">$response.body#/username</span>
+  <span class="hljs-attr">UserRepositories:</span>
+    <span class="hljs-comment"># returns array of &#x27;#/components/schemas/repository&#x27;</span>
+    <span class="hljs-attr">operationRef:</span> <span class="hljs-string">&#x27;#/paths/~12.0~1repositories~1{username}/get&#x27;</span>
+    <span class="hljs-attr">parameters:</span>
+      <span class="hljs-attr">username:</span> <span class="hljs-string">$response.body#/username</span>
 </code></pre>
 <p>or an absolute <code>operationRef</code>:</p>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">links:</span>
-<span class="hljs-attr">  UserRepositories:</span>
-    <span class="hljs-comment"># returns array of '#/components/schemas/repository'</span>
-<span class="hljs-attr">    operationRef:</span> <span class="hljs-string">'https://na2.gigantic-server.com/#/paths/~12.0~1repositories~1{username}/get'</span>
-<span class="hljs-attr">    parameters:</span>
-<span class="hljs-attr">      username:</span> <span class="hljs-string">$response.body#/username</span>
+  <span class="hljs-attr">UserRepositories:</span>
+    <span class="hljs-comment"># returns array of &#x27;#/components/schemas/repository&#x27;</span>
+    <span class="hljs-attr">operationRef:</span> <span class="hljs-string">&#x27;https://na2.gigantic-server.com/#/paths/~12.0~1repositories~1{username}/get&#x27;</span>
+    <span class="hljs-attr">parameters:</span>
+      <span class="hljs-attr">username:</span> <span class="hljs-string">$response.body#/username</span>
 </code></pre>
 <p>Note that in the use of <code>operationRef</code>, the <em>escaped forward-slash</em> is necessary when
 using JSON references.</p>
 </section><section><h4><span id="runtimeExpression">Runtime Expressions</span></h4>
 <p>Runtime expressions allow defining values based on information that will only be available within the HTTP message in an actual API call.
 This mechanism is used by <a href="#linkObject">Link Objects</a> and <a href="#callbackObject">Callback Objects</a>.</p>
-<p>The runtime expression is defined by the following [Augmented Backus-Naur Form] syntax</p>
+<p>The runtime expression is defined by the following [ABNF] syntax</p>
 <pre class="highlight "><code>
       expression = ( &quot;$url&quot; | &quot;$method&quot; | &quot;$statusCode&quot; | &quot;$request.&quot; source | &quot;$response.&quot; source )
       source = ( header-reference | query-reference | path-reference | body-reference )  
@@ -2695,16 +2695,16 @@ Expressions can be embedded into string values by surrounding the expression wit
 <p>A simple header of type <code>integer</code>:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"The number of allowed requests in the current period"</span>,
-  <span class="hljs-attr">"schema"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>
+  <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;The number of allowed requests in the current period&quot;</span>,
+  <span class="hljs-attr">&quot;schema&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>
   }
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">description:</span> <span class="hljs-string">The</span> <span class="hljs-string">number</span> <span class="hljs-string">of</span> <span class="hljs-string">allowed</span> <span class="hljs-string">requests</span> <span class="hljs-string">in</span> <span class="hljs-string">the</span> <span class="hljs-string">current</span> <span class="hljs-string">period</span>
 <span class="hljs-attr">schema:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">integer</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
 </code></pre>
 </section></section><section><h3><span id="tagObject">Tag Object</span></h3>
 <p>Adds metadata to a single tag that is used by the <a href="#operationObject">Operation Object</a>.
@@ -2740,8 +2740,8 @@ It is not mandatory to have a Tag Object per tag defined in the Operation Object
 </section><section><h4>Tag Object Example</h4>
 <pre class="nohighlight"><code>
 {
-	<span class="hljs-attr">"name"</span>: <span class="hljs-string">"pet"</span>,
-	<span class="hljs-attr">"description"</span>: <span class="hljs-string">"Pets operations"</span>
+	<span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;pet&quot;</span>,
+	<span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;Pets operations&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -2773,16 +2773,16 @@ It is not mandatory to have a Tag Object per tag defined in the Operation Object
 </section><section><h4>Reference Object Example</h4>
 <pre class="nohighlight"><code>
 {
-	<span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/Pet"</span>
+	<span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/Pet&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
-<span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Pet'</span>
+<span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/Pet&#x27;</span>
 </code></pre>
 </section><section><h4>Relative Schema Document Example</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"Pet.json"</span>
+  <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;Pet.json&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -2791,7 +2791,7 @@ It is not mandatory to have a Tag Object per tag defined in the Operation Object
 </section><section><h4>Relative Documents With Embedded Schema Example</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"definitions.json#/Pet"</span>
+  <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;definitions.json#/Pet&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -2913,8 +2913,8 @@ The <a href="#xmlObject">XML Object</a> contains additional information about th
 <section><h5>Primitive Sample</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
-  <span class="hljs-attr">"format"</span>: <span class="hljs-string">"email"</span>
+  <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>,
+  <span class="hljs-attr">&quot;format&quot;</span>: <span class="hljs-string">&quot;email&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -2924,21 +2924,21 @@ The <a href="#xmlObject">XML Object</a> contains additional information about th
 </section><section><h5>Simple Model</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-  <span class="hljs-attr">"required"</span>: [
-    <span class="hljs-string">"name"</span>
+  <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+  <span class="hljs-attr">&quot;required&quot;</span>: [
+    <span class="hljs-string">&quot;name&quot;</span>
   ],
-  <span class="hljs-attr">"properties"</span>: {
-    <span class="hljs-attr">"name"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+  <span class="hljs-attr">&quot;properties&quot;</span>: {
+    <span class="hljs-attr">&quot;name&quot;</span>: {
+      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
     },
-    <span class="hljs-attr">"address"</span>: {
-      <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/Address"</span>
+    <span class="hljs-attr">&quot;address&quot;</span>: {
+      <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/Address&quot;</span>
     },
-    <span class="hljs-attr">"age"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>,
-      <span class="hljs-attr">"format"</span>: <span class="hljs-string">"int32"</span>,
-      <span class="hljs-attr">"minimum"</span>: <span class="hljs-number">0</span>
+    <span class="hljs-attr">&quot;age&quot;</span>: {
+      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>,
+      <span class="hljs-attr">&quot;format&quot;</span>: <span class="hljs-string">&quot;int32&quot;</span>,
+      <span class="hljs-attr">&quot;minimum&quot;</span>: <span class="hljs-number">0</span>
     }
   }
 }
@@ -2948,115 +2948,115 @@ The <a href="#xmlObject">XML Object</a> contains additional information about th
 <span class="hljs-attr">required:</span>
 <span class="hljs-bullet">-</span> <span class="hljs-string">name</span>
 <span class="hljs-attr">properties:</span>
-<span class="hljs-attr">  name:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">  address:</span>
-    <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Address'</span>
-<span class="hljs-attr">  age:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">integer</span>
-<span class="hljs-attr">    format:</span> <span class="hljs-string">int32</span>
-<span class="hljs-attr">    minimum:</span> <span class="hljs-number">0</span>
+  <span class="hljs-attr">name:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">address:</span>
+    <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/Address&#x27;</span>
+  <span class="hljs-attr">age:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+    <span class="hljs-attr">format:</span> <span class="hljs-string">int32</span>
+    <span class="hljs-attr">minimum:</span> <span class="hljs-number">0</span>
 </code></pre>
 </section><section><h5>Model with Map/Dictionary Properties</h5>
 <p>For a simple string to string mapping:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-  <span class="hljs-attr">"additionalProperties"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+  <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+  <span class="hljs-attr">&quot;additionalProperties&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
   }
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
 <span class="hljs-attr">additionalProperties:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
 </code></pre>
 <p>For a string to model mapping:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-  <span class="hljs-attr">"additionalProperties"</span>: {
-    <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/ComplexModel"</span>
+  <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+  <span class="hljs-attr">&quot;additionalProperties&quot;</span>: {
+    <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/ComplexModel&quot;</span>
   }
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
 <span class="hljs-attr">additionalProperties:</span>
-  <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/ComplexModel'</span>
+  <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/ComplexModel&#x27;</span>
 </code></pre>
 </section><section><h5>Model with Example</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-  <span class="hljs-attr">"properties"</span>: {
-    <span class="hljs-attr">"id"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>,
-      <span class="hljs-attr">"format"</span>: <span class="hljs-string">"int64"</span>
+  <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+  <span class="hljs-attr">&quot;properties&quot;</span>: {
+    <span class="hljs-attr">&quot;id&quot;</span>: {
+      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>,
+      <span class="hljs-attr">&quot;format&quot;</span>: <span class="hljs-string">&quot;int64&quot;</span>
     },
-    <span class="hljs-attr">"name"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+    <span class="hljs-attr">&quot;name&quot;</span>: {
+      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
     }
   },
-  <span class="hljs-attr">"required"</span>: [
-    <span class="hljs-string">"name"</span>
+  <span class="hljs-attr">&quot;required&quot;</span>: [
+    <span class="hljs-string">&quot;name&quot;</span>
   ],
-  <span class="hljs-attr">"example"</span>: {
-    <span class="hljs-attr">"name"</span>: <span class="hljs-string">"Puma"</span>,
-    <span class="hljs-attr">"id"</span>: <span class="hljs-number">1</span>
+  <span class="hljs-attr">&quot;example&quot;</span>: {
+    <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;Puma&quot;</span>,
+    <span class="hljs-attr">&quot;id&quot;</span>: <span class="hljs-number">1</span>
   }
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
 <span class="hljs-attr">properties:</span>
-<span class="hljs-attr">  id:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">integer</span>
-<span class="hljs-attr">    format:</span> <span class="hljs-string">int64</span>
-<span class="hljs-attr">  name:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">id:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+    <span class="hljs-attr">format:</span> <span class="hljs-string">int64</span>
+  <span class="hljs-attr">name:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
 <span class="hljs-attr">required:</span>
 <span class="hljs-bullet">-</span> <span class="hljs-string">name</span>
 <span class="hljs-attr">example:</span>
-<span class="hljs-attr">  name:</span> <span class="hljs-string">Puma</span>
-<span class="hljs-attr">  id:</span> <span class="hljs-number">1</span>
+  <span class="hljs-attr">name:</span> <span class="hljs-string">Puma</span>
+  <span class="hljs-attr">id:</span> <span class="hljs-number">1</span>
 </code></pre>
 </section><section><h5>Models with Composition</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"components"</span>: {
-    <span class="hljs-attr">"schemas"</span>: {
-      <span class="hljs-attr">"ErrorModel"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-        <span class="hljs-attr">"required"</span>: [
-          <span class="hljs-string">"message"</span>,
-          <span class="hljs-string">"code"</span>
+  <span class="hljs-attr">&quot;components&quot;</span>: {
+    <span class="hljs-attr">&quot;schemas&quot;</span>: {
+      <span class="hljs-attr">&quot;ErrorModel&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+        <span class="hljs-attr">&quot;required&quot;</span>: [
+          <span class="hljs-string">&quot;message&quot;</span>,
+          <span class="hljs-string">&quot;code&quot;</span>
         ],
-        <span class="hljs-attr">"properties"</span>: {
-          <span class="hljs-attr">"message"</span>: {
-            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+        <span class="hljs-attr">&quot;properties&quot;</span>: {
+          <span class="hljs-attr">&quot;message&quot;</span>: {
+            <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
           },
-          <span class="hljs-attr">"code"</span>: {
-            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>,
-            <span class="hljs-attr">"minimum"</span>: <span class="hljs-number">100</span>,
-            <span class="hljs-attr">"maximum"</span>: <span class="hljs-number">600</span>
+          <span class="hljs-attr">&quot;code&quot;</span>: {
+            <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>,
+            <span class="hljs-attr">&quot;minimum&quot;</span>: <span class="hljs-number">100</span>,
+            <span class="hljs-attr">&quot;maximum&quot;</span>: <span class="hljs-number">600</span>
           }
         }
       },
-      <span class="hljs-attr">"ExtendedErrorModel"</span>: {
-        <span class="hljs-attr">"allOf"</span>: [
+      <span class="hljs-attr">&quot;ExtendedErrorModel&quot;</span>: {
+        <span class="hljs-attr">&quot;allOf&quot;</span>: [
           {
-            <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/ErrorModel"</span>
+            <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/ErrorModel&quot;</span>
           },
           {
-            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-            <span class="hljs-attr">"required"</span>: [
-              <span class="hljs-string">"rootCause"</span>
+            <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+            <span class="hljs-attr">&quot;required&quot;</span>: [
+              <span class="hljs-string">&quot;rootCause&quot;</span>
             ],
-            <span class="hljs-attr">"properties"</span>: {
-              <span class="hljs-attr">"rootCause"</span>: {
-                <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+            <span class="hljs-attr">&quot;properties&quot;</span>: {
+              <span class="hljs-attr">&quot;rootCause&quot;</span>: {
+                <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
               }
             }
           }
@@ -3068,98 +3068,98 @@ The <a href="#xmlObject">XML Object</a> contains additional information about th
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">components:</span>
-<span class="hljs-attr">  schemas:</span>
-<span class="hljs-attr">    ErrorModel:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">      required:</span>
-<span class="hljs-bullet">      -</span> <span class="hljs-string">message</span>
-<span class="hljs-bullet">      -</span> <span class="hljs-string">code</span>
-<span class="hljs-attr">      properties:</span>
-<span class="hljs-attr">        message:</span>
-<span class="hljs-attr">          type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">        code:</span>
-<span class="hljs-attr">          type:</span> <span class="hljs-string">integer</span>
-<span class="hljs-attr">          minimum:</span> <span class="hljs-number">100</span>
-<span class="hljs-attr">          maximum:</span> <span class="hljs-number">600</span>
-<span class="hljs-attr">    ExtendedErrorModel:</span>
-<span class="hljs-attr">      allOf:</span>
-<span class="hljs-bullet">      -</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/ErrorModel'</span>
-<span class="hljs-attr">      - type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">        required:</span>
-<span class="hljs-bullet">        -</span> <span class="hljs-string">rootCause</span>
-<span class="hljs-attr">        properties:</span>
-<span class="hljs-attr">          rootCause:</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">schemas:</span>
+    <span class="hljs-attr">ErrorModel:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+      <span class="hljs-attr">required:</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-string">message</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-string">code</span>
+      <span class="hljs-attr">properties:</span>
+        <span class="hljs-attr">message:</span>
+          <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+        <span class="hljs-attr">code:</span>
+          <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+          <span class="hljs-attr">minimum:</span> <span class="hljs-number">100</span>
+          <span class="hljs-attr">maximum:</span> <span class="hljs-number">600</span>
+    <span class="hljs-attr">ExtendedErrorModel:</span>
+      <span class="hljs-attr">allOf:</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/ErrorModel&#x27;</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+        <span class="hljs-attr">required:</span>
+        <span class="hljs-bullet">-</span> <span class="hljs-string">rootCause</span>
+        <span class="hljs-attr">properties:</span>
+          <span class="hljs-attr">rootCause:</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
 </code></pre>
 </section><section><h5>Models with Polymorphism Support</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"components"</span>: {
-    <span class="hljs-attr">"schemas"</span>: {
-      <span class="hljs-attr">"Pet"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-        <span class="hljs-attr">"discriminator"</span>: {
-          <span class="hljs-attr">"propertyName"</span>: <span class="hljs-string">"petType"</span>
+  <span class="hljs-attr">&quot;components&quot;</span>: {
+    <span class="hljs-attr">&quot;schemas&quot;</span>: {
+      <span class="hljs-attr">&quot;Pet&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+        <span class="hljs-attr">&quot;discriminator&quot;</span>: {
+          <span class="hljs-attr">&quot;propertyName&quot;</span>: <span class="hljs-string">&quot;petType&quot;</span>
         },
-        <span class="hljs-attr">"properties"</span>: {
-          <span class="hljs-attr">"name"</span>: {
-            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+        <span class="hljs-attr">&quot;properties&quot;</span>: {
+          <span class="hljs-attr">&quot;name&quot;</span>: {
+            <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
           },
-          <span class="hljs-attr">"petType"</span>: {
-            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+          <span class="hljs-attr">&quot;petType&quot;</span>: {
+            <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
           }
         },
-        <span class="hljs-attr">"required"</span>: [
-          <span class="hljs-string">"name"</span>,
-          <span class="hljs-string">"petType"</span>
+        <span class="hljs-attr">&quot;required&quot;</span>: [
+          <span class="hljs-string">&quot;name&quot;</span>,
+          <span class="hljs-string">&quot;petType&quot;</span>
         ]
       },
-      <span class="hljs-attr">"Cat"</span>: {
-        <span class="hljs-attr">"description"</span>: <span class="hljs-string">"A representation of a cat. Note that `Cat` will be used as the discriminator value."</span>,
-        <span class="hljs-attr">"allOf"</span>: [
+      <span class="hljs-attr">&quot;Cat&quot;</span>: {
+        <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;A representation of a cat. Note that `Cat` will be used as the discriminator value.&quot;</span>,
+        <span class="hljs-attr">&quot;allOf&quot;</span>: [
           {
-            <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/Pet"</span>
+            <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/Pet&quot;</span>
           },
           {
-            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-            <span class="hljs-attr">"properties"</span>: {
-              <span class="hljs-attr">"huntingSkill"</span>: {
-                <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
-                <span class="hljs-attr">"description"</span>: <span class="hljs-string">"The measured skill for hunting"</span>,
-                <span class="hljs-attr">"default"</span>: <span class="hljs-string">"lazy"</span>,
-                <span class="hljs-attr">"enum"</span>: [
-                  <span class="hljs-string">"clueless"</span>,
-                  <span class="hljs-string">"lazy"</span>,
-                  <span class="hljs-string">"adventurous"</span>,
-                  <span class="hljs-string">"aggressive"</span>
+            <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+            <span class="hljs-attr">&quot;properties&quot;</span>: {
+              <span class="hljs-attr">&quot;huntingSkill&quot;</span>: {
+                <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>,
+                <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;The measured skill for hunting&quot;</span>,
+                <span class="hljs-attr">&quot;default&quot;</span>: <span class="hljs-string">&quot;lazy&quot;</span>,
+                <span class="hljs-attr">&quot;enum&quot;</span>: [
+                  <span class="hljs-string">&quot;clueless&quot;</span>,
+                  <span class="hljs-string">&quot;lazy&quot;</span>,
+                  <span class="hljs-string">&quot;adventurous&quot;</span>,
+                  <span class="hljs-string">&quot;aggressive&quot;</span>
                 ]
               }
             },
-            <span class="hljs-attr">"required"</span>: [
-              <span class="hljs-string">"huntingSkill"</span>
+            <span class="hljs-attr">&quot;required&quot;</span>: [
+              <span class="hljs-string">&quot;huntingSkill&quot;</span>
             ]
           }
         ]
       },
-      <span class="hljs-attr">"Dog"</span>: {
-        <span class="hljs-attr">"description"</span>: <span class="hljs-string">"A representation of a dog. Note that `Dog` will be used as the discriminator value."</span>,
-        <span class="hljs-attr">"allOf"</span>: [
+      <span class="hljs-attr">&quot;Dog&quot;</span>: {
+        <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;A representation of a dog. Note that `Dog` will be used as the discriminator value.&quot;</span>,
+        <span class="hljs-attr">&quot;allOf&quot;</span>: [
           {
-            <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/Pet"</span>
+            <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/Pet&quot;</span>
           },
           {
-            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-            <span class="hljs-attr">"properties"</span>: {
-              <span class="hljs-attr">"packSize"</span>: {
-                <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>,
-                <span class="hljs-attr">"format"</span>: <span class="hljs-string">"int32"</span>,
-                <span class="hljs-attr">"description"</span>: <span class="hljs-string">"the size of the pack the dog is from"</span>,
-                <span class="hljs-attr">"default"</span>: <span class="hljs-number">0</span>,
-                <span class="hljs-attr">"minimum"</span>: <span class="hljs-number">0</span>
+            <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+            <span class="hljs-attr">&quot;properties&quot;</span>: {
+              <span class="hljs-attr">&quot;packSize&quot;</span>: {
+                <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>,
+                <span class="hljs-attr">&quot;format&quot;</span>: <span class="hljs-string">&quot;int32&quot;</span>,
+                <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;the size of the pack the dog is from&quot;</span>,
+                <span class="hljs-attr">&quot;default&quot;</span>: <span class="hljs-number">0</span>,
+                <span class="hljs-attr">&quot;minimum&quot;</span>: <span class="hljs-number">0</span>
               }
             },
-            <span class="hljs-attr">"required"</span>: [
-              <span class="hljs-string">"packSize"</span>
+            <span class="hljs-attr">&quot;required&quot;</span>: [
+              <span class="hljs-string">&quot;packSize&quot;</span>
             ]
           }
         ]
@@ -3170,49 +3170,49 @@ The <a href="#xmlObject">XML Object</a> contains additional information about th
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">components:</span>
-<span class="hljs-attr">  schemas:</span>
-<span class="hljs-attr">    Pet:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">      discriminator:</span>
-<span class="hljs-attr">        propertyName:</span> <span class="hljs-string">petType</span>
-<span class="hljs-attr">      properties:</span>
-<span class="hljs-attr">        name:</span>
-<span class="hljs-attr">          type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">        petType:</span>
-<span class="hljs-attr">          type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">      required:</span>
-<span class="hljs-bullet">      -</span> <span class="hljs-string">name</span>
-<span class="hljs-bullet">      -</span> <span class="hljs-string">petType</span>
-<span class="hljs-attr">    Cat:</span>  <span class="hljs-comment">## "Cat" will be used as the discriminator value</span>
-<span class="hljs-attr">      description:</span> <span class="hljs-string">A</span> <span class="hljs-string">representation</span> <span class="hljs-string">of</span> <span class="hljs-string">a</span> <span class="hljs-string">cat</span>
-<span class="hljs-attr">      allOf:</span>
-<span class="hljs-bullet">      -</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Pet'</span>
-<span class="hljs-attr">      - type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">        properties:</span>
-<span class="hljs-attr">          huntingSkill:</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">            description:</span> <span class="hljs-string">The</span> <span class="hljs-string">measured</span> <span class="hljs-string">skill</span> <span class="hljs-string">for</span> <span class="hljs-string">hunting</span>
-<span class="hljs-attr">            enum:</span>
-<span class="hljs-bullet">            -</span> <span class="hljs-string">clueless</span>
-<span class="hljs-bullet">            -</span> <span class="hljs-string">lazy</span>
-<span class="hljs-bullet">            -</span> <span class="hljs-string">adventurous</span>
-<span class="hljs-bullet">            -</span> <span class="hljs-string">aggressive</span>
-<span class="hljs-attr">        required:</span>
-<span class="hljs-bullet">        -</span> <span class="hljs-string">huntingSkill</span>
-<span class="hljs-attr">    Dog:</span>  <span class="hljs-comment">## "Dog" will be used as the discriminator value</span>
-<span class="hljs-attr">      description:</span> <span class="hljs-string">A</span> <span class="hljs-string">representation</span> <span class="hljs-string">of</span> <span class="hljs-string">a</span> <span class="hljs-string">dog</span>
-<span class="hljs-attr">      allOf:</span>
-<span class="hljs-bullet">      -</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Pet'</span>
-<span class="hljs-attr">      - type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">        properties:</span>
-<span class="hljs-attr">          packSize:</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">integer</span>
-<span class="hljs-attr">            format:</span> <span class="hljs-string">int32</span>
-<span class="hljs-attr">            description:</span> <span class="hljs-string">the</span> <span class="hljs-string">size</span> <span class="hljs-string">of</span> <span class="hljs-string">the</span> <span class="hljs-string">pack</span> <span class="hljs-string">the</span> <span class="hljs-string">dog</span> <span class="hljs-string">is</span> <span class="hljs-string">from</span>
-<span class="hljs-attr">            default:</span> <span class="hljs-number">0</span>
-<span class="hljs-attr">            minimum:</span> <span class="hljs-number">0</span>
-<span class="hljs-attr">        required:</span>
-<span class="hljs-bullet">        -</span> <span class="hljs-string">packSize</span>
+  <span class="hljs-attr">schemas:</span>
+    <span class="hljs-attr">Pet:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+      <span class="hljs-attr">discriminator:</span>
+        <span class="hljs-attr">propertyName:</span> <span class="hljs-string">petType</span>
+      <span class="hljs-attr">properties:</span>
+        <span class="hljs-attr">name:</span>
+          <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+        <span class="hljs-attr">petType:</span>
+          <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+      <span class="hljs-attr">required:</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-string">name</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-string">petType</span>
+    <span class="hljs-attr">Cat:</span>  <span class="hljs-comment">## &quot;Cat&quot; will be used as the discriminator value</span>
+      <span class="hljs-attr">description:</span> <span class="hljs-string">A</span> <span class="hljs-string">representation</span> <span class="hljs-string">of</span> <span class="hljs-string">a</span> <span class="hljs-string">cat</span>
+      <span class="hljs-attr">allOf:</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/Pet&#x27;</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+        <span class="hljs-attr">properties:</span>
+          <span class="hljs-attr">huntingSkill:</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+            <span class="hljs-attr">description:</span> <span class="hljs-string">The</span> <span class="hljs-string">measured</span> <span class="hljs-string">skill</span> <span class="hljs-string">for</span> <span class="hljs-string">hunting</span>
+            <span class="hljs-attr">enum:</span>
+            <span class="hljs-bullet">-</span> <span class="hljs-string">clueless</span>
+            <span class="hljs-bullet">-</span> <span class="hljs-string">lazy</span>
+            <span class="hljs-bullet">-</span> <span class="hljs-string">adventurous</span>
+            <span class="hljs-bullet">-</span> <span class="hljs-string">aggressive</span>
+        <span class="hljs-attr">required:</span>
+        <span class="hljs-bullet">-</span> <span class="hljs-string">huntingSkill</span>
+    <span class="hljs-attr">Dog:</span>  <span class="hljs-comment">## &quot;Dog&quot; will be used as the discriminator value</span>
+      <span class="hljs-attr">description:</span> <span class="hljs-string">A</span> <span class="hljs-string">representation</span> <span class="hljs-string">of</span> <span class="hljs-string">a</span> <span class="hljs-string">dog</span>
+      <span class="hljs-attr">allOf:</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/Pet&#x27;</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+        <span class="hljs-attr">properties:</span>
+          <span class="hljs-attr">packSize:</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+            <span class="hljs-attr">format:</span> <span class="hljs-string">int32</span>
+            <span class="hljs-attr">description:</span> <span class="hljs-string">the</span> <span class="hljs-string">size</span> <span class="hljs-string">of</span> <span class="hljs-string">the</span> <span class="hljs-string">pack</span> <span class="hljs-string">the</span> <span class="hljs-string">dog</span> <span class="hljs-string">is</span> <span class="hljs-string">from</span>
+            <span class="hljs-attr">default:</span> <span class="hljs-number">0</span>
+            <span class="hljs-attr">minimum:</span> <span class="hljs-number">0</span>
+        <span class="hljs-attr">required:</span>
+        <span class="hljs-bullet">-</span> <span class="hljs-string">packSize</span>
 </code></pre>
 </section></section></section><section><h3><span id="discriminatorObject">Discriminator Object</span></h3>
 <p>When request bodies or response payloads may be one of a number of different schemas, a <code>discriminator</code> object can be used to aid in serialization, deserialization, and validation.  The discriminator is a specific object in a schema which is used to inform the consumer of the specification of an alternative schema based on the value associated with it.</p>
@@ -3243,42 +3243,42 @@ The <a href="#xmlObject">XML Object</a> contains additional information about th
 <p>In OAS 3.0, a response payload MAY be described to be exactly one of any number of types:</p>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">MyResponseType:</span>
-<span class="hljs-attr">  oneOf:</span>
-<span class="hljs-bullet">  -</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Cat'</span>
-<span class="hljs-bullet">  -</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Dog'</span>
-<span class="hljs-bullet">  -</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Lizard'</span>
+  <span class="hljs-attr">oneOf:</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/Cat&#x27;</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/Dog&#x27;</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/Lizard&#x27;</span>
 </code></pre>
 <p>which means the payload <em>MUST</em>, by validation, match exactly one of the schemas described by <code>Cat</code>, <code>Dog</code>, or <code>Lizard</code>.  In this case, a discriminator MAY act as a “hint” to shortcut validation and selection of the matching schema which may be a costly operation, depending on the complexity of the schema. We can then describe exactly which field tells us which schema to use:</p>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">MyResponseType:</span>
-<span class="hljs-attr">  oneOf:</span>
-<span class="hljs-bullet">  -</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Cat'</span>
-<span class="hljs-bullet">  -</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Dog'</span>
-<span class="hljs-bullet">  -</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Lizard'</span>
-<span class="hljs-attr">  discriminator:</span>
-<span class="hljs-attr">    propertyName:</span> <span class="hljs-string">petType</span>
+  <span class="hljs-attr">oneOf:</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/Cat&#x27;</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/Dog&#x27;</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/Lizard&#x27;</span>
+  <span class="hljs-attr">discriminator:</span>
+    <span class="hljs-attr">propertyName:</span> <span class="hljs-string">petType</span>
 </code></pre>
 <p>The expectation now is that a property with name <code>petType</code> <em>MUST</em> be present in the response payload, and the value will correspond to the name of a schema defined in the OAS document.  Thus the response payload:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"id"</span>: <span class="hljs-number">12345</span>,
-  <span class="hljs-attr">"petType"</span>: <span class="hljs-string">"Cat"</span>
+  <span class="hljs-attr">&quot;id&quot;</span>: <span class="hljs-number">12345</span>,
+  <span class="hljs-attr">&quot;petType&quot;</span>: <span class="hljs-string">&quot;Cat&quot;</span>
 }
 </code></pre>
 <p>Will indicate that the <code>Cat</code> schema be used in conjunction with this payload.</p>
 <p>In scenarios where the value of the discriminator field does not match the schema name or implicit mapping is not possible, an optional <code>mapping</code> definition MAY be used:</p>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">MyResponseType:</span>
-<span class="hljs-attr">  oneOf:</span>
-<span class="hljs-bullet">  -</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Cat'</span>
-<span class="hljs-bullet">  -</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Dog'</span>
-<span class="hljs-bullet">  -</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Lizard'</span>
-<span class="hljs-bullet">  -</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'https://gigantic-server.com/schemas/Monster/schema.json'</span>
-<span class="hljs-attr">  discriminator:</span>
-<span class="hljs-attr">    propertyName:</span> <span class="hljs-string">petType</span>
-<span class="hljs-attr">    mapping:</span>
-<span class="hljs-attr">      dog:</span> <span class="hljs-string">'#/components/schemas/Dog'</span>
-<span class="hljs-attr">      monster:</span> <span class="hljs-string">'https://gigantic-server.com/schemas/Monster/schema.json'</span>
+  <span class="hljs-attr">oneOf:</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/Cat&#x27;</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/Dog&#x27;</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/Lizard&#x27;</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;https://gigantic-server.com/schemas/Monster/schema.json&#x27;</span>
+  <span class="hljs-attr">discriminator:</span>
+    <span class="hljs-attr">propertyName:</span> <span class="hljs-string">petType</span>
+    <span class="hljs-attr">mapping:</span>
+      <span class="hljs-attr">dog:</span> <span class="hljs-string">&#x27;#/components/schemas/Dog&#x27;</span>
+      <span class="hljs-attr">monster:</span> <span class="hljs-string">&#x27;https://gigantic-server.com/schemas/Monster/schema.json&#x27;</span>
 </code></pre>
 <p>Here the discriminator <em>value</em> of <code>dog</code> will map to the schema <code>#/components/schemas/Dog</code>, rather than the default (implicit) value of <code>Dog</code>.  If the discriminator <em>value</em> does not match an implicit or explicit mapping, no schema can be determined and validation SHOULD fail. Mapping keys MUST be string values, but tooling MAY convert response values to strings for comparison.</p>
 <p>When used in conjunction with the <code>anyOf</code> construct, the use of the discriminator can avoid ambiguity where multiple schemas may satisfy a single payload.</p>
@@ -3286,55 +3286,55 @@ The <a href="#xmlObject">XML Object</a> contains additional information about th
 <p>For example:</p>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">components:</span>
-<span class="hljs-attr">  schemas:</span>
-<span class="hljs-attr">    Pet:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">      required:</span>
-<span class="hljs-bullet">      -</span> <span class="hljs-string">petType</span>
-<span class="hljs-attr">      properties:</span>
-<span class="hljs-attr">        petType:</span>
-<span class="hljs-attr">          type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">      discriminator:</span>
-<span class="hljs-attr">        propertyName:</span> <span class="hljs-string">petType</span>
-<span class="hljs-attr">        mapping:</span>
-<span class="hljs-attr">          dog:</span> <span class="hljs-string">Dog</span>
-<span class="hljs-attr">    Cat:</span>
-<span class="hljs-attr">      allOf:</span>
-<span class="hljs-bullet">      -</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Pet'</span>
-<span class="hljs-attr">      - type:</span> <span class="hljs-string">object</span>
+  <span class="hljs-attr">schemas:</span>
+    <span class="hljs-attr">Pet:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+      <span class="hljs-attr">required:</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-string">petType</span>
+      <span class="hljs-attr">properties:</span>
+        <span class="hljs-attr">petType:</span>
+          <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+      <span class="hljs-attr">discriminator:</span>
+        <span class="hljs-attr">propertyName:</span> <span class="hljs-string">petType</span>
+        <span class="hljs-attr">mapping:</span>
+          <span class="hljs-attr">dog:</span> <span class="hljs-string">Dog</span>
+    <span class="hljs-attr">Cat:</span>
+      <span class="hljs-attr">allOf:</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/Pet&#x27;</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
         <span class="hljs-comment"># all other properties specific to a `Cat`</span>
-<span class="hljs-attr">        properties:</span>
-<span class="hljs-attr">          name:</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">    Dog:</span>
-<span class="hljs-attr">      allOf:</span>
-<span class="hljs-bullet">      -</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Pet'</span>
-<span class="hljs-attr">      - type:</span> <span class="hljs-string">object</span>
+        <span class="hljs-attr">properties:</span>
+          <span class="hljs-attr">name:</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+    <span class="hljs-attr">Dog:</span>
+      <span class="hljs-attr">allOf:</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/Pet&#x27;</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
         <span class="hljs-comment"># all other properties specific to a `Dog`</span>
-<span class="hljs-attr">        properties:</span>
-<span class="hljs-attr">          bark:</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">    Lizard:</span>
-<span class="hljs-attr">      allOf:</span>
-<span class="hljs-bullet">      -</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Pet'</span>
-<span class="hljs-attr">      - type:</span> <span class="hljs-string">object</span>
+        <span class="hljs-attr">properties:</span>
+          <span class="hljs-attr">bark:</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+    <span class="hljs-attr">Lizard:</span>
+      <span class="hljs-attr">allOf:</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/Pet&#x27;</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
         <span class="hljs-comment"># all other properties specific to a `Lizard`</span>
-<span class="hljs-attr">        properties:</span>
-<span class="hljs-attr">          lovesRocks:</span>
-<span class="hljs-attr">            type:</span> <span class="hljs-string">boolean</span>
+        <span class="hljs-attr">properties:</span>
+          <span class="hljs-attr">lovesRocks:</span>
+            <span class="hljs-attr">type:</span> <span class="hljs-string">boolean</span>
 </code></pre>
 <p>a payload like this:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"petType"</span>: <span class="hljs-string">"Cat"</span>,
-  <span class="hljs-attr">"name"</span>: <span class="hljs-string">"misty"</span>
+  <span class="hljs-attr">&quot;petType&quot;</span>: <span class="hljs-string">&quot;Cat&quot;</span>,
+  <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;misty&quot;</span>
 }
 </code></pre>
 <p>will indicate that the <code>Cat</code> schema be used.  Likewise this schema:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"petType"</span>: <span class="hljs-string">"dog"</span>,
-  <span class="hljs-attr">"bark"</span>: <span class="hljs-string">"soft"</span>
+  <span class="hljs-attr">&quot;petType&quot;</span>: <span class="hljs-string">&quot;dog&quot;</span>,
+  <span class="hljs-attr">&quot;bark&quot;</span>: <span class="hljs-string">&quot;soft&quot;</span>
 }
 </code></pre>
 <p>will map to <code>Dog</code> because of the definition in the <code>mappings</code> element.</p>
@@ -3386,14 +3386,14 @@ See examples for expected behavior.</p>
 <p>Basic string property:</p>
 <pre class="nohighlight"><code>
 {
-    <span class="hljs-attr">"animals"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+    <span class="hljs-attr">&quot;animals&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
     }
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">animals:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-tag">&lt;<span class="hljs-name">animals</span>&gt;</span>...<span class="hljs-tag">&lt;/<span class="hljs-name">animals</span>&gt;</span>
@@ -3401,19 +3401,19 @@ See examples for expected behavior.</p>
 <p>Basic string array property (<a href="#xmlWrapped"><code>wrapped</code></a> is <code>false</code> by default):</p>
 <pre class="nohighlight"><code>
 {
-    <span class="hljs-attr">"animals"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-        <span class="hljs-attr">"items"</span>: {
-            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+    <span class="hljs-attr">&quot;animals&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+        <span class="hljs-attr">&quot;items&quot;</span>: {
+            <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
         }
     }
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">animals:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">  items:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+  <span class="hljs-attr">items:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-tag">&lt;<span class="hljs-name">animals</span>&gt;</span>...<span class="hljs-tag">&lt;/<span class="hljs-name">animals</span>&gt;</span>
@@ -3423,19 +3423,19 @@ See examples for expected behavior.</p>
 </section><section><h5>XML Name Replacement</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"animals"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
-    <span class="hljs-attr">"xml"</span>: {
-      <span class="hljs-attr">"name"</span>: <span class="hljs-string">"animal"</span>
+  <span class="hljs-attr">&quot;animals&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>,
+    <span class="hljs-attr">&quot;xml&quot;</span>: {
+      <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;animal&quot;</span>
     }
   }
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">animals:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">  xml:</span>
-<span class="hljs-attr">    name:</span> <span class="hljs-string">animal</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">xml:</span>
+    <span class="hljs-attr">name:</span> <span class="hljs-string">animal</span>
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-tag">&lt;<span class="hljs-name">animal</span>&gt;</span>...<span class="hljs-tag">&lt;/<span class="hljs-name">animal</span>&gt;</span>
@@ -3444,21 +3444,21 @@ See examples for expected behavior.</p>
 <p>In this example, a full model definition is shown.</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"Person"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-    <span class="hljs-attr">"properties"</span>: {
-      <span class="hljs-attr">"id"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>,
-        <span class="hljs-attr">"format"</span>: <span class="hljs-string">"int32"</span>,
-        <span class="hljs-attr">"xml"</span>: {
-          <span class="hljs-attr">"attribute"</span>: <span class="hljs-literal">true</span>
+  <span class="hljs-attr">&quot;Person&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+    <span class="hljs-attr">&quot;properties&quot;</span>: {
+      <span class="hljs-attr">&quot;id&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>,
+        <span class="hljs-attr">&quot;format&quot;</span>: <span class="hljs-string">&quot;int32&quot;</span>,
+        <span class="hljs-attr">&quot;xml&quot;</span>: {
+          <span class="hljs-attr">&quot;attribute&quot;</span>: <span class="hljs-literal">true</span>
         }
       },
-      <span class="hljs-attr">"name"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
-        <span class="hljs-attr">"xml"</span>: {
-          <span class="hljs-attr">"namespace"</span>: <span class="hljs-string">"http://example.com/schema/sample"</span>,
-          <span class="hljs-attr">"prefix"</span>: <span class="hljs-string">"sample"</span>
+      <span class="hljs-attr">&quot;name&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>,
+        <span class="hljs-attr">&quot;xml&quot;</span>: {
+          <span class="hljs-attr">&quot;namespace&quot;</span>: <span class="hljs-string">&quot;http://example.com/schema/sample&quot;</span>,
+          <span class="hljs-attr">&quot;prefix&quot;</span>: <span class="hljs-string">&quot;sample&quot;</span>
         }
       }
     }
@@ -3467,34 +3467,34 @@ See examples for expected behavior.</p>
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">Person:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">object</span>
-<span class="hljs-attr">  properties:</span>
-<span class="hljs-attr">    id:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">integer</span>
-<span class="hljs-attr">      format:</span> <span class="hljs-string">int32</span>
-<span class="hljs-attr">      xml:</span>
-<span class="hljs-attr">        attribute:</span> <span class="hljs-literal">true</span>
-<span class="hljs-attr">    name:</span>
-<span class="hljs-attr">      type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">      xml:</span>
-<span class="hljs-attr">        namespace:</span> <span class="hljs-attr">http://example.com/schema/sample</span>
-<span class="hljs-attr">        prefix:</span> <span class="hljs-string">sample</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
+  <span class="hljs-attr">properties:</span>
+    <span class="hljs-attr">id:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
+      <span class="hljs-attr">format:</span> <span class="hljs-string">int32</span>
+      <span class="hljs-attr">xml:</span>
+        <span class="hljs-attr">attribute:</span> <span class="hljs-literal">true</span>
+    <span class="hljs-attr">name:</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+      <span class="hljs-attr">xml:</span>
+        <span class="hljs-attr">namespace:</span> <span class="hljs-string">http://example.com/schema/sample</span>
+        <span class="hljs-attr">prefix:</span> <span class="hljs-string">sample</span>
 </code></pre>
 <pre class="nohighlight"><code>
-<span class="hljs-tag">&lt;<span class="hljs-name">Person</span> <span class="hljs-attr">id</span>=<span class="hljs-string">"123"</span>&gt;</span>
-    <span class="hljs-tag">&lt;<span class="hljs-name">sample:name</span> <span class="hljs-attr">xmlns:sample</span>=<span class="hljs-string">"http://example.com/schema/sample"</span>&gt;</span>example<span class="hljs-tag">&lt;/<span class="hljs-name">sample:name</span>&gt;</span>
+<span class="hljs-tag">&lt;<span class="hljs-name">Person</span> <span class="hljs-attr">id</span>=<span class="hljs-string">&quot;123&quot;</span>&gt;</span>
+    <span class="hljs-tag">&lt;<span class="hljs-name">sample:name</span> <span class="hljs-attr">xmlns:sample</span>=<span class="hljs-string">&quot;http://example.com/schema/sample&quot;</span>&gt;</span>example<span class="hljs-tag">&lt;/<span class="hljs-name">sample:name</span>&gt;</span>
 <span class="hljs-tag">&lt;/<span class="hljs-name">Person</span>&gt;</span>
 </code></pre>
 </section><section><h5>XML Arrays</h5>
 <p>Changing the element names:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"animals"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-    <span class="hljs-attr">"items"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
-      <span class="hljs-attr">"xml"</span>: {
-        <span class="hljs-attr">"name"</span>: <span class="hljs-string">"animal"</span>
+  <span class="hljs-attr">&quot;animals&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+    <span class="hljs-attr">&quot;items&quot;</span>: {
+      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>,
+      <span class="hljs-attr">&quot;xml&quot;</span>: {
+        <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;animal&quot;</span>
       }
     }
   }
@@ -3502,11 +3502,11 @@ See examples for expected behavior.</p>
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">animals:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">  items:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">    xml:</span>
-<span class="hljs-attr">      name:</span> <span class="hljs-string">animal</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+  <span class="hljs-attr">items:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+    <span class="hljs-attr">xml:</span>
+      <span class="hljs-attr">name:</span> <span class="hljs-string">animal</span>
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-tag">&lt;<span class="hljs-name">animal</span>&gt;</span>value<span class="hljs-tag">&lt;/<span class="hljs-name">animal</span>&gt;</span>
@@ -3515,29 +3515,29 @@ See examples for expected behavior.</p>
 <p>The external <code>name</code> property has no effect on the XML:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"animals"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-    <span class="hljs-attr">"items"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
-      <span class="hljs-attr">"xml"</span>: {
-        <span class="hljs-attr">"name"</span>: <span class="hljs-string">"animal"</span>
+  <span class="hljs-attr">&quot;animals&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+    <span class="hljs-attr">&quot;items&quot;</span>: {
+      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>,
+      <span class="hljs-attr">&quot;xml&quot;</span>: {
+        <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;animal&quot;</span>
       }
     },
-    <span class="hljs-attr">"xml"</span>: {
-      <span class="hljs-attr">"name"</span>: <span class="hljs-string">"aliens"</span>
+    <span class="hljs-attr">&quot;xml&quot;</span>: {
+      <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;aliens&quot;</span>
     }
   }
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">animals:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">  items:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">    xml:</span>
-<span class="hljs-attr">      name:</span> <span class="hljs-string">animal</span>
-<span class="hljs-attr">  xml:</span>
-<span class="hljs-attr">    name:</span> <span class="hljs-string">aliens</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+  <span class="hljs-attr">items:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+    <span class="hljs-attr">xml:</span>
+      <span class="hljs-attr">name:</span> <span class="hljs-string">animal</span>
+  <span class="hljs-attr">xml:</span>
+    <span class="hljs-attr">name:</span> <span class="hljs-string">aliens</span>
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-tag">&lt;<span class="hljs-name">animal</span>&gt;</span>value<span class="hljs-tag">&lt;/<span class="hljs-name">animal</span>&gt;</span>
@@ -3546,24 +3546,24 @@ See examples for expected behavior.</p>
 <p>Even when the array is wrapped, if a name is not explicitly defined, the same name will be used both internally and externally:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"animals"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-    <span class="hljs-attr">"items"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+  <span class="hljs-attr">&quot;animals&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+    <span class="hljs-attr">&quot;items&quot;</span>: {
+      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
     },
-    <span class="hljs-attr">"xml"</span>: {
-      <span class="hljs-attr">"wrapped"</span>: <span class="hljs-literal">true</span>
+    <span class="hljs-attr">&quot;xml&quot;</span>: {
+      <span class="hljs-attr">&quot;wrapped&quot;</span>: <span class="hljs-literal">true</span>
     }
   }
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">animals:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">  items:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">  xml:</span>
-<span class="hljs-attr">    wrapped:</span> <span class="hljs-literal">true</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+  <span class="hljs-attr">items:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">xml:</span>
+    <span class="hljs-attr">wrapped:</span> <span class="hljs-literal">true</span>
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-tag">&lt;<span class="hljs-name">animals</span>&gt;</span>
@@ -3574,29 +3574,29 @@ See examples for expected behavior.</p>
 <p>To overcome the naming problem in the example above, the following definition can be used:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"animals"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-    <span class="hljs-attr">"items"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
-      <span class="hljs-attr">"xml"</span>: {
-        <span class="hljs-attr">"name"</span>: <span class="hljs-string">"animal"</span>
+  <span class="hljs-attr">&quot;animals&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+    <span class="hljs-attr">&quot;items&quot;</span>: {
+      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>,
+      <span class="hljs-attr">&quot;xml&quot;</span>: {
+        <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;animal&quot;</span>
       }
     },
-    <span class="hljs-attr">"xml"</span>: {
-      <span class="hljs-attr">"wrapped"</span>: <span class="hljs-literal">true</span>
+    <span class="hljs-attr">&quot;xml&quot;</span>: {
+      <span class="hljs-attr">&quot;wrapped&quot;</span>: <span class="hljs-literal">true</span>
     }
   }
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">animals:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">  items:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">    xml:</span>
-<span class="hljs-attr">      name:</span> <span class="hljs-string">animal</span>
-<span class="hljs-attr">  xml:</span>
-<span class="hljs-attr">    wrapped:</span> <span class="hljs-literal">true</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+  <span class="hljs-attr">items:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+    <span class="hljs-attr">xml:</span>
+      <span class="hljs-attr">name:</span> <span class="hljs-string">animal</span>
+  <span class="hljs-attr">xml:</span>
+    <span class="hljs-attr">wrapped:</span> <span class="hljs-literal">true</span>
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-tag">&lt;<span class="hljs-name">animals</span>&gt;</span>
@@ -3607,31 +3607,31 @@ See examples for expected behavior.</p>
 <p>Affecting both internal and external names:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"animals"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-    <span class="hljs-attr">"items"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
-      <span class="hljs-attr">"xml"</span>: {
-        <span class="hljs-attr">"name"</span>: <span class="hljs-string">"animal"</span>
+  <span class="hljs-attr">&quot;animals&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+    <span class="hljs-attr">&quot;items&quot;</span>: {
+      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>,
+      <span class="hljs-attr">&quot;xml&quot;</span>: {
+        <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;animal&quot;</span>
       }
     },
-    <span class="hljs-attr">"xml"</span>: {
-      <span class="hljs-attr">"name"</span>: <span class="hljs-string">"aliens"</span>,
-      <span class="hljs-attr">"wrapped"</span>: <span class="hljs-literal">true</span>
+    <span class="hljs-attr">&quot;xml&quot;</span>: {
+      <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;aliens&quot;</span>,
+      <span class="hljs-attr">&quot;wrapped&quot;</span>: <span class="hljs-literal">true</span>
     }
   }
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">animals:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">  items:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">    xml:</span>
-<span class="hljs-attr">      name:</span> <span class="hljs-string">animal</span>
-<span class="hljs-attr">  xml:</span>
-<span class="hljs-attr">    name:</span> <span class="hljs-string">aliens</span>
-<span class="hljs-attr">    wrapped:</span> <span class="hljs-literal">true</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+  <span class="hljs-attr">items:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+    <span class="hljs-attr">xml:</span>
+      <span class="hljs-attr">name:</span> <span class="hljs-string">animal</span>
+  <span class="hljs-attr">xml:</span>
+    <span class="hljs-attr">name:</span> <span class="hljs-string">aliens</span>
+    <span class="hljs-attr">wrapped:</span> <span class="hljs-literal">true</span>
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-tag">&lt;<span class="hljs-name">aliens</span>&gt;</span>
@@ -3642,26 +3642,26 @@ See examples for expected behavior.</p>
 <p>If we change the external element but not the internal ones:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"animals"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-    <span class="hljs-attr">"items"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+  <span class="hljs-attr">&quot;animals&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+    <span class="hljs-attr">&quot;items&quot;</span>: {
+      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
     },
-    <span class="hljs-attr">"xml"</span>: {
-      <span class="hljs-attr">"name"</span>: <span class="hljs-string">"aliens"</span>,
-      <span class="hljs-attr">"wrapped"</span>: <span class="hljs-literal">true</span>
+    <span class="hljs-attr">&quot;xml&quot;</span>: {
+      <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;aliens&quot;</span>,
+      <span class="hljs-attr">&quot;wrapped&quot;</span>: <span class="hljs-literal">true</span>
     }
   }
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">animals:</span>
-<span class="hljs-attr">  type:</span> <span class="hljs-string">array</span>
-<span class="hljs-attr">  items:</span>
-<span class="hljs-attr">    type:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">  xml:</span>
-<span class="hljs-attr">    name:</span> <span class="hljs-string">aliens</span>
-<span class="hljs-attr">    wrapped:</span> <span class="hljs-literal">true</span>
+  <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
+  <span class="hljs-attr">items:</span>
+    <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
+  <span class="hljs-attr">xml:</span>
+    <span class="hljs-attr">name:</span> <span class="hljs-string">aliens</span>
+    <span class="hljs-attr">wrapped:</span> <span class="hljs-literal">true</span>
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-tag">&lt;<span class="hljs-name">aliens</span>&gt;</span>
@@ -3738,8 +3738,8 @@ Supported schemes are HTTP authentication, an API key (either as a header, a coo
 <section><h5>Basic Authentication Sample</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"http"</span>,
-  <span class="hljs-attr">"scheme"</span>: <span class="hljs-string">"basic"</span>
+  <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;http&quot;</span>,
+  <span class="hljs-attr">&quot;scheme&quot;</span>: <span class="hljs-string">&quot;basic&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -3749,9 +3749,9 @@ Supported schemes are HTTP authentication, an API key (either as a header, a coo
 </section><section><h5>API Key Sample</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"apiKey"</span>,
-  <span class="hljs-attr">"name"</span>: <span class="hljs-string">"api_key"</span>,
-  <span class="hljs-attr">"in"</span>: <span class="hljs-string">"header"</span>
+  <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;apiKey&quot;</span>,
+  <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;api_key&quot;</span>,
+  <span class="hljs-attr">&quot;in&quot;</span>: <span class="hljs-string">&quot;header&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -3762,9 +3762,9 @@ Supported schemes are HTTP authentication, an API key (either as a header, a coo
 </section><section><h5>JWT Bearer Sample</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"http"</span>,
-  <span class="hljs-attr">"scheme"</span>: <span class="hljs-string">"bearer"</span>,
-  <span class="hljs-attr">"bearerFormat"</span>: <span class="hljs-string">"JWT"</span>,
+  <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;http&quot;</span>,
+  <span class="hljs-attr">&quot;scheme&quot;</span>: <span class="hljs-string">&quot;bearer&quot;</span>,
+  <span class="hljs-attr">&quot;bearerFormat&quot;</span>: <span class="hljs-string">&quot;JWT&quot;</span>,
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -3775,13 +3775,13 @@ Supported schemes are HTTP authentication, an API key (either as a header, a coo
 </section><section><h5>Implicit OAuth2 Sample</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"oauth2"</span>,
-  <span class="hljs-attr">"flows"</span>: {
-    <span class="hljs-attr">"implicit"</span>: {
-      <span class="hljs-attr">"authorizationUrl"</span>: <span class="hljs-string">"https://example.com/api/oauth/dialog"</span>,
-      <span class="hljs-attr">"scopes"</span>: {
-        <span class="hljs-attr">"write:pets"</span>: <span class="hljs-string">"modify pets in your account"</span>,
-        <span class="hljs-attr">"read:pets"</span>: <span class="hljs-string">"read your pets"</span>
+  <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;oauth2&quot;</span>,
+  <span class="hljs-attr">&quot;flows&quot;</span>: {
+    <span class="hljs-attr">&quot;implicit&quot;</span>: {
+      <span class="hljs-attr">&quot;authorizationUrl&quot;</span>: <span class="hljs-string">&quot;https://example.com/api/oauth/dialog&quot;</span>,
+      <span class="hljs-attr">&quot;scopes&quot;</span>: {
+        <span class="hljs-attr">&quot;write:pets&quot;</span>: <span class="hljs-string">&quot;modify pets in your account&quot;</span>,
+        <span class="hljs-attr">&quot;read:pets&quot;</span>: <span class="hljs-string">&quot;read your pets&quot;</span>
       }
     }
   }
@@ -3790,11 +3790,11 @@ Supported schemes are HTTP authentication, an API key (either as a header, a coo
 <pre class="nohighlight"><code>
 <span class="hljs-attr">type:</span> <span class="hljs-string">oauth2</span>
 <span class="hljs-attr">flows:</span> 
-<span class="hljs-attr">  implicit:</span>
-<span class="hljs-attr">    authorizationUrl:</span> <span class="hljs-attr">https://example.com/api/oauth/dialog</span>
-<span class="hljs-attr">    scopes:</span>
-<span class="hljs-attr">      write:</span><span class="hljs-attr">pets:</span> <span class="hljs-string">modify</span> <span class="hljs-string">pets</span> <span class="hljs-string">in</span> <span class="hljs-string">your</span> <span class="hljs-string">account</span>
-<span class="hljs-attr">      read:</span><span class="hljs-attr">pets:</span> <span class="hljs-string">read</span> <span class="hljs-string">your</span> <span class="hljs-string">pets</span>
+  <span class="hljs-attr">implicit:</span>
+    <span class="hljs-attr">authorizationUrl:</span> <span class="hljs-string">https://example.com/api/oauth/dialog</span>
+    <span class="hljs-attr">scopes:</span>
+      <span class="hljs-attr">write:pets:</span> <span class="hljs-string">modify</span> <span class="hljs-string">pets</span> <span class="hljs-string">in</span> <span class="hljs-string">your</span> <span class="hljs-string">account</span>
+      <span class="hljs-attr">read:pets:</span> <span class="hljs-string">read</span> <span class="hljs-string">your</span> <span class="hljs-string">pets</span>
 </code></pre>
 </section></section></section><section><h3><span id="oauthFlowsObject">OAuth Flows Object</span></h3>
 <p>Allows configuration of the supported OAuth Flows.</p>
@@ -3874,21 +3874,21 @@ Supported schemes are HTTP authentication, an API key (either as a header, a coo
 </section><section><h4>OAuth Flow Object Examples</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"oauth2"</span>,
-  <span class="hljs-attr">"flows"</span>: {
-    <span class="hljs-attr">"implicit"</span>: {
-      <span class="hljs-attr">"authorizationUrl"</span>: <span class="hljs-string">"https://example.com/api/oauth/dialog"</span>,
-      <span class="hljs-attr">"scopes"</span>: {
-        <span class="hljs-attr">"write:pets"</span>: <span class="hljs-string">"modify pets in your account"</span>,
-        <span class="hljs-attr">"read:pets"</span>: <span class="hljs-string">"read your pets"</span>
+  <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;oauth2&quot;</span>,
+  <span class="hljs-attr">&quot;flows&quot;</span>: {
+    <span class="hljs-attr">&quot;implicit&quot;</span>: {
+      <span class="hljs-attr">&quot;authorizationUrl&quot;</span>: <span class="hljs-string">&quot;https://example.com/api/oauth/dialog&quot;</span>,
+      <span class="hljs-attr">&quot;scopes&quot;</span>: {
+        <span class="hljs-attr">&quot;write:pets&quot;</span>: <span class="hljs-string">&quot;modify pets in your account&quot;</span>,
+        <span class="hljs-attr">&quot;read:pets&quot;</span>: <span class="hljs-string">&quot;read your pets&quot;</span>
       }
     },
-    <span class="hljs-attr">"authorizationCode"</span>: {
-      <span class="hljs-attr">"authorizationUrl"</span>: <span class="hljs-string">"https://example.com/api/oauth/dialog"</span>,
-      <span class="hljs-attr">"tokenUrl"</span>: <span class="hljs-string">"https://example.com/api/oauth/token"</span>,
-      <span class="hljs-attr">"scopes"</span>: {
-        <span class="hljs-attr">"write:pets"</span>: <span class="hljs-string">"modify pets in your account"</span>,
-        <span class="hljs-attr">"read:pets"</span>: <span class="hljs-string">"read your pets"</span>
+    <span class="hljs-attr">&quot;authorizationCode&quot;</span>: {
+      <span class="hljs-attr">&quot;authorizationUrl&quot;</span>: <span class="hljs-string">&quot;https://example.com/api/oauth/dialog&quot;</span>,
+      <span class="hljs-attr">&quot;tokenUrl&quot;</span>: <span class="hljs-string">&quot;https://example.com/api/oauth/token&quot;</span>,
+      <span class="hljs-attr">&quot;scopes&quot;</span>: {
+        <span class="hljs-attr">&quot;write:pets&quot;</span>: <span class="hljs-string">&quot;modify pets in your account&quot;</span>,
+        <span class="hljs-attr">&quot;read:pets&quot;</span>: <span class="hljs-string">&quot;read your pets&quot;</span>
       }
     }
   }
@@ -3897,17 +3897,17 @@ Supported schemes are HTTP authentication, an API key (either as a header, a coo
 <pre class="nohighlight"><code>
 <span class="hljs-attr">type:</span> <span class="hljs-string">oauth2</span>
 <span class="hljs-attr">flows:</span> 
-<span class="hljs-attr">  implicit:</span>
-<span class="hljs-attr">    authorizationUrl:</span> <span class="hljs-attr">https://example.com/api/oauth/dialog</span>
-<span class="hljs-attr">    scopes:</span>
-<span class="hljs-attr">      write:</span><span class="hljs-attr">pets:</span> <span class="hljs-string">modify</span> <span class="hljs-string">pets</span> <span class="hljs-string">in</span> <span class="hljs-string">your</span> <span class="hljs-string">account</span>
-<span class="hljs-attr">      read:</span><span class="hljs-attr">pets:</span> <span class="hljs-string">read</span> <span class="hljs-string">your</span> <span class="hljs-string">pets</span>
-<span class="hljs-attr">  authorizationCode:</span>
-<span class="hljs-attr">    authorizationUrl:</span> <span class="hljs-attr">https://example.com/api/oauth/dialog</span>
-<span class="hljs-attr">    tokenUrl:</span> <span class="hljs-attr">https://example.com/api/oauth/token</span>
-<span class="hljs-attr">    scopes:</span>
-<span class="hljs-attr">      write:</span><span class="hljs-attr">pets:</span> <span class="hljs-string">modify</span> <span class="hljs-string">pets</span> <span class="hljs-string">in</span> <span class="hljs-string">your</span> <span class="hljs-string">account</span>
-<span class="hljs-attr">      read:</span><span class="hljs-attr">pets:</span> <span class="hljs-string">read</span> <span class="hljs-string">your</span> <span class="hljs-string">pets</span> 
+  <span class="hljs-attr">implicit:</span>
+    <span class="hljs-attr">authorizationUrl:</span> <span class="hljs-string">https://example.com/api/oauth/dialog</span>
+    <span class="hljs-attr">scopes:</span>
+      <span class="hljs-attr">write:pets:</span> <span class="hljs-string">modify</span> <span class="hljs-string">pets</span> <span class="hljs-string">in</span> <span class="hljs-string">your</span> <span class="hljs-string">account</span>
+      <span class="hljs-attr">read:pets:</span> <span class="hljs-string">read</span> <span class="hljs-string">your</span> <span class="hljs-string">pets</span>
+  <span class="hljs-attr">authorizationCode:</span>
+    <span class="hljs-attr">authorizationUrl:</span> <span class="hljs-string">https://example.com/api/oauth/dialog</span>
+    <span class="hljs-attr">tokenUrl:</span> <span class="hljs-string">https://example.com/api/oauth/token</span>
+    <span class="hljs-attr">scopes:</span>
+      <span class="hljs-attr">write:pets:</span> <span class="hljs-string">modify</span> <span class="hljs-string">pets</span> <span class="hljs-string">in</span> <span class="hljs-string">your</span> <span class="hljs-string">account</span>
+      <span class="hljs-attr">read:pets:</span> <span class="hljs-string">read</span> <span class="hljs-string">your</span> <span class="hljs-string">pets</span> 
 </code></pre>
 </section></section><section><h3><span id="securityRequirementObject">Security Requirement Object</span></h3>
 <p>Lists the required security schemes to execute this operation.
@@ -3936,25 +3936,25 @@ This enables support for scenarios where multiple query parameters or HTTP heade
 <section><h5>Non-OAuth2 Security Requirement</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"api_key"</span>: []
+  <span class="hljs-attr">&quot;api_key&quot;</span>: []
 }
 </code></pre>
 <pre class="nohighlight"><code>
-<span class="hljs-attr">api_key:</span> <span class="hljs-string">[]</span>
+<span class="hljs-attr">api_key:</span> []
 </code></pre>
 </section><section><h5>OAuth2 Security Requirement</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"petstore_auth"</span>: [
-    <span class="hljs-string">"write:pets"</span>,
-    <span class="hljs-string">"read:pets"</span>
+  <span class="hljs-attr">&quot;petstore_auth&quot;</span>: [
+    <span class="hljs-string">&quot;write:pets&quot;</span>,
+    <span class="hljs-string">&quot;read:pets&quot;</span>
   ]
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">petstore_auth:</span>
-<span class="hljs-attr">- write:</span><span class="hljs-string">pets</span>
-<span class="hljs-attr">- read:</span><span class="hljs-string">pets</span>
+<span class="hljs-bullet">-</span> <span class="hljs-string">write:pets</span>
+<span class="hljs-bullet">-</span> <span class="hljs-string">read:pets</span>
 </code></pre>
 </section></section></section></section><section><h2><span id="specificationExtensions">Specification Extensions</span></h2>
 <p>While the OpenAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.</p>

--- a/oas/v3.0.3.html
+++ b/oas/v3.0.3.html
@@ -1,4 +1,12 @@
-<html><head><meta charset="UTF-8"><title>OpenAPI Specification</title><script src="https://spec.openapis.org/js/respec-oai.js" class="remove"></script><script class="remove">var respecConfig = {"specStatus":"base","editors":[{"name":"Darrel Miller "},{"name":"Jeremy Whitlock "},{"name":"Marsh Gardiner "},{"name":"Mike Ralphson "},{"name":"Ron Ratovsky "},{"name":"Uri Sarid "}],"formerEditors":[{"name":"Jason Harmon "},{"name":"Tony Tam "}],"publishDate":"2020-02-20T00:00:00.000Z","subtitle":"Version 3.0.3","processVersion":2017,"edDraftURI":"https://github.com/OAI/OpenAPI-Specification/","github":{"repoURL":"https://github.com/OAI/OpenAPI-Specification/","branch":"master"},"shortName":"OAS","noTOC":false,"lint":false,"additionalCopyrightHolders":"the Linux Foundation","includePermalinks":true};</script></head><body><style>#respec-ui { visibility: hidden; }h1,h2,h3 { color: #629b34; }a[href] { color: #45512c; }body:not(.toc-inline) #toc h2 { color: #45512c; }table { display: block; width: 100%; overflow: auto; }table th { font-weight: 600; }table th, table td { padding: 6px 13px; border: 1px solid #dfe2e5; }table tr { background-color: #fff; border-top: 1px solid #c6cbd1; }table tr:nth-child(2n) { background-color: #f6f8fa; }pre { background-color: #f6f8fa !important; }/**  * GitHub Gist Theme  * Author : Louis Barranqueiro - https://github.com/LouisBarranqueiro  */  .hljs {   display: block;   background: white;   padding: 0.5em;   color: #333333;   overflow-x: auto; }  .hljs-comment, .hljs-meta {   color: #969896; }  .hljs-string, .hljs-variable, .hljs-template-variable, .hljs-strong, .hljs-emphasis, .hljs-quote {   color: #df5000; }  .hljs-keyword, .hljs-selector-tag, .hljs-type {   color: #a71d5d; }  .hljs-literal, .hljs-symbol, .hljs-bullet, .hljs-attribute {   color: #0086b3; }  .hljs-section, .hljs-name {   color: #63a35c; }  .hljs-tag {   color: #333333; }  .hljs-title, .hljs-attr, .hljs-selector-id, .hljs-selector-class, .hljs-selector-attr, .hljs-selector-pseudo {   color: #795da3; }  .hljs-addition {   color: #55a532;   background-color: #eaffea; }  .hljs-deletion {   color: #bd2c00;   background-color: #ffecec; }  .hljs-link {   text-decoration: underline; } </style><section id="abstract">The OpenAPI Specification (OAS) defines a standard, programming language-agnostic interface description for REST APIs, which allows both humans and computers to discover and understand the capabilities of a service without requiring access to source code, additional documentation, or inspection of network traffic. When properly defined via OpenAPI, a consumer can understand and interact with the remote service with a minimal amount of implementation logic. Similar to what interface descriptions have done for lower-level programming, the OpenAPI Specification removes guesswork in calling a service.</section><section class="notoc" id="sotd"><h2>Status of This Document</h2>The source-of-truth for the specification is the GitHub markdown file referenced above.</section>
+<html lang="en"><head><meta charset="UTF-8"><title>OpenAPI Specification</title><script src="https://spec.openapis.org/js/respec-oai.js" class="remove"></script><script class="remove">var respecConfig = {"specStatus":"base","editors":[{"name":"Darrel Miller "},{"name":"Jeremy Whitlock "},{"name":"Marsh Gardiner "},{"name":"Mike Ralphson "},{"name":"Ron Ratovsky "},{"name":"Uri Sarid "}],"formerEditors":[{"name":"Jason Harmon "},{"name":"Tony Tam "}],"publishDate":"2020-02-20T00:00:00.000Z","subtitle":"Version 3.0.3","processVersion":2017,"edDraftURI":"https://github.com/OAI/OpenAPI-Specification/","github":{"repoURL":"https://github.com/OAI/OpenAPI-Specification/","branch":"master"},"shortName":"OAS","noTOC":false,"lint":false,"additionalCopyrightHolders":"the Linux Foundation","includePermalinks":true};</script><!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-831873-42"></script>
+<script>
+ window.dataLayer = window.dataLayer || [];
+ function gtag(){dataLayer.push(arguments);}
+ gtag('js', new Date());
+ gtag('config', 'UA-831873-42');
+</script>
+</head><body><style>#respec-ui { visibility: hidden; }h1,h2,h3 { color: #629b34; }a[href] { color: #45512c; }body:not(.toc-inline) #toc h2 { color: #45512c; }table { display: block; width: 100%; overflow: auto; }table th { font-weight: 600; }table th, table td { padding: 6px 13px; border: 1px solid #dfe2e5; }table tr { background-color: #fff; border-top: 1px solid #c6cbd1; }table tr:nth-child(2n) { background-color: #f6f8fa; }pre { background-color: #f6f8fa !important; }/**  * GitHub Gist Theme  * Author : Louis Barranqueiro - https://github.com/LouisBarranqueiro  */  .hljs {   display: block;   background: white;   padding: 0.5em;   color: #333333;   overflow-x: auto; }  .hljs-comment, .hljs-meta {   color: #969896; }  .hljs-string, .hljs-variable, .hljs-template-variable, .hljs-strong, .hljs-emphasis, .hljs-quote {   color: #df5000; }  .hljs-keyword, .hljs-selector-tag, .hljs-type {   color: #a71d5d; }  .hljs-literal, .hljs-symbol, .hljs-bullet, .hljs-attribute {   color: #0086b3; }  .hljs-section, .hljs-name {   color: #63a35c; }  .hljs-tag {   color: #333333; }  .hljs-title, .hljs-attr, .hljs-selector-id, .hljs-selector-class, .hljs-selector-attr, .hljs-selector-pseudo {   color: #795da3; }  .hljs-addition {   color: #55a532;   background-color: #eaffea; }  .hljs-deletion {   color: #bd2c00;   background-color: #ffecec; }  .hljs-link {   text-decoration: underline; } </style><section id="abstract">The OpenAPI Specification (OAS) defines a standard, programming language-agnostic interface description for REST APIs, which allows both humans and computers to discover and understand the capabilities of a service without requiring access to source code, additional documentation, or inspection of network traffic. When properly defined via OpenAPI, a consumer can understand and interact with the remote service with a minimal amount of implementation logic. Similar to what interface descriptions have done for lower-level programming, the OpenAPI Specification removes guesswork in calling a service.</section><section class="notoc" id="sotd"><h2>Status of This Document</h2>The source-of-truth for the specification is the GitHub markdown file referenced above.</section>
 <section><h1>OpenAPI Specification</h1>
 <section><h3>Version 3.0.3</h3>
 <p>The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “NOT RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be interpreted as described in <a href="https://tools.ietf.org/html/bcp14">BCP 14</a> [[!RFC2119]] [[!RFC8174]] when, and only when, they appear in all capitals, as shown here.</p>
@@ -44,7 +52,7 @@ The available status codes are defined by [[!RFC7231]] and registered status cod
 <p>For example, if a field has an array value, the JSON array representation will be used:</p>
 <pre class="nohighlight"><code>
 {
-   <span class="hljs-attr">"field"</span>: [ <span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span> ]
+   <span class="hljs-attr">&quot;field&quot;</span>: [ <span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span> ]
 }
 </code></pre>
 <p>All field names in the specification are <strong>case sensitive</strong>.
@@ -250,19 +258,19 @@ The metadata MAY be used by the clients if needed, and MAY be presented in editi
 </section><section><h4>Info Object Example</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"title"</span>: <span class="hljs-string">"Sample Pet Store App"</span>,
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"This is a sample server for a pet store."</span>,
-  <span class="hljs-attr">"termsOfService"</span>: <span class="hljs-string">"http://example.com/terms/"</span>,
-  <span class="hljs-attr">"contact"</span>: {
-    <span class="hljs-attr">"name"</span>: <span class="hljs-string">"API Support"</span>,
-    <span class="hljs-attr">"url"</span>: <span class="hljs-string">"http://www.example.com/support"</span>,
-    <span class="hljs-attr">"email"</span>: <span class="hljs-string">"support@example.com"</span>
+  <span class="hljs-attr">&quot;title&quot;</span>: <span class="hljs-string">&quot;Sample Pet Store App&quot;</span>,
+  <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;This is a sample server for a pet store.&quot;</span>,
+  <span class="hljs-attr">&quot;termsOfService&quot;</span>: <span class="hljs-string">&quot;http://example.com/terms/&quot;</span>,
+  <span class="hljs-attr">&quot;contact&quot;</span>: {
+    <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;API Support&quot;</span>,
+    <span class="hljs-attr">&quot;url&quot;</span>: <span class="hljs-string">&quot;http://www.example.com/support&quot;</span>,
+    <span class="hljs-attr">&quot;email&quot;</span>: <span class="hljs-string">&quot;support@example.com&quot;</span>
   },
-  <span class="hljs-attr">"license"</span>: {
-    <span class="hljs-attr">"name"</span>: <span class="hljs-string">"Apache 2.0"</span>,
-    <span class="hljs-attr">"url"</span>: <span class="hljs-string">"https://www.apache.org/licenses/LICENSE-2.0.html"</span>
+  <span class="hljs-attr">&quot;license&quot;</span>: {
+    <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;Apache 2.0&quot;</span>,
+    <span class="hljs-attr">&quot;url&quot;</span>: <span class="hljs-string">&quot;https://www.apache.org/licenses/LICENSE-2.0.html&quot;</span>
   },
-  <span class="hljs-attr">"version"</span>: <span class="hljs-string">"1.0.1"</span>
+  <span class="hljs-attr">&quot;version&quot;</span>: <span class="hljs-string">&quot;1.0.1&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -311,9 +319,9 @@ The metadata MAY be used by the clients if needed, and MAY be presented in editi
 </section><section><h4>Contact Object Example</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"name"</span>: <span class="hljs-string">"API Support"</span>,
-  <span class="hljs-attr">"url"</span>: <span class="hljs-string">"http://www.example.com/support"</span>,
-  <span class="hljs-attr">"email"</span>: <span class="hljs-string">"support@example.com"</span>
+  <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;API Support&quot;</span>,
+  <span class="hljs-attr">&quot;url&quot;</span>: <span class="hljs-string">&quot;http://www.example.com/support&quot;</span>,
+  <span class="hljs-attr">&quot;email&quot;</span>: <span class="hljs-string">&quot;support@example.com&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -349,8 +357,8 @@ The metadata MAY be used by the clients if needed, and MAY be presented in editi
 </section><section><h4>License Object Example</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"name"</span>: <span class="hljs-string">"Apache 2.0"</span>,
-  <span class="hljs-attr">"url"</span>: <span class="hljs-string">"https://www.apache.org/licenses/LICENSE-2.0.html"</span>
+  <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;Apache 2.0&quot;</span>,
+  <span class="hljs-attr">&quot;url&quot;</span>: <span class="hljs-string">&quot;https://www.apache.org/licenses/LICENSE-2.0.html&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -391,8 +399,8 @@ The metadata MAY be used by the clients if needed, and MAY be presented in editi
 <p>A single server would be described as:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"url"</span>: <span class="hljs-string">"https://development.gigantic-server.com/v1"</span>,
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Development server"</span>
+  <span class="hljs-attr">&quot;url&quot;</span>: <span class="hljs-string">&quot;https://development.gigantic-server.com/v1&quot;</span>,
+  <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;Development server&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -402,18 +410,18 @@ The metadata MAY be used by the clients if needed, and MAY be presented in editi
 <p>The following shows how multiple servers can be described, for example, at the OpenAPI Object’s <a href="#oasServers"><code>servers</code></a>:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"servers"</span>: [
+  <span class="hljs-attr">&quot;servers&quot;</span>: [
     {
-      <span class="hljs-attr">"url"</span>: <span class="hljs-string">"https://development.gigantic-server.com/v1"</span>,
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Development server"</span>
+      <span class="hljs-attr">&quot;url&quot;</span>: <span class="hljs-string">&quot;https://development.gigantic-server.com/v1&quot;</span>,
+      <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;Development server&quot;</span>
     },
     {
-      <span class="hljs-attr">"url"</span>: <span class="hljs-string">"https://staging.gigantic-server.com/v1"</span>,
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Staging server"</span>
+      <span class="hljs-attr">&quot;url&quot;</span>: <span class="hljs-string">&quot;https://staging.gigantic-server.com/v1&quot;</span>,
+      <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;Staging server&quot;</span>
     },
     {
-      <span class="hljs-attr">"url"</span>: <span class="hljs-string">"https://api.gigantic-server.com/v1"</span>,
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Production server"</span>
+      <span class="hljs-attr">&quot;url&quot;</span>: <span class="hljs-string">&quot;https://api.gigantic-server.com/v1&quot;</span>,
+      <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;Production server&quot;</span>
     }
   ]
 }
@@ -430,24 +438,24 @@ The metadata MAY be used by the clients if needed, and MAY be presented in editi
 <p>The following shows how variables can be used for a server configuration:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"servers"</span>: [
+  <span class="hljs-attr">&quot;servers&quot;</span>: [
     {
-      <span class="hljs-attr">"url"</span>: <span class="hljs-string">"https://{username}.gigantic-server.com:{port}/{basePath}"</span>,
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"The production API server"</span>,
-      <span class="hljs-attr">"variables"</span>: {
-        <span class="hljs-attr">"username"</span>: {
-          <span class="hljs-attr">"default"</span>: <span class="hljs-string">"demo"</span>,
-          <span class="hljs-attr">"description"</span>: <span class="hljs-string">"this value is assigned by the service provider, in this example `gigantic-server.com`"</span>
+      <span class="hljs-attr">&quot;url&quot;</span>: <span class="hljs-string">&quot;https://{username}.gigantic-server.com:{port}/{basePath}&quot;</span>,
+      <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;The production API server&quot;</span>,
+      <span class="hljs-attr">&quot;variables&quot;</span>: {
+        <span class="hljs-attr">&quot;username&quot;</span>: {
+          <span class="hljs-attr">&quot;default&quot;</span>: <span class="hljs-string">&quot;demo&quot;</span>,
+          <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;this value is assigned by the service provider, in this example `gigantic-server.com`&quot;</span>
         },
-        <span class="hljs-attr">"port"</span>: {
-          <span class="hljs-attr">"enum"</span>: [
-            <span class="hljs-string">"8443"</span>,
-            <span class="hljs-string">"443"</span>
+        <span class="hljs-attr">&quot;port&quot;</span>: {
+          <span class="hljs-attr">&quot;enum&quot;</span>: [
+            <span class="hljs-string">&quot;8443&quot;</span>,
+            <span class="hljs-string">&quot;443&quot;</span>
           ],
-          <span class="hljs-attr">"default"</span>: <span class="hljs-string">"8443"</span>
+          <span class="hljs-attr">&quot;default&quot;</span>: <span class="hljs-string">&quot;8443&quot;</span>
         },
-        <span class="hljs-attr">"basePath"</span>: {
-          <span class="hljs-attr">"default"</span>: <span class="hljs-string">"v2"</span>
+        <span class="hljs-attr">&quot;basePath&quot;</span>: {
+          <span class="hljs-attr">&quot;default&quot;</span>: <span class="hljs-string">&quot;v2&quot;</span>
         }
       }
     }
@@ -465,9 +473,9 @@ The metadata MAY be used by the clients if needed, and MAY be presented in editi
       <span class="hljs-attr">description:</span> <span class="hljs-string">this</span> <span class="hljs-string">value</span> <span class="hljs-string">is</span> <span class="hljs-string">assigned</span> <span class="hljs-string">by</span> <span class="hljs-string">the</span> <span class="hljs-string">service</span> <span class="hljs-string">provider,</span> <span class="hljs-string">in</span> <span class="hljs-string">this</span> <span class="hljs-string">example</span> <span class="hljs-string">`gigantic-server.com`</span>
     <span class="hljs-attr">port:</span>
       <span class="hljs-attr">enum:</span>
-        <span class="hljs-bullet">-</span> <span class="hljs-string">'8443'</span>
-        <span class="hljs-bullet">-</span> <span class="hljs-string">'443'</span>
-      <span class="hljs-attr">default:</span> <span class="hljs-string">'8443'</span>
+        <span class="hljs-bullet">-</span> <span class="hljs-string">&#x27;8443&#x27;</span>
+        <span class="hljs-bullet">-</span> <span class="hljs-string">&#x27;443&#x27;</span>
+      <span class="hljs-attr">default:</span> <span class="hljs-string">&#x27;8443&#x27;</span>
     <span class="hljs-attr">basePath:</span>
       <span class="hljs-comment"># open meaning there is the opportunity to use special base paths as assigned by the provider, default is `v2`</span>
       <span class="hljs-attr">default:</span> <span class="hljs-string">v2</span>
@@ -517,47 +525,47 @@ All objects defined within the components object will have no effect on the API 
 <tbody>
 <tr>
 <td><a id="componentsSchemas"> </a> schemas</td>
-<td style="text-align:left">Map[<code>string</code>, <a href="#schemaObject">Schema Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:left">Map[<code>string</code>, <a href="#schemaObject">Schema Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>An object to hold reusable <a href="#schemaObject">Schema Objects</a>.</td>
 </tr>
 <tr>
 <td><a id="componentsResponses"> </a> responses</td>
-<td style="text-align:left">Map[<code>string</code>, <a href="#responseObject">Response Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:left">Map[<code>string</code>, <a href="#responseObject">Response Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>An object to hold reusable <a href="#responseObject">Response Objects</a>.</td>
 </tr>
 <tr>
 <td><a id="componentsParameters"> </a> parameters</td>
-<td style="text-align:left">Map[<code>string</code>, <a href="#parameterObject">Parameter Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:left">Map[<code>string</code>, <a href="#parameterObject">Parameter Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>An object to hold reusable <a href="#parameterObject">Parameter Objects</a>.</td>
 </tr>
 <tr>
 <td><a id="componentsExamples"> </a> examples</td>
-<td style="text-align:left">Map[<code>string</code>, <a href="#exampleObject">Example Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:left">Map[<code>string</code>, <a href="#exampleObject">Example Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>An object to hold reusable <a href="#exampleObject">Example Objects</a>.</td>
 </tr>
 <tr>
 <td><a id="componentsRequestBodies"> </a> requestBodies</td>
-<td style="text-align:left">Map[<code>string</code>, <a href="#requestBodyObject">Request Body Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:left">Map[<code>string</code>, <a href="#requestBodyObject">Request Body Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>An object to hold reusable <a href="#requestBodyObject">Request Body Objects</a>.</td>
 </tr>
 <tr>
 <td><a id="componentsHeaders"> </a> headers</td>
-<td style="text-align:left">Map[<code>string</code>, <a href="#headerObject">Header Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:left">Map[<code>string</code>, <a href="#headerObject">Header Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>An object to hold reusable <a href="#headerObject">Header Objects</a>.</td>
 </tr>
 <tr>
 <td><a id="componentsSecuritySchemes"> </a> securitySchemes</td>
-<td style="text-align:left">Map[<code>string</code>, <a href="#securitySchemeObject">Security Scheme Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:left">Map[<code>string</code>, <a href="#securitySchemeObject">Security Scheme Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>An object to hold reusable <a href="#securitySchemeObject">Security Scheme Objects</a>.</td>
 </tr>
 <tr>
 <td><a id="componentsLinks"> </a> links</td>
-<td style="text-align:left">Map[<code>string</code>, <a href="#linkObject">Link Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:left">Map[<code>string</code>, <a href="#linkObject">Link Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>An object to hold reusable <a href="#linkObject">Link Objects</a>.</td>
 </tr>
 <tr>
 <td><a id="componentsCallbacks"> </a> callbacks</td>
-<td style="text-align:left">Map[<code>string</code>, <a href="#callbackObject">Callback Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:left">Map[<code>string</code>, <a href="#callbackObject">Callback Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>An object to hold reusable <a href="#callbackObject">Callback Objects</a>.</td>
 </tr>
 </tbody>
@@ -574,99 +582,99 @@ my.org.User
 </code></pre>
 </section><section><h4>Components Object Example</h4>
 <pre class="nohighlight"><code>
-<span class="hljs-string">"components"</span>: {
-  <span class="hljs-attr">"schemas"</span>: {
-    <span class="hljs-attr">"GeneralError"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-      <span class="hljs-attr">"properties"</span>: {
-        <span class="hljs-attr">"code"</span>: {
-          <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>,
-          <span class="hljs-attr">"format"</span>: <span class="hljs-string">"int32"</span>
+&quot;components&quot;: {
+  &quot;schemas&quot;: {
+    &quot;GeneralError&quot;: {
+      &quot;type&quot;: &quot;object&quot;,
+      &quot;properties&quot;: {
+        &quot;code&quot;: {
+          &quot;type&quot;: &quot;integer&quot;,
+          &quot;format&quot;: &quot;int32&quot;
         },
-        <span class="hljs-attr">"message"</span>: {
-          <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+        &quot;message&quot;: {
+          &quot;type&quot;: &quot;string&quot;
         }
       }
     },
-    <span class="hljs-attr">"Category"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-      <span class="hljs-attr">"properties"</span>: {
-        <span class="hljs-attr">"id"</span>: {
-          <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>,
-          <span class="hljs-attr">"format"</span>: <span class="hljs-string">"int64"</span>
+    &quot;Category&quot;: {
+      &quot;type&quot;: &quot;object&quot;,
+      &quot;properties&quot;: {
+        &quot;id&quot;: {
+          &quot;type&quot;: &quot;integer&quot;,
+          &quot;format&quot;: &quot;int64&quot;
         },
-        <span class="hljs-attr">"name"</span>: {
-          <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+        &quot;name&quot;: {
+          &quot;type&quot;: &quot;string&quot;
         }
       }
     },
-    <span class="hljs-attr">"Tag"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-      <span class="hljs-attr">"properties"</span>: {
-        <span class="hljs-attr">"id"</span>: {
-          <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>,
-          <span class="hljs-attr">"format"</span>: <span class="hljs-string">"int64"</span>
+    &quot;Tag&quot;: {
+      &quot;type&quot;: &quot;object&quot;,
+      &quot;properties&quot;: {
+        &quot;id&quot;: {
+          &quot;type&quot;: &quot;integer&quot;,
+          &quot;format&quot;: &quot;int64&quot;
         },
-        <span class="hljs-attr">"name"</span>: {
-          <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+        &quot;name&quot;: {
+          &quot;type&quot;: &quot;string&quot;
         }
       }
     }
   },
-  <span class="hljs-attr">"parameters"</span>: {
-    <span class="hljs-attr">"skipParam"</span>: {
-      <span class="hljs-attr">"name"</span>: <span class="hljs-string">"skip"</span>,
-      <span class="hljs-attr">"in"</span>: <span class="hljs-string">"query"</span>,
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"number of items to skip"</span>,
-      <span class="hljs-attr">"required"</span>: <span class="hljs-literal">true</span>,
-      <span class="hljs-attr">"schema"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>,
-        <span class="hljs-attr">"format"</span>: <span class="hljs-string">"int32"</span>
+  &quot;parameters&quot;: {
+    &quot;skipParam&quot;: {
+      &quot;name&quot;: &quot;skip&quot;,
+      &quot;in&quot;: &quot;query&quot;,
+      &quot;description&quot;: &quot;number of items to skip&quot;,
+      &quot;required&quot;: true,
+      &quot;schema&quot;: {
+        &quot;type&quot;: &quot;integer&quot;,
+        &quot;format&quot;: &quot;int32&quot;
       }
     },
-    <span class="hljs-attr">"limitParam"</span>: {
-      <span class="hljs-attr">"name"</span>: <span class="hljs-string">"limit"</span>,
-      <span class="hljs-attr">"in"</span>: <span class="hljs-string">"query"</span>,
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"max records to return"</span>,
-      <span class="hljs-attr">"required"</span>: <span class="hljs-literal">true</span>,
-      <span class="hljs-attr">"schema"</span> : {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>,
-        <span class="hljs-attr">"format"</span>: <span class="hljs-string">"int32"</span>
+    &quot;limitParam&quot;: {
+      &quot;name&quot;: &quot;limit&quot;,
+      &quot;in&quot;: &quot;query&quot;,
+      &quot;description&quot;: &quot;max records to return&quot;,
+      &quot;required&quot;: true,
+      &quot;schema&quot; : {
+        &quot;type&quot;: &quot;integer&quot;,
+        &quot;format&quot;: &quot;int32&quot;
       }
     }
   },
-  <span class="hljs-attr">"responses"</span>: {
-    <span class="hljs-attr">"NotFound"</span>: {
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Entity not found."</span>
+  &quot;responses&quot;: {
+    &quot;NotFound&quot;: {
+      &quot;description&quot;: &quot;Entity not found.&quot;
     },
-    <span class="hljs-attr">"IllegalInput"</span>: {
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Illegal input for operation."</span>
+    &quot;IllegalInput&quot;: {
+      &quot;description&quot;: &quot;Illegal input for operation.&quot;
     },
-    <span class="hljs-attr">"GeneralError"</span>: {
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"General Error"</span>,
-      <span class="hljs-attr">"content"</span>: {
-        <span class="hljs-attr">"application/json"</span>: {
-          <span class="hljs-attr">"schema"</span>: {
-            <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/GeneralError"</span>
+    &quot;GeneralError&quot;: {
+      &quot;description&quot;: &quot;General Error&quot;,
+      &quot;content&quot;: {
+        &quot;application/json&quot;: {
+          &quot;schema&quot;: {
+            &quot;$ref&quot;: &quot;#/components/schemas/GeneralError&quot;
           }
         }
       }
     }
   },
-  <span class="hljs-attr">"securitySchemes"</span>: {
-    <span class="hljs-attr">"api_key"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"apiKey"</span>,
-      <span class="hljs-attr">"name"</span>: <span class="hljs-string">"api_key"</span>,
-      <span class="hljs-attr">"in"</span>: <span class="hljs-string">"header"</span>
+  &quot;securitySchemes&quot;: {
+    &quot;api_key&quot;: {
+      &quot;type&quot;: &quot;apiKey&quot;,
+      &quot;name&quot;: &quot;api_key&quot;,
+      &quot;in&quot;: &quot;header&quot;
     },
-    <span class="hljs-attr">"petstore_auth"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"oauth2"</span>,
-      <span class="hljs-attr">"flows"</span>: {
-        <span class="hljs-attr">"implicit"</span>: {
-          <span class="hljs-attr">"authorizationUrl"</span>: <span class="hljs-string">"http://example.org/api/oauth/dialog"</span>,
-          <span class="hljs-attr">"scopes"</span>: {
-            <span class="hljs-attr">"write:pets"</span>: <span class="hljs-string">"modify pets in your account"</span>,
-            <span class="hljs-attr">"read:pets"</span>: <span class="hljs-string">"read your pets"</span>
+    &quot;petstore_auth&quot;: {
+      &quot;type&quot;: &quot;oauth2&quot;,
+      &quot;flows&quot;: {
+        &quot;implicit&quot;: {
+          &quot;authorizationUrl&quot;: &quot;http://example.org/api/oauth/dialog&quot;,
+          &quot;scopes&quot;: {
+            &quot;write:pets&quot;: &quot;modify pets in your account&quot;,
+            &quot;read:pets&quot;: &quot;read your pets&quot;
           }
         }
       }
@@ -728,7 +736,7 @@ my.org.User
       <span class="hljs-attr">content:</span>
         <span class="hljs-attr">application/json:</span>
           <span class="hljs-attr">schema:</span>
-            <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/GeneralError'</span>
+            <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/GeneralError&#x27;</span>
   <span class="hljs-attr">securitySchemes:</span>
     <span class="hljs-attr">api_key:</span>
       <span class="hljs-attr">type:</span> <span class="hljs-string">apiKey</span>
@@ -759,7 +767,7 @@ The path is appended to the URL from the <a href="#serverObject"><code>Server Ob
 <tr>
 <td><a id="pathsPath"> </a>/{path}</td>
 <td style="text-align:center"><a href="#pathItemObject">Path Item Object</a></td>
-<td>A relative path to an individual endpoint. The field name MUST begin with a forward slash (<code>/</code>). The path is <strong>appended</strong> (no relative URL resolution) to the expanded URL from the <a href="#serverObject"><code>Server Object</code></a>'s <code>url</code> field in order to construct the full URL. <a href="#pathTemplating">Path templating</a> is allowed. When matching URLs, concrete (non-templated) paths would be matched before their templated counterparts. Templated paths with the same hierarchy but different templated names MUST NOT exist as they are identical. In case of ambiguous matching, it’s up to the tooling to decide which one to use.</td>
+<td>A relative path to an individual endpoint. The field name MUST begin with a forward slash (<code>/</code>). The path is <strong>appended</strong> (no relative URL resolution) to the expanded URL from the <a href="#serverObject"><code>Server Object</code></a>’s <code>url</code> field in order to construct the full URL. <a href="#pathTemplating">Path templating</a> is allowed. When matching URLs, concrete (non-templated) paths would be matched before their templated counterparts. Templated paths with the same hierarchy but different templated names MUST NOT exist as they are identical. In case of ambiguous matching, it’s up to the tooling to decide which one to use.</td>
 </tr>
 </tbody>
 </table>
@@ -783,18 +791,18 @@ The path is appended to the URL from the <a href="#serverObject"><code>Server Ob
 </section><section><h4>Paths Object Example</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"/pets"</span>: {
-    <span class="hljs-attr">"get"</span>: {
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Returns all pets from the system that the user has access to"</span>,
-      <span class="hljs-attr">"responses"</span>: {
-        <span class="hljs-attr">"200"</span>: {          
-          <span class="hljs-attr">"description"</span>: <span class="hljs-string">"A list of pets."</span>,
-          <span class="hljs-attr">"content"</span>: {
-            <span class="hljs-attr">"application/json"</span>: {
-              <span class="hljs-attr">"schema"</span>: {
-                <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-                <span class="hljs-attr">"items"</span>: {
-                  <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/pet"</span>
+  <span class="hljs-attr">&quot;/pets&quot;</span>: {
+    <span class="hljs-attr">&quot;get&quot;</span>: {
+      <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;Returns all pets from the system that the user has access to&quot;</span>,
+      <span class="hljs-attr">&quot;responses&quot;</span>: {
+        <span class="hljs-attr">&quot;200&quot;</span>: {          
+          <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;A list of pets.&quot;</span>,
+          <span class="hljs-attr">&quot;content&quot;</span>: {
+            <span class="hljs-attr">&quot;application/json&quot;</span>: {
+              <span class="hljs-attr">&quot;schema&quot;</span>: {
+                <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+                <span class="hljs-attr">&quot;items&quot;</span>: {
+                  <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/pet&quot;</span>
                 }
               }
             }
@@ -810,14 +818,14 @@ The path is appended to the URL from the <a href="#serverObject"><code>Server Ob
   <span class="hljs-attr">get:</span>
     <span class="hljs-attr">description:</span> <span class="hljs-string">Returns</span> <span class="hljs-string">all</span> <span class="hljs-string">pets</span> <span class="hljs-string">from</span> <span class="hljs-string">the</span> <span class="hljs-string">system</span> <span class="hljs-string">that</span> <span class="hljs-string">the</span> <span class="hljs-string">user</span> <span class="hljs-string">has</span> <span class="hljs-string">access</span> <span class="hljs-string">to</span>
     <span class="hljs-attr">responses:</span>
-      <span class="hljs-attr">'200':</span>
+      <span class="hljs-attr">&#x27;200&#x27;:</span>
         <span class="hljs-attr">description:</span> <span class="hljs-string">A</span> <span class="hljs-string">list</span> <span class="hljs-string">of</span> <span class="hljs-string">pets.</span>
         <span class="hljs-attr">content:</span>
           <span class="hljs-attr">application/json:</span>
             <span class="hljs-attr">schema:</span>
               <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
               <span class="hljs-attr">items:</span>
-                <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/pet'</span>
+                <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/pet&#x27;</span>
 </code></pre>
 </section></section><section><h3><span id="pathItemObject">Path Item Object</span></h3>
 <p>Describes the operations available on a single path.
@@ -895,7 +903,7 @@ The path itself is still exposed to the documentation viewer but they will not k
 </tr>
 <tr>
 <td><a id="pathItemParameters"> </a>parameters</td>
-<td style="text-align:center">[<a href="#parameterObject">Parameter Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:center">[<a href="#parameterObject">Parameter Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>A list of parameters that are applicable for all the operations described under this path. These parameters can be overridden at the operation level, but cannot be removed there. The list MUST NOT include duplicated parameters. A unique parameter is defined by a combination of a <a href="#parameterName">name</a> and <a href="#parameterIn">location</a>. The list can use the <a href="#referenceObject">Reference Object</a> to link to parameters that are defined at the <a href="#componentsParameters">OpenAPI Object’s components/parameters</a>.</td>
 </tr>
 </tbody>
@@ -904,49 +912,49 @@ The path itself is still exposed to the documentation viewer but they will not k
 </section><section><h4>Path Item Object Example</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"get"</span>: {
-    <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Returns pets based on ID"</span>,
-    <span class="hljs-attr">"summary"</span>: <span class="hljs-string">"Find pets by ID"</span>,
-    <span class="hljs-attr">"operationId"</span>: <span class="hljs-string">"getPetsById"</span>,
-    <span class="hljs-attr">"responses"</span>: {
-      <span class="hljs-attr">"200"</span>: {
-        <span class="hljs-attr">"description"</span>: <span class="hljs-string">"pet response"</span>,
-        <span class="hljs-attr">"content"</span>: {
-          <span class="hljs-attr">"*/*"</span>: {
-            <span class="hljs-attr">"schema"</span>: {
-              <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-              <span class="hljs-attr">"items"</span>: {
-                <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/Pet"</span>
+  <span class="hljs-attr">&quot;get&quot;</span>: {
+    <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;Returns pets based on ID&quot;</span>,
+    <span class="hljs-attr">&quot;summary&quot;</span>: <span class="hljs-string">&quot;Find pets by ID&quot;</span>,
+    <span class="hljs-attr">&quot;operationId&quot;</span>: <span class="hljs-string">&quot;getPetsById&quot;</span>,
+    <span class="hljs-attr">&quot;responses&quot;</span>: {
+      <span class="hljs-attr">&quot;200&quot;</span>: {
+        <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;pet response&quot;</span>,
+        <span class="hljs-attr">&quot;content&quot;</span>: {
+          <span class="hljs-attr">&quot;*/*&quot;</span>: {
+            <span class="hljs-attr">&quot;schema&quot;</span>: {
+              <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+              <span class="hljs-attr">&quot;items&quot;</span>: {
+                <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/Pet&quot;</span>
               }
             }
           }
         }
       },
-      <span class="hljs-attr">"default"</span>: {
-        <span class="hljs-attr">"description"</span>: <span class="hljs-string">"error payload"</span>,
-        <span class="hljs-attr">"content"</span>: {
-          <span class="hljs-attr">"text/html"</span>: {
-            <span class="hljs-attr">"schema"</span>: {
-              <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/ErrorModel"</span>
+      <span class="hljs-attr">&quot;default&quot;</span>: {
+        <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;error payload&quot;</span>,
+        <span class="hljs-attr">&quot;content&quot;</span>: {
+          <span class="hljs-attr">&quot;text/html&quot;</span>: {
+            <span class="hljs-attr">&quot;schema&quot;</span>: {
+              <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/ErrorModel&quot;</span>
             }
           }
         }
       }
     }
   },
-  <span class="hljs-attr">"parameters"</span>: [
+  <span class="hljs-attr">&quot;parameters&quot;</span>: [
     {
-      <span class="hljs-attr">"name"</span>: <span class="hljs-string">"id"</span>,
-      <span class="hljs-attr">"in"</span>: <span class="hljs-string">"path"</span>,
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"ID of pet to use"</span>,
-      <span class="hljs-attr">"required"</span>: <span class="hljs-literal">true</span>,
-      <span class="hljs-attr">"schema"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-        <span class="hljs-attr">"items"</span>: {
-          <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+      <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;id&quot;</span>,
+      <span class="hljs-attr">&quot;in&quot;</span>: <span class="hljs-string">&quot;path&quot;</span>,
+      <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;ID of pet to use&quot;</span>,
+      <span class="hljs-attr">&quot;required&quot;</span>: <span class="hljs-literal">true</span>,
+      <span class="hljs-attr">&quot;schema&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+        <span class="hljs-attr">&quot;items&quot;</span>: {
+          <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
         }
       },
-      <span class="hljs-attr">"style"</span>: <span class="hljs-string">"simple"</span>
+      <span class="hljs-attr">&quot;style&quot;</span>: <span class="hljs-string">&quot;simple&quot;</span>
     }
   ]
 }
@@ -957,20 +965,20 @@ The path itself is still exposed to the documentation viewer but they will not k
   <span class="hljs-attr">summary:</span> <span class="hljs-string">Find</span> <span class="hljs-string">pets</span> <span class="hljs-string">by</span> <span class="hljs-string">ID</span>
   <span class="hljs-attr">operationId:</span> <span class="hljs-string">getPetsById</span>
   <span class="hljs-attr">responses:</span>
-    <span class="hljs-attr">'200':</span>
+    <span class="hljs-attr">&#x27;200&#x27;:</span>
       <span class="hljs-attr">description:</span> <span class="hljs-string">pet</span> <span class="hljs-string">response</span>
       <span class="hljs-attr">content:</span>
-        <span class="hljs-string">'*/*'</span> <span class="hljs-string">:</span>
+        <span class="hljs-string">&#x27;*/*&#x27;</span> <span class="hljs-string">:</span>
           <span class="hljs-attr">schema:</span>
             <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
             <span class="hljs-attr">items:</span>
-              <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Pet'</span>
+              <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/Pet&#x27;</span>
     <span class="hljs-attr">default:</span>
       <span class="hljs-attr">description:</span> <span class="hljs-string">error</span> <span class="hljs-string">payload</span>
       <span class="hljs-attr">content:</span>
-        <span class="hljs-attr">'text/html':</span>
+        <span class="hljs-attr">&#x27;text/html&#x27;:</span>
           <span class="hljs-attr">schema:</span>
-            <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/ErrorModel'</span>
+            <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/ErrorModel&#x27;</span>
 <span class="hljs-attr">parameters:</span>
 <span class="hljs-bullet">-</span> <span class="hljs-attr">name:</span> <span class="hljs-string">id</span>
   <span class="hljs-attr">in:</span> <span class="hljs-string">path</span>
@@ -1021,12 +1029,12 @@ The path itself is still exposed to the documentation viewer but they will not k
 </tr>
 <tr>
 <td><a id="operationParameters"> </a>parameters</td>
-<td style="text-align:center">[<a href="#parameterObject">Parameter Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:center">[<a href="#parameterObject">Parameter Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>A list of parameters that are applicable for this operation. If a parameter is already defined at the <a href="#pathItemParameters">Path Item</a>, the new definition will override it but can never remove it. The list MUST NOT include duplicated parameters. A unique parameter is defined by a combination of a <a href="#parameterName">name</a> and <a href="#parameterIn">location</a>. The list can use the <a href="#referenceObject">Reference Object</a> to link to parameters that are defined at the <a href="#componentsParameters">OpenAPI Object’s components/parameters</a>.</td>
 </tr>
 <tr>
 <td><a id="operationRequestBody"> </a>requestBody</td>
-<td style="text-align:center"><a href="#requestBodyObject">Request Body Object</a> ¦ <a href="#referenceObject">Reference Object</a></td>
+<td style="text-align:center"><a href="#requestBodyObject">Request Body Object</a> | <a href="#referenceObject">Reference Object</a></td>
 <td>The request body applicable for this operation.  The <code>requestBody</code> is only supported in HTTP methods where the HTTP 1.1 specification [[!RFC7231]] has explicitly defined semantics for request bodies.  In other cases where the HTTP spec is vague, <code>requestBody</code> SHALL be ignored by consumers.</td>
 </tr>
 <tr>
@@ -1036,7 +1044,7 @@ The path itself is still exposed to the documentation viewer but they will not k
 </tr>
 <tr>
 <td><a id="operationCallbacks"> </a>callbacks</td>
-<td style="text-align:center">Map[<code>string</code>, <a href="#callbackObject">Callback Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:center">Map[<code>string</code>, <a href="#callbackObject">Callback Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>A map of possible out-of band callbacks related to the parent operation. The key is a unique identifier for the Callback Object. Each value in the map is a <a href="#callbackObject">Callback Object</a> that describes a request that may be initiated by the API provider and the expected responses.</td>
 </tr>
 <tr>
@@ -1060,63 +1068,63 @@ The path itself is still exposed to the documentation viewer but they will not k
 </section><section><h4>Operation Object Example</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"tags"</span>: [
-    <span class="hljs-string">"pet"</span>
+  <span class="hljs-attr">&quot;tags&quot;</span>: [
+    <span class="hljs-string">&quot;pet&quot;</span>
   ],
-  <span class="hljs-attr">"summary"</span>: <span class="hljs-string">"Updates a pet in the store with form data"</span>,
-  <span class="hljs-attr">"operationId"</span>: <span class="hljs-string">"updatePetWithForm"</span>,
-  <span class="hljs-attr">"parameters"</span>: [
+  <span class="hljs-attr">&quot;summary&quot;</span>: <span class="hljs-string">&quot;Updates a pet in the store with form data&quot;</span>,
+  <span class="hljs-attr">&quot;operationId&quot;</span>: <span class="hljs-string">&quot;updatePetWithForm&quot;</span>,
+  <span class="hljs-attr">&quot;parameters&quot;</span>: [
     {
-      <span class="hljs-attr">"name"</span>: <span class="hljs-string">"petId"</span>,
-      <span class="hljs-attr">"in"</span>: <span class="hljs-string">"path"</span>,
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"ID of pet that needs to be updated"</span>,
-      <span class="hljs-attr">"required"</span>: <span class="hljs-literal">true</span>,
-      <span class="hljs-attr">"schema"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+      <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;petId&quot;</span>,
+      <span class="hljs-attr">&quot;in&quot;</span>: <span class="hljs-string">&quot;path&quot;</span>,
+      <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;ID of pet that needs to be updated&quot;</span>,
+      <span class="hljs-attr">&quot;required&quot;</span>: <span class="hljs-literal">true</span>,
+      <span class="hljs-attr">&quot;schema&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
       }
     }
   ],
-  <span class="hljs-attr">"requestBody"</span>: {
-    <span class="hljs-attr">"content"</span>: {
-      <span class="hljs-attr">"application/x-www-form-urlencoded"</span>: {
-        <span class="hljs-attr">"schema"</span>: {
-          <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-          <span class="hljs-attr">"properties"</span>: {
-            <span class="hljs-attr">"name"</span>: { 
-              <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Updated name of the pet"</span>,
-              <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+  <span class="hljs-attr">&quot;requestBody&quot;</span>: {
+    <span class="hljs-attr">&quot;content&quot;</span>: {
+      <span class="hljs-attr">&quot;application/x-www-form-urlencoded&quot;</span>: {
+        <span class="hljs-attr">&quot;schema&quot;</span>: {
+          <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+          <span class="hljs-attr">&quot;properties&quot;</span>: {
+            <span class="hljs-attr">&quot;name&quot;</span>: { 
+              <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;Updated name of the pet&quot;</span>,
+              <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
             },
-            <span class="hljs-attr">"status"</span>: {
-              <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Updated status of the pet"</span>,
-              <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+            <span class="hljs-attr">&quot;status&quot;</span>: {
+              <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;Updated status of the pet&quot;</span>,
+              <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
             }
           },
-          <span class="hljs-attr">"required"</span>: [<span class="hljs-string">"status"</span>] 
+          <span class="hljs-attr">&quot;required&quot;</span>: [<span class="hljs-string">&quot;status&quot;</span>] 
         }
       }
     }
   },
-  <span class="hljs-attr">"responses"</span>: {
-    <span class="hljs-attr">"200"</span>: {
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Pet updated."</span>,
-      <span class="hljs-attr">"content"</span>: {
-        <span class="hljs-attr">"application/json"</span>: {},
-        <span class="hljs-attr">"application/xml"</span>: {}
+  <span class="hljs-attr">&quot;responses&quot;</span>: {
+    <span class="hljs-attr">&quot;200&quot;</span>: {
+      <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;Pet updated.&quot;</span>,
+      <span class="hljs-attr">&quot;content&quot;</span>: {
+        <span class="hljs-attr">&quot;application/json&quot;</span>: {},
+        <span class="hljs-attr">&quot;application/xml&quot;</span>: {}
       }
     },
-    <span class="hljs-attr">"405"</span>: {
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Method Not Allowed"</span>,
-      <span class="hljs-attr">"content"</span>: {
-        <span class="hljs-attr">"application/json"</span>: {},
-        <span class="hljs-attr">"application/xml"</span>: {}
+    <span class="hljs-attr">&quot;405&quot;</span>: {
+      <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;Method Not Allowed&quot;</span>,
+      <span class="hljs-attr">&quot;content&quot;</span>: {
+        <span class="hljs-attr">&quot;application/json&quot;</span>: {},
+        <span class="hljs-attr">&quot;application/xml&quot;</span>: {}
       }
     }
   },
-  <span class="hljs-attr">"security"</span>: [
+  <span class="hljs-attr">&quot;security&quot;</span>: [
     {
-      <span class="hljs-attr">"petstore_auth"</span>: [
-        <span class="hljs-string">"write:pets"</span>,
-        <span class="hljs-string">"read:pets"</span>
+      <span class="hljs-attr">&quot;petstore_auth&quot;</span>: [
+        <span class="hljs-string">&quot;write:pets&quot;</span>,
+        <span class="hljs-string">&quot;read:pets&quot;</span>
       ]
     }
   ]
@@ -1136,7 +1144,7 @@ The path itself is still exposed to the documentation viewer but they will not k
     <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
 <span class="hljs-attr">requestBody:</span>
   <span class="hljs-attr">content:</span>
-    <span class="hljs-attr">'application/x-www-form-urlencoded':</span>
+    <span class="hljs-attr">&#x27;application/x-www-form-urlencoded&#x27;:</span>
       <span class="hljs-attr">schema:</span>
        <span class="hljs-attr">properties:</span>
           <span class="hljs-attr">name:</span> 
@@ -1148,16 +1156,16 @@ The path itself is still exposed to the documentation viewer but they will not k
        <span class="hljs-attr">required:</span>
          <span class="hljs-bullet">-</span> <span class="hljs-string">status</span>
 <span class="hljs-attr">responses:</span>
-  <span class="hljs-attr">'200':</span>
+  <span class="hljs-attr">&#x27;200&#x27;:</span>
     <span class="hljs-attr">description:</span> <span class="hljs-string">Pet</span> <span class="hljs-string">updated.</span>
     <span class="hljs-attr">content:</span> 
-      <span class="hljs-attr">'application/json':</span> <span class="hljs-string">{}</span>
-      <span class="hljs-attr">'application/xml':</span> <span class="hljs-string">{}</span>
-  <span class="hljs-attr">'405':</span>
+      <span class="hljs-attr">&#x27;application/json&#x27;:</span> {}
+      <span class="hljs-attr">&#x27;application/xml&#x27;:</span> {}
+  <span class="hljs-attr">&#x27;405&#x27;:</span>
     <span class="hljs-attr">description:</span> <span class="hljs-string">Method</span> <span class="hljs-string">Not</span> <span class="hljs-string">Allowed</span>
     <span class="hljs-attr">content:</span> 
-      <span class="hljs-attr">'application/json':</span> <span class="hljs-string">{}</span>
-      <span class="hljs-attr">'application/xml':</span> <span class="hljs-string">{}</span>
+      <span class="hljs-attr">&#x27;application/json&#x27;:</span> {}
+      <span class="hljs-attr">&#x27;application/xml&#x27;:</span> {}
 <span class="hljs-attr">security:</span>
 <span class="hljs-bullet">-</span> <span class="hljs-attr">petstore_auth:</span>
   <span class="hljs-bullet">-</span> <span class="hljs-string">write:pets</span>
@@ -1191,8 +1199,8 @@ The path itself is still exposed to the documentation viewer but they will not k
 </section><section><h4>External Documentation Object Example</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Find more info here"</span>,
-  <span class="hljs-attr">"url"</span>: <span class="hljs-string">"https://example.com"</span>
+  <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;Find more info here&quot;</span>,
+  <span class="hljs-attr">&quot;url&quot;</span>: <span class="hljs-string">&quot;https://example.com&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -1280,7 +1288,7 @@ For simpler scenarios, a <a href="#parameterSchema"><code>schema</code></a> and 
 </tr>
 <tr>
 <td><a id="parameterSchema"> </a>schema</td>
-<td style="text-align:center"><a href="#schemaObject">Schema Object</a> ¦ <a href="#referenceObject">Reference Object</a></td>
+<td style="text-align:center"><a href="#schemaObject">Schema Object</a> | <a href="#referenceObject">Reference Object</a></td>
 <td>The schema defining the type used for the parameter.</td>
 </tr>
 <tr>
@@ -1290,7 +1298,7 @@ For simpler scenarios, a <a href="#parameterSchema"><code>schema</code></a> and 
 </tr>
 <tr>
 <td><a id="parameterExamples"> </a>examples</td>
-<td style="text-align:center">Map[ <code>string</code>, <a href="#exampleObject">Example Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:center">Map[ <code>string</code>, <a href="#exampleObject">Example Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>Examples of the parameter’s potential value. Each example SHOULD contain a value in the correct format as specified in the parameter encoding. The <code>examples</code> field is mutually exclusive of the <code>example</code> field. Furthermore, if referencing a <code>schema</code> that contains an example, the <code>examples</code> value SHALL <em>override</em> the example provided by the schema.</td>
 </tr>
 </tbody>
@@ -1467,8 +1475,8 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 <td>false</td>
 <td>n/a</td>
 <td>n/a</td>
-<td>blue¦black¦brown</td>
-<td>R¦100¦G¦200¦B¦150</td>
+<td>blue|black|brown</td>
+<td>R|100|G|200|B|150</td>
 </tr>
 <tr>
 <td>deepObject</td>
@@ -1476,7 +1484,7 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 <td>n/a</td>
 <td>n/a</td>
 <td>n/a</td>
-<td>color\R=100&amp;color\G=200&amp;color\B=150</td>
+<td>color&#91;R&#93;=100&amp;color&#91;G&#93;=200&amp;color&#91;B&#93;=150</td>
 </tr>
 </tbody>
 </table>
@@ -1485,18 +1493,18 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 <p>A header parameter with an array of 64 bit integer numbers:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"name"</span>: <span class="hljs-string">"token"</span>,
-  <span class="hljs-attr">"in"</span>: <span class="hljs-string">"header"</span>,
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"token to be passed as a header"</span>,
-  <span class="hljs-attr">"required"</span>: <span class="hljs-literal">true</span>,
-  <span class="hljs-attr">"schema"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-    <span class="hljs-attr">"items"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>,
-      <span class="hljs-attr">"format"</span>: <span class="hljs-string">"int64"</span>
+  <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;token&quot;</span>,
+  <span class="hljs-attr">&quot;in&quot;</span>: <span class="hljs-string">&quot;header&quot;</span>,
+  <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;token to be passed as a header&quot;</span>,
+  <span class="hljs-attr">&quot;required&quot;</span>: <span class="hljs-literal">true</span>,
+  <span class="hljs-attr">&quot;schema&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+    <span class="hljs-attr">&quot;items&quot;</span>: {
+      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>,
+      <span class="hljs-attr">&quot;format&quot;</span>: <span class="hljs-string">&quot;int64&quot;</span>
     }
   },
-  <span class="hljs-attr">"style"</span>: <span class="hljs-string">"simple"</span>
+  <span class="hljs-attr">&quot;style&quot;</span>: <span class="hljs-string">&quot;simple&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -1514,12 +1522,12 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 <p>A path parameter of a string value:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"name"</span>: <span class="hljs-string">"username"</span>,
-  <span class="hljs-attr">"in"</span>: <span class="hljs-string">"path"</span>,
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"username to fetch"</span>,
-  <span class="hljs-attr">"required"</span>: <span class="hljs-literal">true</span>,
-  <span class="hljs-attr">"schema"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+  <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;username&quot;</span>,
+  <span class="hljs-attr">&quot;in&quot;</span>: <span class="hljs-string">&quot;path&quot;</span>,
+  <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;username to fetch&quot;</span>,
+  <span class="hljs-attr">&quot;required&quot;</span>: <span class="hljs-literal">true</span>,
+  <span class="hljs-attr">&quot;schema&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
   }
 }
 </code></pre>
@@ -1534,18 +1542,18 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 <p>An optional query parameter of a string value, allowing multiple values by repeating the query parameter:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"name"</span>: <span class="hljs-string">"id"</span>,
-  <span class="hljs-attr">"in"</span>: <span class="hljs-string">"query"</span>,
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"ID of the object to fetch"</span>,
-  <span class="hljs-attr">"required"</span>: <span class="hljs-literal">false</span>,
-  <span class="hljs-attr">"schema"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-    <span class="hljs-attr">"items"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+  <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;id&quot;</span>,
+  <span class="hljs-attr">&quot;in&quot;</span>: <span class="hljs-string">&quot;query&quot;</span>,
+  <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;ID of the object to fetch&quot;</span>,
+  <span class="hljs-attr">&quot;required&quot;</span>: <span class="hljs-literal">false</span>,
+  <span class="hljs-attr">&quot;schema&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+    <span class="hljs-attr">&quot;items&quot;</span>: {
+      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
     }
   },
-  <span class="hljs-attr">"style"</span>: <span class="hljs-string">"form"</span>,
-  <span class="hljs-attr">"explode"</span>: <span class="hljs-literal">true</span>
+  <span class="hljs-attr">&quot;style&quot;</span>: <span class="hljs-string">&quot;form&quot;</span>,
+  <span class="hljs-attr">&quot;explode&quot;</span>: <span class="hljs-literal">true</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -1563,15 +1571,15 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 <p>A free-form query parameter, allowing undefined parameters of a specific type:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"in"</span>: <span class="hljs-string">"query"</span>,
-  <span class="hljs-attr">"name"</span>: <span class="hljs-string">"freeForm"</span>,
-  <span class="hljs-attr">"schema"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-    <span class="hljs-attr">"additionalProperties"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>
+  <span class="hljs-attr">&quot;in&quot;</span>: <span class="hljs-string">&quot;query&quot;</span>,
+  <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;freeForm&quot;</span>,
+  <span class="hljs-attr">&quot;schema&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+    <span class="hljs-attr">&quot;additionalProperties&quot;</span>: {
+      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>
     },
   },
-  <span class="hljs-attr">"style"</span>: <span class="hljs-string">"form"</span>
+  <span class="hljs-attr">&quot;style&quot;</span>: <span class="hljs-string">&quot;form&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -1586,22 +1594,22 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 <p>A complex parameter using <code>content</code> to define serialization:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"in"</span>: <span class="hljs-string">"query"</span>,
-  <span class="hljs-attr">"name"</span>: <span class="hljs-string">"coordinates"</span>,
-  <span class="hljs-attr">"content"</span>: {
-    <span class="hljs-attr">"application/json"</span>: {
-      <span class="hljs-attr">"schema"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-        <span class="hljs-attr">"required"</span>: [
-          <span class="hljs-string">"lat"</span>,
-          <span class="hljs-string">"long"</span>
+  <span class="hljs-attr">&quot;in&quot;</span>: <span class="hljs-string">&quot;query&quot;</span>,
+  <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;coordinates&quot;</span>,
+  <span class="hljs-attr">&quot;content&quot;</span>: {
+    <span class="hljs-attr">&quot;application/json&quot;</span>: {
+      <span class="hljs-attr">&quot;schema&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+        <span class="hljs-attr">&quot;required&quot;</span>: [
+          <span class="hljs-string">&quot;lat&quot;</span>,
+          <span class="hljs-string">&quot;long&quot;</span>
         ],
-        <span class="hljs-attr">"properties"</span>: {
-          <span class="hljs-attr">"lat"</span>: {
-            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"number"</span>
+        <span class="hljs-attr">&quot;properties&quot;</span>: {
+          <span class="hljs-attr">&quot;lat&quot;</span>: {
+            <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;number&quot;</span>
           },
-          <span class="hljs-attr">"long"</span>: {
-            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"number"</span>
+          <span class="hljs-attr">&quot;long&quot;</span>: {
+            <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;number&quot;</span>
           }
         }
       }
@@ -1659,43 +1667,43 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 <p>A request body with a referenced model definition.</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"user to add to the system"</span>,
-  <span class="hljs-attr">"content"</span>: {
-    <span class="hljs-attr">"application/json"</span>: {
-      <span class="hljs-attr">"schema"</span>: {
-        <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/User"</span>
+  <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;user to add to the system&quot;</span>,
+  <span class="hljs-attr">&quot;content&quot;</span>: {
+    <span class="hljs-attr">&quot;application/json&quot;</span>: {
+      <span class="hljs-attr">&quot;schema&quot;</span>: {
+        <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/User&quot;</span>
       },
-      <span class="hljs-attr">"examples"</span>: {
-          <span class="hljs-attr">"user"</span> : {
-            <span class="hljs-attr">"summary"</span>: <span class="hljs-string">"User Example"</span>, 
-            <span class="hljs-attr">"externalValue"</span>: <span class="hljs-string">"http://foo.bar/examples/user-example.json"</span>
+      <span class="hljs-attr">&quot;examples&quot;</span>: {
+          <span class="hljs-attr">&quot;user&quot;</span> : {
+            <span class="hljs-attr">&quot;summary&quot;</span>: <span class="hljs-string">&quot;User Example&quot;</span>, 
+            <span class="hljs-attr">&quot;externalValue&quot;</span>: <span class="hljs-string">&quot;http://foo.bar/examples/user-example.json&quot;</span>
           } 
         }
     },
-    <span class="hljs-attr">"application/xml"</span>: {
-      <span class="hljs-attr">"schema"</span>: {
-        <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/User"</span>
+    <span class="hljs-attr">&quot;application/xml&quot;</span>: {
+      <span class="hljs-attr">&quot;schema&quot;</span>: {
+        <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/User&quot;</span>
       },
-      <span class="hljs-attr">"examples"</span>: {
-          <span class="hljs-attr">"user"</span> : {
-            <span class="hljs-attr">"summary"</span>: <span class="hljs-string">"User example in XML"</span>,
-            <span class="hljs-attr">"externalValue"</span>: <span class="hljs-string">"http://foo.bar/examples/user-example.xml"</span>
+      <span class="hljs-attr">&quot;examples&quot;</span>: {
+          <span class="hljs-attr">&quot;user&quot;</span> : {
+            <span class="hljs-attr">&quot;summary&quot;</span>: <span class="hljs-string">&quot;User example in XML&quot;</span>,
+            <span class="hljs-attr">&quot;externalValue&quot;</span>: <span class="hljs-string">&quot;http://foo.bar/examples/user-example.xml&quot;</span>
           }
         }
     },
-    <span class="hljs-attr">"text/plain"</span>: {
-      <span class="hljs-attr">"examples"</span>: {
-        <span class="hljs-attr">"user"</span> : {
-            <span class="hljs-attr">"summary"</span>: <span class="hljs-string">"User example in Plain text"</span>,
-            <span class="hljs-attr">"externalValue"</span>: <span class="hljs-string">"http://foo.bar/examples/user-example.txt"</span> 
+    <span class="hljs-attr">&quot;text/plain&quot;</span>: {
+      <span class="hljs-attr">&quot;examples&quot;</span>: {
+        <span class="hljs-attr">&quot;user&quot;</span> : {
+            <span class="hljs-attr">&quot;summary&quot;</span>: <span class="hljs-string">&quot;User example in Plain text&quot;</span>,
+            <span class="hljs-attr">&quot;externalValue&quot;</span>: <span class="hljs-string">&quot;http://foo.bar/examples/user-example.txt&quot;</span> 
         }
       } 
     },
-    <span class="hljs-attr">"*/*"</span>: {
-      <span class="hljs-attr">"examples"</span>: {
-        <span class="hljs-attr">"user"</span> : {
-            <span class="hljs-attr">"summary"</span>: <span class="hljs-string">"User example in other format"</span>,
-            <span class="hljs-attr">"externalValue"</span>: <span class="hljs-string">"http://foo.bar/examples/user-example.whatever"</span>
+    <span class="hljs-attr">&quot;*/*&quot;</span>: {
+      <span class="hljs-attr">&quot;examples&quot;</span>: {
+        <span class="hljs-attr">&quot;user&quot;</span> : {
+            <span class="hljs-attr">&quot;summary&quot;</span>: <span class="hljs-string">&quot;User example in other format&quot;</span>,
+            <span class="hljs-attr">&quot;externalValue&quot;</span>: <span class="hljs-string">&quot;http://foo.bar/examples/user-example.whatever&quot;</span>
         }
       }
     }
@@ -1705,41 +1713,41 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 <pre class="nohighlight"><code>
 <span class="hljs-attr">description:</span> <span class="hljs-string">user</span> <span class="hljs-string">to</span> <span class="hljs-string">add</span> <span class="hljs-string">to</span> <span class="hljs-string">the</span> <span class="hljs-string">system</span>
 <span class="hljs-attr">content:</span> 
-  <span class="hljs-attr">'application/json':</span>
+  <span class="hljs-attr">&#x27;application/json&#x27;:</span>
     <span class="hljs-attr">schema:</span>
-      <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/User'</span>
+      <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/User&#x27;</span>
     <span class="hljs-attr">examples:</span>
       <span class="hljs-attr">user:</span>
         <span class="hljs-attr">summary:</span> <span class="hljs-string">User</span> <span class="hljs-string">Example</span>
-        <span class="hljs-attr">externalValue:</span> <span class="hljs-string">'http://foo.bar/examples/user-example.json'</span>
-  <span class="hljs-attr">'application/xml':</span>
+        <span class="hljs-attr">externalValue:</span> <span class="hljs-string">&#x27;http://foo.bar/examples/user-example.json&#x27;</span>
+  <span class="hljs-attr">&#x27;application/xml&#x27;:</span>
     <span class="hljs-attr">schema:</span>
-      <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/User'</span>
+      <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/User&#x27;</span>
     <span class="hljs-attr">examples:</span>
       <span class="hljs-attr">user:</span>
         <span class="hljs-attr">summary:</span> <span class="hljs-string">User</span> <span class="hljs-string">Example</span> <span class="hljs-string">in</span> <span class="hljs-string">XML</span>
-        <span class="hljs-attr">externalValue:</span> <span class="hljs-string">'http://foo.bar/examples/user-example.xml'</span>
-  <span class="hljs-attr">'text/plain':</span>
+        <span class="hljs-attr">externalValue:</span> <span class="hljs-string">&#x27;http://foo.bar/examples/user-example.xml&#x27;</span>
+  <span class="hljs-attr">&#x27;text/plain&#x27;:</span>
     <span class="hljs-attr">examples:</span>
       <span class="hljs-attr">user:</span>
         <span class="hljs-attr">summary:</span> <span class="hljs-string">User</span> <span class="hljs-string">example</span> <span class="hljs-string">in</span> <span class="hljs-string">text</span> <span class="hljs-string">plain</span> <span class="hljs-string">format</span>
-        <span class="hljs-attr">externalValue:</span> <span class="hljs-string">'http://foo.bar/examples/user-example.txt'</span>
-  <span class="hljs-string">'*/*'</span><span class="hljs-string">:</span>
+        <span class="hljs-attr">externalValue:</span> <span class="hljs-string">&#x27;http://foo.bar/examples/user-example.txt&#x27;</span>
+  <span class="hljs-string">&#x27;*/*&#x27;</span><span class="hljs-string">:</span>
     <span class="hljs-attr">examples:</span>
       <span class="hljs-attr">user:</span> 
         <span class="hljs-attr">summary:</span> <span class="hljs-string">User</span> <span class="hljs-string">example</span> <span class="hljs-string">in</span> <span class="hljs-string">other</span> <span class="hljs-string">format</span>
-        <span class="hljs-attr">externalValue:</span> <span class="hljs-string">'http://foo.bar/examples/user-example.whatever'</span>
+        <span class="hljs-attr">externalValue:</span> <span class="hljs-string">&#x27;http://foo.bar/examples/user-example.whatever&#x27;</span>
 </code></pre>
 <p>A body parameter that is an array of string values:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"user to add to the system"</span>,
-  <span class="hljs-attr">"content"</span>: {
-    <span class="hljs-attr">"text/plain"</span>: {
-      <span class="hljs-attr">"schema"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-        <span class="hljs-attr">"items"</span>: {
-          <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+  <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;user to add to the system&quot;</span>,
+  <span class="hljs-attr">&quot;content&quot;</span>: {
+    <span class="hljs-attr">&quot;text/plain&quot;</span>: {
+      <span class="hljs-attr">&quot;schema&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+        <span class="hljs-attr">&quot;items&quot;</span>: {
+          <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
         }
       }
     }
@@ -1770,7 +1778,7 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 <tbody>
 <tr>
 <td><a id="mediaTypeSchema"> </a>schema</td>
-<td style="text-align:center"><a href="#schemaObject">Schema Object</a> ¦ <a href="#referenceObject">Reference Object</a></td>
+<td style="text-align:center"><a href="#schemaObject">Schema Object</a> | <a href="#referenceObject">Reference Object</a></td>
 <td>The schema defining the content of the request, response, or parameter.</td>
 </tr>
 <tr>
@@ -1780,7 +1788,7 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 </tr>
 <tr>
 <td><a id="mediaTypeExamples"> </a>examples</td>
-<td style="text-align:center">Map[ <code>string</code>, <a href="#exampleObject">Example Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:center">Map[ <code>string</code>, <a href="#exampleObject">Example Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>Examples of the media type.  Each example object SHOULD  match the media type and specified schema if present.  The <code>examples</code> field is mutually exclusive of the <code>example</code> field.  Furthermore, if referencing a <code>schema</code> which contains an example, the <code>examples</code> value SHALL <em>override</em> the example provided by the schema.</td>
 </tr>
 <tr>
@@ -1794,33 +1802,33 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 </section><section><h4>Media Type Examples</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"application/json"</span>: {
-    <span class="hljs-attr">"schema"</span>: {
-         <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/Pet"</span>
+  <span class="hljs-attr">&quot;application/json&quot;</span>: {
+    <span class="hljs-attr">&quot;schema&quot;</span>: {
+         <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/Pet&quot;</span>
     },
-    <span class="hljs-attr">"examples"</span>: {
-      <span class="hljs-attr">"cat"</span> : {
-        <span class="hljs-attr">"summary"</span>: <span class="hljs-string">"An example of a cat"</span>,
-        <span class="hljs-attr">"value"</span>: 
+    <span class="hljs-attr">&quot;examples&quot;</span>: {
+      <span class="hljs-attr">&quot;cat&quot;</span> : {
+        <span class="hljs-attr">&quot;summary&quot;</span>: <span class="hljs-string">&quot;An example of a cat&quot;</span>,
+        <span class="hljs-attr">&quot;value&quot;</span>: 
           {
-            <span class="hljs-attr">"name"</span>: <span class="hljs-string">"Fluffy"</span>,
-            <span class="hljs-attr">"petType"</span>: <span class="hljs-string">"Cat"</span>,
-            <span class="hljs-attr">"color"</span>: <span class="hljs-string">"White"</span>,
-            <span class="hljs-attr">"gender"</span>: <span class="hljs-string">"male"</span>,
-            <span class="hljs-attr">"breed"</span>: <span class="hljs-string">"Persian"</span>
+            <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;Fluffy&quot;</span>,
+            <span class="hljs-attr">&quot;petType&quot;</span>: <span class="hljs-string">&quot;Cat&quot;</span>,
+            <span class="hljs-attr">&quot;color&quot;</span>: <span class="hljs-string">&quot;White&quot;</span>,
+            <span class="hljs-attr">&quot;gender&quot;</span>: <span class="hljs-string">&quot;male&quot;</span>,
+            <span class="hljs-attr">&quot;breed&quot;</span>: <span class="hljs-string">&quot;Persian&quot;</span>
           }
       },
-      <span class="hljs-attr">"dog"</span>: {
-        <span class="hljs-attr">"summary"</span>: <span class="hljs-string">"An example of a dog with a cat's name"</span>,
-        <span class="hljs-attr">"value"</span> :  { 
-          <span class="hljs-attr">"name"</span>: <span class="hljs-string">"Puma"</span>,
-          <span class="hljs-attr">"petType"</span>: <span class="hljs-string">"Dog"</span>,
-          <span class="hljs-attr">"color"</span>: <span class="hljs-string">"Black"</span>,
-          <span class="hljs-attr">"gender"</span>: <span class="hljs-string">"Female"</span>,
-          <span class="hljs-attr">"breed"</span>: <span class="hljs-string">"Mixed"</span>
+      <span class="hljs-attr">&quot;dog&quot;</span>: {
+        <span class="hljs-attr">&quot;summary&quot;</span>: <span class="hljs-string">&quot;An example of a dog with a cat&#x27;s name&quot;</span>,
+        <span class="hljs-attr">&quot;value&quot;</span> :  { 
+          <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;Puma&quot;</span>,
+          <span class="hljs-attr">&quot;petType&quot;</span>: <span class="hljs-string">&quot;Dog&quot;</span>,
+          <span class="hljs-attr">&quot;color&quot;</span>: <span class="hljs-string">&quot;Black&quot;</span>,
+          <span class="hljs-attr">&quot;gender&quot;</span>: <span class="hljs-string">&quot;Female&quot;</span>,
+          <span class="hljs-attr">&quot;breed&quot;</span>: <span class="hljs-string">&quot;Mixed&quot;</span>
         },
-      <span class="hljs-attr">"frog"</span>: {
-          <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/examples/frog-example"</span>
+      <span class="hljs-attr">&quot;frog&quot;</span>: {
+          <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/examples/frog-example&quot;</span>
         }
       }
     }
@@ -1830,7 +1838,7 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 <pre class="nohighlight"><code>
 <span class="hljs-attr">application/json:</span> 
   <span class="hljs-attr">schema:</span>
-    <span class="hljs-string">$ref:</span> <span class="hljs-string">"#/components/schemas/Pet"</span>
+    <span class="hljs-string">$ref:</span> <span class="hljs-string">&quot;#/components/schemas/Pet&quot;</span>
   <span class="hljs-attr">examples:</span>
     <span class="hljs-attr">cat:</span>
       <span class="hljs-attr">summary:</span> <span class="hljs-string">An</span> <span class="hljs-string">example</span> <span class="hljs-string">of</span> <span class="hljs-string">a</span> <span class="hljs-string">cat</span>
@@ -1841,7 +1849,7 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
         <span class="hljs-attr">gender:</span> <span class="hljs-string">male</span>
         <span class="hljs-attr">breed:</span> <span class="hljs-string">Persian</span>
     <span class="hljs-attr">dog:</span>
-      <span class="hljs-attr">summary:</span> <span class="hljs-string">An</span> <span class="hljs-string">example</span> <span class="hljs-string">of</span> <span class="hljs-string">a</span> <span class="hljs-string">dog</span> <span class="hljs-string">with</span> <span class="hljs-string">a</span> <span class="hljs-string">cat's</span> <span class="hljs-string">name</span>
+      <span class="hljs-attr">summary:</span> <span class="hljs-string">An</span> <span class="hljs-string">example</span> <span class="hljs-string">of</span> <span class="hljs-string">a</span> <span class="hljs-string">dog</span> <span class="hljs-string">with</span> <span class="hljs-string">a</span> <span class="hljs-string">cat&#x27;s</span> <span class="hljs-string">name</span>
       <span class="hljs-attr">value:</span>
         <span class="hljs-attr">name:</span> <span class="hljs-string">Puma</span>
         <span class="hljs-attr">petType:</span> <span class="hljs-string">Dog</span>
@@ -1849,7 +1857,7 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
         <span class="hljs-attr">gender:</span> <span class="hljs-string">Female</span>
         <span class="hljs-attr">breed:</span> <span class="hljs-string">Mixed</span>
     <span class="hljs-attr">frog:</span>
-      <span class="hljs-string">$ref:</span> <span class="hljs-string">"#/components/examples/frog-example"</span>
+      <span class="hljs-string">$ref:</span> <span class="hljs-string">&quot;#/components/examples/frog-example&quot;</span>
 </code></pre>
 </section><section><h4>Considerations for File Uploads</h4>
 <p>In contrast with the 2.0 specification, <code>file</code> input/output content in OpenAPI is described with the same semantics as any other schema type. Specifically:</p>
@@ -1882,11 +1890,11 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 <span class="hljs-attr">requestBody:</span>
   <span class="hljs-attr">content:</span>
       <span class="hljs-comment"># a binary file of type png or jpeg</span>
-    <span class="hljs-attr">'image/jpeg':</span>
+    <span class="hljs-attr">&#x27;image/jpeg&#x27;:</span>
       <span class="hljs-attr">schema:</span>
         <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
         <span class="hljs-attr">format:</span> <span class="hljs-string">binary</span>
-    <span class="hljs-attr">'image/png':</span>
+    <span class="hljs-attr">&#x27;image/png&#x27;:</span>
       <span class="hljs-attr">schema:</span>
         <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
         <span class="hljs-attr">format:</span> <span class="hljs-string">binary</span>        
@@ -1898,7 +1906,7 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
     <span class="hljs-attr">multipart/form-data:</span>
       <span class="hljs-attr">schema:</span>
         <span class="hljs-attr">properties:</span>
-          <span class="hljs-comment"># The property name 'file' will be used for all files.</span>
+          <span class="hljs-comment"># The property name &#x27;file&#x27; will be used for all files.</span>
           <span class="hljs-attr">file:</span>
             <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
             <span class="hljs-attr">items:</span>
@@ -1922,10 +1930,10 @@ definition may be used:</p>
           <span class="hljs-attr">address:</span>
             <span class="hljs-comment"># complex types are stringified to support RFC 1866</span>
             <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
-            <span class="hljs-attr">properties:</span> <span class="hljs-string">{}</span>
+            <span class="hljs-attr">properties:</span> {}
 </code></pre>
 <p>In this example, the contents in the <code>requestBody</code> MUST be stringified per [[!RFC1866]] when passed to the server.  In addition, the <code>address</code> field complex object will be stringified.</p>
-<p>When passing complex objects in the <code>application/x-www-form-urlencoded</code> content type, the default serialization strategy of such properties is described in the <a href="#encodingObject"><code>Encoding Object</code></a>'s <a href="#encodingStyle"><code>style</code></a> property as <code>form</code>.</p>
+<p>When passing complex objects in the <code>application/x-www-form-urlencoded</code> content type, the default serialization strategy of such properties is described in the <a href="#encodingObject"><code>Encoding Object</code></a>’s <a href="#encodingStyle"><code>style</code></a> property as <code>form</code>.</p>
 </section><section><h4>Special Considerations for <code>multipart</code> Content</h4>
 <p>It is common to use <code>multipart/form-data</code> as a <code>Content-Type</code> when transferring request bodies to operations.  In contrast to 2.0, a <code>schema</code> is REQUIRED to define the input parameters to the operation when using <code>multipart</code> content.  This supports complex structures as well as supporting mechanisms for multiple file uploads.</p>
 <p>When passing in <code>multipart</code> types, boundaries MAY be used to separate sections of the content being transferred — thus, the following default <code>Content-Type</code>s are defined for <code>multipart</code>:</p>
@@ -1948,7 +1956,7 @@ definition may be used:</p>
           <span class="hljs-attr">address:</span>
             <span class="hljs-comment"># default Content-Type for objects is `application/json`</span>
             <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
-            <span class="hljs-attr">properties:</span> <span class="hljs-string">{}</span>
+            <span class="hljs-attr">properties:</span> {}
           <span class="hljs-attr">profileImage:</span>
             <span class="hljs-comment"># default Content-Type for string/binary is `application/octet-stream`</span>
             <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
@@ -1962,7 +1970,7 @@ definition may be used:</p>
             <span class="hljs-comment"># default Content-Type for arrays is based on the `inner` type (object shown, so `application/json` in this example)</span>
             <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
             <span class="hljs-attr">items:</span>
-              <span class="hljs-attr">type:</span> <span class="hljs-string">'#/components/schemas/Address'</span>
+              <span class="hljs-attr">type:</span> <span class="hljs-string">&#x27;#/components/schemas/Address&#x27;</span>
 </code></pre>
 <p>An <code>encoding</code> attribute is introduced to give you control over the serialization of parts of <code>multipart</code> request bodies.  This attribute is <em>only</em> applicable to <code>multipart</code> and <code>application/x-www-form-urlencoded</code> request bodies.</p>
 </section></section><section><h3><span id="encodingObject">Encoding Object</span></h3>
@@ -1984,7 +1992,7 @@ definition may be used:</p>
 </tr>
 <tr>
 <td><a id="encodingHeaders"> </a>headers</td>
-<td style="text-align:center">Map[<code>string</code>, <a href="#headerObject">Header Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:center">Map[<code>string</code>, <a href="#headerObject">Header Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>A map allowing additional information to be provided as headers, for example <code>Content-Disposition</code>.  <code>Content-Type</code> is described separately and SHALL be ignored in this section. This property SHALL be ignored if the request body media type is not a <code>multipart</code>.</td>
 </tr>
 <tr>
@@ -2020,12 +2028,12 @@ definition may be used:</p>
           <span class="hljs-attr">address:</span>
             <span class="hljs-comment"># default is application/json</span>
             <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
-            <span class="hljs-attr">properties:</span> <span class="hljs-string">{}</span>
+            <span class="hljs-attr">properties:</span> {}
           <span class="hljs-attr">historyMetadata:</span>
             <span class="hljs-comment"># need to declare XML format!</span>
             <span class="hljs-attr">description:</span> <span class="hljs-string">metadata</span> <span class="hljs-string">in</span> <span class="hljs-string">XML</span> <span class="hljs-string">format</span>
             <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
-            <span class="hljs-attr">properties:</span> <span class="hljs-string">{}</span>
+            <span class="hljs-attr">properties:</span> {}
           <span class="hljs-attr">profileImage:</span>
             <span class="hljs-comment"># default is application/octet-stream, need to declare an image type only!</span>
             <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
@@ -2064,7 +2072,7 @@ SHOULD be the response for a successful operation call.</p>
 <tbody>
 <tr>
 <td><a id="responsesDefault"> </a>default</td>
-<td style="text-align:center"><a href="#responseObject">Response Object</a> ¦ <a href="#referenceObject">Reference Object</a></td>
+<td style="text-align:center"><a href="#responseObject">Response Object</a> | <a href="#referenceObject">Reference Object</a></td>
 <td>The documentation of responses other than the ones declared for specific HTTP response codes. Use this field to cover undeclared responses. A <a href="#referenceObject">Reference Object</a> can link to a response that the <a href="#componentsResponses">OpenAPI Object’s components/responses</a> section defines.</td>
 </tr>
 </tbody>
@@ -2081,7 +2089,7 @@ SHOULD be the response for a successful operation call.</p>
 <tbody>
 <tr>
 <td><a id="responsesCode"> </a><a href="#httpCodes">HTTP Status Code</a></td>
-<td style="text-align:center"><a href="#responseObject">Response Object</a> ¦ <a href="#referenceObject">Reference Object</a></td>
+<td style="text-align:center"><a href="#responseObject">Response Object</a> | <a href="#referenceObject">Reference Object</a></td>
 <td>Any <a href="#httpCodes">HTTP status code</a> can be used as the property name, but only one property per code, to describe the expected response for that HTTP status code.  A <a href="#referenceObject">Reference Object</a> can link to a response that is defined in the <a href="#componentsResponses">OpenAPI Object’s components/responses</a> section. This field MUST be enclosed in quotation marks (for example, “200”) for compatibility between JSON and YAML. To define a range of response codes, this field MAY contain the uppercase wildcard character <code>X</code>. For example, <code>2XX</code> represents all response codes between <code>[200-299]</code>. Only the following range definitions are allowed: <code>1XX</code>, <code>2XX</code>, <code>3XX</code>, <code>4XX</code>, and <code>5XX</code>. If a response is defined using an explicit code, the explicit code definition takes precedence over the range definition for that code.</td>
 </tr>
 </tbody>
@@ -2091,22 +2099,22 @@ SHOULD be the response for a successful operation call.</p>
 <p>A 200 response for a successful operation and a default response for others (implying an error):</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"200"</span>: {
-    <span class="hljs-attr">"description"</span>: <span class="hljs-string">"a pet to be returned"</span>,
-    <span class="hljs-attr">"content"</span>: {
-      <span class="hljs-attr">"application/json"</span>: {
-        <span class="hljs-attr">"schema"</span>: {
-          <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/Pet"</span>
+  <span class="hljs-attr">&quot;200&quot;</span>: {
+    <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;a pet to be returned&quot;</span>,
+    <span class="hljs-attr">&quot;content&quot;</span>: {
+      <span class="hljs-attr">&quot;application/json&quot;</span>: {
+        <span class="hljs-attr">&quot;schema&quot;</span>: {
+          <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/Pet&quot;</span>
         }
       }
     }
   },
-  <span class="hljs-attr">"default"</span>: {
-    <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Unexpected error"</span>,
-    <span class="hljs-attr">"content"</span>: {
-      <span class="hljs-attr">"application/json"</span>: {
-        <span class="hljs-attr">"schema"</span>: {
-          <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/ErrorModel"</span>
+  <span class="hljs-attr">&quot;default&quot;</span>: {
+    <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;Unexpected error&quot;</span>,
+    <span class="hljs-attr">&quot;content&quot;</span>: {
+      <span class="hljs-attr">&quot;application/json&quot;</span>: {
+        <span class="hljs-attr">&quot;schema&quot;</span>: {
+          <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/ErrorModel&quot;</span>
         }
       }
     }
@@ -2114,18 +2122,18 @@ SHOULD be the response for a successful operation call.</p>
 }
 </code></pre>
 <pre class="nohighlight"><code>
-<span class="hljs-attr">'200':</span>
+<span class="hljs-attr">&#x27;200&#x27;:</span>
   <span class="hljs-attr">description:</span> <span class="hljs-string">a</span> <span class="hljs-string">pet</span> <span class="hljs-string">to</span> <span class="hljs-string">be</span> <span class="hljs-string">returned</span>
   <span class="hljs-attr">content:</span> 
     <span class="hljs-attr">application/json:</span>
       <span class="hljs-attr">schema:</span>
-        <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Pet'</span>
+        <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/Pet&#x27;</span>
 <span class="hljs-attr">default:</span>
   <span class="hljs-attr">description:</span> <span class="hljs-string">Unexpected</span> <span class="hljs-string">error</span>
   <span class="hljs-attr">content:</span>
     <span class="hljs-attr">application/json:</span>
       <span class="hljs-attr">schema:</span>
-        <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/ErrorModel'</span>
+        <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/ErrorModel&#x27;</span>
 </code></pre>
 </section></section><section><h3><span id="responseObject">Response Object</span></h3>
 <p>Describes a single response from an API Operation, including design-time, static
@@ -2147,7 +2155,7 @@ SHOULD be the response for a successful operation call.</p>
 </tr>
 <tr>
 <td><a id="responseHeaders"> </a>headers</td>
-<td style="text-align:center">Map[<code>string</code>, <a href="#headerObject">Header Object</a>  ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:center">Map[<code>string</code>, <a href="#headerObject">Header Object</a>  | <a href="#referenceObject">Reference Object</a>]</td>
 <td>Maps a header name to its definition. [[!RFC7230]] states header names are case insensitive. If a response header is defined with the name <code>&quot;Content-Type&quot;</code>, it SHALL be ignored.</td>
 </tr>
 <tr>
@@ -2157,7 +2165,7 @@ SHOULD be the response for a successful operation call.</p>
 </tr>
 <tr>
 <td><a id="responseLinks"> </a>links</td>
-<td style="text-align:center">Map[<code>string</code>, <a href="#linkObject">Link Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:center">Map[<code>string</code>, <a href="#linkObject">Link Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>A map of operations links that can be followed from the response. The key of the map is a short name for the link, following the naming constraints of the names for <a href="#componentsObject">Component Objects</a>.</td>
 </tr>
 </tbody>
@@ -2167,13 +2175,13 @@ SHOULD be the response for a successful operation call.</p>
 <p>Response of an array of a complex type:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"A complex object array response"</span>,
-  <span class="hljs-attr">"content"</span>: {
-    <span class="hljs-attr">"application/json"</span>: {
-      <span class="hljs-attr">"schema"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-        <span class="hljs-attr">"items"</span>: {
-          <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/VeryComplexType"</span>
+  <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;A complex object array response&quot;</span>,
+  <span class="hljs-attr">&quot;content&quot;</span>: {
+    <span class="hljs-attr">&quot;application/json&quot;</span>: {
+      <span class="hljs-attr">&quot;schema&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+        <span class="hljs-attr">&quot;items&quot;</span>: {
+          <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/VeryComplexType&quot;</span>
         }
       }
     }
@@ -2187,16 +2195,16 @@ SHOULD be the response for a successful operation call.</p>
     <span class="hljs-attr">schema:</span> 
       <span class="hljs-attr">type:</span> <span class="hljs-string">array</span>
       <span class="hljs-attr">items:</span>
-        <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/VeryComplexType'</span>
+        <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/VeryComplexType&#x27;</span>
 </code></pre>
 <p>Response with a string type:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"A simple string response"</span>,
-  <span class="hljs-attr">"content"</span>: {
-    <span class="hljs-attr">"text/plain"</span>: {
-      <span class="hljs-attr">"schema"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+  <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;A simple string response&quot;</span>,
+  <span class="hljs-attr">&quot;content&quot;</span>: {
+    <span class="hljs-attr">&quot;text/plain&quot;</span>: {
+      <span class="hljs-attr">&quot;schema&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
       }
     }
   }
@@ -2213,32 +2221,32 @@ SHOULD be the response for a successful operation call.</p>
 <p>Plain text response with headers:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"A simple string response"</span>,
-  <span class="hljs-attr">"content"</span>: {
-    <span class="hljs-attr">"text/plain"</span>: {
-      <span class="hljs-attr">"schema"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
-        <span class="hljs-attr">"example"</span>: <span class="hljs-string">"whoa!"</span>
+  <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;A simple string response&quot;</span>,
+  <span class="hljs-attr">&quot;content&quot;</span>: {
+    <span class="hljs-attr">&quot;text/plain&quot;</span>: {
+      <span class="hljs-attr">&quot;schema&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>,
+        <span class="hljs-attr">&quot;example&quot;</span>: <span class="hljs-string">&quot;whoa!&quot;</span>
       }
     }
   },
-  <span class="hljs-attr">"headers"</span>: {
-    <span class="hljs-attr">"X-Rate-Limit-Limit"</span>: {
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"The number of allowed requests in the current period"</span>,
-      <span class="hljs-attr">"schema"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>
+  <span class="hljs-attr">&quot;headers&quot;</span>: {
+    <span class="hljs-attr">&quot;X-Rate-Limit-Limit&quot;</span>: {
+      <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;The number of allowed requests in the current period&quot;</span>,
+      <span class="hljs-attr">&quot;schema&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>
       }
     },
-    <span class="hljs-attr">"X-Rate-Limit-Remaining"</span>: {
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"The number of remaining requests in the current period"</span>,
-      <span class="hljs-attr">"schema"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>
+    <span class="hljs-attr">&quot;X-Rate-Limit-Remaining&quot;</span>: {
+      <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;The number of remaining requests in the current period&quot;</span>,
+      <span class="hljs-attr">&quot;schema&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>
       }
     },
-    <span class="hljs-attr">"X-Rate-Limit-Reset"</span>: {
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"The number of seconds left in the current period"</span>,
-      <span class="hljs-attr">"schema"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>
+    <span class="hljs-attr">&quot;X-Rate-Limit-Reset&quot;</span>: {
+      <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;The number of seconds left in the current period&quot;</span>,
+      <span class="hljs-attr">&quot;schema&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>
       }
     }
   }
@@ -2250,7 +2258,7 @@ SHOULD be the response for a successful operation call.</p>
   <span class="hljs-attr">text/plain:</span>
     <span class="hljs-attr">schema:</span>
       <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
-    <span class="hljs-attr">example:</span> <span class="hljs-string">'whoa!'</span>
+    <span class="hljs-attr">example:</span> <span class="hljs-string">&#x27;whoa!&#x27;</span>
 <span class="hljs-attr">headers:</span>
   <span class="hljs-attr">X-Rate-Limit-Limit:</span>
     <span class="hljs-attr">description:</span> <span class="hljs-string">The</span> <span class="hljs-string">number</span> <span class="hljs-string">of</span> <span class="hljs-string">allowed</span> <span class="hljs-string">requests</span> <span class="hljs-string">in</span> <span class="hljs-string">the</span> <span class="hljs-string">current</span> <span class="hljs-string">period</span>
@@ -2268,7 +2276,7 @@ SHOULD be the response for a successful operation call.</p>
 <p>Response with no return value:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"object created"</span>
+  <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;object created&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -2303,22 +2311,22 @@ However, using a <a href="#runtimeExpression">runtime expression</a> the complet
 This includes accessing any part of a body that a JSON Pointer [[!RFC6901]] can reference.</p>
 <p>For example, given the following HTTP request:</p>
 <pre class="nohighlight"><code>
-<span class="hljs-keyword">POST</span> <span class="hljs-string">/subscribe/myevent?queryUrl=http://clientdomain.com/stillrunning</span> HTTP/1.1
-<span class="hljs-attribute">Host</span>: example.org
-<span class="hljs-attribute">Content-Type</span>: application/json
-<span class="hljs-attribute">Content-Length</span>: 187
+<span class="hljs-keyword">POST</span> <span class="hljs-string">/subscribe/myevent?queryUrl=http://clientdomain.com/stillrunning</span> <span class="hljs-meta">HTTP/1.1</span>
+<span class="hljs-attribute">Host</span><span class="hljs-punctuation">: </span>example.org
+<span class="hljs-attribute">Content-Type</span><span class="hljs-punctuation">: </span>application/json
+<span class="hljs-attribute">Content-Length</span><span class="hljs-punctuation">: </span>187
 
-<span class="groovy">{
-  <span class="hljs-string">"failedUrl"</span> : <span class="hljs-string">"http://clientdomain.com/failed"</span>,
-  <span class="hljs-string">"successUrls"</span> : [
-    <span class="hljs-string">"http://clientdomain.com/fast"</span>,
-    <span class="hljs-string">"http://clientdomain.com/medium"</span>,
-    <span class="hljs-string">"http://clientdomain.com/slow"</span>
+<span class="awk">{
+  <span class="hljs-string">&quot;failedUrl&quot;</span> : <span class="hljs-string">&quot;http://clientdomain.com/failed&quot;</span>,
+  <span class="hljs-string">&quot;successUrls&quot;</span> : [
+    <span class="hljs-string">&quot;http://clientdomain.com/fast&quot;</span>,
+    <span class="hljs-string">&quot;http://clientdomain.com/medium&quot;</span>,
+    <span class="hljs-string">&quot;http://clientdomain.com/slow&quot;</span>
   ] 
 }
 
 <span class="hljs-number">201</span> Created
-<span class="hljs-string">Location:</span> <span class="hljs-string">http:</span><span class="hljs-comment">//example.org/subscription/1</span>
+Location: http:<span class="hljs-regexp">//</span>example.org<span class="hljs-regexp">/subscription/</span><span class="hljs-number">1</span>
 </span></code></pre>
 <p>The following examples show how the various expressions evaluate, assuming the callback operation has a path parameter named <code>eventType</code> and a query parameter named <code>queryUrl</code>.</p>
 <table>
@@ -2367,31 +2375,31 @@ This includes accessing any part of a body that a JSON Pointer [[!RFC6901]] can 
 <p>The following example uses the user provided <code>queryUrl</code> query string parameter to define the callback URL.  This is an example of how to use a callback object to describe a WebHook callback that goes with the subscription operation to enable registering for the WebHook.</p>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">myCallback:</span>
-  <span class="hljs-string">'{$request.query.queryUrl}'</span><span class="hljs-string">:</span>
+  <span class="hljs-string">&#x27;{$request.query.queryUrl}&#x27;</span><span class="hljs-string">:</span>
     <span class="hljs-attr">post:</span>
       <span class="hljs-attr">requestBody:</span>
         <span class="hljs-attr">description:</span> <span class="hljs-string">Callback</span> <span class="hljs-string">payload</span>
         <span class="hljs-attr">content:</span> 
-          <span class="hljs-attr">'application/json':</span>
+          <span class="hljs-attr">&#x27;application/json&#x27;:</span>
             <span class="hljs-attr">schema:</span>
-              <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/SomePayload'</span>
+              <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/SomePayload&#x27;</span>
       <span class="hljs-attr">responses:</span>
-        <span class="hljs-attr">'200':</span>
+        <span class="hljs-attr">&#x27;200&#x27;:</span>
           <span class="hljs-attr">description:</span> <span class="hljs-string">callback</span> <span class="hljs-string">successfully</span> <span class="hljs-string">processed</span>
 </code></pre>
 <p>The following example shows a callback where the server is hard-coded, but the query string parameters are populated from the <code>id</code> and <code>email</code> property in the request body.</p>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">transactionCallback:</span>
-  <span class="hljs-string">'http://notificationServer.com?transactionId={$request.body#/id}&amp;email={$request.body#/email}'</span><span class="hljs-string">:</span>
+  <span class="hljs-string">&#x27;http://notificationServer.com?transactionId={$request.body#/id}&amp;email={$request.body#/email}&#x27;</span><span class="hljs-string">:</span>
     <span class="hljs-attr">post:</span>
       <span class="hljs-attr">requestBody:</span>
         <span class="hljs-attr">description:</span> <span class="hljs-string">Callback</span> <span class="hljs-string">payload</span>
         <span class="hljs-attr">content:</span> 
-          <span class="hljs-attr">'application/json':</span>
+          <span class="hljs-attr">&#x27;application/json&#x27;:</span>
             <span class="hljs-attr">schema:</span>
-              <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/SomePayload'</span>
+              <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/SomePayload&#x27;</span>
       <span class="hljs-attr">responses:</span>
-        <span class="hljs-attr">'200':</span>
+        <span class="hljs-attr">&#x27;200&#x27;:</span>
           <span class="hljs-attr">description:</span> <span class="hljs-string">callback</span> <span class="hljs-string">successfully</span> <span class="hljs-string">processed</span>
 </code></pre>
 </section></section><section><h3><span id="exampleObject">Example Object</span></h3>
@@ -2436,51 +2444,51 @@ validate compatibility automatically, and reject the example value(s) if incompa
 <pre class="nohighlight"><code>
 <span class="hljs-attr">requestBody:</span>
   <span class="hljs-attr">content:</span>
-    <span class="hljs-attr">'application/json':</span>
+    <span class="hljs-attr">&#x27;application/json&#x27;:</span>
       <span class="hljs-attr">schema:</span>
-        <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Address'</span>
+        <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/Address&#x27;</span>
       <span class="hljs-attr">examples:</span> 
         <span class="hljs-attr">foo:</span>
           <span class="hljs-attr">summary:</span> <span class="hljs-string">A</span> <span class="hljs-string">foo</span> <span class="hljs-string">example</span>
-          <span class="hljs-attr">value:</span> <span class="hljs-string">{"foo":</span> <span class="hljs-string">"bar"</span><span class="hljs-string">}</span>
+          <span class="hljs-attr">value:</span> {<span class="hljs-attr">&quot;foo&quot;:</span> <span class="hljs-string">&quot;bar&quot;</span>}
         <span class="hljs-attr">bar:</span>
           <span class="hljs-attr">summary:</span> <span class="hljs-string">A</span> <span class="hljs-string">bar</span> <span class="hljs-string">example</span>
-          <span class="hljs-attr">value:</span> <span class="hljs-string">{"bar":</span> <span class="hljs-string">"baz"</span><span class="hljs-string">}</span>
-    <span class="hljs-attr">'application/xml':</span>
+          <span class="hljs-attr">value:</span> {<span class="hljs-attr">&quot;bar&quot;:</span> <span class="hljs-string">&quot;baz&quot;</span>}
+    <span class="hljs-attr">&#x27;application/xml&#x27;:</span>
       <span class="hljs-attr">examples:</span> 
         <span class="hljs-attr">xmlExample:</span>
           <span class="hljs-attr">summary:</span> <span class="hljs-string">This</span> <span class="hljs-string">is</span> <span class="hljs-string">an</span> <span class="hljs-string">example</span> <span class="hljs-string">in</span> <span class="hljs-string">XML</span>
-          <span class="hljs-attr">externalValue:</span> <span class="hljs-string">'http://example.org/examples/address-example.xml'</span>
-    <span class="hljs-attr">'text/plain':</span>
+          <span class="hljs-attr">externalValue:</span> <span class="hljs-string">&#x27;http://example.org/examples/address-example.xml&#x27;</span>
+    <span class="hljs-attr">&#x27;text/plain&#x27;:</span>
       <span class="hljs-attr">examples:</span>
         <span class="hljs-attr">textExample:</span> 
           <span class="hljs-attr">summary:</span> <span class="hljs-string">This</span> <span class="hljs-string">is</span> <span class="hljs-string">a</span> <span class="hljs-string">text</span> <span class="hljs-string">example</span>
-          <span class="hljs-attr">externalValue:</span> <span class="hljs-string">'http://foo.bar/examples/address-example.txt'</span>
+          <span class="hljs-attr">externalValue:</span> <span class="hljs-string">&#x27;http://foo.bar/examples/address-example.txt&#x27;</span>
 </code></pre>
 <p>In a parameter:</p>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">parameters:</span>
-  <span class="hljs-bullet">-</span> <span class="hljs-attr">name:</span> <span class="hljs-string">'zipCode'</span>
-    <span class="hljs-attr">in:</span> <span class="hljs-string">'query'</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-attr">name:</span> <span class="hljs-string">&#x27;zipCode&#x27;</span>
+    <span class="hljs-attr">in:</span> <span class="hljs-string">&#x27;query&#x27;</span>
     <span class="hljs-attr">schema:</span>
-      <span class="hljs-attr">type:</span> <span class="hljs-string">'string'</span>
-      <span class="hljs-attr">format:</span> <span class="hljs-string">'zip-code'</span>
+      <span class="hljs-attr">type:</span> <span class="hljs-string">&#x27;string&#x27;</span>
+      <span class="hljs-attr">format:</span> <span class="hljs-string">&#x27;zip-code&#x27;</span>
     <span class="hljs-attr">examples:</span>
       <span class="hljs-attr">zip-example:</span> 
-        <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/examples/zip-example'</span>
+        <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/examples/zip-example&#x27;</span>
 </code></pre>
 <p>In a response:</p>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">responses:</span>
-  <span class="hljs-attr">'200':</span>
+  <span class="hljs-attr">&#x27;200&#x27;:</span>
     <span class="hljs-attr">description:</span> <span class="hljs-string">your</span> <span class="hljs-string">car</span> <span class="hljs-string">appointment</span> <span class="hljs-string">has</span> <span class="hljs-string">been</span> <span class="hljs-string">booked</span>
     <span class="hljs-attr">content:</span> 
       <span class="hljs-attr">application/json:</span>
         <span class="hljs-attr">schema:</span>
-          <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/SuccessResponse'</span>
+          <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/SuccessResponse&#x27;</span>
         <span class="hljs-attr">examples:</span>
           <span class="hljs-attr">confirmation-success:</span>
-            <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/examples/confirmation-success'</span>
+            <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/examples/confirmation-success&#x27;</span>
 </code></pre>
 </section></section><section><h3><span id="linkObject">Link Object</span></h3>
 <p>The <code>Link object</code> represents a possible design-time link for a response.
@@ -2509,12 +2517,12 @@ The presence of a link does not guarantee the caller’s ability to successfully
 </tr>
 <tr>
 <td><a id="linkParameters"> </a>parameters</td>
-<td style="text-align:center">Map[<code>string</code>, Any ¦ <a href="#runtimeExpression">{expression}</a>]</td>
+<td style="text-align:center">Map[<code>string</code>, Any | <a href="#runtimeExpression">{expression}</a>]</td>
 <td>A map representing parameters to pass to an operation as specified with <code>operationId</code> or identified via <code>operationRef</code>. The key is the parameter name to be used, whereas the value can be a constant or an expression to be evaluated and passed to the linked operation.  The parameter name can be qualified using the <a href="#parameterIn">parameter location</a> <code>[{in}.]{name}</code> for operations that use the same parameter name in different locations (e.g. <a href="http://path.id">path.id</a>).</td>
 </tr>
 <tr>
 <td><a id="linkRequestBody"> </a>requestBody</td>
-<td style="text-align:center">Any ¦ <a href="#runtimeExpression">{expression}</a></td>
+<td style="text-align:center">Any | <a href="#runtimeExpression">{expression}</a></td>
 <td>A literal value or <a href="#runtimeExpression">{expression}</a> to use as a request body when calling the target operation.</td>
 </tr>
 <tr>
@@ -2548,7 +2556,7 @@ for specifications with external references.</p>
         <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
     <span class="hljs-attr">get:</span>
       <span class="hljs-attr">responses:</span>
-        <span class="hljs-attr">'200':</span>
+        <span class="hljs-attr">&#x27;200&#x27;:</span>
           <span class="hljs-attr">description:</span> <span class="hljs-string">the</span> <span class="hljs-string">user</span> <span class="hljs-string">being</span> <span class="hljs-string">returned</span>
           <span class="hljs-attr">content:</span>
             <span class="hljs-attr">application/json:</span>
@@ -2578,8 +2586,8 @@ for specifications with external references.</p>
     <span class="hljs-attr">get:</span>
       <span class="hljs-attr">operationId:</span> <span class="hljs-string">getUserAddress</span>
       <span class="hljs-attr">responses:</span>
-        <span class="hljs-attr">'200':</span>
-          <span class="hljs-attr">description:</span> <span class="hljs-string">the</span> <span class="hljs-string">user's</span> <span class="hljs-string">address</span>
+        <span class="hljs-attr">&#x27;200&#x27;:</span>
+          <span class="hljs-attr">description:</span> <span class="hljs-string">the</span> <span class="hljs-string">user&#x27;s</span> <span class="hljs-string">address</span>
 </code></pre>
 <p>When a runtime expression fails to evaluate, no parameter value is passed to the target operation.</p>
 <p>Values from the response body can be used to drive a linked operation.</p>
@@ -2600,8 +2608,8 @@ field in an <a href="#operationObject">Operation Object</a>), references MAY als
 <pre class="nohighlight"><code>
 <span class="hljs-attr">links:</span>
   <span class="hljs-attr">UserRepositories:</span>
-    <span class="hljs-comment"># returns array of '#/components/schemas/repository'</span>
-    <span class="hljs-attr">operationRef:</span> <span class="hljs-string">'#/paths/~12.0~1repositories~1{username}/get'</span>
+    <span class="hljs-comment"># returns array of &#x27;#/components/schemas/repository&#x27;</span>
+    <span class="hljs-attr">operationRef:</span> <span class="hljs-string">&#x27;#/paths/~12.0~1repositories~1{username}/get&#x27;</span>
     <span class="hljs-attr">parameters:</span>
       <span class="hljs-attr">username:</span> <span class="hljs-string">$response.body#/username</span>
 </code></pre>
@@ -2609,8 +2617,8 @@ field in an <a href="#operationObject">Operation Object</a>), references MAY als
 <pre class="nohighlight"><code>
 <span class="hljs-attr">links:</span>
   <span class="hljs-attr">UserRepositories:</span>
-    <span class="hljs-comment"># returns array of '#/components/schemas/repository'</span>
-    <span class="hljs-attr">operationRef:</span> <span class="hljs-string">'https://na2.gigantic-server.com/#/paths/~12.0~1repositories~1{username}/get'</span>
+    <span class="hljs-comment"># returns array of &#x27;#/components/schemas/repository&#x27;</span>
+    <span class="hljs-attr">operationRef:</span> <span class="hljs-string">&#x27;https://na2.gigantic-server.com/#/paths/~12.0~1repositories~1{username}/get&#x27;</span>
     <span class="hljs-attr">parameters:</span>
       <span class="hljs-attr">username:</span> <span class="hljs-string">$response.body#/username</span>
 </code></pre>
@@ -2621,22 +2629,22 @@ using JSON references.</p>
 This mechanism is used by <a href="#linkObject">Link Objects</a> and <a href="#callbackObject">Callback Objects</a>.</p>
 <p>The runtime expression is defined by the following [ABNF] syntax</p>
 <pre class="nohighlight"><code>
-      expression = ( <span class="hljs-string">"$url"</span> / <span class="hljs-string">"$method"</span> / <span class="hljs-string">"$statusCode"</span> / <span class="hljs-string">"$request."</span> source / <span class="hljs-string">"$response."</span> source )
+      expression = ( <span class="hljs-string">&quot;$url&quot;</span> / <span class="hljs-string">&quot;$method&quot;</span> / <span class="hljs-string">&quot;$statusCode&quot;</span> / <span class="hljs-string">&quot;$request.&quot;</span> source / <span class="hljs-string">&quot;$response.&quot;</span> source )
       source = ( header-reference / query-reference / path-reference / body-reference )
-      header-reference = <span class="hljs-string">"header."</span> token
-      query-reference = <span class="hljs-string">"query."</span> name  
-      path-reference = <span class="hljs-string">"path."</span> name
-      body-reference = <span class="hljs-string">"body"</span> [<span class="hljs-string">"#"</span> json-pointer ]
-      json-pointer    = *( <span class="hljs-string">"/"</span> reference-token )
+      header-reference = <span class="hljs-string">&quot;header.&quot;</span> token
+      query-reference = <span class="hljs-string">&quot;query.&quot;</span> name  
+      path-reference = <span class="hljs-string">&quot;path.&quot;</span> name
+      body-reference = <span class="hljs-string">&quot;body&quot;</span> [<span class="hljs-string">&quot;#&quot;</span> json-pointer ]
+      json-pointer    = *( <span class="hljs-string">&quot;/&quot;</span> reference-token )
       reference-token = *( unescaped / escaped )
       unescaped       = <span class="hljs-symbol">%x00-2E</span> / <span class="hljs-symbol">%x30-7D</span> / <span class="hljs-symbol">%x7F-10FFFF</span>
-         <span class="hljs-comment">; %x2F ('/') and %x7E ('~') are excluded from 'unescaped'</span>
-      escaped         = <span class="hljs-string">"~"</span> ( <span class="hljs-string">"0"</span> / <span class="hljs-string">"1"</span> )
-        <span class="hljs-comment">; representing '~' and '/', respectively</span>
+         <span class="hljs-comment">; %x2F (&#x27;/&#x27;) and %x7E (&#x27;~&#x27;) are excluded from &#x27;unescaped&#x27;</span>
+      escaped         = <span class="hljs-string">&quot;~&quot;</span> ( <span class="hljs-string">&quot;0&quot;</span> / <span class="hljs-string">&quot;1&quot;</span> )
+        <span class="hljs-comment">; representing &#x27;~&#x27; and &#x27;/&#x27;, respectively</span>
       name = *( <span class="hljs-keyword">CHAR</span> )
       token = <span class="hljs-number">1</span>*tchar
-      tchar = <span class="hljs-string">"!"</span> / <span class="hljs-string">"#"</span> / <span class="hljs-string">"$"</span> / <span class="hljs-string">"%"</span> / <span class="hljs-string">"&amp;"</span> / <span class="hljs-string">"'"</span> / <span class="hljs-string">"*"</span> / <span class="hljs-string">"+"</span> / <span class="hljs-string">"-"</span> / <span class="hljs-string">"."</span> /
-        <span class="hljs-string">"^"</span> / <span class="hljs-string">"_"</span> / <span class="hljs-string">"`"</span> / <span class="hljs-string">"|"</span> / <span class="hljs-string">"~"</span> / <span class="hljs-keyword">DIGIT</span> / <span class="hljs-keyword">ALPHA</span>
+      tchar = <span class="hljs-string">&quot;!&quot;</span> / <span class="hljs-string">&quot;#&quot;</span> / <span class="hljs-string">&quot;$&quot;</span> / <span class="hljs-string">&quot;%&quot;</span> / <span class="hljs-string">&quot;&amp;&quot;</span> / <span class="hljs-string">&quot;&#x27;&quot;</span> / <span class="hljs-string">&quot;*&quot;</span> / <span class="hljs-string">&quot;+&quot;</span> / <span class="hljs-string">&quot;-&quot;</span> / <span class="hljs-string">&quot;.&quot;</span> /
+        <span class="hljs-string">&quot;^&quot;</span> / <span class="hljs-string">&quot;_&quot;</span> / <span class="hljs-string">&quot;`&quot;</span> / <span class="hljs-string">&quot;|&quot;</span> / <span class="hljs-string">&quot;~&quot;</span> / <span class="hljs-keyword">DIGIT</span> / <span class="hljs-keyword">ALPHA</span>
 </code></pre>
 <p>Here, <code>json-pointer</code> is taken from [[!RFC6901]], <code>char</code> from [[!RFC7159]] and <code>token</code> from [[!RFC7230]].</p>
 <p>The <code>name</code> identifier is case-sensitive, whereas <code>token</code> is not.</p>
@@ -2701,9 +2709,9 @@ Expressions can be embedded into string values by surrounding the expression wit
 <p>A simple header of type <code>integer</code>:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"The number of allowed requests in the current period"</span>,
-  <span class="hljs-attr">"schema"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>
+  <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;The number of allowed requests in the current period&quot;</span>,
+  <span class="hljs-attr">&quot;schema&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>
   }
 }
 </code></pre>
@@ -2746,8 +2754,8 @@ It is not mandatory to have a Tag Object per tag defined in the Operation Object
 </section><section><h4>Tag Object Example</h4>
 <pre class="nohighlight"><code>
 {
-	<span class="hljs-attr">"name"</span>: <span class="hljs-string">"pet"</span>,
-	<span class="hljs-attr">"description"</span>: <span class="hljs-string">"Pets operations"</span>
+	<span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;pet&quot;</span>,
+	<span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;Pets operations&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -2779,16 +2787,16 @@ It is not mandatory to have a Tag Object per tag defined in the Operation Object
 </section><section><h4>Reference Object Example</h4>
 <pre class="nohighlight"><code>
 {
-	<span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/Pet"</span>
+	<span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/Pet&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
-<span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Pet'</span>
+<span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/Pet&#x27;</span>
 </code></pre>
 </section><section><h4>Relative Schema Document Example</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"Pet.json"</span>
+  <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;Pet.json&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -2797,7 +2805,7 @@ It is not mandatory to have a Tag Object per tag defined in the Operation Object
 </section><section><h4>Relative Documents With Embedded Schema Example</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"definitions.json#/Pet"</span>
+  <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;definitions.json#/Pet&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -2919,8 +2927,8 @@ The <a href="#xmlObject">XML Object</a> contains additional information about th
 <section><h5>Primitive Sample</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
-  <span class="hljs-attr">"format"</span>: <span class="hljs-string">"email"</span>
+  <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>,
+  <span class="hljs-attr">&quot;format&quot;</span>: <span class="hljs-string">&quot;email&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -2930,21 +2938,21 @@ The <a href="#xmlObject">XML Object</a> contains additional information about th
 </section><section><h5>Simple Model</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-  <span class="hljs-attr">"required"</span>: [
-    <span class="hljs-string">"name"</span>
+  <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+  <span class="hljs-attr">&quot;required&quot;</span>: [
+    <span class="hljs-string">&quot;name&quot;</span>
   ],
-  <span class="hljs-attr">"properties"</span>: {
-    <span class="hljs-attr">"name"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+  <span class="hljs-attr">&quot;properties&quot;</span>: {
+    <span class="hljs-attr">&quot;name&quot;</span>: {
+      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
     },
-    <span class="hljs-attr">"address"</span>: {
-      <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/Address"</span>
+    <span class="hljs-attr">&quot;address&quot;</span>: {
+      <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/Address&quot;</span>
     },
-    <span class="hljs-attr">"age"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>,
-      <span class="hljs-attr">"format"</span>: <span class="hljs-string">"int32"</span>,
-      <span class="hljs-attr">"minimum"</span>: <span class="hljs-number">0</span>
+    <span class="hljs-attr">&quot;age&quot;</span>: {
+      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>,
+      <span class="hljs-attr">&quot;format&quot;</span>: <span class="hljs-string">&quot;int32&quot;</span>,
+      <span class="hljs-attr">&quot;minimum&quot;</span>: <span class="hljs-number">0</span>
     }
   }
 }
@@ -2957,7 +2965,7 @@ The <a href="#xmlObject">XML Object</a> contains additional information about th
   <span class="hljs-attr">name:</span>
     <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
   <span class="hljs-attr">address:</span>
-    <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Address'</span>
+    <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/Address&#x27;</span>
   <span class="hljs-attr">age:</span>
     <span class="hljs-attr">type:</span> <span class="hljs-string">integer</span>
     <span class="hljs-attr">format:</span> <span class="hljs-string">int32</span>
@@ -2967,9 +2975,9 @@ The <a href="#xmlObject">XML Object</a> contains additional information about th
 <p>For a simple string to string mapping:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-  <span class="hljs-attr">"additionalProperties"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+  <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+  <span class="hljs-attr">&quot;additionalProperties&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
   }
 }
 </code></pre>
@@ -2981,36 +2989,36 @@ The <a href="#xmlObject">XML Object</a> contains additional information about th
 <p>For a string to model mapping:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-  <span class="hljs-attr">"additionalProperties"</span>: {
-    <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/ComplexModel"</span>
+  <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+  <span class="hljs-attr">&quot;additionalProperties&quot;</span>: {
+    <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/ComplexModel&quot;</span>
   }
 }
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
 <span class="hljs-attr">additionalProperties:</span>
-  <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/ComplexModel'</span>
+  <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/ComplexModel&#x27;</span>
 </code></pre>
 </section><section><h5>Model with Example</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-  <span class="hljs-attr">"properties"</span>: {
-    <span class="hljs-attr">"id"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>,
-      <span class="hljs-attr">"format"</span>: <span class="hljs-string">"int64"</span>
+  <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+  <span class="hljs-attr">&quot;properties&quot;</span>: {
+    <span class="hljs-attr">&quot;id&quot;</span>: {
+      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>,
+      <span class="hljs-attr">&quot;format&quot;</span>: <span class="hljs-string">&quot;int64&quot;</span>
     },
-    <span class="hljs-attr">"name"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+    <span class="hljs-attr">&quot;name&quot;</span>: {
+      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
     }
   },
-  <span class="hljs-attr">"required"</span>: [
-    <span class="hljs-string">"name"</span>
+  <span class="hljs-attr">&quot;required&quot;</span>: [
+    <span class="hljs-string">&quot;name&quot;</span>
   ],
-  <span class="hljs-attr">"example"</span>: {
-    <span class="hljs-attr">"name"</span>: <span class="hljs-string">"Puma"</span>,
-    <span class="hljs-attr">"id"</span>: <span class="hljs-number">1</span>
+  <span class="hljs-attr">&quot;example&quot;</span>: {
+    <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;Puma&quot;</span>,
+    <span class="hljs-attr">&quot;id&quot;</span>: <span class="hljs-number">1</span>
   }
 }
 </code></pre>
@@ -3031,38 +3039,38 @@ The <a href="#xmlObject">XML Object</a> contains additional information about th
 </section><section><h5>Models with Composition</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"components"</span>: {
-    <span class="hljs-attr">"schemas"</span>: {
-      <span class="hljs-attr">"ErrorModel"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-        <span class="hljs-attr">"required"</span>: [
-          <span class="hljs-string">"message"</span>,
-          <span class="hljs-string">"code"</span>
+  <span class="hljs-attr">&quot;components&quot;</span>: {
+    <span class="hljs-attr">&quot;schemas&quot;</span>: {
+      <span class="hljs-attr">&quot;ErrorModel&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+        <span class="hljs-attr">&quot;required&quot;</span>: [
+          <span class="hljs-string">&quot;message&quot;</span>,
+          <span class="hljs-string">&quot;code&quot;</span>
         ],
-        <span class="hljs-attr">"properties"</span>: {
-          <span class="hljs-attr">"message"</span>: {
-            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+        <span class="hljs-attr">&quot;properties&quot;</span>: {
+          <span class="hljs-attr">&quot;message&quot;</span>: {
+            <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
           },
-          <span class="hljs-attr">"code"</span>: {
-            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>,
-            <span class="hljs-attr">"minimum"</span>: <span class="hljs-number">100</span>,
-            <span class="hljs-attr">"maximum"</span>: <span class="hljs-number">600</span>
+          <span class="hljs-attr">&quot;code&quot;</span>: {
+            <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>,
+            <span class="hljs-attr">&quot;minimum&quot;</span>: <span class="hljs-number">100</span>,
+            <span class="hljs-attr">&quot;maximum&quot;</span>: <span class="hljs-number">600</span>
           }
         }
       },
-      <span class="hljs-attr">"ExtendedErrorModel"</span>: {
-        <span class="hljs-attr">"allOf"</span>: [
+      <span class="hljs-attr">&quot;ExtendedErrorModel&quot;</span>: {
+        <span class="hljs-attr">&quot;allOf&quot;</span>: [
           {
-            <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/ErrorModel"</span>
+            <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/ErrorModel&quot;</span>
           },
           {
-            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-            <span class="hljs-attr">"required"</span>: [
-              <span class="hljs-string">"rootCause"</span>
+            <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+            <span class="hljs-attr">&quot;required&quot;</span>: [
+              <span class="hljs-string">&quot;rootCause&quot;</span>
             ],
-            <span class="hljs-attr">"properties"</span>: {
-              <span class="hljs-attr">"rootCause"</span>: {
-                <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+            <span class="hljs-attr">&quot;properties&quot;</span>: {
+              <span class="hljs-attr">&quot;rootCause&quot;</span>: {
+                <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
               }
             }
           }
@@ -3089,7 +3097,7 @@ The <a href="#xmlObject">XML Object</a> contains additional information about th
           <span class="hljs-attr">maximum:</span> <span class="hljs-number">600</span>
     <span class="hljs-attr">ExtendedErrorModel:</span>
       <span class="hljs-attr">allOf:</span>
-      <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/ErrorModel'</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/ErrorModel&#x27;</span>
       <span class="hljs-bullet">-</span> <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
         <span class="hljs-attr">required:</span>
         <span class="hljs-bullet">-</span> <span class="hljs-string">rootCause</span>
@@ -3100,72 +3108,72 @@ The <a href="#xmlObject">XML Object</a> contains additional information about th
 </section><section><h5>Models with Polymorphism Support</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"components"</span>: {
-    <span class="hljs-attr">"schemas"</span>: {
-      <span class="hljs-attr">"Pet"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-        <span class="hljs-attr">"discriminator"</span>: {
-          <span class="hljs-attr">"propertyName"</span>: <span class="hljs-string">"petType"</span>
+  <span class="hljs-attr">&quot;components&quot;</span>: {
+    <span class="hljs-attr">&quot;schemas&quot;</span>: {
+      <span class="hljs-attr">&quot;Pet&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+        <span class="hljs-attr">&quot;discriminator&quot;</span>: {
+          <span class="hljs-attr">&quot;propertyName&quot;</span>: <span class="hljs-string">&quot;petType&quot;</span>
         },
-        <span class="hljs-attr">"properties"</span>: {
-          <span class="hljs-attr">"name"</span>: {
-            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+        <span class="hljs-attr">&quot;properties&quot;</span>: {
+          <span class="hljs-attr">&quot;name&quot;</span>: {
+            <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
           },
-          <span class="hljs-attr">"petType"</span>: {
-            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+          <span class="hljs-attr">&quot;petType&quot;</span>: {
+            <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
           }
         },
-        <span class="hljs-attr">"required"</span>: [
-          <span class="hljs-string">"name"</span>,
-          <span class="hljs-string">"petType"</span>
+        <span class="hljs-attr">&quot;required&quot;</span>: [
+          <span class="hljs-string">&quot;name&quot;</span>,
+          <span class="hljs-string">&quot;petType&quot;</span>
         ]
       },
-      <span class="hljs-attr">"Cat"</span>: {
-        <span class="hljs-attr">"description"</span>: <span class="hljs-string">"A representation of a cat. Note that `Cat` will be used as the discriminator value."</span>,
-        <span class="hljs-attr">"allOf"</span>: [
+      <span class="hljs-attr">&quot;Cat&quot;</span>: {
+        <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;A representation of a cat. Note that `Cat` will be used as the discriminator value.&quot;</span>,
+        <span class="hljs-attr">&quot;allOf&quot;</span>: [
           {
-            <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/Pet"</span>
+            <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/Pet&quot;</span>
           },
           {
-            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-            <span class="hljs-attr">"properties"</span>: {
-              <span class="hljs-attr">"huntingSkill"</span>: {
-                <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
-                <span class="hljs-attr">"description"</span>: <span class="hljs-string">"The measured skill for hunting"</span>,
-                <span class="hljs-attr">"default"</span>: <span class="hljs-string">"lazy"</span>,
-                <span class="hljs-attr">"enum"</span>: [
-                  <span class="hljs-string">"clueless"</span>,
-                  <span class="hljs-string">"lazy"</span>,
-                  <span class="hljs-string">"adventurous"</span>,
-                  <span class="hljs-string">"aggressive"</span>
+            <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+            <span class="hljs-attr">&quot;properties&quot;</span>: {
+              <span class="hljs-attr">&quot;huntingSkill&quot;</span>: {
+                <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>,
+                <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;The measured skill for hunting&quot;</span>,
+                <span class="hljs-attr">&quot;default&quot;</span>: <span class="hljs-string">&quot;lazy&quot;</span>,
+                <span class="hljs-attr">&quot;enum&quot;</span>: [
+                  <span class="hljs-string">&quot;clueless&quot;</span>,
+                  <span class="hljs-string">&quot;lazy&quot;</span>,
+                  <span class="hljs-string">&quot;adventurous&quot;</span>,
+                  <span class="hljs-string">&quot;aggressive&quot;</span>
                 ]
               }
             },
-            <span class="hljs-attr">"required"</span>: [
-              <span class="hljs-string">"huntingSkill"</span>
+            <span class="hljs-attr">&quot;required&quot;</span>: [
+              <span class="hljs-string">&quot;huntingSkill&quot;</span>
             ]
           }
         ]
       },
-      <span class="hljs-attr">"Dog"</span>: {
-        <span class="hljs-attr">"description"</span>: <span class="hljs-string">"A representation of a dog. Note that `Dog` will be used as the discriminator value."</span>,
-        <span class="hljs-attr">"allOf"</span>: [
+      <span class="hljs-attr">&quot;Dog&quot;</span>: {
+        <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;A representation of a dog. Note that `Dog` will be used as the discriminator value.&quot;</span>,
+        <span class="hljs-attr">&quot;allOf&quot;</span>: [
           {
-            <span class="hljs-attr">"$ref"</span>: <span class="hljs-string">"#/components/schemas/Pet"</span>
+            <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/Pet&quot;</span>
           },
           {
-            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-            <span class="hljs-attr">"properties"</span>: {
-              <span class="hljs-attr">"packSize"</span>: {
-                <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>,
-                <span class="hljs-attr">"format"</span>: <span class="hljs-string">"int32"</span>,
-                <span class="hljs-attr">"description"</span>: <span class="hljs-string">"the size of the pack the dog is from"</span>,
-                <span class="hljs-attr">"default"</span>: <span class="hljs-number">0</span>,
-                <span class="hljs-attr">"minimum"</span>: <span class="hljs-number">0</span>
+            <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+            <span class="hljs-attr">&quot;properties&quot;</span>: {
+              <span class="hljs-attr">&quot;packSize&quot;</span>: {
+                <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>,
+                <span class="hljs-attr">&quot;format&quot;</span>: <span class="hljs-string">&quot;int32&quot;</span>,
+                <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;the size of the pack the dog is from&quot;</span>,
+                <span class="hljs-attr">&quot;default&quot;</span>: <span class="hljs-number">0</span>,
+                <span class="hljs-attr">&quot;minimum&quot;</span>: <span class="hljs-number">0</span>
               }
             },
-            <span class="hljs-attr">"required"</span>: [
-              <span class="hljs-string">"packSize"</span>
+            <span class="hljs-attr">&quot;required&quot;</span>: [
+              <span class="hljs-string">&quot;packSize&quot;</span>
             ]
           }
         ]
@@ -3189,10 +3197,10 @@ The <a href="#xmlObject">XML Object</a> contains additional information about th
       <span class="hljs-attr">required:</span>
       <span class="hljs-bullet">-</span> <span class="hljs-string">name</span>
       <span class="hljs-bullet">-</span> <span class="hljs-string">petType</span>
-    <span class="hljs-attr">Cat:</span>  <span class="hljs-comment">## "Cat" will be used as the discriminator value</span>
+    <span class="hljs-attr">Cat:</span>  <span class="hljs-comment">## &quot;Cat&quot; will be used as the discriminator value</span>
       <span class="hljs-attr">description:</span> <span class="hljs-string">A</span> <span class="hljs-string">representation</span> <span class="hljs-string">of</span> <span class="hljs-string">a</span> <span class="hljs-string">cat</span>
       <span class="hljs-attr">allOf:</span>
-      <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Pet'</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/Pet&#x27;</span>
       <span class="hljs-bullet">-</span> <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
         <span class="hljs-attr">properties:</span>
           <span class="hljs-attr">huntingSkill:</span>
@@ -3205,10 +3213,10 @@ The <a href="#xmlObject">XML Object</a> contains additional information about th
             <span class="hljs-bullet">-</span> <span class="hljs-string">aggressive</span>
         <span class="hljs-attr">required:</span>
         <span class="hljs-bullet">-</span> <span class="hljs-string">huntingSkill</span>
-    <span class="hljs-attr">Dog:</span>  <span class="hljs-comment">## "Dog" will be used as the discriminator value</span>
+    <span class="hljs-attr">Dog:</span>  <span class="hljs-comment">## &quot;Dog&quot; will be used as the discriminator value</span>
       <span class="hljs-attr">description:</span> <span class="hljs-string">A</span> <span class="hljs-string">representation</span> <span class="hljs-string">of</span> <span class="hljs-string">a</span> <span class="hljs-string">dog</span>
       <span class="hljs-attr">allOf:</span>
-      <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Pet'</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/Pet&#x27;</span>
       <span class="hljs-bullet">-</span> <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
         <span class="hljs-attr">properties:</span>
           <span class="hljs-attr">packSize:</span>
@@ -3250,25 +3258,25 @@ The <a href="#xmlObject">XML Object</a> contains additional information about th
 <pre class="nohighlight"><code>
 <span class="hljs-attr">MyResponseType:</span>
   <span class="hljs-attr">oneOf:</span>
-  <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Cat'</span>
-  <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Dog'</span>
-  <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Lizard'</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/Cat&#x27;</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/Dog&#x27;</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/Lizard&#x27;</span>
 </code></pre>
 <p>which means the payload <em>MUST</em>, by validation, match exactly one of the schemas described by <code>Cat</code>, <code>Dog</code>, or <code>Lizard</code>.  In this case, a discriminator MAY act as a “hint” to shortcut validation and selection of the matching schema which may be a costly operation, depending on the complexity of the schema. We can then describe exactly which field tells us which schema to use:</p>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">MyResponseType:</span>
   <span class="hljs-attr">oneOf:</span>
-  <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Cat'</span>
-  <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Dog'</span>
-  <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Lizard'</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/Cat&#x27;</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/Dog&#x27;</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/Lizard&#x27;</span>
   <span class="hljs-attr">discriminator:</span>
     <span class="hljs-attr">propertyName:</span> <span class="hljs-string">petType</span>
 </code></pre>
 <p>The expectation now is that a property with name <code>petType</code> <em>MUST</em> be present in the response payload, and the value will correspond to the name of a schema defined in the OAS document.  Thus the response payload:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"id"</span>: <span class="hljs-number">12345</span>,
-  <span class="hljs-attr">"petType"</span>: <span class="hljs-string">"Cat"</span>
+  <span class="hljs-attr">&quot;id&quot;</span>: <span class="hljs-number">12345</span>,
+  <span class="hljs-attr">&quot;petType&quot;</span>: <span class="hljs-string">&quot;Cat&quot;</span>
 }
 </code></pre>
 <p>Will indicate that the <code>Cat</code> schema be used in conjunction with this payload.</p>
@@ -3276,15 +3284,15 @@ The <a href="#xmlObject">XML Object</a> contains additional information about th
 <pre class="nohighlight"><code>
 <span class="hljs-attr">MyResponseType:</span>
   <span class="hljs-attr">oneOf:</span>
-  <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Cat'</span>
-  <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Dog'</span>
-  <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Lizard'</span>
-  <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'https://gigantic-server.com/schemas/Monster/schema.json'</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/Cat&#x27;</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/Dog&#x27;</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/Lizard&#x27;</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;https://gigantic-server.com/schemas/Monster/schema.json&#x27;</span>
   <span class="hljs-attr">discriminator:</span>
     <span class="hljs-attr">propertyName:</span> <span class="hljs-string">petType</span>
     <span class="hljs-attr">mapping:</span>
-      <span class="hljs-attr">dog:</span> <span class="hljs-string">'#/components/schemas/Dog'</span>
-      <span class="hljs-attr">monster:</span> <span class="hljs-string">'https://gigantic-server.com/schemas/Monster/schema.json'</span>
+      <span class="hljs-attr">dog:</span> <span class="hljs-string">&#x27;#/components/schemas/Dog&#x27;</span>
+      <span class="hljs-attr">monster:</span> <span class="hljs-string">&#x27;https://gigantic-server.com/schemas/Monster/schema.json&#x27;</span>
 </code></pre>
 <p>Here the discriminator <em>value</em> of <code>dog</code> will map to the schema <code>#/components/schemas/Dog</code>, rather than the default (implicit) value of <code>Dog</code>.  If the discriminator <em>value</em> does not match an implicit or explicit mapping, no schema can be determined and validation SHOULD fail. Mapping keys MUST be string values, but tooling MAY convert response values to strings for comparison.</p>
 <p>When used in conjunction with the <code>anyOf</code> construct, the use of the discriminator can avoid ambiguity where multiple schemas may satisfy a single payload.</p>
@@ -3306,7 +3314,7 @@ The <a href="#xmlObject">XML Object</a> contains additional information about th
           <span class="hljs-attr">dog:</span> <span class="hljs-string">Dog</span>
     <span class="hljs-attr">Cat:</span>
       <span class="hljs-attr">allOf:</span>
-      <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Pet'</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/Pet&#x27;</span>
       <span class="hljs-bullet">-</span> <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
         <span class="hljs-comment"># all other properties specific to a `Cat`</span>
         <span class="hljs-attr">properties:</span>
@@ -3314,7 +3322,7 @@ The <a href="#xmlObject">XML Object</a> contains additional information about th
             <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
     <span class="hljs-attr">Dog:</span>
       <span class="hljs-attr">allOf:</span>
-      <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Pet'</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/Pet&#x27;</span>
       <span class="hljs-bullet">-</span> <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
         <span class="hljs-comment"># all other properties specific to a `Dog`</span>
         <span class="hljs-attr">properties:</span>
@@ -3322,7 +3330,7 @@ The <a href="#xmlObject">XML Object</a> contains additional information about th
             <span class="hljs-attr">type:</span> <span class="hljs-string">string</span>
     <span class="hljs-attr">Lizard:</span>
       <span class="hljs-attr">allOf:</span>
-      <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">'#/components/schemas/Pet'</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-string">$ref:</span> <span class="hljs-string">&#x27;#/components/schemas/Pet&#x27;</span>
       <span class="hljs-bullet">-</span> <span class="hljs-attr">type:</span> <span class="hljs-string">object</span>
         <span class="hljs-comment"># all other properties specific to a `Lizard`</span>
         <span class="hljs-attr">properties:</span>
@@ -3332,15 +3340,15 @@ The <a href="#xmlObject">XML Object</a> contains additional information about th
 <p>a payload like this:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"petType"</span>: <span class="hljs-string">"Cat"</span>,
-  <span class="hljs-attr">"name"</span>: <span class="hljs-string">"misty"</span>
+  <span class="hljs-attr">&quot;petType&quot;</span>: <span class="hljs-string">&quot;Cat&quot;</span>,
+  <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;misty&quot;</span>
 }
 </code></pre>
 <p>will indicate that the <code>Cat</code> schema be used.  Likewise this schema:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"petType"</span>: <span class="hljs-string">"dog"</span>,
-  <span class="hljs-attr">"bark"</span>: <span class="hljs-string">"soft"</span>
+  <span class="hljs-attr">&quot;petType&quot;</span>: <span class="hljs-string">&quot;dog&quot;</span>,
+  <span class="hljs-attr">&quot;bark&quot;</span>: <span class="hljs-string">&quot;soft&quot;</span>
 }
 </code></pre>
 <p>will map to <code>Dog</code> because of the definition in the <code>mappings</code> element.</p>
@@ -3392,8 +3400,8 @@ See examples for expected behavior.</p>
 <p>Basic string property:</p>
 <pre class="nohighlight"><code>
 {
-    <span class="hljs-attr">"animals"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+    <span class="hljs-attr">&quot;animals&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
     }
 }
 </code></pre>
@@ -3407,10 +3415,10 @@ See examples for expected behavior.</p>
 <p>Basic string array property (<a href="#xmlWrapped"><code>wrapped</code></a> is <code>false</code> by default):</p>
 <pre class="nohighlight"><code>
 {
-    <span class="hljs-attr">"animals"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-        <span class="hljs-attr">"items"</span>: {
-            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+    <span class="hljs-attr">&quot;animals&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+        <span class="hljs-attr">&quot;items&quot;</span>: {
+            <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
         }
     }
 }
@@ -3429,10 +3437,10 @@ See examples for expected behavior.</p>
 </section><section><h5>XML Name Replacement</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"animals"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
-    <span class="hljs-attr">"xml"</span>: {
-      <span class="hljs-attr">"name"</span>: <span class="hljs-string">"animal"</span>
+  <span class="hljs-attr">&quot;animals&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>,
+    <span class="hljs-attr">&quot;xml&quot;</span>: {
+      <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;animal&quot;</span>
     }
   }
 }
@@ -3450,21 +3458,21 @@ See examples for expected behavior.</p>
 <p>In this example, a full model definition is shown.</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"Person"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-    <span class="hljs-attr">"properties"</span>: {
-      <span class="hljs-attr">"id"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"integer"</span>,
-        <span class="hljs-attr">"format"</span>: <span class="hljs-string">"int32"</span>,
-        <span class="hljs-attr">"xml"</span>: {
-          <span class="hljs-attr">"attribute"</span>: <span class="hljs-literal">true</span>
+  <span class="hljs-attr">&quot;Person&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
+    <span class="hljs-attr">&quot;properties&quot;</span>: {
+      <span class="hljs-attr">&quot;id&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>,
+        <span class="hljs-attr">&quot;format&quot;</span>: <span class="hljs-string">&quot;int32&quot;</span>,
+        <span class="hljs-attr">&quot;xml&quot;</span>: {
+          <span class="hljs-attr">&quot;attribute&quot;</span>: <span class="hljs-literal">true</span>
         }
       },
-      <span class="hljs-attr">"name"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
-        <span class="hljs-attr">"xml"</span>: {
-          <span class="hljs-attr">"namespace"</span>: <span class="hljs-string">"http://example.com/schema/sample"</span>,
-          <span class="hljs-attr">"prefix"</span>: <span class="hljs-string">"sample"</span>
+      <span class="hljs-attr">&quot;name&quot;</span>: {
+        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>,
+        <span class="hljs-attr">&quot;xml&quot;</span>: {
+          <span class="hljs-attr">&quot;namespace&quot;</span>: <span class="hljs-string">&quot;http://example.com/schema/sample&quot;</span>,
+          <span class="hljs-attr">&quot;prefix&quot;</span>: <span class="hljs-string">&quot;sample&quot;</span>
         }
       }
     }
@@ -3487,20 +3495,20 @@ See examples for expected behavior.</p>
         <span class="hljs-attr">prefix:</span> <span class="hljs-string">sample</span>
 </code></pre>
 <pre class="nohighlight"><code>
-<span class="hljs-tag">&lt;<span class="hljs-name">Person</span> <span class="hljs-attr">id</span>=<span class="hljs-string">"123"</span>&gt;</span>
-    <span class="hljs-tag">&lt;<span class="hljs-name">sample:name</span> <span class="hljs-attr">xmlns:sample</span>=<span class="hljs-string">"http://example.com/schema/sample"</span>&gt;</span>example<span class="hljs-tag">&lt;/<span class="hljs-name">sample:name</span>&gt;</span>
+<span class="hljs-tag">&lt;<span class="hljs-name">Person</span> <span class="hljs-attr">id</span>=<span class="hljs-string">&quot;123&quot;</span>&gt;</span>
+    <span class="hljs-tag">&lt;<span class="hljs-name">sample:name</span> <span class="hljs-attr">xmlns:sample</span>=<span class="hljs-string">&quot;http://example.com/schema/sample&quot;</span>&gt;</span>example<span class="hljs-tag">&lt;/<span class="hljs-name">sample:name</span>&gt;</span>
 <span class="hljs-tag">&lt;/<span class="hljs-name">Person</span>&gt;</span>
 </code></pre>
 </section><section><h5>XML Arrays</h5>
 <p>Changing the element names:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"animals"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-    <span class="hljs-attr">"items"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
-      <span class="hljs-attr">"xml"</span>: {
-        <span class="hljs-attr">"name"</span>: <span class="hljs-string">"animal"</span>
+  <span class="hljs-attr">&quot;animals&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+    <span class="hljs-attr">&quot;items&quot;</span>: {
+      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>,
+      <span class="hljs-attr">&quot;xml&quot;</span>: {
+        <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;animal&quot;</span>
       }
     }
   }
@@ -3521,16 +3529,16 @@ See examples for expected behavior.</p>
 <p>The external <code>name</code> property has no effect on the XML:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"animals"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-    <span class="hljs-attr">"items"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
-      <span class="hljs-attr">"xml"</span>: {
-        <span class="hljs-attr">"name"</span>: <span class="hljs-string">"animal"</span>
+  <span class="hljs-attr">&quot;animals&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+    <span class="hljs-attr">&quot;items&quot;</span>: {
+      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>,
+      <span class="hljs-attr">&quot;xml&quot;</span>: {
+        <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;animal&quot;</span>
       }
     },
-    <span class="hljs-attr">"xml"</span>: {
-      <span class="hljs-attr">"name"</span>: <span class="hljs-string">"aliens"</span>
+    <span class="hljs-attr">&quot;xml&quot;</span>: {
+      <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;aliens&quot;</span>
     }
   }
 }
@@ -3552,13 +3560,13 @@ See examples for expected behavior.</p>
 <p>Even when the array is wrapped, if a name is not explicitly defined, the same name will be used both internally and externally:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"animals"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-    <span class="hljs-attr">"items"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+  <span class="hljs-attr">&quot;animals&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+    <span class="hljs-attr">&quot;items&quot;</span>: {
+      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
     },
-    <span class="hljs-attr">"xml"</span>: {
-      <span class="hljs-attr">"wrapped"</span>: <span class="hljs-literal">true</span>
+    <span class="hljs-attr">&quot;xml&quot;</span>: {
+      <span class="hljs-attr">&quot;wrapped&quot;</span>: <span class="hljs-literal">true</span>
     }
   }
 }
@@ -3580,16 +3588,16 @@ See examples for expected behavior.</p>
 <p>To overcome the naming problem in the example above, the following definition can be used:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"animals"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-    <span class="hljs-attr">"items"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
-      <span class="hljs-attr">"xml"</span>: {
-        <span class="hljs-attr">"name"</span>: <span class="hljs-string">"animal"</span>
+  <span class="hljs-attr">&quot;animals&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+    <span class="hljs-attr">&quot;items&quot;</span>: {
+      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>,
+      <span class="hljs-attr">&quot;xml&quot;</span>: {
+        <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;animal&quot;</span>
       }
     },
-    <span class="hljs-attr">"xml"</span>: {
-      <span class="hljs-attr">"wrapped"</span>: <span class="hljs-literal">true</span>
+    <span class="hljs-attr">&quot;xml&quot;</span>: {
+      <span class="hljs-attr">&quot;wrapped&quot;</span>: <span class="hljs-literal">true</span>
     }
   }
 }
@@ -3613,17 +3621,17 @@ See examples for expected behavior.</p>
 <p>Affecting both internal and external names:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"animals"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-    <span class="hljs-attr">"items"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
-      <span class="hljs-attr">"xml"</span>: {
-        <span class="hljs-attr">"name"</span>: <span class="hljs-string">"animal"</span>
+  <span class="hljs-attr">&quot;animals&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+    <span class="hljs-attr">&quot;items&quot;</span>: {
+      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>,
+      <span class="hljs-attr">&quot;xml&quot;</span>: {
+        <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;animal&quot;</span>
       }
     },
-    <span class="hljs-attr">"xml"</span>: {
-      <span class="hljs-attr">"name"</span>: <span class="hljs-string">"aliens"</span>,
-      <span class="hljs-attr">"wrapped"</span>: <span class="hljs-literal">true</span>
+    <span class="hljs-attr">&quot;xml&quot;</span>: {
+      <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;aliens&quot;</span>,
+      <span class="hljs-attr">&quot;wrapped&quot;</span>: <span class="hljs-literal">true</span>
     }
   }
 }
@@ -3648,14 +3656,14 @@ See examples for expected behavior.</p>
 <p>If we change the external element but not the internal ones:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"animals"</span>: {
-    <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-    <span class="hljs-attr">"items"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+  <span class="hljs-attr">&quot;animals&quot;</span>: {
+    <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;array&quot;</span>,
+    <span class="hljs-attr">&quot;items&quot;</span>: {
+      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
     },
-    <span class="hljs-attr">"xml"</span>: {
-      <span class="hljs-attr">"name"</span>: <span class="hljs-string">"aliens"</span>,
-      <span class="hljs-attr">"wrapped"</span>: <span class="hljs-literal">true</span>
+    <span class="hljs-attr">&quot;xml&quot;</span>: {
+      <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;aliens&quot;</span>,
+      <span class="hljs-attr">&quot;wrapped&quot;</span>: <span class="hljs-literal">true</span>
     }
   }
 }
@@ -3744,8 +3752,8 @@ Supported schemes are HTTP authentication, an API key (either as a header, a coo
 <section><h5>Basic Authentication Sample</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"http"</span>,
-  <span class="hljs-attr">"scheme"</span>: <span class="hljs-string">"basic"</span>
+  <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;http&quot;</span>,
+  <span class="hljs-attr">&quot;scheme&quot;</span>: <span class="hljs-string">&quot;basic&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -3755,9 +3763,9 @@ Supported schemes are HTTP authentication, an API key (either as a header, a coo
 </section><section><h5>API Key Sample</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"apiKey"</span>,
-  <span class="hljs-attr">"name"</span>: <span class="hljs-string">"api_key"</span>,
-  <span class="hljs-attr">"in"</span>: <span class="hljs-string">"header"</span>
+  <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;apiKey&quot;</span>,
+  <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;api_key&quot;</span>,
+  <span class="hljs-attr">&quot;in&quot;</span>: <span class="hljs-string">&quot;header&quot;</span>
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -3768,9 +3776,9 @@ Supported schemes are HTTP authentication, an API key (either as a header, a coo
 </section><section><h5>JWT Bearer Sample</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"http"</span>,
-  <span class="hljs-attr">"scheme"</span>: <span class="hljs-string">"bearer"</span>,
-  <span class="hljs-attr">"bearerFormat"</span>: <span class="hljs-string">"JWT"</span>,
+  <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;http&quot;</span>,
+  <span class="hljs-attr">&quot;scheme&quot;</span>: <span class="hljs-string">&quot;bearer&quot;</span>,
+  <span class="hljs-attr">&quot;bearerFormat&quot;</span>: <span class="hljs-string">&quot;JWT&quot;</span>,
 }
 </code></pre>
 <pre class="nohighlight"><code>
@@ -3781,13 +3789,13 @@ Supported schemes are HTTP authentication, an API key (either as a header, a coo
 </section><section><h5>Implicit OAuth2 Sample</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"oauth2"</span>,
-  <span class="hljs-attr">"flows"</span>: {
-    <span class="hljs-attr">"implicit"</span>: {
-      <span class="hljs-attr">"authorizationUrl"</span>: <span class="hljs-string">"https://example.com/api/oauth/dialog"</span>,
-      <span class="hljs-attr">"scopes"</span>: {
-        <span class="hljs-attr">"write:pets"</span>: <span class="hljs-string">"modify pets in your account"</span>,
-        <span class="hljs-attr">"read:pets"</span>: <span class="hljs-string">"read your pets"</span>
+  <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;oauth2&quot;</span>,
+  <span class="hljs-attr">&quot;flows&quot;</span>: {
+    <span class="hljs-attr">&quot;implicit&quot;</span>: {
+      <span class="hljs-attr">&quot;authorizationUrl&quot;</span>: <span class="hljs-string">&quot;https://example.com/api/oauth/dialog&quot;</span>,
+      <span class="hljs-attr">&quot;scopes&quot;</span>: {
+        <span class="hljs-attr">&quot;write:pets&quot;</span>: <span class="hljs-string">&quot;modify pets in your account&quot;</span>,
+        <span class="hljs-attr">&quot;read:pets&quot;</span>: <span class="hljs-string">&quot;read your pets&quot;</span>
       }
     }
   }
@@ -3880,21 +3888,21 @@ Supported schemes are HTTP authentication, an API key (either as a header, a coo
 </section><section><h4>OAuth Flow Object Examples</h4>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"oauth2"</span>,
-  <span class="hljs-attr">"flows"</span>: {
-    <span class="hljs-attr">"implicit"</span>: {
-      <span class="hljs-attr">"authorizationUrl"</span>: <span class="hljs-string">"https://example.com/api/oauth/dialog"</span>,
-      <span class="hljs-attr">"scopes"</span>: {
-        <span class="hljs-attr">"write:pets"</span>: <span class="hljs-string">"modify pets in your account"</span>,
-        <span class="hljs-attr">"read:pets"</span>: <span class="hljs-string">"read your pets"</span>
+  <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;oauth2&quot;</span>,
+  <span class="hljs-attr">&quot;flows&quot;</span>: {
+    <span class="hljs-attr">&quot;implicit&quot;</span>: {
+      <span class="hljs-attr">&quot;authorizationUrl&quot;</span>: <span class="hljs-string">&quot;https://example.com/api/oauth/dialog&quot;</span>,
+      <span class="hljs-attr">&quot;scopes&quot;</span>: {
+        <span class="hljs-attr">&quot;write:pets&quot;</span>: <span class="hljs-string">&quot;modify pets in your account&quot;</span>,
+        <span class="hljs-attr">&quot;read:pets&quot;</span>: <span class="hljs-string">&quot;read your pets&quot;</span>
       }
     },
-    <span class="hljs-attr">"authorizationCode"</span>: {
-      <span class="hljs-attr">"authorizationUrl"</span>: <span class="hljs-string">"https://example.com/api/oauth/dialog"</span>,
-      <span class="hljs-attr">"tokenUrl"</span>: <span class="hljs-string">"https://example.com/api/oauth/token"</span>,
-      <span class="hljs-attr">"scopes"</span>: {
-        <span class="hljs-attr">"write:pets"</span>: <span class="hljs-string">"modify pets in your account"</span>,
-        <span class="hljs-attr">"read:pets"</span>: <span class="hljs-string">"read your pets"</span>
+    <span class="hljs-attr">&quot;authorizationCode&quot;</span>: {
+      <span class="hljs-attr">&quot;authorizationUrl&quot;</span>: <span class="hljs-string">&quot;https://example.com/api/oauth/dialog&quot;</span>,
+      <span class="hljs-attr">&quot;tokenUrl&quot;</span>: <span class="hljs-string">&quot;https://example.com/api/oauth/token&quot;</span>,
+      <span class="hljs-attr">&quot;scopes&quot;</span>: {
+        <span class="hljs-attr">&quot;write:pets&quot;</span>: <span class="hljs-string">&quot;modify pets in your account&quot;</span>,
+        <span class="hljs-attr">&quot;read:pets&quot;</span>: <span class="hljs-string">&quot;read your pets&quot;</span>
       }
     }
   }
@@ -3942,18 +3950,18 @@ This enables support for scenarios where multiple query parameters or HTTP heade
 <section><h5>Non-OAuth2 Security Requirement</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"api_key"</span>: []
+  <span class="hljs-attr">&quot;api_key&quot;</span>: []
 }
 </code></pre>
 <pre class="nohighlight"><code>
-<span class="hljs-attr">api_key:</span> <span class="hljs-string">[]</span>
+<span class="hljs-attr">api_key:</span> []
 </code></pre>
 </section><section><h5>OAuth2 Security Requirement</h5>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"petstore_auth"</span>: [
-    <span class="hljs-string">"write:pets"</span>,
-    <span class="hljs-string">"read:pets"</span>
+  <span class="hljs-attr">&quot;petstore_auth&quot;</span>: [
+    <span class="hljs-string">&quot;write:pets&quot;</span>,
+    <span class="hljs-string">&quot;read:pets&quot;</span>
   ]
 }
 </code></pre>
@@ -3966,12 +3974,12 @@ This enables support for scenarios where multiple query parameters or HTTP heade
 <p>Optional OAuth2 security as would be defined in an <a href="#openapi-object">OpenAPI Object</a> or an <a href="#operation-object">Operation Object</a>:</p>
 <pre class="nohighlight"><code>
 {
-  <span class="hljs-attr">"security"</span>: [
+  <span class="hljs-attr">&quot;security&quot;</span>: [
     {},
     {
-      <span class="hljs-attr">"petstore_auth"</span>: [
-        <span class="hljs-string">"write:pets"</span>,
-        <span class="hljs-string">"read:pets"</span>
+      <span class="hljs-attr">&quot;petstore_auth&quot;</span>: [
+        <span class="hljs-string">&quot;write:pets&quot;</span>,
+        <span class="hljs-string">&quot;read:pets&quot;</span>
       ]
     }
   ]
@@ -3979,7 +3987,7 @@ This enables support for scenarios where multiple query parameters or HTTP heade
 </code></pre>
 <pre class="nohighlight"><code>
 <span class="hljs-attr">security:</span>
-  <span class="hljs-bullet">-</span> <span class="hljs-string">{}</span>
+  <span class="hljs-bullet">-</span> {}
   <span class="hljs-bullet">-</span> <span class="hljs-attr">petstore_auth:</span>
     <span class="hljs-bullet">-</span> <span class="hljs-string">write:pets</span>
     <span class="hljs-bullet">-</span> <span class="hljs-string">read:pets</span>

--- a/oas/v3.1.0.html
+++ b/oas/v3.1.0.html
@@ -162,7 +162,7 @@ Unless specified otherwise, relative references are resolved using the URLs defi
 </tr>
 <tr>
 <td><a id="oasWebhooks"> </a>webhooks</td>
-<td style="text-align:center">Map[<code>string</code>, <a href="#pathItemObject">Path Item Object</a> ¦ <a href="#referenceObject">Reference Object</a>] ]</td>
+<td style="text-align:center">Map[<code>string</code>, <a href="#pathItemObject">Path Item Object</a> | <a href="#referenceObject">Reference Object</a>] ]</td>
 <td>The incoming webhooks that MAY be received as part of this API and that the API consumer MAY choose to implement. Closely related to the <code>callbacks</code> feature, this section describes requests initiated other than by an API call, for example by an out of band registration. The key name is a unique string to refer to each webhook, while the (optionally referenced) Path Item Object describes a request that may be initiated by the API provider and the expected responses. An <a href="https://github.com/OAI/OpenAPI-Specification/tree/master/examples/v3.1/webhook-example.yaml">example</a> is available.</td>
 </tr>
 <tr>
@@ -521,47 +521,47 @@ All objects defined within the components object will have no effect on the API 
 </tr>
 <tr>
 <td><a id="componentsResponses"> </a> responses</td>
-<td style="text-align:left">Map[<code>string</code>, <a href="#responseObject">Response Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:left">Map[<code>string</code>, <a href="#responseObject">Response Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>An object to hold reusable <a href="#responseObject">Response Objects</a>.</td>
 </tr>
 <tr>
 <td><a id="componentsParameters"> </a> parameters</td>
-<td style="text-align:left">Map[<code>string</code>, <a href="#parameterObject">Parameter Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:left">Map[<code>string</code>, <a href="#parameterObject">Parameter Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>An object to hold reusable <a href="#parameterObject">Parameter Objects</a>.</td>
 </tr>
 <tr>
 <td><a id="componentsExamples"> </a> examples</td>
-<td style="text-align:left">Map[<code>string</code>, <a href="#exampleObject">Example Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:left">Map[<code>string</code>, <a href="#exampleObject">Example Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>An object to hold reusable <a href="#exampleObject">Example Objects</a>.</td>
 </tr>
 <tr>
 <td><a id="componentsRequestBodies"> </a> requestBodies</td>
-<td style="text-align:left">Map[<code>string</code>, <a href="#requestBodyObject">Request Body Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:left">Map[<code>string</code>, <a href="#requestBodyObject">Request Body Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>An object to hold reusable <a href="#requestBodyObject">Request Body Objects</a>.</td>
 </tr>
 <tr>
 <td><a id="componentsHeaders"> </a> headers</td>
-<td style="text-align:left">Map[<code>string</code>, <a href="#headerObject">Header Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:left">Map[<code>string</code>, <a href="#headerObject">Header Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>An object to hold reusable <a href="#headerObject">Header Objects</a>.</td>
 </tr>
 <tr>
 <td><a id="componentsSecuritySchemes"> </a> securitySchemes</td>
-<td style="text-align:left">Map[<code>string</code>, <a href="#securitySchemeObject">Security Scheme Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:left">Map[<code>string</code>, <a href="#securitySchemeObject">Security Scheme Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>An object to hold reusable <a href="#securitySchemeObject">Security Scheme Objects</a>.</td>
 </tr>
 <tr>
 <td><a id="componentsLinks"> </a> links</td>
-<td style="text-align:left">Map[<code>string</code>, <a href="#linkObject">Link Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:left">Map[<code>string</code>, <a href="#linkObject">Link Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>An object to hold reusable <a href="#linkObject">Link Objects</a>.</td>
 </tr>
 <tr>
 <td><a id="componentsCallbacks"> </a> callbacks</td>
-<td style="text-align:left">Map[<code>string</code>, <a href="#callbackObject">Callback Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:left">Map[<code>string</code>, <a href="#callbackObject">Callback Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>An object to hold reusable <a href="#callbackObject">Callback Objects</a>.</td>
 </tr>
 <tr>
 <td><a id="componentsPathItems"> </a> pathItems</td>
-<td style="text-align:left">Map[<code>string</code>, <a href="#pathItemObject">Path Item Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:left">Map[<code>string</code>, <a href="#pathItemObject">Path Item Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>An object to hold reusable <a href="#pathItemObject">Path Item Object</a>.</td>
 </tr>
 </tbody>
@@ -578,99 +578,99 @@ my.org.User
 </code></pre>
 </section><section><h4>Components Object Example</h4>
 <pre class="nohighlight"><code>
-<span class="hljs-string">&quot;components&quot;</span>: {
-  <span class="hljs-attr">&quot;schemas&quot;</span>: {
-    <span class="hljs-attr">&quot;GeneralError&quot;</span>: {
-      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
-      <span class="hljs-attr">&quot;properties&quot;</span>: {
-        <span class="hljs-attr">&quot;code&quot;</span>: {
-          <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>,
-          <span class="hljs-attr">&quot;format&quot;</span>: <span class="hljs-string">&quot;int32&quot;</span>
+&quot;components&quot;: {
+  &quot;schemas&quot;: {
+    &quot;GeneralError&quot;: {
+      &quot;type&quot;: &quot;object&quot;,
+      &quot;properties&quot;: {
+        &quot;code&quot;: {
+          &quot;type&quot;: &quot;integer&quot;,
+          &quot;format&quot;: &quot;int32&quot;
         },
-        <span class="hljs-attr">&quot;message&quot;</span>: {
-          <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
+        &quot;message&quot;: {
+          &quot;type&quot;: &quot;string&quot;
         }
       }
     },
-    <span class="hljs-attr">&quot;Category&quot;</span>: {
-      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
-      <span class="hljs-attr">&quot;properties&quot;</span>: {
-        <span class="hljs-attr">&quot;id&quot;</span>: {
-          <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>,
-          <span class="hljs-attr">&quot;format&quot;</span>: <span class="hljs-string">&quot;int64&quot;</span>
+    &quot;Category&quot;: {
+      &quot;type&quot;: &quot;object&quot;,
+      &quot;properties&quot;: {
+        &quot;id&quot;: {
+          &quot;type&quot;: &quot;integer&quot;,
+          &quot;format&quot;: &quot;int64&quot;
         },
-        <span class="hljs-attr">&quot;name&quot;</span>: {
-          <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
+        &quot;name&quot;: {
+          &quot;type&quot;: &quot;string&quot;
         }
       }
     },
-    <span class="hljs-attr">&quot;Tag&quot;</span>: {
-      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;object&quot;</span>,
-      <span class="hljs-attr">&quot;properties&quot;</span>: {
-        <span class="hljs-attr">&quot;id&quot;</span>: {
-          <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>,
-          <span class="hljs-attr">&quot;format&quot;</span>: <span class="hljs-string">&quot;int64&quot;</span>
+    &quot;Tag&quot;: {
+      &quot;type&quot;: &quot;object&quot;,
+      &quot;properties&quot;: {
+        &quot;id&quot;: {
+          &quot;type&quot;: &quot;integer&quot;,
+          &quot;format&quot;: &quot;int64&quot;
         },
-        <span class="hljs-attr">&quot;name&quot;</span>: {
-          <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
+        &quot;name&quot;: {
+          &quot;type&quot;: &quot;string&quot;
         }
       }
     }
   },
-  <span class="hljs-attr">&quot;parameters&quot;</span>: {
-    <span class="hljs-attr">&quot;skipParam&quot;</span>: {
-      <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;skip&quot;</span>,
-      <span class="hljs-attr">&quot;in&quot;</span>: <span class="hljs-string">&quot;query&quot;</span>,
-      <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;number of items to skip&quot;</span>,
-      <span class="hljs-attr">&quot;required&quot;</span>: <span class="hljs-literal">true</span>,
-      <span class="hljs-attr">&quot;schema&quot;</span>: {
-        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>,
-        <span class="hljs-attr">&quot;format&quot;</span>: <span class="hljs-string">&quot;int32&quot;</span>
+  &quot;parameters&quot;: {
+    &quot;skipParam&quot;: {
+      &quot;name&quot;: &quot;skip&quot;,
+      &quot;in&quot;: &quot;query&quot;,
+      &quot;description&quot;: &quot;number of items to skip&quot;,
+      &quot;required&quot;: true,
+      &quot;schema&quot;: {
+        &quot;type&quot;: &quot;integer&quot;,
+        &quot;format&quot;: &quot;int32&quot;
       }
     },
-    <span class="hljs-attr">&quot;limitParam&quot;</span>: {
-      <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;limit&quot;</span>,
-      <span class="hljs-attr">&quot;in&quot;</span>: <span class="hljs-string">&quot;query&quot;</span>,
-      <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;max records to return&quot;</span>,
-      <span class="hljs-attr">&quot;required&quot;</span>: <span class="hljs-literal">true</span>,
-      <span class="hljs-attr">&quot;schema&quot;</span> : {
-        <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;integer&quot;</span>,
-        <span class="hljs-attr">&quot;format&quot;</span>: <span class="hljs-string">&quot;int32&quot;</span>
+    &quot;limitParam&quot;: {
+      &quot;name&quot;: &quot;limit&quot;,
+      &quot;in&quot;: &quot;query&quot;,
+      &quot;description&quot;: &quot;max records to return&quot;,
+      &quot;required&quot;: true,
+      &quot;schema&quot; : {
+        &quot;type&quot;: &quot;integer&quot;,
+        &quot;format&quot;: &quot;int32&quot;
       }
     }
   },
-  <span class="hljs-attr">&quot;responses&quot;</span>: {
-    <span class="hljs-attr">&quot;NotFound&quot;</span>: {
-      <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;Entity not found.&quot;</span>
+  &quot;responses&quot;: {
+    &quot;NotFound&quot;: {
+      &quot;description&quot;: &quot;Entity not found.&quot;
     },
-    <span class="hljs-attr">&quot;IllegalInput&quot;</span>: {
-      <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;Illegal input for operation.&quot;</span>
+    &quot;IllegalInput&quot;: {
+      &quot;description&quot;: &quot;Illegal input for operation.&quot;
     },
-    <span class="hljs-attr">&quot;GeneralError&quot;</span>: {
-      <span class="hljs-attr">&quot;description&quot;</span>: <span class="hljs-string">&quot;General Error&quot;</span>,
-      <span class="hljs-attr">&quot;content&quot;</span>: {
-        <span class="hljs-attr">&quot;application/json&quot;</span>: {
-          <span class="hljs-attr">&quot;schema&quot;</span>: {
-            <span class="hljs-attr">&quot;$ref&quot;</span>: <span class="hljs-string">&quot;#/components/schemas/GeneralError&quot;</span>
+    &quot;GeneralError&quot;: {
+      &quot;description&quot;: &quot;General Error&quot;,
+      &quot;content&quot;: {
+        &quot;application/json&quot;: {
+          &quot;schema&quot;: {
+            &quot;$ref&quot;: &quot;#/components/schemas/GeneralError&quot;
           }
         }
       }
     }
   },
-  <span class="hljs-attr">&quot;securitySchemes&quot;</span>: {
-    <span class="hljs-attr">&quot;api_key&quot;</span>: {
-      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;apiKey&quot;</span>,
-      <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;api_key&quot;</span>,
-      <span class="hljs-attr">&quot;in&quot;</span>: <span class="hljs-string">&quot;header&quot;</span>
+  &quot;securitySchemes&quot;: {
+    &quot;api_key&quot;: {
+      &quot;type&quot;: &quot;apiKey&quot;,
+      &quot;name&quot;: &quot;api_key&quot;,
+      &quot;in&quot;: &quot;header&quot;
     },
-    <span class="hljs-attr">&quot;petstore_auth&quot;</span>: {
-      <span class="hljs-attr">&quot;type&quot;</span>: <span class="hljs-string">&quot;oauth2&quot;</span>,
-      <span class="hljs-attr">&quot;flows&quot;</span>: {
-        <span class="hljs-attr">&quot;implicit&quot;</span>: {
-          <span class="hljs-attr">&quot;authorizationUrl&quot;</span>: <span class="hljs-string">&quot;https://example.org/api/oauth/dialog&quot;</span>,
-          <span class="hljs-attr">&quot;scopes&quot;</span>: {
-            <span class="hljs-attr">&quot;write:pets&quot;</span>: <span class="hljs-string">&quot;modify pets in your account&quot;</span>,
-            <span class="hljs-attr">&quot;read:pets&quot;</span>: <span class="hljs-string">&quot;read your pets&quot;</span>
+    &quot;petstore_auth&quot;: {
+      &quot;type&quot;: &quot;oauth2&quot;,
+      &quot;flows&quot;: {
+        &quot;implicit&quot;: {
+          &quot;authorizationUrl&quot;: &quot;https://example.org/api/oauth/dialog&quot;,
+          &quot;scopes&quot;: {
+            &quot;write:pets&quot;: &quot;modify pets in your account&quot;,
+            &quot;read:pets&quot;: &quot;read your pets&quot;
           }
         }
       }
@@ -899,7 +899,7 @@ The path itself is still exposed to the documentation viewer but they will not k
 </tr>
 <tr>
 <td><a id="pathItemParameters"> </a>parameters</td>
-<td style="text-align:center">[<a href="#parameterObject">Parameter Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:center">[<a href="#parameterObject">Parameter Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>A list of parameters that are applicable for all the operations described under this path. These parameters can be overridden at the operation level, but cannot be removed there. The list MUST NOT include duplicated parameters. A unique parameter is defined by a combination of a <a href="#parameterName">name</a> and <a href="#parameterIn">location</a>. The list can use the <a href="#referenceObject">Reference Object</a> to link to parameters that are defined at the <a href="#componentsParameters">OpenAPI Object’s components/parameters</a>.</td>
 </tr>
 </tbody>
@@ -1025,12 +1025,12 @@ The path itself is still exposed to the documentation viewer but they will not k
 </tr>
 <tr>
 <td><a id="operationParameters"> </a>parameters</td>
-<td style="text-align:center">[<a href="#parameterObject">Parameter Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:center">[<a href="#parameterObject">Parameter Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>A list of parameters that are applicable for this operation. If a parameter is already defined at the <a href="#pathItemParameters">Path Item</a>, the new definition will override it but can never remove it. The list MUST NOT include duplicated parameters. A unique parameter is defined by a combination of a <a href="#parameterName">name</a> and <a href="#parameterIn">location</a>. The list can use the <a href="#referenceObject">Reference Object</a> to link to parameters that are defined at the <a href="#componentsParameters">OpenAPI Object’s components/parameters</a>.</td>
 </tr>
 <tr>
 <td><a id="operationRequestBody"> </a>requestBody</td>
-<td style="text-align:center"><a href="#requestBodyObject">Request Body Object</a> ¦ <a href="#referenceObject">Reference Object</a></td>
+<td style="text-align:center"><a href="#requestBodyObject">Request Body Object</a> | <a href="#referenceObject">Reference Object</a></td>
 <td>The request body applicable for this operation.  The <code>requestBody</code> is fully supported in HTTP methods where the HTTP 1.1 specification [[!RFC7231]] has explicitly defined semantics for request bodies.  In other cases where the HTTP spec is vague (such as [GET]section-4.3.1), [HEAD]section-4.3.2) and [DELETE]section-4.3.5)), <code>requestBody</code> is permitted but does not have well-defined semantics and SHOULD be avoided if possible.</td>
 </tr>
 <tr>
@@ -1040,7 +1040,7 @@ The path itself is still exposed to the documentation viewer but they will not k
 </tr>
 <tr>
 <td><a id="operationCallbacks"> </a>callbacks</td>
-<td style="text-align:center">Map[<code>string</code>, <a href="#callbackObject">Callback Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:center">Map[<code>string</code>, <a href="#callbackObject">Callback Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>A map of possible out-of band callbacks related to the parent operation. The key is a unique identifier for the Callback Object. Each value in the map is a <a href="#callbackObject">Callback Object</a> that describes a request that may be initiated by the API provider and the expected responses.</td>
 </tr>
 <tr>
@@ -1295,7 +1295,7 @@ For simpler scenarios, a <a href="#parameterSchema"><code>schema</code></a> and 
 </tr>
 <tr>
 <td><a id="parameterExamples"> </a>examples</td>
-<td style="text-align:center">Map[ <code>string</code>, <a href="#exampleObject">Example Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:center">Map[ <code>string</code>, <a href="#exampleObject">Example Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>Examples of the parameter’s potential value. Each example SHOULD contain a value in the correct format as specified in the parameter encoding. The <code>examples</code> field is mutually exclusive of the <code>example</code> field. Furthermore, if referencing a <code>schema</code> that contains an example, the <code>examples</code> value SHALL <em>override</em> the example provided by the schema.</td>
 </tr>
 </tbody>
@@ -1472,8 +1472,8 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 <td>false</td>
 <td>n/a</td>
 <td>n/a</td>
-<td>blue¦black¦brown</td>
-<td>R¦100¦G¦200¦B¦150</td>
+<td>blue|black|brown</td>
+<td>R|100|G|200|B|150</td>
 </tr>
 <tr>
 <td>deepObject</td>
@@ -1481,7 +1481,7 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 <td>n/a</td>
 <td>n/a</td>
 <td>n/a</td>
-<td>color\R=100&amp;color\G=200&amp;color\B=150</td>
+<td>color&#91;R&#93;=100&amp;color&#91;G&#93;=200&amp;color&#91;B&#93;=150</td>
 </tr>
 </tbody>
 </table>
@@ -1786,7 +1786,7 @@ When <code>example</code> or <code>examples</code> are provided in conjunction w
 </tr>
 <tr>
 <td><a id="mediaTypeExamples"> </a>examples</td>
-<td style="text-align:center">Map[ <code>string</code>, <a href="#exampleObject">Example Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:center">Map[ <code>string</code>, <a href="#exampleObject">Example Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>Examples of the media type.  Each example object SHOULD  match the media type and specified schema if present.  The <code>examples</code> field is mutually exclusive of the <code>example</code> field.  Furthermore, if referencing a <code>schema</code> which contains an example, the <code>examples</code> value SHALL <em>override</em> the example provided by the schema.</td>
 </tr>
 <tr>
@@ -1994,7 +1994,7 @@ definition may be used:</p>
 </tr>
 <tr>
 <td><a id="encodingHeaders"> </a>headers</td>
-<td style="text-align:center">Map[<code>string</code>, <a href="#headerObject">Header Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:center">Map[<code>string</code>, <a href="#headerObject">Header Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>A map allowing additional information to be provided as headers, for example <code>Content-Disposition</code>.  <code>Content-Type</code> is described separately and SHALL be ignored in this section. This property SHALL be ignored if the request body media type is not a <code>multipart</code>.</td>
 </tr>
 <tr>
@@ -2072,7 +2072,7 @@ call.</p>
 <tbody>
 <tr>
 <td><a id="responsesDefault"> </a>default</td>
-<td style="text-align:center"><a href="#responseObject">Response Object</a> ¦ <a href="#referenceObject">Reference Object</a></td>
+<td style="text-align:center"><a href="#responseObject">Response Object</a> | <a href="#referenceObject">Reference Object</a></td>
 <td>The documentation of responses other than the ones declared for specific HTTP response codes. Use this field to cover undeclared responses.</td>
 </tr>
 </tbody>
@@ -2089,7 +2089,7 @@ call.</p>
 <tbody>
 <tr>
 <td><a id="responsesCode"> </a><a href="#httpCodes">HTTP Status Code</a></td>
-<td style="text-align:center"><a href="#responseObject">Response Object</a> ¦ <a href="#referenceObject">Reference Object</a></td>
+<td style="text-align:center"><a href="#responseObject">Response Object</a> | <a href="#referenceObject">Reference Object</a></td>
 <td>Any <a href="#httpCodes">HTTP status code</a> can be used as the property name, but only one property per code, to describe the expected response for that HTTP status code. This field MUST be enclosed in quotation marks (for example, “200”) for compatibility between JSON and YAML. To define a range of response codes, this field MAY contain the uppercase wildcard character <code>X</code>. For example, <code>2XX</code> represents all response codes between <code>[200-299]</code>. Only the following range definitions are allowed: <code>1XX</code>, <code>2XX</code>, <code>3XX</code>, <code>4XX</code>, and <code>5XX</code>. If a response is defined using an explicit code, the explicit code definition takes precedence over the range definition for that code.</td>
 </tr>
 </tbody>
@@ -2155,7 +2155,7 @@ call.</p>
 </tr>
 <tr>
 <td><a id="responseHeaders"> </a>headers</td>
-<td style="text-align:center">Map[<code>string</code>, <a href="#headerObject">Header Object</a>  ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:center">Map[<code>string</code>, <a href="#headerObject">Header Object</a>  | <a href="#referenceObject">Reference Object</a>]</td>
 <td>Maps a header name to its definition. [[!RFC7230]] states header names are case insensitive. If a response header is defined with the name <code>&quot;Content-Type&quot;</code>, it SHALL be ignored.</td>
 </tr>
 <tr>
@@ -2165,7 +2165,7 @@ call.</p>
 </tr>
 <tr>
 <td><a id="responseLinks"> </a>links</td>
-<td style="text-align:center">Map[<code>string</code>, <a href="#linkObject">Link Object</a> ¦ <a href="#referenceObject">Reference Object</a>]</td>
+<td style="text-align:center">Map[<code>string</code>, <a href="#linkObject">Link Object</a> | <a href="#referenceObject">Reference Object</a>]</td>
 <td>A map of operations links that can be followed from the response. The key of the map is a short name for the link, following the naming constraints of the names for <a href="#componentsObject">Component Objects</a>.</td>
 </tr>
 </tbody>
@@ -2299,7 +2299,7 @@ The key value used to identify the path item object is an expression, evaluated 
 <tbody>
 <tr>
 <td><a id="callbackExpression"> </a>{expression}</td>
-<td style="text-align:center"><a href="#pathItemObject">Path Item Object</a> ¦ <a href="#referenceObject">Reference Object</a></td>
+<td style="text-align:center"><a href="#pathItemObject">Path Item Object</a> | <a href="#referenceObject">Reference Object</a></td>
 <td>A Path Item Object, or a reference to one, used to define a callback request and expected responses.  A <a href="https://github.com/OAI/OpenAPI-Specification/tree/master/examples/v3.0/callback-example.yaml">complete example</a> is available.</td>
 </tr>
 </tbody>
@@ -2518,12 +2518,12 @@ The presence of a link does not guarantee the caller’s ability to successfully
 </tr>
 <tr>
 <td><a id="linkParameters"> </a>parameters</td>
-<td style="text-align:center">Map[<code>string</code>, Any ¦ <a href="#runtimeExpression">{expression}</a>]</td>
+<td style="text-align:center">Map[<code>string</code>, Any | <a href="#runtimeExpression">{expression}</a>]</td>
 <td>A map representing parameters to pass to an operation as specified with <code>operationId</code> or identified via <code>operationRef</code>. The key is the parameter name to be used, whereas the value can be a constant or an expression to be evaluated and passed to the linked operation.  The parameter name can be qualified using the <a href="#parameterIn">parameter location</a> <code>[{in}.]{name}</code> for operations that use the same parameter name in different locations (e.g. <a href="http://path.id">path.id</a>).</td>
 </tr>
 <tr>
 <td><a id="linkRequestBody"> </a>requestBody</td>
-<td style="text-align:center">Any ¦ <a href="#runtimeExpression">{expression}</a></td>
+<td style="text-align:center">Any | <a href="#runtimeExpression">{expression}</a></td>
 <td>A literal value or <a href="#runtimeExpression">{expression}</a> to use as a request body when calling the target operation.</td>
 </tr>
 <tr>


### PR DESCRIPTION
Corrects the pipe character issue and where `[R][G][B]` had been mangled as if they were references.

Thanks @hkosova. Closes #2488

Follow up PR incoming to add the scripts used to generate these as a GitHub Action, to positively affect the bus-factor here.

Signed-off-by: Mike Ralphson <mike.ralphson@gmail.com>