### PR TITLE
format:base64 doesn't exist -> format:byte

### DIFF
--- a/versions/3.0.4.md
+++ b/versions/3.0.4.md
@@ -162,10 +162,8 @@ The formats defined by the OAS are:
 `integer` | `int64` | signed 64 bits (a.k.a long)
 `number` | `float` | |
 `number` | `double` | |
-`string` | | |
 `string` | `byte` | base64 encoded characters
 `string` | `binary` | any sequence of octets
-`boolean` | | |
 `string` | `date` | As defined by `full-date` - [RFC3339](https://xml2rfc.ietf.org/public/rfc/html/rfc3339.html#anchor14)
 `string` | `date-time` | As defined by `date-time` - [RFC3339](https://xml2rfc.ietf.org/public/rfc/html/rfc3339.html#anchor14)
 `string` | `password` | A hint to UIs to obscure input.

--- a/versions/3.0.4.md
+++ b/versions/3.0.4.md
@@ -1446,7 +1446,7 @@ In contrast with the 2.0 specification, `file` input/output content in OpenAPI i
 # content transferred with base64 encoding
 schema:
   type: string
-  format: base64
+  format: byte
 ```
 
 ```yaml
@@ -1537,7 +1537,7 @@ When passing in `multipart` types, boundaries MAY be used to separate sections o
 
 * If the property is a primitive, or an array of primitive values, the default Content-Type is `text/plain`
 * If the property is complex, or an array of complex values, the default Content-Type is `application/json`
-* If the property is a `type: string` with `format: binary` or `format: base64` (aka a file object), the default Content-Type is `application/octet-stream`
+* If the property is a `type: string` with `format: binary` or `format: byte` (aka a file object), the default Content-Type is `application/octet-stream`
 
 
 Examples:


### PR DESCRIPTION
- Fixes https://github.com/OAI/OpenAPI-Specification/issues/3174
- Removes lines without format from Data Formats table