### PR TITLE
Add a GitHub workflow to run the metaschema tests (incl. boolean schemas)

### DIFF
--- a/.github/workflows/schema-tests.yaml
+++ b/.github/workflows/schema-tests.yaml
@@ -1,0 +1,31 @@
+name: schema-test
+
+# Author: @MikeRalphson / runs @jdesrosiers tests
+# Issue: https://github.com/OAI/OpenAPI-Specification/pull/2489
+
+#
+# This workflow runs the npm test script to validate passing and failing
+# testcases for the metaschema.
+#
+
+# run this on push to any branch and creation of pull-requests
+on: 
+  push: {}
+  pull_request: {}
+  workflow_dispatch: {}
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1 # checkout repo content
+    - uses: actions/setup-node@v1 # setup Node.js
+      with:
+        node-version: '14.x'
+    - name: Install dependencies
+      run: npm i
+    - name: Run tests
+      run: npm run test
+

--- a/.github/workflows/validate-markdown.yaml
+++ b/.github/workflows/validate-markdown.yaml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/checkout@v2 # checkout repo content
     - uses: actions/setup-node@v1 # setup Node.js
       with:
-        node-version: '12.x'
+        node-version: '14.x'
     - name: Validate markdown
       run: npx mdv versions/3.*.md
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "url": "https://github.com/OAI/OpenAPI-Specification.git"
   },
   "license": "Apache-2.0",
+  "scripts": {
+    "test": "npx mocha tests/**/test.js"
+  },
   "readmeFilename": "README.md",
   "files": [
     "README.md",

--- a/tests/v3.1/fail/invalid_schema_types.yaml
+++ b/tests/v3.1/fail/invalid_schema_types.yaml
@@ -1,0 +1,13 @@
+openapi: 3.1.1
+
+# this example shows invalid types for the schemaObject
+
+info:
+  title: API
+  version: 1.0.0
+components:
+  schemas:
+    invalid_null: null
+    invalid_number: 0
+    invalid_array: []
+

--- a/tests/v3.1/pass/valid_schema_types.yaml
+++ b/tests/v3.1/pass/valid_schema_types.yaml
@@ -1,0 +1,14 @@
+openapi: 3.1.1
+
+# this example shows that top-level schemaObjects MAY be booleans
+
+info:
+  title: API
+  version: 1.0.0
+components:
+  schemas:
+    anything_boolean: true
+    nothing_boolean: false
+    anything_object: {}
+    nothing_object: { not: {} }
+

--- a/tests/v3.1/test.js
+++ b/tests/v3.1/test.js
@@ -17,7 +17,7 @@ before(async () => {
   metaSchema = await JsonSchema.get("https://spec.openapis.org/oas/3.1/schema/2021-05-20");
 });
 
-describe("Pass", () => {
+describe("v3.1 Pass", () => {
   fs.readdirSync(`${__dirname}/pass`, { withFileTypes: true })
     .filter((entry) => entry.isFile() && /\.yaml$/.test(entry.name))
     .forEach((entry) => {
@@ -32,7 +32,7 @@ describe("Pass", () => {
     });
 });
 
-describe("Fail", () => {
+describe("v3.1 Fail", () => {
   fs.readdirSync(`${__dirname}/fail`, { withFileTypes: true })
     .filter((entry) => entry.isFile() && /\.yaml$/.test(entry.name))
     .forEach((entry) => {


### PR DESCRIPTION
Runs the existing test script on pushes to any branch and on pull-requests.

The `mdv` workflow is also updated to use node.js v14 as that is the current LTS version.