### PR TITLE
Add new extension namespace registry

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -30,3 +30,8 @@ collections:
     name: Alternative Schema Type Registry
     output: true
     permalink: /registry/:collection/:title
+  namespace:
+    slug: namespace
+    name: Extension Namespace Registry
+    output: true
+    permalink: /registry/:collection/:title

--- a/api/namespace.json
+++ b/api/namespace.json
@@ -1,0 +1,11 @@
+---
+---
+{
+{% for page in site.namespace %}"{{ page.slug }}": {
+  "slug": "{{ page.slug }}",
+  "issue": "{{ page.issue }}",
+  "description": "{{ page.description }}",
+  "owner": "{{ page.owner }}"
+}{% unless forloop.last %},{% endunless %}
+{% endfor %}
+}

--- a/registries/_namespace/ms.md
+++ b/registries/_namespace/ms.md
@@ -1,0 +1,19 @@
+---
+owner: DarrelMiller
+issue: 
+description: Extensions created and used by Microsoft
+layout: default
+---
+
+# <a href="..">{{ page.collection }}</a>
+
+## {{ page.slug }} - {{ page.description }}
+
+
+The `x-{{page.slug}}-` prefix is reserved for extensions created by Microsoft. These extensions are available for use by anyone.
+
+{% if page.issue %}
+### GitHub Issue
+
+* [#{{ page.issue }}](https://github.com/OAI/OpenAPI-Specification/issues/{{ page.issue }})
+{% endif %}

--- a/registries/_namespace/oas-draft.md
+++ b/registries/_namespace/oas-draft.md
@@ -1,0 +1,19 @@
+---
+owner: DarrelMiller
+issue: 
+description: Extensions created by OAI to indicate proposed changes to the OAS specification
+layout: default
+---
+
+# <a href="..">{{ page.collection }}</a>
+
+## {{ page.slug }} - {{ page.description }}
+
+
+The `x-{{page.slug}}-` prefix is reserved for extensions created as part of the [draft features(https://github.com/OAI/OpenAPI-Specification/blob/main/DEVELOPMENT.md#draft-features)] process. These extensions are available for use by anyone.
+
+{% if page.issue %}
+### GitHub Issue
+
+* [#{{ page.issue }}](https://github.com/OAI/OpenAPI-Specification/issues/{{ page.issue }})
+{% endif %}

--- a/registry/format.md
+++ b/registry/format.md
@@ -16,7 +16,7 @@ Please raise a [Pull-Request](https://github.com/OAI/OpenAPI-Specification/pulls
 ## Values
 
 |Value|Description|Issue|
-|---|---|---|
+|---|---|---|---|
 {% for value in site.format %}| <a href="/registry/format/{{ value.slug }}.html">{{ value.slug }}</a> | {{ value.description }} | {% if value.issue %}<a href="https://github.com/OAI/OpenAPI-Specification/issues/{{ value.issue }}">#{{ value.issue }}</a>{% endif %} |
 {% endfor %}
 

--- a/registry/format.md
+++ b/registry/format.md
@@ -16,7 +16,7 @@ Please raise a [Pull-Request](https://github.com/OAI/OpenAPI-Specification/pulls
 ## Values
 
 |Value|Description|Issue|
-|---|---|---|---|
+|---|---|---|
 {% for value in site.format %}| <a href="/registry/format/{{ value.slug }}.html">{{ value.slug }}</a> | {{ value.description }} | {% if value.issue %}<a href="https://github.com/OAI/OpenAPI-Specification/issues/{{ value.issue }}">#{{ value.issue }}</a>{% endif %} |
 {% endfor %}
 

--- a/registry/index.md
+++ b/registry/index.md
@@ -5,7 +5,7 @@ permalink: /registry/index.html
 
 ## Contributing
 
-Please raise a [Pull-Request](https://github.com/OAI/OpenAPI-Specification/pulls) or [Issue](https://github.com/OAI/OpenAPI-Specification/issues) to contribute or discuss a registry value.
+Please raise a [Pull-Request](https://github.com/OAI/OpenAPI-Specification/pulls) against the `gh-pages` branch and add a new file to a folder in the `registries/_{registryName}`. The name of the file is considered the registration entry, ignoring the file extension. Alternatively you can open an issue [Issue](https://github.com/OAI/OpenAPI-Specification/issues) to discuss a registry value.
 
 ### Contents
 

--- a/registry/index.md
+++ b/registry/index.md
@@ -5,7 +5,7 @@ permalink: /registry/index.html
 
 ## Contributing
 
-Please raise a [Pull-Request](https://github.com/OAI/OpenAPI-Specification/pulls) against the `gh-pages` branch and add a new file to a folder in the `registries/_{registryName}`. The name of the file is considered the registration entry, ignoring the file extension. Alternatively you can open an issue [Issue](https://github.com/OAI/OpenAPI-Specification/issues) to discuss a registry value.
+Please raise a [Pull-Request](https://github.com/OAI/OpenAPI-Specification/pulls) against the `gh-pages` branch and add a new Markdown file to a folder in the `registries/_{registryName}`. The name of the file is considered the registration entry, ignoring the file extension. Alternatively you can open an [Issue](https://github.com/OAI/OpenAPI-Specification/issues) to discuss a registry value.
 
 ### Contents
 

--- a/registry/namespace.md
+++ b/registry/namespace.md
@@ -1,0 +1,19 @@
+---
+layout: default
+permalink: /registry/namespace/index.html
+---
+
+# Namespace Registry
+
+To allow for creators of OpenAPI descriptions to define new extensions without the risk of name collisions, a namespace registry is maintained by OAI. The namespace registry is a simple list of unique identifiers that are used as part of a prefix for extensions to ensure uniqueness. A prefix has the format `x-{namespace}-` where `{namespace}` is a unique string associated to the creator of the extensions within the namespace. Namespace identifiers MUST be registered as lowercase identifiers.
+
+## Contributing
+
+Please raise a [Pull-Request](https://github.com/OAI/OpenAPI-Specification/pulls) or [Issue](https://github.com/OAI/OpenAPI-Specification/issues) to contribute or discuss a registry value.
+
+## Values
+
+|Value|Prefix|Description|Issue|
+|---|---|---|---|
+{% for value in site.namespace %}| <a href="/registry/namespace/{{ value.slug }}.html">{{ value.slug }}</a> | x-{{ value.slug }}-|{{ value.description }} | {% if value.issue %}<a href="https://github.com/OAI/OpenAPI-Specification/issues/{{ value.issue }}">#{{ value.issue }}</a>{% endif %} |
+{% endfor %}


### PR DESCRIPTION
In order to encourage the creation and registration of extensions in a central registry, this PR proposes creating a new namespace registry for extensions so that OpenAPI users can reserve an extension prefix for their organization to ensure uniqueness.