### PR TITLE
Respec fix and SEO changes

### DIFF
--- a/.github/workflows/respec.yaml
+++ b/.github/workflows/respec.yaml
@@ -22,6 +22,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2 # checkout main branch
+      with:
+        fetch-depth: 0
 
     - name: Install dependencies
       run: npm i

--- a/scripts/md2html/build.sh
+++ b/scripts/md2html/build.sh
@@ -14,6 +14,7 @@ cp -p markdown/* ../../deploy/ 2> /dev/null
 node md2html.js --respec --maintainers ./history/MAINTAINERS_v2.0.md ../../versions/2.0.md > ../../deploy/oas/v2.0.html
 
 latest=`git describe --abbrev=0 --tags`
+latestCopied=none
 for filename in ../../versions/[3456789].*.md ; do
   version=$(basename "$filename" .md)
   node md2html.js --respec --maintainers ../../MAINTAINERS.md ${filename} > ../../deploy/oas/v$version.html
@@ -21,7 +22,9 @@ for filename in ../../versions/[3456789].*.md ; do
     if [[ ${version} != *"rc"* ]];then
       # version is not a Release Candidate
       cp -p ../../deploy/oas/v$version.html ../../deploy/oas/latest.html
+      latestCopied=v$version
     fi
   fi
 done
+echo Latest tag is $latest, copied $latestCopied to latest.html
 

--- a/scripts/md2html/md2html.js
+++ b/scripts/md2html/md2html.js
@@ -67,6 +67,11 @@ function preface(title,options) {
     };
 
     let preface = `<html lang="en"><head><meta charset="UTF-8"><title>${md.utils.escapeHtml(title)}</title>`;
+
+    // SEO
+    preface += '<meta name="description" content="The OpenAPI Specification (OAS) defines a standard, programming language-agnostic interface description for HTTP APIs.">';
+    preface += '<link rel="canonical" href="https://spec.openapis.org/oas/latest.html" />';
+
     if (options.respec) {
         preface += '<script src="https://spec.openapis.org/js/respec-oai.js" class="remove"></script>';
         preface += `<script class="remove">var respecConfig = ${JSON.stringify(respec)};</script>`;
@@ -86,7 +91,7 @@ function preface(title,options) {
         preface += fs.readFileSync(path.resolve(__dirname,'gist.css'),'utf8').split('\n').join(' ');
         preface += '</style>';
         preface += '<section id="abstract">';
-        preface += 'The OpenAPI Specification (OAS) defines a standard, programming language-agnostic interface description for REST APIs, which allows both humans and computers to discover and understand the capabilities of a service without requiring access to source code, additional documentation, or inspection of network traffic. When properly defined via OpenAPI, a consumer can understand and interact with the remote service with a minimal amount of implementation logic. Similar to what interface descriptions have done for lower-level programming, the OpenAPI Specification removes guesswork in calling a service.';
+        preface += 'The OpenAPI Specification (OAS) defines a standard, programming language-agnostic interface description for HTTP APIs, which allows both humans and computers to discover and understand the capabilities of a service without requiring access to source code, additional documentation, or inspection of network traffic. When properly defined via OpenAPI, a consumer can understand and interact with the remote service with a minimal amount of implementation logic. Similar to what interface descriptions have done for lower-level programming, the OpenAPI Specification removes guesswork in calling a service.';
         preface += '</section>';
         preface += '<section class="notoc" id="sotd">';
         preface += '<h2>Status of This Document</h2>';
@@ -303,7 +308,7 @@ for (let l in lines) {
     lines[l] = line;
 }
 
-s = preface('OpenAPI Specification',argv)+'\n\n'+lines.join('\n');
+s = preface(`OpenAPI Specification v${argv.subtitle} | Introduction, Definitions, & More`,argv)+'\n\n'+lines.join('\n');
 let out = md.render(s);
 out = out.replace(/\[([RGB])\]/g,function(match,group1){
     console.warn('Fixing',match,group1);


### PR DESCRIPTION
This PR fixes the respec workflow which previously only did a shallow clone of the repo. This meant the correct `MAINTAINERS.md` data wasn't found for the `v2.0.html` version, nor was `latest.html` correctly created.

It also corrects the extraction of the version number and release date from the spec as this table is not the last in the file in `v2.0`.

Largely non-visible (metadata) changes were also made to as suggested by Rebecca Johnston-Gilbert. The page html title has changed to include the version number and the text suffix `| Introduction, Definitions, & More'.