### PR TITLE
fix(petstore): Set to correct api url

### DIFF
--- a/examples/v3.0/petstore-expanded.yaml
+++ b/examples/v3.0/petstore-expanded.yaml
@@ -12,7 +12,7 @@ info:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
 servers:
-  - url: http://petstore.swagger.io/api
+  - url: https://petstore.swagger.io
 paths:
   /pets:
     get:

--- a/examples/v3.0/petstore-expanded.yaml
+++ b/examples/v3.0/petstore-expanded.yaml
@@ -12,7 +12,7 @@ info:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
 servers:
-  - url: https://petstore.swagger.io
+  - url: https://petstore.swagger.io/v2
 paths:
   /pets:
     get:


### PR DESCRIPTION
Petstore api is now listening at: https://petstore.swagger.io/