### PR TITLE
Fix for format decimal: comma-separated base_type list

### DIFF
--- a/registries/_format/decimal.md
+++ b/registries/_format/decimal.md
@@ -2,7 +2,7 @@
 owner: baywet
 issue: 889
 description: A fixed point decimal number of unspecified precision and range
-base_type: string number
+base_type: string, number
 layout: default
 remarks: This format is used in a variety of conflicting ways and is not interoperable.
 ---


### PR DESCRIPTION
As requested by @baywet 