### PR TITLE
fix: Reference published RFC8414 instead of draft

### DIFF
--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -3188,7 +3188,7 @@ animals:
 
 Defines a security scheme that can be used by the operations.
 
-Supported schemes are HTTP authentication, an API key (either as a header, a cookie parameter or as a query parameter), mutual TLS (use of a client certificate), OAuth2's common flows (implicit, password, client credentials and authorization code) as defined in [RFC6749](https://tools.ietf.org/html/rfc6749), and [OpenID Connect Discovery](https://tools.ietf.org/html/draft-ietf-oauth-discovery-06).
+Supported schemes are HTTP authentication, an API key (either as a header, a cookie parameter or as a query parameter), mutual TLS (use of a client certificate), OAuth2's common flows (implicit, password, client credentials and authorization code) as defined in [RFC6749](https://tools.ietf.org/html/rfc6749), and [RFC8414](https://datatracker.ietf.org/doc/html/rfc8414).
 Please note that as of 2020, the implicit flow is about to be deprecated by [OAuth 2.0 Security Best Current Practice](https://tools.ietf.org/html/draft-ietf-oauth-security-topics). Recommended for most use case is Authorization Code Grant flow with PKCE.
 
 ##### Fixed Fields


### PR DESCRIPTION
A minor change that does not alter the meaning of the specification. The draft expired in 2017 and the RFC was published in 2018.