### PR TITLE
Update decimal.md

### DIFF
--- a/registries/_format/decimal.md
+++ b/registries/_format/decimal.md
@@ -2,7 +2,7 @@
 owner: baywet
 issue: 889
 description: A fixed point decimal number of unspecified precision and range
-base_type: string|number
+base_type: string number
 layout: default
 remarks: This format is used in a variety of conflicting ways and is not interoperable.
 ---


### PR DESCRIPTION
Fix formatting of registry entry for `decimal` format in https://spec.openapis.org/registry/format/

Formatting is currently off due to use of `|` in "Type" field:
![image](https://user-images.githubusercontent.com/951576/226667903-1eb817a2-a9d1-422e-9eb5-8a27048360ed.png)

Using a space instead produces:
![image](https://user-images.githubusercontent.com/951576/226668033-faed2423-9277-439d-9e59-5743b6b445ed.png)
