### PR TITLE
Add format for imf-fixdate used in HTTP headers

### DIFF
--- a/registries/_format/imf-fixdate.md
+++ b/registries/_format/imf-fixdate.md
@@ -1,0 +1,28 @@
+---
+owner: mikekistler
+issue: 
+description: date and time as defined by IMF-fixdate - [RFC7231](https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.1.1)
+base_type: string
+layout: default
+remarks: This format is appropriate for HTTP date headers.
+---
+
+# <a href="..">{{ page.collection }}</a>
+
+## {{ page.slug }} - {{ page.description }}
+
+Base type: `{{ page.base_type }}`.
+
+The `{{page.slug}}` format represents a date and time as defined by IMF-fixdate - [RFC7231](https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.1.1).
+
+{% if page.issue %}
+### GitHub Issue
+
+* [#{{ page.issue }}](https://github.com/OAI/OpenAPI-Specification/issues/{{ page.issue }})
+{% endif %}
+
+{% if page.remarks %}
+### Remarks
+
+{{ page.remarks }}
+{% endif %}

--- a/registries/_format/imf-fixdate.md
+++ b/registries/_format/imf-fixdate.md
@@ -4,7 +4,6 @@ issue:
 description: date and time as defined by IMF-fixdate - [RFC7231](https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.1.1)
 base_type: string
 layout: default
-remarks: This format is appropriate for HTTP date headers.
 ---
 
 # <a href="..">{{ page.collection }}</a>
@@ -14,6 +13,10 @@ remarks: This format is appropriate for HTTP date headers.
 Base type: `{{ page.base_type }}`.
 
 The `{{page.slug}}` format represents a date and time as defined by IMF-fixdate - [RFC7231](https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.1.1).
+
+Example: "Sun, 06 Nov 1994 08:49:37 GMT"
+
+This is the preferred format for dates passed in HTTP headers.
 
 {% if page.issue %}
 ### GitHub Issue


### PR DESCRIPTION
This PR adds a new format for the date-time format used in HTTP headers, as described in [RFC 7231, Section 7.1.1.1](https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.1.1).