### PR TITLE
Update schemas for v1.2 to draft-07

### DIFF
--- a/schemas/v1.2/apiDeclaration.json
+++ b/schemas/v1.2/apiDeclaration.json
@@ -1,6 +1,6 @@
 {
-    "id": "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/schemas/v1.2/apiDeclaration.json#",
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$id": "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/schemas/v1.2/apiDeclaration.json#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "required": [ "swaggerVersion", "basePath", "apis" ],
     "properties": {
@@ -13,7 +13,7 @@
         },
         "resourcePath": {
             "type": "string",
-            "format": "uri",
+            "format": "uri-reference",
             "pattern": "^/"
         },
         "apis": {

--- a/schemas/v1.2/authorizationObject.json
+++ b/schemas/v1.2/authorizationObject.json
@@ -1,6 +1,6 @@
 {
-    "id": "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/schemas/v1.2/authorizationObject.json#",
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$id": "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/schemas/v1.2/authorizationObject.json#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "additionalProperties": {
         "oneOf": [

--- a/schemas/v1.2/dataType.json
+++ b/schemas/v1.2/dataType.json
@@ -1,6 +1,6 @@
 {
-    "id": "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/schemas/v1.2/dataType.json#",
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$id": "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/schemas/v1.2/dataType.json#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "Data type as described by the specification (version 1.2)",
     "type": "object",
     "oneOf": [

--- a/schemas/v1.2/dataTypeBase.json
+++ b/schemas/v1.2/dataTypeBase.json
@@ -1,6 +1,6 @@
 {
-    "id": "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/schemas/v1.2/dataTypeBase.json#",
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$id": "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/schemas/v1.2/dataTypeBase.json#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "Data type fields (section 4.3.3)",
     "type": "object",
     "oneOf": [

--- a/schemas/v1.2/infoObject.json
+++ b/schemas/v1.2/infoObject.json
@@ -1,6 +1,6 @@
 {
-    "id": "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/schemas/v1.2/infoObject.json#",
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$id": "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/schemas/v1.2/infoObject.json#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "info object (section 5.1.3)",
     "type": "object",
     "required": [ "title", "description" ],

--- a/schemas/v1.2/modelsObject.json
+++ b/schemas/v1.2/modelsObject.json
@@ -1,6 +1,6 @@
 {
-    "id": "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/schemas/v1.2/modelsObject.json#",
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$id": "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/schemas/v1.2/modelsObject.json#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "required": [ "id", "properties" ],
     "properties": {

--- a/schemas/v1.2/oauth2GrantType.json
+++ b/schemas/v1.2/oauth2GrantType.json
@@ -1,6 +1,6 @@
 {
-    "id": "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/schemas/v1.2/oauth2GrantType.json#",
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$id": "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/schemas/v1.2/oauth2GrantType.json#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "minProperties": 1,
     "properties": {

--- a/schemas/v1.2/operationObject.json
+++ b/schemas/v1.2/operationObject.json
@@ -1,6 +1,6 @@
 {
-    "id": "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/schemas/v1.2/operationObject.json#",
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$id": "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/schemas/v1.2/operationObject.json#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "allOf": [
         { "$ref": "dataTypeBase.json#" },
@@ -50,8 +50,7 @@
         "rfc2616section10": {
             "type": "integer",
             "minimum": 100,
-            "maximum": 600,
-            "exclusiveMaximum": true
+            "exclusiveMaximum": 600
         },
         "mimeTypeArray": {
             "type": "array",

--- a/schemas/v1.2/parameterObject.json
+++ b/schemas/v1.2/parameterObject.json
@@ -1,6 +1,6 @@
 {
-    "id": "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/schemas/v1.2/parameterObject.json#",
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$id": "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/schemas/v1.2/parameterObject.json#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "allOf": [
         { "$ref": "dataTypeBase.json#" },

--- a/schemas/v1.2/resourceListing.json
+++ b/schemas/v1.2/resourceListing.json
@@ -1,6 +1,6 @@
 {
-    "id": "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/schemas/v1.2/resourceListing.json#",
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$id": "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/schemas/v1.2/resourceListing.json#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "required": [ "swaggerVersion", "apis" ],
     "properties": {

--- a/schemas/v1.2/resourceObject.json
+++ b/schemas/v1.2/resourceObject.json
@@ -1,10 +1,10 @@
 {
-    "id": "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/schemas/v1.2/resourceObject.json#",
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$id": "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/schemas/v1.2/resourceObject.json#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "required": [ "path" ],
     "properties": {
-        "path": { "type": "string", "format": "uri" },
+        "path": { "type": "string", "format": "uri-reference" },
         "description": { "type": "string" }
     },
     "additionalProperties": false


### PR DESCRIPTION
Title pretty much says it all :)

This allows differentiating between the `uri` and `uri-reference` format. Draft-04 was [ambiguous](https://json-schema.org/understanding-json-schema/reference/string.html#resource-identifiers) in that regard, causing false-positive validation failures with some validator implementations.