### PR TITLE
Clarify deepObject applicability

### DIFF
--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -1059,7 +1059,7 @@ form |  `primitive`, `array`, `object` |  `query`, `cookie` | Form style paramet
 simple | `array` | `path`, `header` | Simple style parameters defined by [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.2).  This option replaces `collectionFormat` with a `csv` value from OpenAPI 2.0.
 spaceDelimited | `array`, `object` | `query` | Space separated array or object values. This option replaces `collectionFormat` equal to `ssv` from OpenAPI 2.0. 
 pipeDelimited | `array`, `object` | `query` | Pipe separated array or object values. This option replaces `collectionFormat` equal to `pipes` from OpenAPI 2.0.
-deepObject | `object` | `query` | Allows simple non-nested objects to be serialized using form parameters.
+deepObject | `object` | `query` | Allows objects with scalar properties to be serialized using form parameters. 
 
 
 ##### Style Examples

--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -1059,7 +1059,7 @@ form |  `primitive`, `array`, `object` |  `query`, `cookie` | Form style paramet
 simple | `array` | `path`, `header` | Simple style parameters defined by [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.2).  This option replaces `collectionFormat` with a `csv` value from OpenAPI 2.0.
 spaceDelimited | `array`, `object` | `query` | Space separated array or object values. This option replaces `collectionFormat` equal to `ssv` from OpenAPI 2.0. 
 pipeDelimited | `array`, `object` | `query` | Pipe separated array or object values. This option replaces `collectionFormat` equal to `pipes` from OpenAPI 2.0.
-deepObject | `object` | `query` | Allows objects with scalar properties to be serialized using form parameters. 
+deepObject | `object` | `query` | Allows objects with scalar properties to be represented using form parameters. The representation of array or object properties is not defined.
 
 
 ##### Style Examples

--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -1059,7 +1059,7 @@ form |  `primitive`, `array`, `object` |  `query`, `cookie` | Form style paramet
 simple | `array` | `path`, `header` | Simple style parameters defined by [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.2).  This option replaces `collectionFormat` with a `csv` value from OpenAPI 2.0.
 spaceDelimited | `array`, `object` | `query` | Space separated array or object values. This option replaces `collectionFormat` equal to `ssv` from OpenAPI 2.0. 
 pipeDelimited | `array`, `object` | `query` | Pipe separated array or object values. This option replaces `collectionFormat` equal to `pipes` from OpenAPI 2.0.
-deepObject | `object` | `query` | Provides a simple way of rendering nested objects using form parameters.
+deepObject | `object` | `query` | Allows simple non-nested objects to be serialized using form parameters.
 
 
 ##### Style Examples


### PR DESCRIPTION
This PR changes the description of the `deepObject` serialization style to mention "simple non-nested objects" instead of "nested objects". I think "nested objects" is a typo because @webron [previously said](https://github.com/swagger-api/swagger-js/issues/1385#issuecomment-423768114) that the `deepObject` behavior is not actually defined for nested objects.

> when we defined `deepObject` in the spec, we explicitly chose to not mention what happens when the object has several levels in it, but in our conversations we went with 'not supported'. If you're looking for supporting that use case, it needs to be addressed by the spec first.

The "nested objects" phrase is confusing some tooling developers and users. I hope this change will help clarify things until #1706 is added to the spec.