### PR TITLE
3.1.1 discriminator improvements

### DIFF
--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -2702,10 +2702,6 @@ schema at `#/components/schemas/Cat` is "Cat". Therefore, when using
 `discriminator`, _inline_ schemas will not be considered because they don't have
 a "name".
 
-Schema names are scoped to the OpenAPI document they are defined in. That means
-if OpenAPI document "A" references a schema in OpenAPI document "B", the schema
-names in "A" aren't considered when evaluating the referenced schema in "B".
-
 ##### Fixed Fields
 Field Name | Type | Description
 ---|:---:|---
@@ -2776,11 +2772,6 @@ For example:
 ```yaml
 components:
   schemas:
-    MyResponseType:
-      oneOf:
-      - $ref: '#/components/schemas/Cat'
-      - $ref: '#/components/schemas/Dog'
-      - $ref: '#/components/schemas/Lizard'
     Pet:
       type: object
       required:
@@ -2818,12 +2809,7 @@ components:
             type: boolean
 ```
 
-The `MyResponseType` schema will use the discriminator defined by the `Pet`
-schema because it is part of the `Cat`, `Dog`, and `Lizard` schemas in the
-`oneOf`. The behavior if not all schemas define a `discriminator` and they are
-not all the same is undefined.
-
-Validated against the `MyResponseType` schema, a payload like this:
+Validated against the `Pet` schema, a payload like this:
 
 ```json
 {

--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -2772,6 +2772,11 @@ For example:
 ```yaml
 components:
   schemas:
+    MyResponseType:
+      oneOf:
+      - $ref: '#/components/schemas/Cat'
+      - $ref: '#/components/schemas/Dog'
+      - $ref: '#/components/schemas/Lizard'
     Pet:
       type: object
       required:
@@ -2809,7 +2814,12 @@ components:
             type: boolean
 ```
 
-a payload like this:
+The `MyResponseType` schema will use the discriminator defined by the `Pet`
+schema because it is part of the `Cat`, `Dog`, and `Lizard` schemas in the
+`oneOf`. The behavior if not all schemas define a `discriminator` and they are
+not all the same is undefined.
+
+Validated against the `MyResponseType` schema, a payload like this:
 
 ```json
 {

--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -2332,7 +2332,8 @@ The OpenAPI Specification's base vocabulary is comprised of the following keywor
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="schemaDiscriminator"></a>discriminator | [Discriminator Object](#discriminatorObject) | Adds support for polymorphism. The discriminator is an object name that is used to differentiate between other schemas which may satisfy the payload description. See [Composition and Inheritance](#schemaComposition) for more details.
+<a name="schemaDiscriminator"></a>discriminator | [Discriminator
+Object](#discriminatorObject) | Adds support for polymorphism. The discriminator is used to determine which of a set of schemas a payload is expected to satisfy. See [Composition and Inheritance](#schemaComposition) for more details.
 <a name="schemaXml"></a>xml | [XML Object](#xmlObject) | This MAY be used only on properties schemas. It has no effect on root schemas. Adds additional metadata to describe the XML representation of this property.
 <a name="schemaExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation for this schema.
 <a name="schemaExample"></a>example | Any | A free-form property to include an example of an instance for this schema. To represent examples that cannot be naturally represented in JSON or YAML, a string value can be used to contain the example with escaping where necessary.<br><br>**Deprecated:** The `example` property has been deprecated in favor of the JSON Schema `examples` keyword. Use of `example` is discouraged, and later versions of this specification may remove it.
@@ -2345,13 +2346,8 @@ The OpenAPI Specification allows combining and extending model definitions using
 `allOf` takes an array of object definitions that are validated *independently* but together compose a single object.
 
 While composition offers model extensibility, it does not imply a hierarchy between the models.
-To support polymorphism, the OpenAPI Specification adds the `discriminator` field.
-When used, the `discriminator` will be the name of the property that decides which schema definition validates the structure of the model.
-As such, the `discriminator` field MUST be a required field.
-There are two ways to define the value of a discriminator for an inheriting instance.
-- Use the schema name.
-- Override the schema name by overriding the property with a new value. If a new value exists, this takes precedence over the schema name.
-As such, inline schema definitions, which do not have a given id, *cannot* be used in polymorphism.
+To support polymorphism, the OpenAPI Specification adds the `discriminator` keyword.
+When used, the `discriminator` will indicate the name of the property that decides which schema definition validates the structure of the model.
 
 ###### XML Modeling
 

--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -2332,8 +2332,7 @@ The OpenAPI Specification's base vocabulary is comprised of the following keywor
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="schemaDiscriminator"></a>discriminator | [Discriminator
-Object](#discriminatorObject) | Adds support for polymorphism. The discriminator is used to determine which of a set of schemas a payload is expected to satisfy. See [Composition and Inheritance](#schemaComposition) for more details.
+<a name="schemaDiscriminator"></a>discriminator | [Discriminator Object](#discriminatorObject) | Adds support for polymorphism. The discriminator is used to determine which of a set of schemas a payload is expected to satisfy. See [Composition and Inheritance](#schemaComposition) for more details.
 <a name="schemaXml"></a>xml | [XML Object](#xmlObject) | This MAY be used only on properties schemas. It has no effect on root schemas. Adds additional metadata to describe the XML representation of this property.
 <a name="schemaExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation for this schema.
 <a name="schemaExample"></a>example | Any | A free-form property to include an example of an instance for this schema. To represent examples that cannot be naturally represented in JSON or YAML, a string value can be used to contain the example with escaping where necessary.<br><br>**Deprecated:** The `example` property has been deprecated in favor of the JSON Schema `examples` keyword. Use of `example` is discouraged, and later versions of this specification may remove it.
@@ -2727,7 +2726,7 @@ MyResponseType:
   - $ref: '#/components/schemas/Lizard'
 ```
 
-which means the payload _MUST_, by validation, match exactly one of the schemas described by `Cat`, `Dog`, or `Lizard`. Evaluating a `oneOf` can be a costly operation, so `discriminator` MAY be used as a "hint" to improve the efficiency of selection of the matching schema. The `discriminator` keyword can not change the validation result of the `oneOf`, it can only help make the evaluation more efficient and provide better error messaging. We can then describe exactly which field tells us which schema is expected to match the instance:
+which means the payload _MUST_, by validation, match exactly one of the schemas described by `Cat`, `Dog`, or `Lizard`. Evaluating a `oneOf` can be a costly operation, so `discriminator` MAY be used as a "hint" to improve the efficiency of selection of the matching schema. The `discriminator` keyword cannot change the validation result of the `oneOf`, it can only help make the evaluation more efficient and provide better error messaging. We can then describe exactly which field tells us which schema is expected to match the instance:
 
 ```yaml
 MyResponseType:

--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -2710,7 +2710,7 @@ names in "A" aren't considered when evaluating the referenced schema in "B".
 ##### Fixed Fields
 Field Name | Type | Description
 ---|:---:|---
-<a name="propertyName"></a>propertyName | `string` | **REQUIRED**. The name of the property in the payload that will hold the discriminator value.
+<a name="propertyName"></a>propertyName | `string` | **REQUIRED**. The name of the property in the payload that will hold the discriminator value. This property MUST be required in the payload schema.
 <a name="discriminatorMapping"></a> mapping | Map[`string`, `string`] | An object to hold mappings between payload values and schema names or references.
 
 This object MAY be extended with [Specification Extensions](#specificationExtensions).

--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -2696,7 +2696,11 @@ components:
 
 When request bodies or response payloads may be one of a number of different schemas, a `discriminator` object can be used to aid in serialization, deserialization, and validation.  The discriminator is a specific object in a schema which is used to inform the consumer of the document of an alternative schema based on the value associated with it.
 
-When using the discriminator, _inline_ schemas will not be considered.
+`discriminator` uses a schema's "name" to automatically map a property value to
+a schema. The schema's "name" is the property name used when declaring the
+schema as a component. For example, the name of the schema at
+`#/components/schemas/Cat` is "Cat". Therefore, when using `discriminator`,
+_inline_ schemas will not be considered because they don't have a "name".
 
 ##### Fixed Fields
 Field Name | Type | Description
@@ -2758,7 +2762,7 @@ MyResponseType:
       monster: 'https://gigantic-server.com/schemas/Monster/schema.json'
 ```
 
-Here the discriminator _value_ of `dog` will map to the schema `#/components/schemas/Dog`, rather than the default (implicit) value of `Dog`.  If the discriminator _value_ does not match an implicit or explicit mapping, no schema can be determined and validation SHOULD fail. Mapping keys MUST be string values, but tooling MAY convert response values to strings for comparison.
+Here the discriminator _value_ of `dog` will map to the schema `#/components/schemas/Dog`, rather than the default (implicit) `#/components/schemas/dog`.  If the discriminator _value_ does not match an implicit or explicit mapping, no schema can be determined and validation SHOULD fail. Mapping keys MUST be string values, but tooling MAY convert response values to strings for comparison.
 
 When used in conjunction with the `anyOf` construct, the use of the discriminator can avoid ambiguity where multiple schemas may satisfy a single payload.
 
@@ -2815,7 +2819,7 @@ a payload like this:
 }
 ```
 
-will indicate that the `Cat` schema be used.  Likewise this schema:
+will indicate that the `#/components/schemas/Cat` schema be used.  Likewise this payload:
 
 ```json
 {
@@ -2824,7 +2828,7 @@ will indicate that the `Cat` schema be used.  Likewise this schema:
 }
 ```
 
-will map to `Dog` because of the definition in the `mapping` element.
+will map to `#/components/schemas/Dog` because the `dog` entry in the `mapping` element maps to `Dog` which is the schema name for `#/components/schemas/Dog`.
 
 
 #### <a name="xmlObject"></a>XML Object

--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -2698,9 +2698,10 @@ When request bodies or response payloads may be one of a number of different sch
 
 `discriminator` uses a schema's "name" to automatically map a property value to
 a schema. The schema's "name" is the property name used when declaring the
-schema as a component. For example, the name of the schema at
-`#/components/schemas/Cat` is "Cat". Therefore, when using `discriminator`,
-_inline_ schemas will not be considered because they don't have a "name".
+schema as a component in an OpenAPI document. For example, the name of the
+schema at `#/components/schemas/Cat` is "Cat". Therefore, when using
+`discriminator`, _inline_ schemas will not be considered because they don't have
+a "name".
 
 ##### Fixed Fields
 Field Name | Type | Description

--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -2703,6 +2703,10 @@ schema at `#/components/schemas/Cat` is "Cat". Therefore, when using
 `discriminator`, _inline_ schemas will not be considered because they don't have
 a "name".
 
+Schema names are scoped to the OpenAPI document they are defined in. That means
+if OpenAPI document "A" references a schema in OpenAPI document "B", the schema
+names in "A" aren't considered when evaluating the referenced schema in "B".
+
 ##### Fixed Fields
 Field Name | Type | Description
 ---|:---:|---

--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -2727,7 +2727,7 @@ MyResponseType:
   - $ref: '#/components/schemas/Lizard'
 ```
 
-which means the payload _MUST_, by validation, match exactly one of the schemas described by `Cat`, `Dog`, or `Lizard`. Evaluating a `oneOf` can be a costly operation, so `discriminator` MAY be used as a "hint" to improve the efficiency of validation and selection of the matching schema. The `discriminator` keyword can not change the validation result of the `oneOf`, it can only help make the evaluation more efficient and provide better error messaging. We can then describe exactly which field tells us which schema is expected to match the instance:
+which means the payload _MUST_, by validation, match exactly one of the schemas described by `Cat`, `Dog`, or `Lizard`. Evaluating a `oneOf` can be a costly operation, so `discriminator` MAY be used as a "hint" to improve the efficiency of selection of the matching schema. The `discriminator` keyword can not change the validation result of the `oneOf`, it can only help make the evaluation more efficient and provide better error messaging. We can then describe exactly which field tells us which schema is expected to match the instance:
 
 ```yaml
 MyResponseType:

--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -2347,7 +2347,7 @@ The OpenAPI Specification allows combining and extending model definitions using
 
 While composition offers model extensibility, it does not imply a hierarchy between the models.
 To support polymorphism, the OpenAPI Specification adds the `discriminator` keyword.
-When used, the `discriminator` will indicate the name of the property that decides which schema definition validates the structure of the model.
+When used, the `discriminator` will indicate the name of the property that hints which schema definition is expected to validate the structure of the model.
 
 ###### XML Modeling
 
@@ -2694,7 +2694,7 @@ components:
 
 #### <a name="discriminatorObject"></a>Discriminator Object
 
-When request bodies or response payloads may be one of a number of different schemas, a `discriminator` object can be used to aid in serialization, deserialization, and validation.  The discriminator is a specific object in a schema which is used to inform the consumer of the document of an alternative schema based on the value associated with it.
+When request bodies or response payloads may be one of a number of different schemas, a `discriminator` object can be used to aid in serialization, deserialization, and validation. The `discriminator` keyword is used to inform the consumer of the document which of the alternatives is expected or preferred.
 
 `discriminator` uses a schema's "name" to automatically map a property value to
 a schema. The schema's "name" is the property name used when declaring the
@@ -2722,8 +2722,7 @@ MyResponseType:
   - $ref: '#/components/schemas/Lizard'
 ```
 
-which means the payload _MUST_, by validation, match exactly one of the schemas described by `Cat`, `Dog`, or `Lizard`.  In this case, a discriminator MAY act as a "hint" to shortcut validation and selection of the matching schema which may be a costly operation, depending on the complexity of the schema. We can then describe exactly which field tells us which schema to use:
-
+which means the payload _MUST_, by validation, match exactly one of the schemas described by `Cat`, `Dog`, or `Lizard`. Evaluating a `oneOf` can be a costly operation, so `discriminator` MAY be used as a "hint" to improve the efficiency of validation and selection of the matching schema. The `discriminator` keyword can not change the validation result of the `oneOf`, it can only help make the evaluation more efficient and provide better error messaging. We can then describe exactly which field tells us which schema is expected to match the instance:
 
 ```yaml
 MyResponseType:
@@ -2744,7 +2743,7 @@ The expectation now is that a property with name `petType` _MUST_ be present in 
 }
 ```
 
-Will indicate that the `Cat` schema be used in conjunction with this payload.
+Will indicate that the `Cat` schema is the alternative that is expected to match this payload.
 
 In scenarios where the value of the discriminator field does not match the schema name or implicit mapping is not possible, an optional `mapping` definition MAY be used:
 
@@ -2764,7 +2763,7 @@ MyResponseType:
 
 Here the discriminator _value_ of `dog` will map to the schema `#/components/schemas/Dog`, rather than the default (implicit) `#/components/schemas/dog`.  If the discriminator _value_ does not match an implicit or explicit mapping, no schema can be determined and validation SHOULD fail. Mapping keys MUST be string values, but tooling MAY convert response values to strings for comparison.
 
-When used in conjunction with the `anyOf` construct, the use of the discriminator can avoid ambiguity where multiple schemas may satisfy a single payload.
+When used in conjunction with the `anyOf` construct, the use of the discriminator can avoid ambiguity for serializers/deserializers where multiple schemas may satisfy a single payload.
 
 In both the `oneOf` and `anyOf` use cases, all possible schemas MUST be listed explicitly.  To avoid redundancy, the discriminator MAY be added to a parent schema definition, and all schemas comprising the parent schema in an `allOf` construct may be used as an alternate schema.
 
@@ -2819,7 +2818,7 @@ a payload like this:
 }
 ```
 
-will indicate that the `#/components/schemas/Cat` schema be used.  Likewise this payload:
+will indicate that the `#/components/schemas/Cat` schema is expected to match.  Likewise this payload:
 
 ```json
 {

--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -2346,7 +2346,7 @@ The OpenAPI Specification allows combining and extending model definitions using
 
 While composition offers model extensibility, it does not imply a hierarchy between the models.
 To support polymorphism, the OpenAPI Specification adds the `discriminator` keyword.
-When used, the `discriminator` will indicate the name of the property that hints which schema definition is expected to validate the structure of the model.
+When used, the `discriminator` indicates the name of the property that hints which schema definition is expected to validate the structure of the model.
 
 ###### XML Modeling
 
@@ -2693,7 +2693,7 @@ components:
 
 #### <a name="discriminatorObject"></a>Discriminator Object
 
-When request bodies or response payloads may be one of a number of different schemas, a `discriminator` object can be used to aid in serialization, deserialization, and validation. The `discriminator` keyword is used to inform the consumer of the document which of the alternatives is expected or preferred.
+When request bodies or response payloads may be one of a number of different schemas, a `discriminator` object gives a hint about the expected schema of the document. It can be used to aid in serialization, deserialization, and validation.
 
 `discriminator` uses a schema's "name" to automatically map a property value to
 a schema. The schema's "name" is the property name used when declaring the
@@ -2726,7 +2726,7 @@ MyResponseType:
   - $ref: '#/components/schemas/Lizard'
 ```
 
-which means the payload _MUST_, by validation, match exactly one of the schemas described by `Cat`, `Dog`, or `Lizard`. Evaluating a `oneOf` can be a costly operation, so `discriminator` MAY be used as a "hint" to improve the efficiency of selection of the matching schema. The `discriminator` keyword cannot change the validation result of the `oneOf`, it can only help make the evaluation more efficient and provide better error messaging. We can then describe exactly which field tells us which schema is expected to match the instance:
+which means the payload _MUST_, by validation, match exactly one of the schemas described by `Cat`, `Dog`, or `Lizard`. Evaluating a `oneOf` can be a costly operation, so `discriminator` MAY be used as a "hint" to improve the efficiency of selection of the matching schema. The `discriminator` keyword cannot change the validation result of the `oneOf`, it can only help make the evaluation more efficient and provide better error messaging. We can specify the exact field that tells us which schema is expected to match the instance:
 
 ```yaml
 MyResponseType:
@@ -2747,7 +2747,7 @@ The expectation now is that a property with name `petType` _MUST_ be present in 
 }
 ```
 
-Will indicate that the `Cat` schema is the alternative that is expected to match this payload.
+Will indicate that the `Cat` schema is expected to match this payload.
 
 In scenarios where the value of the discriminator field does not match the schema name or implicit mapping is not possible, an optional `mapping` definition MAY be used:
 

--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -2722,7 +2722,7 @@ MyResponseType:
   - $ref: '#/components/schemas/Lizard'
 ```
 
-which means the payload _MUST_, by validation, match exactly one of the schemas described by `Cat`, `Dog`, or `Lizard`. Evaluating a `oneOf` can be a costly operation, so `discriminator` MAY be used as a "hint" to improve the efficiency of selection of the matching schema. The `discriminator` keyword cannot change the validation result of the `oneOf`, it can only help make the evaluation more efficient and provide better error messaging. We can specify the exact field that tells us which schema is expected to match the instance:
+which means the payload _MUST_, by validation, match exactly one of the schemas described by `Cat`, `Dog`, or `Lizard`. Deserialization of a `oneOf` can be a costly operation, as it requires determining which schema matches the payload and thus should be used in deserialization. This problem also exists for `anyOf` schemas. A `discriminator` MAY be used as a "hint" to improve the efficiency of selection of the matching schema. The `discriminator` keyword cannot change the validation result of the `oneOf`, it can only help make the deserialization more efficient and provide better error messaging. We can specify the exact field that tells us which schema is expected to match the instance:
 
 ```yaml
 MyResponseType:


### PR DESCRIPTION
Here are some updates for the `discriminator` keyword specification. Mostly, this update is to make it clear that `discriminator` shouldn't change the validation behavior of the `oneOf`/`anyOf` keywords. `discriminator` can only be used to improve efficiency or messaging of evaluating `oneOf`/`anyOf` I also fixed bugs and clarified some confusing parts.

- The language in the table introducing `discriminator` seems to describe the value of the `discriminator` keyword to be an "object name" (whatever that means) rather than an object. I tweaked the wording to avoid that contradiction.

- The `discriminator` keyword uses the concept of "schema names", but what that means is never defined. There is no concept of a schema having a name in JSON Schema. They only have URIs. I defined "schema name" and added some clarifications where the use of schema names got confusing.

- The `discriminator` keyword can't be a shortcut, only a hint. I tried to tweak any language that might suggest that `discriminator` overrides the behavior of `anyOf`/`oneOf` in any way.

- The last example was super confusing, which is mostly because it doesn't indicate which schema the payload examples are being applied to. So, I added the schema and an explanation of what is happening.

