### PR TITLE
Register format decimal128

### DIFF
--- a/registries/_format/decimal128.md
+++ b/registries/_format/decimal128.md
@@ -2,7 +2,7 @@
 owner:
 issue:
 description: A decimal floating-point number with 34 significant decimal digits
-base_type: string number
+base_type: string, number
 layout: default
 ---
 

--- a/registries/_format/decimal128.md
+++ b/registries/_format/decimal128.md
@@ -14,6 +14,10 @@ Base type: `{{ page.base_type }}`.
 
 The `{{page.slug}}` format represents a [128-bit decimal floating-point number](https://en.wikipedia.org/wiki/Decimal128_floating-point_format) as defined by IEEE 754 2008 and ISO/IEC/IEEE 60559:2011.
 
+Representation as a JSON string is preferred as this avoids problems with recipients that parse JSON numbers into [binary64](https://en.wikipedia.org/wiki/Double-precision_floating-point_format) memory representation.
+
+String representation allows expressing the special values `NaN`, `-INF`, and `INF` that cannot be expressed as JSON numbers.
+
 {% if page.issue %}
 ### GitHub Issue
 

--- a/registries/_format/decimal128.md
+++ b/registries/_format/decimal128.md
@@ -1,0 +1,27 @@
+---
+owner:
+issue:
+description: A decimal floating-point number with 34 significant decimal digits
+base_type: string number
+layout: default
+---
+
+# <a href="..">{{ page.collection }}</a>
+
+## {{ page.slug }} - {{ page.description }}
+
+Base type: `{{ page.base_type }}`.
+
+The `{{page.slug}}` format represents a [128-bit decimal floating-point number](https://en.wikipedia.org/wiki/Decimal128_floating-point_format) as defined by IEEE 754 2008 and ISO/IEC/IEEE 60559:2011.
+
+{% if page.issue %}
+### GitHub Issue
+
+* [#{{ page.issue }}](https://github.com/OAI/OpenAPI-Specification/issues/{{ page.issue }})
+{% endif %}
+
+{% if page.remarks %}
+### Remarks
+
+{{ page.issue }}
+{% endif %}


### PR DESCRIPTION
Format for 128-bit decimal floating-point numbers as proposed in proposal in https://github.com/OAI/OpenAPI-Specification/pull/3190#issuecomment-1466611719.

Fixes #603 with proposal for representing `NaN`, `-INF`, and `INF`.