### PR TITLE
Change server-variable property to 'description'

### DIFF
--- a/schemas/v3.1/schema.json
+++ b/schemas/v3.1/schema.json
@@ -189,7 +189,7 @@
         "default": {
           "type": "string"
         },
-        "descriptions": {
+        "description": {
           "type": "string"
         }
       },

--- a/schemas/v3.1/schema.yaml
+++ b/schemas/v3.1/schema.yaml
@@ -130,7 +130,7 @@ $defs:
         minItems: 1
       default:
         type: string
-      descriptions:
+      description:
         type: string
     required:
       - default


### PR DESCRIPTION
According to the spec: https://spec.openapis.org/oas/v3.1.0#server-variable-object

This should validate a `description` field, not `descriptions`.