### PR TITLE
require that responses object has 'default' or a response code (fixes #2833)

### DIFF
--- a/schemas/v3.1/schema.json
+++ b/schemas/v3.1/schema.json
@@ -840,7 +840,16 @@
       },
       "minProperties": 1,
       "$ref": "#/$defs/specification-extensions",
-      "unevaluatedProperties": false
+      "unevaluatedProperties": false,
+      "if": {
+        "$comment": "either default, or at least one response code property must exist",
+        "patternProperties": {
+          "^[1-5](?:[0-9]{2}|XX)$": false
+        }
+      },
+      "then" : {
+        "required": [ "default" ]
+      }
     },
     "response": {
       "$comment": "https://spec.openapis.org/oas/v3.1.0#response-object",

--- a/schemas/v3.1/schema.yaml
+++ b/schemas/v3.1/schema.yaml
@@ -574,6 +574,12 @@ $defs:
     minProperties: 1
     $ref: '#/$defs/specification-extensions'
     unevaluatedProperties: false
+    if:
+      $comment: either default, or at least one response code property must exist
+      patternProperties:
+        '^[1-5](?:[0-9]{2}|XX)$': false
+    then:
+      required: [default]
 
   response:
     $comment: https://spec.openapis.org/oas/v3.1.0#response-object


### PR DESCRIPTION
ref. https://spec.openapis.org/oas/v3.1.0#responses-object

I realized that there is a way of saying "the patternProperties keyword must match something", by using a `false` in a conditional.

We decided in https://github.com/OAI/OpenAPI-Specification/pull/2799 that a numeric response code was not required as long as `default` was present instead.

I tested it with the following test cases (using the format used by https://github.com/json-schema-org/JSON-Schema-Test-Suite).

```json
[
    {
        "description": "openapi v3.1 test stuff",
        "schema": {
          "$defs": {
            "specification-extensions": {
              "patternProperties": {
                "^x-": true
              }
            }
          },
          "type": "object",
          "properties": {
            "default": true
          },
          "patternProperties": {
            "^[1-5](?:[0-9]{2}|XX)$": true
          },
          "minProperties": 1,
          "$ref": "#/$defs/specification-extensions",
          "unevaluatedProperties": false,
          "$comment": "either default, or at least one response code property must exist",
          "if": {
            "patternProperties": {
              "^[1-5](?:[0-9]{2}|XX)$": false
            }
          },
          "then" : {
            "required": [ "default" ]
          }
        },
        "tests": [
            {
                "description": "one number property",
                "data": { "400": true },
                "valid": true
            },
            {
                "description": "one number property and x-",
                "data": { "400": true, "x-blah": 1 },
                "valid": true
            },
            {
                "description": "default property",
                "data": { "default": true },
                "valid": true
            },
            {
                "description": "default property and x-",
                "data": { "default": true, "x-blah": 1 },
                "valid": true
            },
            {
                "description": "one number property and x-, extra fields not permitted",
                "data": { "400": true, "bloop": 1 },
                "valid": false
            },
            {
                "description": "one number property and x-, extra fields not permitted",
                "data": { "400": true, "x-blah": 1, "bloop": 1 },
                "valid": false
            },
            {
                "description": "default property, extra fields not permitted",
                "data": { "default": true, "bloop": 1 },
                "valid": false
            },
            {
                "description": "default property and x-",
                "data": { "default": true, "x-blah": 1, "bloop": 1 },
                "valid": false
            },
            {
                "description": "no properties",
                "data": {},
                "valid": false
            },
            {
                "description": "no required properties, with x-",
                "data": { "x-blah": 1 },
                "valid": false
            },
            {
                "description": "no required properties, extra properties not permitted-",
                "data": { "bloop": 1 },
                "valid": false
            }
        ]
    }
]
```