### PR TITLE
Allow booleans in place of any top-level schema field

### DIFF
--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -2306,7 +2306,7 @@ $ref: definitions.yaml#/Pet
 #### <a name="schemaObject"></a>Schema Object
 
 The Schema Object allows the definition of input and output data types.
-These types can be objects, but also primitives and arrays. This object is a superset of the [JSON Schema Specification Draft 2020-12](https://tools.ietf.org/html/draft-bhutton-json-schema-00).
+These types can be objects, but also primitives and arrays. This object is a superset of the [JSON Schema Specification Draft 2020-12](https://tools.ietf.org/html/draft-bhutton-json-schema-00). The empty schema (which allows any instance to validate) MAY be represented by the `boolean` value `true` and a schema which allows no instance to validate MAY be represented by the `boolean` value `false`.
 
 For more information about the properties, see [JSON Schema Core](https://tools.ietf.org/html/draft-bhutton-json-schema-00) and [JSON Schema Validation](https://tools.ietf.org/html/draft-bhutton-json-schema-validation-00).
 

--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -2712,7 +2712,7 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
 
 The discriminator object is legal only when using one of the composite keywords `oneOf`, `anyOf`, `allOf`.
 
-In OAS 3.0, a response payload MAY be described to be exactly one of any number of types:
+In OAS 3.x, a response payload MAY be described to be exactly one of any number of types:
 
 ```yaml
 MyResponseType:


### PR DESCRIPTION
Replacement PR for #2598 

This targets `v3.1.1` as we have agreed this is a clarification. The change spells out that `boolean` values MAY be used wherever a `schemaObject` is allowed.

A separate PR (#2614) updates the `tests` folder with passing and failing cases for this issue.

 Plus one bonus fix.