### PR TITLE
Correct Data Type: date-time RFC-3339 reference link

### DIFF
--- a/versions/2.0.md
+++ b/versions/2.0.md
@@ -92,8 +92,8 @@ string | `string` | | |
 byte | `string` | `byte` | base64 encoded characters
 binary | `string` | `binary` | any sequence of octets
 boolean | `boolean` | | |
-date | `string` | `date` | As defined by `full-date` - [RFC3339](http://xml2rfc.ietf.org/public/rfc/html/rfc3339.html#anchor14)
-dateTime | `string` | `date-time` | As defined by `date-time` - [RFC3339](http://xml2rfc.ietf.org/public/rfc/html/rfc3339.html#anchor14)
+date | `string` | `date` | As defined by `full-date` - [RFC3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6)
+dateTime | `string` | `date-time` | As defined by `date-time` - [RFC3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6)
 password | `string` | `password` | Used to hint UIs the input needs to be obscured.
 
 ### Schema

--- a/versions/3.0.0.md
+++ b/versions/3.0.0.md
@@ -161,8 +161,8 @@ string | `string` | | |
 byte | `string` | `byte` | base64 encoded characters
 binary | `string` | `binary` | any sequence of octets
 boolean | `boolean` | | |
-date | `string` | `date` | As defined by `full-date` - [RFC3339](http://xml2rfc.ietf.org/public/rfc/html/rfc3339.html#anchor14)
-dateTime | `string` | `date-time` | As defined by `date-time` - [RFC3339](http://xml2rfc.ietf.org/public/rfc/html/rfc3339.html#anchor14)
+date | `string` | `date` | As defined by `full-date` - [RFC3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6)
+dateTime | `string` | `date-time` | As defined by `date-time` - [RFC3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6)
 password | `string` | `password` | A hint to UIs to obscure input.
 
 ### <a name="richText"></a>Rich Text Formatting

--- a/versions/3.0.1.md
+++ b/versions/3.0.1.md
@@ -161,8 +161,8 @@ string | `string` | | |
 byte | `string` | `byte` | base64 encoded characters
 binary | `string` | `binary` | any sequence of octets
 boolean | `boolean` | | |
-date | `string` | `date` | As defined by `full-date` - [RFC3339](https://xml2rfc.ietf.org/public/rfc/html/rfc3339.html#anchor14)
-dateTime | `string` | `date-time` | As defined by `date-time` - [RFC3339](https://xml2rfc.ietf.org/public/rfc/html/rfc3339.html#anchor14)
+date | `string` | `date` | As defined by `full-date` - [RFC3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6)
+dateTime | `string` | `date-time` | As defined by `date-time` - [RFC3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6)
 password | `string` | `password` | A hint to UIs to obscure input.
 
 ### <a name="richText"></a>Rich Text Formatting

--- a/versions/3.0.2.md
+++ b/versions/3.0.2.md
@@ -162,8 +162,8 @@ The formats defined by the OAS are:
 `string` | `byte` | base64 encoded characters
 `string` | `binary` | any sequence of octets
 `boolean` | | |
-`string` | `date` | As defined by `full-date` - [RFC3339](https://xml2rfc.ietf.org/public/rfc/html/rfc3339.html#anchor14)
-`string` | `date-time` | As defined by `date-time` - [RFC3339](https://xml2rfc.ietf.org/public/rfc/html/rfc3339.html#anchor14)
+`string` | `date` | As defined by `full-date` - [RFC3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6)
+`string` | `date-time` | As defined by `date-time` - [RFC3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6)
 `string` | `password` | A hint to UIs to obscure input.
 
 

--- a/versions/3.0.3.md
+++ b/versions/3.0.3.md
@@ -166,8 +166,8 @@ The formats defined by the OAS are:
 `string` | `byte` | base64 encoded characters
 `string` | `binary` | any sequence of octets
 `boolean` | | |
-`string` | `date` | As defined by `full-date` - [RFC3339](https://xml2rfc.ietf.org/public/rfc/html/rfc3339.html#anchor14)
-`string` | `date-time` | As defined by `date-time` - [RFC3339](https://xml2rfc.ietf.org/public/rfc/html/rfc3339.html#anchor14)
+`string` | `date` | As defined by `full-date` - [RFC3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6)
+`string` | `date-time` | As defined by `date-time` - [RFC3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6)
 `string` | `password` | A hint to UIs to obscure input.
 
 


### PR DESCRIPTION
Noticed broken link while reading data-type section in 3.0.3 spec: https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#data-types

Hence fixing date-time format RFC-3339 reference link.


