### PR TITLE
more schema tweaks for parameter objects

### DIFF
--- a/schemas/v3.1/schema.json
+++ b/schemas/v3.1/schema.json
@@ -491,10 +491,6 @@
             },
             "explode": {
               "type": "boolean"
-            },
-            "allowReserved": {
-              "default": false,
-              "type": "boolean"
             }
           },
           "allOf": [
@@ -592,6 +588,10 @@
                       "pipeDelimited",
                       "deepObject"
                     ]
+                  },
+                  "allowReserved": {
+                    "default": false,
+                    "type": "boolean"
                   }
                 }
               }

--- a/schemas/v3.1/schema.json
+++ b/schemas/v3.1/schema.json
@@ -440,10 +440,6 @@
           "default": false,
           "type": "boolean"
         },
-        "allowEmptyValue": {
-          "default": false,
-          "type": "boolean"
-        },
         "schema": {
           "$dynamicRef": "#meta"
         },
@@ -469,6 +465,24 @@
           ]
         }
       ],
+      "if": {
+        "properties": {
+          "in": {
+            "const": "query"
+          }
+        },
+        "required": [
+          "in"
+        ]
+      },
+      "then": {
+        "properties": {
+          "allowEmptyValue": {
+            "default": false,
+            "type": "boolean"
+          }
+        }
+      },
       "dependentSchemas": {
         "schema": {
           "properties": {

--- a/schemas/v3.1/schema.yaml
+++ b/schemas/v3.1/schema.yaml
@@ -343,9 +343,6 @@ $defs:
             type: string
           explode:
             type: boolean
-          allowReserved:
-            default: false
-            type: boolean
         allOf:
           - $ref: '#/$defs/examples'
           - $ref: '#/$defs/parameter/dependentSchemas/schema/$defs/styles-for-path'
@@ -406,7 +403,9 @@ $defs:
                     - spaceDelimited
                     - pipeDelimited
                     - deepObject
-
+                allowReserved:
+                  default: false
+                  type: boolean
           styles-for-cookie:
             if:
               properties:

--- a/schemas/v3.1/schema.yaml
+++ b/schemas/v3.1/schema.yaml
@@ -311,9 +311,6 @@ $defs:
       deprecated:
         default: false
         type: boolean
-      allowEmptyValue:
-        default: false
-        type: boolean
       schema:
         $dynamicRef: '#meta'
       content:
@@ -328,6 +325,17 @@ $defs:
         - schema
       - required:
         - content
+    if:
+      properties:
+        in:
+          const: query
+      required:
+        - in
+    then:
+      properties:
+        allowEmptyValue:
+          default: false
+          type: boolean
     dependentSchemas:
       schema:
         properties:


### PR DESCRIPTION
- allowEmptyValue is valid only for query parameters
- allowReserved only applies to parameters with a value of query

https://spec.openapis.org/oas/v3.1.0#parameter-object