### PR TITLE
fix: typo in style example

### DIFF
--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -1077,7 +1077,7 @@ The following table shows examples of rendering differences for each value.
 ----------- | ------ | -------- | -------- | -------- | -------
 matrix | false | ;color | ;color=blue | ;color=blue,black,brown | ;color=R,100,G,200,B,150
 matrix | true | ;color | ;color=blue | ;color=blue;color=black;color=brown | ;R=100;G=200;B=150
-label | false | .  | .blue |  .blue.black.brown | .R.100.G.200.B.150
+label | false | .  | .blue |  .blue,black,brown | .R,100,G,200,B,150
 label | true | . | .blue |  .blue.black.brown | .R=100.G=200.B=150
 form | false | color= | color=blue | color=blue,black,brown | color=R,100,G,200,B,150
 form | true | color= | color=blue | color=blue&color=black&color=brown | R=100&G=200&B=150


### PR DESCRIPTION
The example for style=label, explode=false in https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#style-examples is incorrect, see comment https://github.com/OAI/OpenAPI-Specification/issues/1508#issuecomment-373590520 from @darrelmiller and the examples in https://swagger.io/docs/specification/serialization/.

The latter source states the RFC6570 template for style=label, explode=false as `{.id}` for a parameter named `id`, which is consistent with using commas as separators after the leading dot.

Fixes #3139

Thanks to @pk-work for finding this typo.