### PR TITLE
Replace imf-fixdate with the more general and useful http-date

### DIFF
--- a/registries/_format/http-date.md
+++ b/registries/_format/http-date.md
@@ -1,7 +1,7 @@
 ---
 owner: mikekistler
 issue: 
-description: date and time as defined by IMF-fixdate - [RFC7231](https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.1.1)
+description: date and time as defined by HTTP-date - [RFC7231](https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.1.1)
 base_type: string
 layout: default
 ---
@@ -12,11 +12,11 @@ layout: default
 
 Base type: `{{ page.base_type }}`.
 
-The `{{page.slug}}` format represents a date and time as defined by IMF-fixdate - [RFC7231](https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.1.1).
+The `{{page.slug}}` format represents a date and time as defined by HTTP-date - [RFC7231](https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.1.1).
 
 Example: "Sun, 06 Nov 1994 08:49:37 GMT"
 
-This is the preferred format for dates passed in HTTP headers.
+This is the format for dates passed in HTTP headers.
 
 {% if page.issue %}
 ### GitHub Issue


### PR DESCRIPTION
This PR replaces the (just added) imf-date format with http-date, which is more general and likely more useful, particularly for request headers.