### PR TITLE
fix: extensions property anchor renamed

### DIFF
--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -3430,7 +3430,7 @@ The extensions properties are implemented as patterned fields that are always pr
 
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="infoExtensions"></a>^x- | Any | Allows extensions to the OpenAPI Schema. The field name MUST begin with `x-`, for example, `x-internal-id`. Field names beginning `x-oai-` and `x-oas-` are reserved for uses defined by the [OpenAPI Initiative](https://www.openapis.org/). The value can be `null`, a primitive, an array or an object.
+<a name="extensionProperties"></a>^x- | Any | Allows extensions to the OpenAPI Schema. The field name MUST begin with `x-`, for example, `x-internal-id`. Field names beginning `x-oai-` and `x-oas-` are reserved for uses defined by the [OpenAPI Initiative](https://www.openapis.org/). The value can be `null`, a primitive, an array or an object.
 
 The extensions may or may not be supported by the available tooling, but those may be extended as well to add requested support (if tools are internal or open-sourced).
 


### PR DESCRIPTION
Spotted in the overlays spec and @webron noted that it was probably also wrong here.

Nothing in the spec links to that anchor, but just for clarity that the definition isn't just for the `info` object, probably should be fixed.