### PR TITLE
Treat security scheme as case insensitive in JSON schema [Issue #2703]

### DIFF
--- a/schemas/v3.0/schema.yaml
+++ b/schemas/v3.0/schema.yaml
@@ -806,7 +806,8 @@ definitions:
       - description: Bearer
         properties:
           scheme:
-            enum: [bearer]
+            type: string
+            pattern: ^[Bb][Ee][Aa][Rr][Ee][Rr]$
 
       - description: Non Bearer
         not:
@@ -814,7 +815,8 @@ definitions:
         properties:
           scheme:
             not:
-              enum: [bearer]
+              type: string
+              pattern: ^[Bb][Ee][Aa][Rr][Ee][Rr]$
 
   OAuth2SecurityScheme:
     type: object

--- a/schemas/v3.1/schema.yaml
+++ b/schemas/v3.1/schema.yaml
@@ -765,7 +765,8 @@ $defs:
             type:
               const: http
             scheme:
-              const: bearer
+              type: string
+              pattern: ^[Bb][Ee][Aa][Rr][Ee][Rr]$
           required:
             - type
             - scheme
@@ -773,8 +774,6 @@ $defs:
           properties:
             bearerFormat:
               type: string
-          required:
-            - scheme
 
       type-oauth2:
         if:


### PR DESCRIPTION
This change updates the JSON Schemas for both 3.0 and 3.1 to allow for the security scheme to be case insensitive when checking for whether the bearerFormat propery is allowed.