### PR TITLE
Don't allow explode: true for cookie parameters

### DIFF
--- a/schemas/v3.1/schema.yaml
+++ b/schemas/v3.1/schema.yaml
@@ -438,7 +438,9 @@ $defs:
                 style:
                   default: form
                   const: form
-
+                explode:
+                  default: false
+                  const: false
           styles-for-form:
             if:
               properties:


### PR DESCRIPTION
This changes the 3.1 schema to not allow `explode: true` for cookie parameters.  Supporting `explode: true` for cookie parameters with array values would end up in a header like ~~`Cookie: ids=1; ids=2`~~ `[UPDATE: I don't know]`, right? I was asking myself if that would be allowed and could not find an explicit "yes" in the spec. I assume it should not be supported.

The description of the 3.0 version on the Swagger site implies that `explode: true` is not supported for cookie parameters:  https://swagger.io/docs/specification/serialization/#cookie
