### PR TITLE
Enforce documented /pets pagination size limit

### DIFF
--- a/examples/v3.0/petstore.yaml
+++ b/examples/v3.0/petstore.yaml
@@ -20,6 +20,7 @@ paths:
           required: false
           schema:
             type: integer
+            maximum: 100
             format: int32
       responses:
         '200':
@@ -96,6 +97,7 @@ components:
           type: string
     Pets:
       type: array
+      maxItems: 100
       items:
         $ref: "#/components/schemas/Pet"
     Error:


### PR DESCRIPTION
This (very petty) PR updates the petstore example appspec to more appropriately enforce the restriction of the `GET /pets` response being paginated to include a maximum of 100 pets at a time as per its 6 year old description ("How many items to return at one time (max 100)").