### PR TITLE
fix: update format for servers.url and links.operationRef in v3.1 schema

### DIFF
--- a/schemas/v3.1/schema.json
+++ b/schemas/v3.1/schema.json
@@ -168,7 +168,7 @@
       "properties": {
         "url": {
           "type": "string",
-          "format": "uri-reference"
+          "format": "templated-url"
         },
         "description": {
           "type": "string"
@@ -961,7 +961,7 @@
       "properties": {
         "operationRef": {
           "type": "string",
-          "format": "uri-reference"
+          "format": "templated-url"
         },
         "operationId": {
           "type": "string"

--- a/schemas/v3.1/schema.yaml
+++ b/schemas/v3.1/schema.yaml
@@ -119,7 +119,7 @@ $defs:
     properties:
       url:
         type: string
-        format: uri-reference
+        format: templated-url
       description:
         type: string
       variables:
@@ -664,7 +664,7 @@ $defs:
     properties:
       operationRef:
         type: string
-        format: uri-reference
+        format: templated-url
       operationId:
         type: string
       parameters:


### PR DESCRIPTION
`uri-reference` is not the right format for these properties, as they can contain unescaped `{` and `}` characters. As @jdesrosiers points out, they are not `uri-template` either, as they do not support RFC6570 URI templates in full.