### PR TITLE
Create SPECIAL_INTEREST_GROUPS

### DIFF
--- a/SPECIAL_INTEREST_GROUPS
+++ b/SPECIAL_INTEREST_GROUPS
@@ -1,0 +1,12 @@
+# OpenAPI Initiative Special Interest Groups (aka SIGs)
+
+The SIGs are currently operating on OpenAPI Slack. If you are part of a member company, you should be able to create an account at https://join.slack.com/t/open-api/signup .
+
+If you have trouble accessing or need a new account on OpenAPI Slack, please email operations@openapis.org to request an account. Please specify what SIG(s) you wish to participate in.
+
+Travel SIG
+Access: Slack - channel sig-travel
+Description/Purpose:
+The Travel SIG will compile and present a collective representation of the API behaviors required by the travel industry documented in the form of use cases and workflows. This effort will include working with various established travel standards and trade association bodies using the Open Travel Alliance as a coordination point. Open Travel will moderate the various needs of sectors such as (but not limited to) air, hotel, car, cruise, rail, tours, distribution channels, etc. with a focus on enabling interoperability across the sectors. The standards bodies and trade associations will lead on what functionality is needed by their members. The Travel SIG will work with other OAI SIGs on how best to support the documented use cases and workflows. The intent here is to avoid duplication of SIG efforts and have the Travel SIG focus on what is needed and work with other SIGs on how to meet that need.
+
+


### PR DESCRIPTION
# OpenAPI Initiative Special Interest Groups (aka SIGs)

To join go to https://join.slack.com/t/open-api/signup and create your account. If this does not work for any reason, please email operations@openapis.org for help, and specify which SIGs you would like to join or monitor.

## Travel SIG
*Discussion: Slack - #sig-travel*
Purpose:
>The Travel SIG will compile and present a collective representation of the API behaviors required by the travel industry documented in the form of use cases and workflows. This effort will include working with various established travel standards and trade association bodies using the Open Travel Alliance as a coordination point. Open Travel will moderate the various needs of sectors such as (but not limited to) air, hotel, car, cruise, rail, tours, distribution channels, etc. with a focus on enabling interoperability across the sectors. The standards bodies and trade associations will lead on what functionality is needed by their members. The Travel SIG will work with other OAI SIGs on how best to support the documented use cases and workflows. The intent here is to avoid duplication of SIG efforts and have the Travel SIG focus on what is needed and work with other SIGs on how to meet that need.

