### PR TITLE
fix: some broken IETF links

### DIFF
--- a/scripts/md2html/md2html.js
+++ b/scripts/md2html/md2html.js
@@ -263,10 +263,6 @@ for (let l in lines) {
             //return (group1 ? group1 : '')+']]';
             return ']]';
         });
-
-        while (line.indexOf('https://tools.ietf.org/html/rfc')>=0) {
-            line = line.replace(/.https:..tools.ietf.org.html.rfc[0-9]{1,5}./g,'');
-        }
     }
 
     // minor fixup to get bibliography link to work


### PR DESCRIPTION
From #2796 some IETF links were correct in the markdown syntax, but the generated HTML had broken links.

For example, the markdown for the [Request Body Object > Fixed Fields (4.8.13.1)](https://spec.openapis.org/oas/latest.html#fixed-fields-10) looks like this:

```markdown
The key is a media type or [media type range](https://tools.ietf.org/html/rfc7231#appendix-D) and
```

But the rendered HTML looks like this:

```html
The key is a media type or [media type range]appendix-D) and
```

The problem occurs due to the markdown pre-processor code used to adjust RFC links.

It looks like the original intent of lines 267-269 was to transform links that looked like this:

```markdown
[RFC2119](https://tools.ietf.org/html/rfc2119)
```

Into this format:

```markdown
[[!RFC2119]]
```

I'm not sure what the reasoning was for that, but if I simply *delete* lines 267-269, it does resolve the issue.

To be thorough, I inspected the output for instances of lines containing `https://tools.ietf.org/html/rfc` at the end, aka what lines 267-269 *would have* operated on, and it's all links where the text is not `RFC\d+`. Specifically:

* In versions 3.0.0-3.1.0 the "Media Type Object" has two instances of `<a href="https://tools.ietf.org/html/rfc7231#appendix-D">media type range</a>`
* In versions 3.0.0-3.1.0 the "Runtime Expressions" section has `<a href="https://tools.ietf.org/html/rfc5234">ABNF</a>`
* In version 3.0.0 only, in the "Operation Object" section under "Fixed Fields", the `requestBodies` section has one for each method, e.g. `<a href="https://tools.ietf.org/html/rfc7231#section-4.3.1">GET</a>`

Since that's the only instances affected by removing lines 267-269, this change seems very safe.