### PR TITLE
Make registry internal links relative [gh-pages]

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This site contains the OpenAPI Initiative Registry and content for the HTML vers
 
 ## Registry
 
-* Proceed to [Registry](/registry/index.html)
+* Proceed to [Registry](./registry/index.html)
 
 ## The Specification
 

--- a/index.md
+++ b/index.md
@@ -8,7 +8,7 @@ This site contains the OpenAPI Initiative Registry and content for the HTML vers
 
 ## Registry
 
-* Proceed to [Registry](/registry/index.html)
+* Proceed to [Registry](./registry/index.html)
 
 ## The Specification
 

--- a/registry/alternative-schema.md
+++ b/registry/alternative-schema.md
@@ -17,6 +17,6 @@ Please raise a [Pull-Request](https://github.com/OAI/OpenAPI-Specification/pulls
 
 |Value|Description|Issue|
 |---|---|---|
-{% for value in site.alternative-schema %}| <a href="/registry/alternative-schema/{{ value.slug }}.html">{{ value.slug }}</a> | <a id="{{ value.slug }}"/>{{ value.description }} | {% if value.issue %}<a href="https://github.com/OAI/OpenAPI-Specification/issues/{{ value.issue }}">#{{ value.issue }}</a>{% endif %} |
+{% for value in site.alternative-schema %}| <a href="./{{ value.slug }}.html">{{ value.slug }}</a> | <a id="{{ value.slug }}"/>{{ value.description }} | {% if value.issue %}<a href="https://github.com/OAI/OpenAPI-Specification/issues/{{ value.issue }}">#{{ value.issue }}</a>{% endif %} |
 {% endfor %}
 

--- a/registry/draft-feature.md
+++ b/registry/draft-feature.md
@@ -17,6 +17,6 @@ Please raise a [Pull-Request](https://github.com/OAI/OpenAPI-Specification/pulls
 
 |Value|Description|Issue|
 |---|---|---|
-{% for value in site.draft-feature %}| <a href="/registry/draft-feature/{{ value.slug }}.html">{{ value.slug }}</a> | {{ value.description }} | {% if value.issue %}<a href="https://github.com/OAI/OpenAPI-Specification/issues/{{ value.issue }}">#{{ value.issue }}</a>{% endif %} |
+{% for value in site.draft-feature %}| <a href="./{{ value.slug }}.html">{{ value.slug }}</a> | {{ value.description }} | {% if value.issue %}<a href="https://github.com/OAI/OpenAPI-Specification/issues/{{ value.issue }}">#{{ value.issue }}</a>{% endif %} |
 {% endfor %}
 

--- a/registry/extension.md
+++ b/registry/extension.md
@@ -17,6 +17,6 @@ Please raise a [Pull-Request](https://github.com/OAI/OpenAPI-Specification/pulls
 
 |Value|Description|Issue|
 |---|---|---|
-{% for value in site.extension %}| <a href="/registry/extension/{{ value.slug }}.html">{{ value.slug }}</a> | {{ value.description }} | {% if value.issue %}<a href="https://github.com/OAI/OpenAPI-Specification/issues/{{ value.issue }}">#{{ value.issue }}</a>{% endif %} |
+{% for value in site.extension %}| <a href="./{{ value.slug }}.html">{{ value.slug }}</a> | {{ value.description }} | {% if value.issue %}<a href="https://github.com/OAI/OpenAPI-Specification/issues/{{ value.issue }}">#{{ value.issue }}</a>{% endif %} |
 {% endfor %}
 

--- a/registry/format.md
+++ b/registry/format.md
@@ -17,6 +17,6 @@ Please raise a [Pull-Request](https://github.com/OAI/OpenAPI-Specification/pulls
 
 |Value|Description|Issue|
 |---|---|---|
-{% for value in site.format %}| <a href="/registry/format/{{ value.slug }}.html">{{ value.slug }}</a> | {{ value.description }} | {% if value.issue %}<a href="https://github.com/OAI/OpenAPI-Specification/issues/{{ value.issue }}">#{{ value.issue }}</a>{% endif %} |
+{% for value in site.format %}| <a href="./{{ value.slug }}.html">{{ value.slug }}</a> | {{ value.description }} | {% if value.issue %}<a href="https://github.com/OAI/OpenAPI-Specification/issues/{{ value.issue }}">#{{ value.issue }}</a>{% endif %} |
 {% endfor %}
 

--- a/registry/index.md
+++ b/registry/index.md
@@ -15,7 +15,7 @@ Please raise a [Pull-Request](https://github.com/OAI/OpenAPI-Specification/pulls
 #### API access
 
 * [registries.json](./api/registries.json) - Registries meta-registry
-{% for registry in site.collections %}{% unless registry.hidden %}* <a href="..//api/{{ registry.slug }}.json">{{ registry.slug }}.json</a>{% endunless %}
+{% for registry in site.collections %}{% unless registry.hidden %}* <a href="../api/{{ registry.slug }}.json">{{ registry.slug }}.json</a>{% endunless %}
 {% endfor %}
 
 #### RSS feed

--- a/registry/index.md
+++ b/registry/index.md
@@ -9,16 +9,16 @@ Please raise a [Pull-Request](https://github.com/OAI/OpenAPI-Specification/pulls
 
 ### Contents
 
-{% for registry in site.collections %}{% unless registry.hidden %}* <a href="/registry/{{ registry.slug }}">{{ registry.name }}{% endunless %}
+{% for registry in site.collections %}{% unless registry.hidden %}* <a href="./{{ registry.slug }}">{{ registry.name }}{% endunless %}
 {% endfor %}
 
 #### API access
 
-* [registries.json](/api/registries.json) - Registries meta-registry
-{% for registry in site.collections %}{% unless registry.hidden %}* <a href="/api/{{ registry.slug }}.json">{{ registry.slug }}.json</a>{% endunless %}
+* [registries.json](./api/registries.json) - Registries meta-registry
+{% for registry in site.collections %}{% unless registry.hidden %}* <a href="..//api/{{ registry.slug }}.json">{{ registry.slug }}.json</a>{% endunless %}
 {% endfor %}
 
 #### RSS feed
 
-* [feed.xml](/rss/feed.xml)
+* [feed.xml](./rss/feed.xml)
 

--- a/registry/index.md
+++ b/registry/index.md
@@ -20,5 +20,5 @@ Please raise a [Pull-Request](https://github.com/OAI/OpenAPI-Specification/pulls
 
 #### RSS feed
 
-* [feed.xml](./rss/feed.xml)
+* [feed.xml](../rss/feed.xml)
 

--- a/registry/namespace.md
+++ b/registry/namespace.md
@@ -15,5 +15,5 @@ Please raise a [Pull-Request](https://github.com/OAI/OpenAPI-Specification/pulls
 
 |Value|Prefix|Description|Issue|
 |---|---|---|---|
-{% for value in site.namespace %}| <a href="/registry/namespace/{{ value.slug }}.html">{{ value.slug }}</a> | x-{{ value.slug }}-|{{ value.description }} | {% if value.issue %}<a href="https://github.com/OAI/OpenAPI-Specification/issues/{{ value.issue }}">#{{ value.issue }}</a>{% endif %} |
+{% for value in site.namespace %}| <a href="./{{ value.slug }}.html">{{ value.slug }}</a> | x-{{ value.slug }}-|{{ value.description }} | {% if value.issue %}<a href="https://github.com/OAI/OpenAPI-Specification/issues/{{ value.issue }}">#{{ value.issue }}</a>{% endif %} |
 {% endfor %}


### PR DESCRIPTION
This allows [renderings of forks](https://handrews.github.io/OpenAPI-Specification/) to work.  Otherwise the links all 404 because forks are rendered under a directory name.