### PR TITLE
Update list of Special Interest Groups

### DIFF
--- a/SPECIAL_INTEREST_GROUPS.md
+++ b/SPECIAL_INTEREST_GROUPS.md
@@ -1,1 +1,43 @@
+## Codegen
+> code-gen vocabulary special interest (working) group
 
+* Slack channel: #sig-codegen
+
+## Formats
+> Focusing on the Formats Registry efforts
+
+* Slack channel: #sig-formats
+
+## Lifecycle
+> A place to discuss how to represent how APIs change in time in the context of OpenAPI
+
+* Slack channel: #sig-lifecycle
+
+## Overlays
+> The Overlay specification defines a way of creating documents that contain information to be merged with an OpenAPI description at some later point in time, for the purpose of updating the OpenAPI description with additional information.
+
+* Github: https://github.com/OAI/Overlay-Specification
+* Slack channel: #sig-overlays
+
+## Security
+> Workgroup to shape security components of the OpenAPI Spec
+* Slack channel: #sig-security
+
+## SLA (Service Level Agreement)
+> Service level agreements and APIs.
+
+* Github: https://github.com/isa-group/SLA4OAI-TC
+* Slack channel: #sig-sla
+
+## Travel
+> An OpenAPI Initiative workgroup to address industry specific connective/API concerns of the travel industry
+
+* Slack channel: #sig-travel
+
+## Workflows
+> This is a channel dedicated to discussing workflows, automations, and scenarios.
+
+> The OpenAPI Specification provides a way to document individual API calls and how to use them, but it doesn't give insight into the common ways to sequence those operations. While all APIs can benefit from formally describing these workflows, this is particularly important when considering more complex or more secure APIs. 
+> The OpenAPI Workflows Special Interest Group was created to address this common problem. The goal is to construct a formal way to describe these sequences and support documentation of flows, such as a multi-part OAuth flow with JSON signing and refresh token behavior. 
+
+* Slack channel: #sig-workflows


### PR DESCRIPTION
The Special Interest Groups document was created, but no content was ever added.

This PR updates the document to list each Special Interest Group, along with a description of the group and a link to its Slack channel and Github repository where available.

### Methodology

This list is constructed from surveying Slack channels on the open-api.slack.com instance, specifically checking for channels prefixed `#sig-`.

After gathering the list of channels I checked each channel's topic and description, and surveyed (briefly) its history.

If there are groups I missed, please let me know.
If this document should contain different information, or be formatted differently, that's doable too.
If this document shouldn't really exist, that's fine too; I'd be happy to PR that removal in-lieu.