### PR TITLE
Add missing type: object field in example schema

### DIFF
--- a/versions/3.0.3.md
+++ b/versions/3.0.3.md
@@ -943,6 +943,7 @@ requestBody:
   content:
     'application/x-www-form-urlencoded':
       schema:
+       type: object
        properties:
           name: 
             description: Updated name of the pet


### PR DESCRIPTION
I think this is missing