### PR TITLE
per the spec, the only allowed ranges are [12345]XX

### DIFF
--- a/schemas/v3.1/schema.json
+++ b/schemas/v3.1/schema.json
@@ -774,7 +774,7 @@
         }
       },
       "patternProperties": {
-        "^[1-5][0-9X]{2}$": {
+        "^[1-5](?:[0-9][0-9]|XX)$": {
           "$ref": "#/$defs/response-or-reference"
         }
       },

--- a/schemas/v3.1/schema.yaml
+++ b/schemas/v3.1/schema.yaml
@@ -520,7 +520,7 @@ $defs:
       default:
         $ref: '#/$defs/response-or-reference'
     patternProperties:
-      '^[1-5][0-9X]{2}$':
+      '^[1-5](?:[0-9][0-9]|XX)$':
         $ref: '#/$defs/response-or-reference'
     $ref: '#/$defs/specification-extensions'
     unevaluatedProperties: false


### PR DESCRIPTION
For example, 50X is NOT permitted.

This was fixed in v3.1 in PR#2690 but the change did not make it to v3.2.0.