### PR TITLE
fix: invalid JSON in v3.1 schema #2723

### DIFF
--- a/schemas/v3.1/schema.json
+++ b/schemas/v3.1/schema.json
@@ -772,7 +772,7 @@
         }
       },
       "patternProperties": {
-        "^[1-5](?:[0-9]{2}|XX)$":
+        "^[1-5](?:[0-9]{2}|XX)$": {
           "$ref": "#/$defs/response-or-reference"
         }
       },


### PR DESCRIPTION
This fixes the invalid JSON in the v3.1 schema as introduced by #2706 and described in #2723 

Kind regards,
Hans
