### PR TITLE
enforce existence of composite applicator keyword adjacent to "discriminator"

### DIFF
--- a/schemas/v3.1/meta/base.schema.json
+++ b/schemas/v3.1/meta/base.schema.json
@@ -18,6 +18,15 @@
         "externalDocs": { "$ref": "#/$defs/external-docs" },
         "xml": { "$ref": "#/$defs/xml" }
     },
+    "dependentSchemas": {
+      "discriminator": {
+        "anyOf": [
+          { "required": [ "oneOf" ] },
+          { "required": [ "anyOf" ] },
+          { "required": [ "allOf" ] }
+        ]
+      }
+    },
 
     "$defs": {
         "extensible": {

--- a/schemas/v3.1/meta/base.schema.yaml
+++ b/schemas/v3.1/meta/base.schema.yaml
@@ -20,6 +20,12 @@ properties:
     $ref: '#/$defs/external-docs'
   xml:
     $ref: '#/$defs/xml'
+dependentSchemas:
+  discriminator:
+    anyOf:
+    - required: [oneOf]
+    - required: [anyOf]
+    - required: [allOf]
 
 $defs:
   discriminator:


### PR DESCRIPTION
"The discriminator object is legal only when using one of the composite keywords oneOf, anyOf, allOf."
https://spec.openapis.org/oas/v3.1.0#discriminator-object