### PR TITLE
fix(docs): update invalid schema property in Encoding Object example

### DIFF
--- a/versions/3.0.4.md
+++ b/versions/3.0.4.md
@@ -1569,7 +1569,7 @@ requestBody:
             # default Content-Type for arrays is based on the `inner` type (object shown, so `application/json` in this example)
             type: array
             items:
-              type: '#/components/schemas/Address'
+              $ref: '#/components/schemas/Address'
 ```
 
 An `encoding` attribute is introduced to give you control over the serialization of parts of `multipart` request bodies.  This attribute is _only_ applicable to `multipart` and `application/x-www-form-urlencoded` request bodies.


### PR DESCRIPTION
closes #3170 