### PR TITLE
Update to create next agenda on Thursday at 16:00 UTC (sometimes 8am PST)

### DIFF
--- a/.github/workflows/agenda.yaml
+++ b/.github/workflows/agenda.yaml
@@ -11,7 +11,7 @@ name: agenda
 
 on:
   schedule:
-    - cron: '0 9 * * 1'
+    - cron: '0 16 * * 4'
   workflow_dispatch: {}
   
 jobs:


### PR DESCRIPTION
Create the agenda for the next weeks meeting so that we can plan for what will be on the next meeting at the end of the current meeting.  This will help to provide visibility into the planned topic and give more opportunities for people to add issues to the agenda.