### PR TITLE
Remove maxLength for operationObject/summary in the v1.2 schema

### DIFF
--- a/schemas/v1.2/operationObject.json
+++ b/schemas/v1.2/operationObject.json
@@ -8,7 +8,7 @@
             "required": [ "method", "nickname", "parameters" ],
             "properties": {
                 "method": { "enum": [ "GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS" ] },
-                "summary": { "type": "string", "maxLength": 120 },
+                "summary": { "type": "string" },
                 "notes": { "type": "string" },
                 "nickname": {
                     "type": "string",


### PR DESCRIPTION
Title pretty much says it all :)

See [section 5.2.3](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/1.2.md#523-operation-object) of the v1.2 spec. The maximum of 120 characters is a "SHOULD", which according to RFC 2119 is a mere recommendation.