### PR TITLE
Use `api-key` instead of `api_key` as example header name

### DIFF
--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -563,7 +563,7 @@ my.org.User
   "securitySchemes": {
     "api_key": {
       "type": "apiKey",
-      "name": "api_key",
+      "name": "api-key",
       "in": "header"
     },
     "petstore_auth": {
@@ -640,7 +640,7 @@ components:
   securitySchemes:
     api_key:
       type: apiKey
-      name: api_key
+      name: api-key
       in: header
     petstore_auth:
       type: oauth2
@@ -3226,14 +3226,14 @@ scheme: basic
 ```json
 {
   "type": "apiKey",
-  "name": "api_key",
+  "name": "api-key",
   "in": "header"
 }
 ```
 
 ```yaml
 type: apiKey
-name: api_key
+name: api-key
 in: header
 ```
 


### PR DESCRIPTION
Several HTTP servers drop http headers with underscores.

Fixes #3225