### PR TITLE
Add a ref to implementation of v3.1 in Go

### DIFF
--- a/IMPLEMENTATIONS.md
+++ b/IMPLEMENTATIONS.md
@@ -24,6 +24,7 @@ These tools are not endorsed by the OAI.
 | openapi | [github/wzshiming/openapi](https://github.com/wzshiming/openapi) | Go | OpenAPI 3 Specification for golang |
 | kin-openapi | [github/getkin/kin-openapi](https://github.com/getkin/kin-openapi) | Go | OpenAPI 3.x implementation for Go (parsing, converting, validation) |
 | openapi-go | [github/swaggest/openapi-go](https://github.com/swaggest/openapi-go) | Go | Type-safe OpenAPI 3.x bindings and generator from code |
+| openapi | [sv-tools/openapi](https://github.com/sv-tools/openapi) | Go | OpenAPI v3.1 Spec implementation in Go with generics |
 | Spectral | [github/stoplightio/spectral](https://github.com/stoplightio/spectral) | TypeScript, JavaScript | A flexible JSON object linter with out of the box support for OpenAPI Specification 2 and 3 |
 | openapi-validator | [gitlab/mmal/openapi-validator](https://gitlab.com/mmalawski/openapi-validator) | PHP | Validates response against OpenAPI schema |
 | OpenAPI-Delphi | [github/paolo-rossi/OpenAPI-Delphi](https://github.com/paolo-rossi/OpenAPI-Delphi) | Delphi | Delphi implementation of a generator, parser and validator for the OpenAPI 3 Specification |


### PR DESCRIPTION
the implementation of the OpenAPI v3.1 Spec in Go with generics