### PR TITLE
Publish v3.1 schemas version 2022-10-07

### DIFF
--- a/schemas/v3.1/schema-base.json
+++ b/schemas/v3.1/schema-base.json
@@ -1,10 +1,10 @@
 {
-  "$id": "https://spec.openapis.org/oas/3.1/schema-base/2022-02-27",
+  "$id": "https://spec.openapis.org/oas/3.1/schema-base/2022-10-07",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
 
   "description": "The description of OpenAPI v3.1.x documents using the OpenAPI JSON Schema dialect, as defined by https://spec.openapis.org/oas/v3.1.0",
 
-  "$ref": "https://spec.openapis.org/oas/3.1/schema/2022-02-27",
+  "$ref": "https://spec.openapis.org/oas/3.1/schema/2022-10-07",
   "properties": {
     "jsonSchemaDialect": { "$ref": "#/$defs/dialect" }
   },

--- a/schemas/v3.1/schema-base.yaml
+++ b/schemas/v3.1/schema-base.yaml
@@ -1,9 +1,9 @@
-$id: 'https://spec.openapis.org/oas/3.1/schema-base/2022-02-27'
+$id: 'https://spec.openapis.org/oas/3.1/schema-base/2022-10-07'
 $schema: 'https://json-schema.org/draft/2020-12/schema'
 
 description: The description of OpenAPI v3.1.x documents using the OpenAPI JSON Schema dialect, as defined by https://spec.openapis.org/oas/v3.1.0
 
-$ref: 'https://spec.openapis.org/oas/3.1/schema/2022-02-27'
+$ref: 'https://spec.openapis.org/oas/3.1/schema/2022-10-07'
 properties:
   jsonSchemaDialect:
     $ref: '#/$defs/dialect'

--- a/schemas/v3.1/schema.json
+++ b/schemas/v3.1/schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://spec.openapis.org/oas/3.1/schema/2022-02-27",
+  "$id": "https://spec.openapis.org/oas/3.1/schema/2022-10-07",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "The description of OpenAPI v3.1.x documents without schema validation, as defined by https://spec.openapis.org/oas/v3.1.0",
   "type": "object",
@@ -22,7 +22,9 @@
         "$ref": "#/$defs/server"
       },
       "default": [
-        { "url": "/" }
+        {
+          "url": "/"
+        }
       ]
     },
     "paths": {
@@ -148,18 +150,15 @@
       "required": [
         "name"
       ],
-      "oneOf": [
-        {
-          "required": [
-            "identifier"
-          ]
-        },
-        {
-          "required": [
-            "url"
-          ]
+      "dependentSchemas": {
+        "identifier": {
+          "not": {
+            "required": [
+              "url"
+            ]
+          }
         }
-      ],
+      },
       "$ref": "#/$defs/specification-extensions",
       "unevaluatedProperties": false
     },

--- a/schemas/v3.1/schema.yaml
+++ b/schemas/v3.1/schema.yaml
@@ -1,4 +1,4 @@
-$id: 'https://spec.openapis.org/oas/3.1/schema/2022-02-27'
+$id: 'https://spec.openapis.org/oas/3.1/schema/2022-10-07'
 $schema: 'https://json-schema.org/draft/2020-12/schema'
 
 description: The description of OpenAPI v3.1.x documents without schema validation, as defined by https://spec.openapis.org/oas/v3.1.0

--- a/tests/v3.1/test.js
+++ b/tests/v3.1/test.js
@@ -14,7 +14,7 @@ before(async () => {
   JsonSchema.add(dialect);
   JsonSchema.add(vocabulary);
   JsonSchema.add(yaml.parse(fs.readFileSync(`${__dirname}/../../schemas/v3.1/schema.yaml`, "utf8"), { prettyErrors: true }));
-  metaSchema = await JsonSchema.get("https://spec.openapis.org/oas/3.1/schema/2022-02-27");
+  metaSchema = await JsonSchema.get("https://spec.openapis.org/oas/3.1/schema/2022-10-07");
 });
 
 describe("v3.1 Pass", () => {


### PR DESCRIPTION
Updates schemas for publishing version 2022-10-07. The new version includes updates from https://github.com/OAI/OpenAPI-Specification/pull/3026 and https://github.com/OAI/OpenAPI-Specification/pull/2991