### PR TITLE
Use $ref to definitions in oneOf for Parameter locations

### DIFF
--- a/schemas/v3.0/schema.yaml
+++ b/schemas/v3.0/schema.yaml
@@ -706,46 +706,51 @@ definitions:
     allOf:
       - $ref: '#/definitions/ExampleXORExamples'
       - $ref: '#/definitions/SchemaXORContent'
-      - $ref: '#/definitions/ParameterLocation'
-
-  ParameterLocation:
-    description: Parameter location
     oneOf:
-      - description: Parameter in path
-        required:
-          - required
-        properties:
-          in:
-            enum: [path]
-          style:
-            enum: [matrix, label, simple]
-            default: simple
-          required:
-            enum: [true]
+      - $ref: '#/definitions/PathParameter'
+      - $ref: '#/definitions/QueryParameter'
+      - $ref: '#/definitions/HeaderParameter'
+      - $ref: '#/definitions/CookieParameter'
 
-      - description: Parameter in query
-        properties:
-          in:
-            enum: [query]
-          style:
-            enum: [form, spaceDelimited, pipeDelimited, deepObject]
-            default: form
+  PathParameter:
+    description: Parameter in path
+    required:
+      - required
+    properties:
+      in:
+        enum: [path]
+      style:
+        enum: [matrix, label, simple]
+        default: simple
+      required:
+        enum: [true]
 
-      - description: Parameter in header
-        properties:
-          in:
-            enum: [header]
-          style:
-            enum: [simple]
-            default: simple
+  QueryParameter:
+    description: Parameter in query
+    properties:
+      in:
+        enum: [query]
+      style:
+        enum: [form, spaceDelimited, pipeDelimited, deepObject]
+        default: form
 
-      - description: Parameter in cookie
-        properties:
-          in:
-            enum: [cookie]
-          style:
-            enum: [form]
-            default: form
+  HeaderParameter:
+    description: Parameter in header
+    properties:
+      in:
+        enum: [header]
+      style:
+        enum: [simple]
+        default: simple
+
+  CookieParameter:
+    description: Parameter in cookie
+    properties:
+      in:
+        enum: [cookie]
+      style:
+        enum: [form]
+        default: form
 
   RequestBody:
     type: object


### PR DESCRIPTION
I'd like to use a JSON Merge Patch (RFC 7386) document to add keywords for the OAS compliance parser project.

JSON Merge Patch does not handle arrays well, so moving these to their own definitions and having the "oneOf" directly in the "Parameter" definition (avoiding duplicate "description" fields on the same instance location) allows merge-patch to work where I need it.

Otherwise, JSON Patch (RFC 6902) will be needed, which is less intuitive.

The 3.1 schema already uses "$defs" here.