### PR TITLE
Referenced Parameter Name in Link Definition Example is Case Sensitive

### DIFF
--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -2082,7 +2082,7 @@ paths:
               operationId: getUserAddress
               parameters:
                 # get the `id` field from the request path parameter named `id`
-                userId: $request.path.id
+                userid: $request.path.id
   # the path item of the linked operation
   /users/{userid}/address:
     parameters:


### PR DESCRIPTION
It’s not much, but it’s been bugging me for a week now.