### PR TITLE
more schema fixes

### DIFF
--- a/schemas/v3.1/schema.json
+++ b/schemas/v3.1/schema.json
@@ -437,10 +437,13 @@
           "$dynamicRef": "#meta"
         },
         "content": {
-          "$ref": "#/$defs/content"
+          "$ref": "#/$defs/content",
+          "minProperties": 1,
+          "maxProperties": 1
         }
       },
       "required": [
+        "name",
         "in"
       ],
       "oneOf": [
@@ -944,7 +947,9 @@
           "$dynamicRef": "#meta"
         },
         "content": {
-          "$ref": "#/$defs/content"
+          "$ref": "#/$defs/content",
+          "minProperties": 1,
+          "maxProperties": 1
         }
       },
       "oneOf": [

--- a/schemas/v3.1/schema.yaml
+++ b/schemas/v3.1/schema.yaml
@@ -307,7 +307,10 @@ $defs:
         $dynamicRef: '#meta'
       content:
         $ref: '#/$defs/content'
+        minProperties: 1
+        maxProperties: 1
     required:
+      - name
       - in
     oneOf:
       - required:
@@ -645,6 +648,8 @@ $defs:
         $dynamicRef: '#meta'
       content:
         $ref: '#/$defs/content'
+        minProperties: 1
+        maxProperties: 1
     oneOf:
       - required:
         - schema


### PR DESCRIPTION
schema fixes for the "parameter" and "header" objects
    
- name is required (for parameter)
- the map under content must contain only one entry
    
as per https://spec.openapis.org/oas/v3.1.0#fixed-fields-9
