### PR TITLE
Fix broken RFC links

### DIFF
--- a/versions/3.0.4.md
+++ b/versions/3.0.4.md
@@ -164,8 +164,8 @@ The formats defined by the OAS are:
 `number` | `double` | |
 `string` | `byte` | base64 encoded characters
 `string` | `binary` | any sequence of octets
-`string` | `date` | As defined by `full-date` - [RFC3339](https://xml2rfc.ietf.org/public/rfc/html/rfc3339.html#anchor14)
-`string` | `date-time` | As defined by `date-time` - [RFC3339](https://xml2rfc.ietf.org/public/rfc/html/rfc3339.html#anchor14)
+`string` | `date` | As defined by `full-date` - [RFC3339](https://www.rfc-editor.org/rfc/rfc3339#section-5.6)
+`string` | `date-time` | As defined by `date-time` - [RFC3339](https://www.rfc-editor.org/rfc/rfc3339#section-5.6)
 `string` | `password` | A hint to UIs to obscure input.
 
 
@@ -1523,7 +1523,7 @@ requestBody:
             properties: {}
 ```
 
-In this example, the contents in the `requestBody` MUST be stringified per [RFC1866](https://tools.ietf.org/html/rfc1866/) when passed to the server.  In addition, the `address` field complex object will be stringified.
+In this example, the contents in the `requestBody` MUST be stringified per [RFC1866](https://tools.ietf.org/html/rfc1866) when passed to the server.  In addition, the `address` field complex object will be stringified.
 
 When passing complex objects in the `application/x-www-form-urlencoded` content type, the default serialization strategy of such properties is described in the [`Encoding Object`](#encodingObject)'s [`style`](#encodingStyle) property as `form`.
 


### PR DESCRIPTION
Fixes #3146.

The IETF apparenlty decided to redo everything about publishing RFCs, and while most of the old URLs redirect, these ones for RFC 3339 did not.  Also, there was a stray trailing '/' that broke another RFC link.