### PR TITLE
Add "type" qualifier to ensure that "if" clauses fail properly

### DIFF
--- a/schemas/v3.1/schema.json
+++ b/schemas/v3.1/schema.json
@@ -316,6 +316,7 @@
     },
     "path-item-or-reference": {
       "if": {
+        "type": "object",
         "required": [
           "$ref"
         ]
@@ -655,6 +656,7 @@
     },
     "request-body-or-reference": {
       "if": {
+        "type": "object",
         "required": [
           "$ref"
         ]
@@ -811,6 +813,7 @@
     },
     "response-or-reference": {
       "if": {
+        "type": "object",
         "required": [
           "$ref"
         ]
@@ -831,6 +834,7 @@
     },
     "callbacks-or-reference": {
       "if": {
+        "type": "object",
         "required": [
           "$ref"
         ]
@@ -909,6 +913,7 @@
     },
     "link-or-reference": {
       "if": {
+        "type": "object",
         "required": [
           "$ref"
         ]
@@ -975,6 +980,7 @@
     },
     "header-or-reference": {
       "if": {
+        "type": "object",
         "required": [
           "$ref"
         ]
@@ -1196,6 +1202,7 @@
     },
     "security-scheme-or-reference": {
       "if": {
+        "type": "object",
         "required": [
           "$ref"
         ]

--- a/schemas/v3.1/schema.yaml
+++ b/schemas/v3.1/schema.yaml
@@ -219,6 +219,7 @@ $defs:
 
   path-item-or-reference:
     if:
+      type: object
       required:
         - $ref
     then:
@@ -418,6 +419,7 @@ $defs:
 
   parameter-or-reference:
     if:
+      type: object
       required:
         - $ref
     then:
@@ -442,6 +444,7 @@ $defs:
 
   request-body-or-reference:
     if:
+      type: object
       required:
         - $ref
     then:
@@ -547,6 +550,7 @@ $defs:
 
   response-or-reference:
     if:
+      type: object
       required:
         - $ref
     then:
@@ -562,6 +566,7 @@ $defs:
 
   callbacks-or-reference:
     if:
+      type: object
       required:
         - $ref
     then:
@@ -585,6 +590,7 @@ $defs:
 
   example-or-reference:
     if:
+      type: object
       required:
         - $ref
     then:
@@ -616,6 +622,7 @@ $defs:
 
   link-or-reference:
     if:
+      type: object
       required:
         - $ref
     then:
@@ -662,6 +669,7 @@ $defs:
 
   header-or-reference:
     if:
+      type: object
       required:
         - $ref
     then:
@@ -807,6 +815,7 @@ $defs:
 
   security-scheme-or-reference:
     if:
+      type: object
       required:
         - $ref
     then:


### PR DESCRIPTION
If the wrong type is used for a particular piece of data, then a bare
"required" will validate as true, causing the "if" clause to be true, which
can lead to confusing errors when the "then" schema then fires, instead of the
error occurring at a higher position in the schema.