### PR TITLE
fix: typo spelling grammar

### DIFF
--- a/proposals/2019-03-15-Alternative-Schema.md
+++ b/proposals/2019-03-15-Alternative-Schema.md
@@ -57,7 +57,7 @@ Values used to populate the Alternative Schema Object are required to come from 
 
 *** Note this is a placeholder registry. Don't take the values seriously. ***  
 
-Inital contents of the registry will include:
+Initial contents of the registry will include:
 
 |Name  |Link  |Description | 
 |--- | --- | --- |
@@ -69,5 +69,5 @@ This proposal makes use of the extensibility features of OpenAPI. All changes so
 
 ## Alternatives considered
 
-Embedding non-JSON content in the OAS document would have imposed an unacceptable burden on tooling. Therefore, an extenal link was prefered. Considerable discussion was held over exactly how the links should be represented in the Schema Object. The selected option should support the greatest number of possible combinations of external schema that can be expressed with the OpenAPI schema language.
+Embedding non-JSON content in the OAS document would have imposed an unacceptable burden on tooling. Therefore, an external link was preferred. Considerable discussion was held over exactly how the links should be represented in the Schema Object. The selected option should support the greatest number of possible combinations of external schema that can be expressed with the OpenAPI schema language.
 

--- a/proposals/2019-07-17-Webhooks.md
+++ b/proposals/2019-07-17-Webhooks.md
@@ -19,7 +19,7 @@
 
 ## Introduction
 
-Modern APIs often consist of two-way API traffic, but OpenAPI currently only supports some types of requests. Standard client-to-server API calls are well supported. Server-to-client callbacks are only supported if they are the result of an earlier API call and are documented by nesting under the path of that earlier call. Incoming HTTP reqests ("webhooks") cannot be described in the current version of OpenAPI if they are the result of subscription arranged outside of the scope of the API (e.g. by setting a callback URL in a web interface).
+Modern APIs often consist of two-way API traffic, but OpenAPI currently only supports some types of requests. Standard client-to-server API calls are well supported. Server-to-client callbacks are only supported if they are the result of an earlier API call and are documented by nesting under the path of that earlier call. Incoming HTTP request ("webhooks") cannot be described in the current version of OpenAPI if they are the result of subscription arranged outside of the scope of the API (e.g. by setting a callback URL in a web interface).
 
 ## Motivation
 
@@ -189,4 +189,4 @@ Adding a new top-level entry is not something to take lightly, however hopefully
 
 ## Alternatives considered
 
-Another option is to add a special `path` that could contain the various webhooks using the exisiting `callback` syntax but existing tools which aren't expecting this special value may not handle it well, so this option was discounted.
+Another option is to add a special `path` that could contain the various webhooks using the existing `callback` syntax but existing tools which aren't expecting this special value may not handle it well, so this option was discounted.

--- a/proposals/2019-07-17-Webhooks.md
+++ b/proposals/2019-07-17-Webhooks.md
@@ -19,7 +19,7 @@
 
 ## Introduction
 
-Modern APIs often consist of two-way API traffic, but OpenAPI currently only supports some types of requests. Standard client-to-server API calls are well supported. Server-to-client callbacks are only supported if they are the result of an earlier API call and are documented by nesting under the path of that earlier call. Incoming HTTP request ("webhooks") cannot be described in the current version of OpenAPI if they are the result of subscription arranged outside of the scope of the API (e.g. by setting a callback URL in a web interface).
+Modern APIs often consist of two-way API traffic, but OpenAPI currently only supports some types of requests. Standard client-to-server API calls are well supported. Server-to-client callbacks are only supported if they are the result of an earlier API call and are documented by nesting under the path of that earlier call. Incoming HTTP requests ("webhooks") cannot be described in the current version of OpenAPI if they are the result of subscription arranged outside of the scope of the API (e.g. by setting a callback URL in a web interface).
 
 ## Motivation
 

--- a/proposals/2019-12-24-Overlays.md
+++ b/proposals/2019-12-24-Overlays.md
@@ -52,7 +52,7 @@ This object contains identifying information about the [OpenAPI Overlay document
 Field Name | Type | Description
 ---|:---:|---
 <a name="overlayTitle"></a>title | `string` | A human readable description of the purpose of the overlay.
-<a name="overlayVersion"></a>version | `string` | A version identifer for indicating changes to an overlay document.
+<a name="overlayVersion"></a>version | `string` | A version identifier for indicating changes to an overlay document.
 
 #### <a name="updateObject"></a>Update Object
 


### PR DESCRIPTION
hello , i fix some typo in documentation and replace to correct words with reference from [Merriam webster](https://www.merriam-webster.com/), thanks