### PR TITLE
Add accessible meetings slide to agenda template

### DIFF
--- a/.github/templates/agenda.md
+++ b/.github/templates/agenda.md
@@ -6,11 +6,14 @@ In order to give some more visibility into the topics we cover in the TDC meetin
 
 **Please submit comments below for topics or proposals that you wish to present in the TDC meeting**
 
+![F10B5460-B4B3-4463-9CDE-C7F782202EA9](https://user-images.githubusercontent.com/21603/121568843-0b260900-ca18-11eb-9362-69fda4162be8.jpeg)
+
 The agenda backlog is currently maintained in issue #2482
 
 | Topic | Owner | Decision/NextStep |
 |-------|---------|---------|  
 | | | |
+Reports from Special Interest Groups | TDC | |
 AOB (see below) | TDC | |
 New issues / PRs labelled [review](https://github.com/OAI/OpenAPI-Specification/labels/review) | @OAI/triage | |
 [New issues](https://github.com/search?q=repo%3Aoai%2Fopenapi-specification+is%3Aissue+comments%3A0+no%3Alabel+is%3Aopen) without response yet | @OAI/triage  | |

--- a/.github/templates/agenda.md
+++ b/.github/templates/agenda.md
@@ -1,6 +1,6 @@
 **NOTE: This meeting is on Thursday at 9am - 10am PT**
 
-Zoom Meeting link: [https://zoom.us/j/975841675](https://zoom.us/j/975841675?pwd=SUh4MjRLaEFKNlI3RElpWTdhRDVVUT09). Dial-in passcode: 763054
+Zoom Meeting link: [https://zoom.us/j/975841675](https://zoom.us/j/975841675?pwd=SUh4MjRLaEFKNlI3RElpWTdhRDVVUT09). Dial-in passcode: 763054 - [Code-of-Conduct](https://github.com/OAI/OpenAPI-Specification/blob/main/CODE_OF_CONDUCT.md#code-of-conduct)
 
 In order to give some more visibility into the topics we cover in the TDC meetings here is the planned agenda for the next meeting.  Hopefully this will allow people to plan to attend meetings for topics that they have an interest in.  And for folks who cannot attend they can comment on this issue prior to the meeting.  Feel free to suggest other potential agenda topics.
 

--- a/.github/workflows/agenda.yaml
+++ b/.github/workflows/agenda.yaml
@@ -11,7 +11,7 @@ name: agenda
 
 on:
   schedule:
-    - cron: '0 9 * * 2'
+    - cron: '0 9 * * 1'
   workflow_dispatch: {}
   
 jobs:


### PR DESCRIPTION
As discussed 2021-06-10, adding the current version of the slide to the agenda template for each week. Link to Code-of-Conduct added also, as it's mentioned on the slide.

Credit for the original slide should go to @savage-alex and Bob Barker @ https://www.oneadvanced.com

Also add a prompt to get updates from Special Interest Groups.

Workflow amended to run on Mondays, not Tuesdays (as intended, as witnessed by the comments).