### PR TITLE
Add Device Code authorization to the supported OAuth Flows

### DIFF
--- a/versions/3.2.0.md
+++ b/versions/3.2.0.md
@@ -3188,7 +3188,7 @@ animals:
 
 Defines a security scheme that can be used by the operations.
 
-Supported schemes are HTTP authentication, an API key (either as a header, a cookie parameter or as a query parameter), mutual TLS (use of a client certificate), OAuth2's common flows (implicit, password, client credentials and authorization code) as defined in [RFC6749](https://tools.ietf.org/html/rfc6749), and [OpenID Connect Discovery](https://tools.ietf.org/html/draft-ietf-oauth-discovery-06).
+Supported schemes are HTTP authentication, an API key (either as a header, a cookie parameter or as a query parameter), mutual TLS (use of a client certificate), OAuth2's common flows (implicit, password, client credentials and authorization code) as defined in [RFC6749](https://tools.ietf.org/html/rfc6749), OAuth2 device authorization flow as defined in [RFC8628](https://tools.ietf.org/html/rfc8628), and [OpenID Connect Discovery](https://tools.ietf.org/html/draft-ietf-oauth-discovery-06).
 Please note that as of 2020, the implicit flow is about to be deprecated by [OAuth 2.0 Security Best Current Practice](https://tools.ietf.org/html/draft-ietf-oauth-security-topics). Recommended for most use case is Authorization Code Grant flow with PKCE.
 
 ##### Fixed Fields
@@ -3292,6 +3292,7 @@ Field Name | Type | Description
 <a name="oauthFlowsPassword"></a>password| [OAuth Flow Object](#oauthFlowObject) | Configuration for the OAuth Resource Owner Password flow 
 <a name="oauthFlowsClientCredentials"></a>clientCredentials| [OAuth Flow Object](#oauthFlowObject) | Configuration for the OAuth Client Credentials flow.  Previously called `application` in OpenAPI 2.0.
 <a name="oauthFlowsAuthorizationCode"></a>authorizationCode| [OAuth Flow Object](#oauthFlowObject) | Configuration for the OAuth Authorization Code flow.  Previously called `accessCode` in OpenAPI 2.0.
+<a name="oauthFlowsDeviceAuthorization"></s>deviceAuthorization| [OAuth Flow Object](#oauthFlowObject) | Configuration for the OAuth Device Authorization flow.
 
 This object MAY be extended with [Specification Extensions](#specificationExtensions).
 
@@ -3303,7 +3304,8 @@ Configuration details for a supported OAuth Flow
 Field Name | Type | Applies To | Description
 ---|:---:|---|---
 <a name="oauthFlowAuthorizationUrl"></a>authorizationUrl | `string` | `oauth2` (`"implicit"`, `"authorizationCode"`) | **REQUIRED**. The authorization URL to be used for this flow. This MUST be in the form of a URL. The OAuth2 standard requires the use of TLS.
-<a name="oauthFlowTokenUrl"></a>tokenUrl | `string` | `oauth2` (`"password"`, `"clientCredentials"`, `"authorizationCode"`) | **REQUIRED**. The token URL to be used for this flow. This MUST be in the form of a URL. The OAuth2 standard requires the use of TLS.
+<a name="oauthFlowDeviceAuthorizationUrl"></s>deviceAuthorizationUrl | `string` | `oauth2` (`"deviceAuthorization"`) | **REQUIRED**. The device authorization URL to be used for this flow. This MUST be in the form of a URL. The OAuth2 standard requires the use of TLS.
+<a name="oauthFlowTokenUrl"></a>tokenUrl | `string` | `oauth2` (`"password"`, `"clientCredentials"`, `"authorizationCode"`, `"deviceAuthorization"`) | **REQUIRED**. The token URL to be used for this flow. This MUST be in the form of a URL. The OAuth2 standard requires the use of TLS.
 <a name="oauthFlowRefreshUrl"></a>refreshUrl | `string` | `oauth2` | The URL to be used for obtaining refresh tokens. This MUST be in the form of a URL. The OAuth2 standard requires the use of TLS.
 <a name="oauthFlowScopes"></a>scopes | Map[`string`, `string`] | `oauth2` | **REQUIRED**. The available scopes for the OAuth2 security scheme. A map between the scope name and a short description for it. The map MAY be empty.
 


### PR DESCRIPTION
Clone of PR #2401, resubmitted against the `v3.2.0-dev` branch [as requested by webron](https://github.com/OAI/OpenAPI-Specification/pull/2401#issuecomment-1170594516). Note that this is not submitted against the `main` branch, but I will happily resubmit it against the `main` branch upon request.

Description of the original PR follows, with some extraneous details edited out:

----

Closes #2381. 

This is a PR for the Device Authorization OAuth Flow, based on [RFC8628](https://tools.ietf.org/html/rfc8628). I suggested this over at #2381 and was asked to make a PR for it.

The URL used for this flow is named `deviceAuthorizationUrl`, separate from `authorizationUrl` as the two have completely different semantics and usages, so I was concerned that using `authorizationUrl` for both might be confusing. That said, I would be happy to merge this into `authorizationUrl` if requested.