### PR TITLE
Complete the example of discriminator mapping

### DIFF
--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -2783,7 +2783,9 @@ components:
       discriminator:
         propertyName: petType
         mapping:
+          cat: Cat
           dog: Dog
+          lizard: Lizard
     Cat:
       allOf:
       - $ref: '#/components/schemas/Pet'


### PR DESCRIPTION
Before this fix, the example contains types of Cat and Lizard, but the
discriminator mapping for them is missing.