### PR TITLE
Draft: refactor: edit links for markdown document navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ package-lock.json
 deploy/
 history
 Gemfile.lock
+
+# macOS
+.DS_Store

--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -16,69 +16,69 @@ An OpenAPI definition can then be used by documentation generation tools to disp
 <!-- TOC depthFrom:1 depthTo:3 withLinks:1 updateOnSave:1 orderedList:0 -->
 
 - [Definitions](#definitions)
-	- [OpenAPI Document](#oasDocument)
-	- [Path Templating](#pathTemplating)
-	- [Media Types](#mediaTypes)
-	- [HTTP Status Codes](#httpCodes)
-- [Specification](#specification)
+	- [OpenAPI Document](#openapi-document)
+	- [Path Templating](#path-templating)
+	- [Media Types](#media-types)
+	- [HTTP Status Codes](#http-status-codes)
+    - [Specification](#specification)
 	- [Versions](#versions)
 	- [Format](#format)
-	- [Document Structure](#documentStructure)
-	- [Data Types](#dataTypes)
-	- [Rich Text Formatting](#richText)
-	- [Relative References In URIs](#relativeReferencesURI)
-	- [Relative References In URLs](#relativeReferencesURL)
+	- [Document Structure](#document-structure)
+	- [Data Types](#data-types)
+	- [Rich Text Formatting](#rich-text-formatting)
+	- [Relative References In URIs](#relative-references-in-uris)
+	- [Relative References In URLs](#relative-references-in-urls)
 	- [Schema](#schema)
-		- [OpenAPI Object](#oasObject)
-		- [Info Object](#infoObject)
-		- [Contact Object](#contactObject)
-		- [License Object](#licenseObject)
-		- [Server Object](#serverObject)
-		- [Server Variable Object](#serverVariableObject)
-		- [Components Object](#componentsObject)
-		- [Paths Object](#pathsObject)
-		- [Path Item Object](#pathItemObject)
-		- [Operation Object](#operationObject)
-		- [External Documentation Object](#externalDocumentationObject)
-		- [Parameter Object](#parameterObject)
-		- [Request Body Object](#requestBodyObject)
-		- [Media Type Object](#mediaTypeObject)
-		- [Encoding Object](#encodingObject)
-		- [Responses Object](#responsesObject)
-		- [Response Object](#responseObject)
-		- [Callback Object](#callbackObject)
-		- [Example Object](#exampleObject)
-		- [Link Object](#linkObject)
-		- [Header Object](#headerObject)
-		- [Tag Object](#tagObject)
-		- [Reference Object](#referenceObject)
-		- [Schema Object](#schemaObject)
-		- [Discriminator Object](#discriminatorObject)
-		- [XML Object](#xmlObject)
-		- [Security Scheme Object](#securitySchemeObject)
-		- [OAuth Flows Object](#oauthFlowsObject)
-		- [OAuth Flow Object](#oauthFlowObject)
-		- [Security Requirement Object](#securityRequirementObject)
-	- [Specification Extensions](#specificationExtensions)
-	- [Security Filtering](#securityFiltering)
-- [Appendix A: Revision History](#revisionHistory)
+		- [OpenAPI Object](#openapi-object)
+		- [Info Object](#info-object)
+		- [Contact Object](#contact-object)
+		- [License Object](#license-object)
+		- [Server Object](#server-object)
+		- [Server Variable Object](#server-variable-object)
+		- [Components Object](#components-object)
+		- [Paths Object](#paths-object)
+		- [Path Item Object](#path-item-object)
+		- [Operation Object](#operation-object)
+		- [External Documentation Object](#external-documentation-object)
+		- [Parameter Object](#parameter-object)
+		- [Request Body Object](#request-body-object)
+		- [Media Type Object](#media-type-object)
+		- [Encoding Object](#encoding-object)
+		- [Responses Object](#responses-object)
+		- [Response Object](#response-object)
+		- [Callback Object](#callback-object)
+		- [Example Object](#example-object)
+		- [Link Object](#link-object)
+		- [Header Object](#header-object)
+		- [Tag Object](#tag-object)
+		- [Reference Object](#reference-object)
+		- [Schema Object](#schema-object)
+		- [Discriminator Object](#discriminator-object)
+		- [XML Object](#xml-object)
+		- [Security Scheme Object](#security-scheme-object)
+		- [OAuth Flows Object](#oauth-flows-object)
+		- [OAuth Flow Object](#oauth-flow-object)
+		- [Security Requirement Object](#security-requirement-object)
+	- [Specification Extensions](#specification-extensions)
+	- [Security Filtering](#security-filtering)
+- [Appendix A: Revision History](#appendix-a-revision-history)
 	
 
 <!-- /TOC -->
 
 ## Definitions
 
-##### <a name="oasDocument"></a>OpenAPI Document
-A self-contained or composite resource which defines or describes an API or elements of an API. The OpenAPI document MUST contain at least one [paths](#pathsObject) field, a [components](#oasComponents) field or a [webhooks](#oasWebhooks) field. An OpenAPI document uses and conforms to the OpenAPI Specification.
+##### OpenAPI Document
+A self-contained or composite resource which defines or describes an API or elements of an API. The OpenAPI document MUST contain at least one [paths](#paths-object) field, a [components](#oasComponents) field or a [webhooks](#oasWebhooks) field. An OpenAPI document uses and conforms to the OpenAPI Specification.
 
-##### <a name="pathTemplating"></a>Path Templating
+##### Path Templating
 Path templating refers to the usage of template expressions, delimited by curly braces ({}), to mark a section of a URL path as replaceable using path parameters.
 
 Each template expression in the path MUST correspond to a path parameter that is included in the [Path Item](#path-item-object) itself and/or in each of the Path Item's [Operations](#operation-object). An exception is if the path item is empty, for example due to ACL constraints, matching path parameters are not required.
 
 The value for these path parameters MUST NOT contain any unescaped "generic syntax" characters described by [RFC3986](https://tools.ietf.org/html/rfc3986#section-3): forward slashes (`/`), question marks (`?`), or hashes (`#`).
 
-##### <a name="mediaTypes"></a>Media Types
+##### Media Types
 Media type definitions are spread across several resources.
 The media type definitions SHOULD be in compliance with [RFC6838](https://tools.ietf.org/html/rfc6838).
 
@@ -95,7 +95,7 @@ Some examples of possible media type definitions:
   application/vnd.github.v3.diff
   application/vnd.github.v3.patch
 ```
-##### <a name="httpCodes"></a>HTTP Status Codes
+##### HTTP Status Codes
 The HTTP Status Codes are used to indicate the status of the executed operation. 
 The available status codes are defined by [RFC7231](https://tools.ietf.org/html/rfc7231#section-6) and registered status codes are listed in the [IANA Status Code Registry](https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml).
 
@@ -134,95 +134,93 @@ In order to preserve the ability to round-trip between YAML and JSON formats, YA
 
 **Note:** While APIs may be defined by OpenAPI documents in either YAML or JSON format, the API request and response bodies and other content are not required to be JSON or YAML.
 
-### <a name="documentStructure"></a>Document Structure
+### Document Structure
 
-An OpenAPI document MAY be made up of a single document or be divided into multiple, connected parts at the discretion of the author. In the latter case, [`Reference Objects`](#referenceObject) and [`Schema Object`](#schemaObject) `$ref` keywords are used.
+An OpenAPI document MAY be made up of a single document or be divided into multiple, connected parts at the discretion of the author. In the latter case, [`Reference Objects`](#reference-object) and [`Schema Object`](#schema-object) `$ref` keywords are used.
 
 It is RECOMMENDED that the root OpenAPI document be named: `openapi.json` or `openapi.yaml`.
 
-### <a name="dataTypes"></a>Data Types
+### Data Types
 
 Data types in the OAS are based on the types supported by the [JSON Schema Specification Draft 2020-12](https://tools.ietf.org/html/draft-bhutton-json-schema-00#section-4.2.1).
 Note that `integer` as a type is also supported and is defined as a JSON number without a fraction or exponent part. 
-Models are defined using the [Schema Object](#schemaObject), which is a superset of JSON Schema Specification Draft 2020-12.
+Models are defined using the [Schema Object](#schema-object), which is a superset of JSON Schema Specification Draft 2020-12.
 
 <a name="dataTypeFormat"></a>As defined by the [JSON Schema Validation vocabulary](https://tools.ietf.org/html/draft-bhutton-json-schema-validation-00#section-7.3), data types can have an optional modifier property: `format`.
 OAS defines additional formats to provide fine detail for primitive data types.
 
 The formats defined by the OAS are:
 
-[`type`](#dataTypes) | [`format`](#dataTypeFormat) | Comments
------- | -------- | --------
-`integer` | `int32` | signed 32 bits
-`integer` | `int64` | signed 64 bits (a.k.a long)
-`number` | `float` | |
-`number` | `double` | |
-`string` | `password` | A hint to UIs to obscure input.
+| [`type`](#data-types) | [`format`](#dataTypeFormat) | Comments                        |
+|-----------------------|-----------------------------|---------------------------------|
+| `integer`             | `int32`                     | signed 32 bits                  |
+| `integer`             | `int64`                     | signed 64 bits (a.k.a long)     |
+| `number`              | `float`                     |                                 |
+| `number`              | `double`                    |                                 |
+| `string`              | `password`                  | A hint to UIs to obscure input. |
 
-### <a name="richText"></a>Rich Text Formatting
+### Rich Text Formatting
 Throughout the specification `description` fields are noted as supporting CommonMark markdown formatting.
 Where OpenAPI tooling renders rich text it MUST support, at a minimum, markdown syntax as described by [CommonMark 0.27](https://spec.commonmark.org/0.27/). Tooling MAY choose to ignore some CommonMark features to address security concerns. 
 
-### <a name="relativeReferencesURI"></a>Relative References in URIs
+### Relative References in URIs
 
 Unless specified otherwise, all properties that are URIs MAY be relative references as defined by [RFC3986](https://tools.ietf.org/html/rfc3986#section-4.2).
 
-Relative references, including those in [`Reference Objects`](#referenceObject), [`PathItem Object`](#pathItemObject) `$ref` fields, [`Link Object`](#linkObject) `operationRef` fields and [`Example Object`](#exampleObject) `externalValue` fields, are resolved using the referring document as the Base URI according to [RFC3986](https://tools.ietf.org/html/rfc3986#section-5.2).
+Relative references, including those in [`Reference Objects`](#reference-object), [`PathItem Object`](#path-item-object) `$ref` fields, [`Link Object`](#link-object) `operationRef` fields and [`Example Object`](#example-object) `externalValue` fields, are resolved using the referring document as the Base URI according to [RFC3986](https://tools.ietf.org/html/rfc3986#section-5.2).
 
 If a URI contains a fragment identifier, then the fragment should be resolved per the fragment resolution mechanism of the referenced document.  If the representation of the referenced document is JSON or YAML, then the fragment identifier SHOULD be interpreted as a JSON-Pointer as per [RFC6901](https://tools.ietf.org/html/rfc6901).
 
-Relative references in [`Schema Objects`](#schemaObject), including any that appear as `$id` values, use the nearest parent `$id` as a Base URI, as described by [JSON Schema Specification Draft 2020-12](https://tools.ietf.org/html/draft-bhutton-json-schema-00#section-8.2).  If no parent schema contains an `$id`, then the Base URI MUST be determined according to [RFC3986](https://tools.ietf.org/html/rfc3986#section-5.1).
+Relative references in [`Schema Objects`](#schema-object), including any that appear as `$id` values, use the nearest parent `$id` as a Base URI, as described by [JSON Schema Specification Draft 2020-12](https://tools.ietf.org/html/draft-bhutton-json-schema-00#section-8.2).  If no parent schema contains an `$id`, then the Base URI MUST be determined according to [RFC3986](https://tools.ietf.org/html/rfc3986#section-5.1).
 
-### <a name="relativeReferencesURL"></a>Relative References in URLs
+### Relative References in URLs
 
 Unless specified otherwise, all properties that are URLs MAY be relative references as defined by [RFC3986](https://tools.ietf.org/html/rfc3986#section-4.2).
-Unless specified otherwise, relative references are resolved using the URLs defined in the [`Server Object`](#serverObject) as a Base URL. Note that these themselves MAY be relative to the referring document.
+Unless specified otherwise, relative references are resolved using the URLs defined in the [`Server Object`](#server-object) as a Base URL. Note that these themselves MAY be relative to the referring document.
 
 ### Schema
 
 In the following description, if a field is not explicitly **REQUIRED** or described with a MUST or SHALL, it can be considered OPTIONAL.
 
-#### <a name="oasObject"></a>OpenAPI Object
+#### OpenAPI Object
 
-This is the root object of the [OpenAPI document](#oasDocument).
+This is the root object of the [OpenAPI document](#openapi-document).
 
 ##### Fixed Fields
 
-Field Name | Type | Description
----|:---:|---
-<a name="oasVersion"></a>openapi | `string` | **REQUIRED**. This string MUST be the [version number](#versions) of the OpenAPI Specification that the OpenAPI document uses. The `openapi` field SHOULD be used by tooling to interpret the OpenAPI document. This is *not* related to the API [`info.version`](#infoVersion) string.
-<a name="oasInfo"></a>info | [Info Object](#infoObject) | **REQUIRED**. Provides metadata about the API. The metadata MAY be used by tooling as required.
-<a name="oasJsonSchemaDialect"></a> jsonSchemaDialect | `string` | The default value for the `$schema` keyword within [Schema Objects](#schemaObject) contained within this OAS document. This MUST be in the form of a URI.
-<a name="oasServers"></a>servers | [[Server Object](#serverObject)] | An array of Server Objects, which provide connectivity information to a target server. If the `servers` property is not provided, or is an empty array, the default value would be a [Server Object](#serverObject) with a [url](#serverUrl) value of `/`.
-<a name="oasPaths"></a>paths | [Paths Object](#pathsObject) | The available paths and operations for the API.
-<a name="oasWebhooks"></a>webhooks | Map[`string`, [Path Item Object](#pathItemObject) \| [Reference Object](#referenceObject)] ] | The incoming webhooks that MAY be received as part of this API and that the API consumer MAY choose to implement. Closely related to the `callbacks` feature, this section describes requests initiated other than by an API call, for example by an out of band registration. The key name is a unique string to refer to each webhook, while the (optionally referenced) Path Item Object describes a request that may be initiated by the API provider and the expected responses. An [example](../examples/v3.1/webhook-example.yaml) is available.
-<a name="oasComponents"></a>components | [Components Object](#componentsObject) | An element to hold various schemas for the document.
-<a name="oasSecurity"></a>security | [[Security Requirement Object](#securityRequirementObject)] | A declaration of which security mechanisms can be used across the API. The list of values includes alternative security requirement objects that can be used. Only one of the security requirement objects need to be satisfied to authorize a request. Individual operations can override this definition. To make security optional, an empty security requirement (`{}`) can be included in the array.
-<a name="oasTags"></a>tags | [[Tag Object](#tagObject)] | A list of tags used by the document with additional metadata. The order of the tags can be used to reflect on their order by the parsing tools. Not all tags that are used by the [Operation Object](#operationObject) must be declared. The tags that are not declared MAY be organized randomly or based on the tools' logic. Each tag name in the list MUST be unique.
-<a name="oasExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation.
+| Field Name                                            |                                              Type                                               | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+|-------------------------------------------------------|:-----------------------------------------------------------------------------------------------:|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| <a name="oasVersion"></a>openapi                      |                                            `string`                                             | **REQUIRED**. This string MUST be the [version number](#versions) of the OpenAPI Specification that the OpenAPI document uses. The `openapi` field SHOULD be used by tooling to interpret the OpenAPI document. This is *not* related to the API [`info.version`](#infoVersion) string.                                                                                                                                                                                                                                                                 |
+| <a name="oasInfo"></a>info                            |                                   [Info Object](#info-object)                                   | **REQUIRED**. Provides metadata about the API. The metadata MAY be used by tooling as required.                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| <a name="oasJsonSchemaDialect"></a> jsonSchemaDialect |                                            `string`                                             | The default value for the `$schema` keyword within [Schema Objects](#schema-object) contained within this OAS document. This MUST be in the form of a URI.                                                                                                                                                                                                                                                                                                                                                                                              |
+| <a name="oasServers"></a>servers                      |                                [[Server Object](#server-object)]                                | An array of Server Objects, which provide connectivity information to a target server. If the `servers` property is not provided, or is an empty array, the default value would be a [Server Object](#server-object) with a [url](#serverUrl) value of `/`.                                                                                                                                                                                                                                                                                             |
+| <a name="oasPaths"></a>paths                          |                                  [Paths Object](#paths-object)                                  | The available paths and operations for the API.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| <a name="oasWebhooks"></a>webhooks                    | Map[`string`, [Path Item Object](#path-item-object) \| [Reference Object](#reference-object)] ] | The incoming webhooks that MAY be received as part of this API and that the API consumer MAY choose to implement. Closely related to the `callbacks` feature, this section describes requests initiated other than by an API call, for example by an out of band registration. The key name is a unique string to refer to each webhook, while the (optionally referenced) Path Item Object describes a request that may be initiated by the API provider and the expected responses. An [example](../examples/v3.1/webhook-example.yaml) is available. |
+| <a name="oasComponents"></a>components                |                             [Components Object](#components-object)                             | An element to hold various schemas for the document.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| <a name="oasSecurity"></a>security                    |                  [[Security Requirement Object](#security-requirement-object)]                  | A declaration of which security mechanisms can be used across the API. The list of values includes alternative security requirement objects that can be used. Only one of the security requirement objects need to be satisfied to authorize a request. Individual operations can override this definition. To make security optional, an empty security requirement (`{}`) can be included in the array.                                                                                                                                               |
+| <a name="oasTags"></a>tags                            |                                   [[Tag Object](#tag-object)]                                   | A list of tags used by the document with additional metadata. The order of the tags can be used to reflect on their order by the parsing tools. Not all tags that are used by the [Operation Object](#operation-object) must be declared. The tags that are not declared MAY be organized randomly or based on the tools' logic. Each tag name in the list MUST be unique.                                                                                                                                                                              |
+| <a name="oasExternalDocs"></a>externalDocs            |                 [External Documentation Object](#external-documentation-object)                 | Additional external documentation.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
 
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
-
-#### <a name="infoObject"></a>Info Object
+#### Info Object
 
 The object provides metadata about the API.
 The metadata MAY be used by the clients if needed, and MAY be presented in editing or documentation generation tools for convenience.
 
 ##### Fixed Fields
 
-Field Name | Type | Description
----|:---:|---
-<a name="infoTitle"></a>title | `string` | **REQUIRED**. The title of the API.
-<a name="infoSummary"></a>summary | `string` | A short summary of the API.
-<a name="infoDescription"></a>description | `string` | A description of the API. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="infoTermsOfService"></a>termsOfService | `string` | A URL to the Terms of Service for the API. This MUST be in the form of a URL.
-<a name="infoContact"></a>contact | [Contact Object](#contactObject) | The contact information for the exposed API.
-<a name="infoLicense"></a>license | [License Object](#licenseObject) | The license information for the exposed API.
-<a name="infoVersion"></a>version | `string` | **REQUIRED**. The version of the OpenAPI document (which is distinct from the [OpenAPI Specification version](#oasVersion) or the API implementation version).
+| Field Name                                      |               Type                | Description                                                                                                                                                    |
+|-------------------------------------------------|:---------------------------------:|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| <a name="infoTitle"></a>title                   |             `string`              | **REQUIRED**. The title of the API.                                                                                                                            |
+| <a name="infoSummary"></a>summary               |             `string`              | A short summary of the API.                                                                                                                                    |
+| <a name="infoDescription"></a>description       |             `string`              | A description of the API. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.                                          |
+| <a name="infoTermsOfService"></a>termsOfService |             `string`              | A URL to the Terms of Service for the API. This MUST be in the form of a URL.                                                                                  |
+| <a name="infoContact"></a>contact               | [Contact Object](#contact-object) | The contact information for the exposed API.                                                                                                                   |
+| <a name="infoLicense"></a>license               | [License Object](#license-object) | The license information for the exposed API.                                                                                                                   |
+| <a name="infoVersion"></a>version               |             `string`              | **REQUIRED**. The version of the OpenAPI document (which is distinct from the [OpenAPI Specification version](#oasVersion) or the API implementation version). |
 
-
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Info Object Example
 
@@ -260,19 +258,19 @@ license:
 version: 1.0.1
 ```
 
-#### <a name="contactObject"></a>Contact Object
+#### Contact Object
 
 Contact information for the exposed API.
 
 ##### Fixed Fields
 
-Field Name | Type | Description
----|:---:|---
-<a name="contactName"></a>name | `string` | The identifying name of the contact person/organization.
-<a name="contactUrl"></a>url | `string` | The URL pointing to the contact information. This MUST be in the form of a URL.
-<a name="contactEmail"></a>email | `string` | The email address of the contact person/organization. This MUST be in the form of an email address.
+| Field Name                       |   Type   | Description                                                                                         |
+|----------------------------------|:--------:|-----------------------------------------------------------------------------------------------------|
+| <a name="contactName"></a>name   | `string` | The identifying name of the contact person/organization.                                            |
+| <a name="contactUrl"></a>url     | `string` | The URL pointing to the contact information. This MUST be in the form of a URL.                     |
+| <a name="contactEmail"></a>email | `string` | The email address of the contact person/organization. This MUST be in the form of an email address. |
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Contact Object Example
 
@@ -290,19 +288,19 @@ url: https://www.example.com/support
 email: support@example.com
 ```
 
-#### <a name="licenseObject"></a>License Object
+#### License Object
 
 License information for the exposed API.
 
 ##### Fixed Fields
 
-Field Name | Type | Description
----|:---:|---
-<a name="licenseName"></a>name | `string` | **REQUIRED**. The license name used for the API.
-<a name="licenseIdentifier"></a>identifier | `string` | An [SPDX](https://spdx.org/spdx-specification-21-web-version#h.jxpfx0ykyb60) license expression for the API. The `identifier` field is mutually exclusive of the `url` field.
-<a name="licenseUrl"></a>url | `string` | A URL to the license used for the API. This MUST be in the form of a URL. The `url` field is mutually exclusive of the `identifier` field.
+| Field Name                                 |   Type   | Description                                                                                                                                                                   |
+|--------------------------------------------|:--------:|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| <a name="licenseName"></a>name             | `string` | **REQUIRED**. The license name used for the API.                                                                                                                              |
+| <a name="licenseIdentifier"></a>identifier | `string` | An [SPDX](https://spdx.org/spdx-specification-21-web-version#h.jxpfx0ykyb60) license expression for the API. The `identifier` field is mutually exclusive of the `url` field. |
+| <a name="licenseUrl"></a>url               | `string` | A URL to the license used for the API. This MUST be in the form of a URL. The `url` field is mutually exclusive of the `identifier` field.                                    |
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### License Object Example
 
@@ -318,19 +316,19 @@ name: Apache 2.0
 identifier: Apache-2.0
 ```
 
-#### <a name="serverObject"></a>Server Object
+#### Server Object
 
 An object representing a Server.
 
 ##### Fixed Fields
 
-Field Name | Type | Description
----|:---:|---
-<a name="serverUrl"></a>url | `string` | **REQUIRED**. A URL to the target host.  This URL supports Server Variables and MAY be relative, to indicate that the host location is relative to the location where the OpenAPI document is being served. Variable substitutions will be made when a variable is named in `{`brackets`}`.
-<a name="serverDescription"></a>description | `string` | An optional string describing the host designated by the URL. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="serverVariables"></a>variables | Map[`string`, [Server Variable Object](#serverVariableObject)] | A map between a variable name and its value.  The value is used for substitution in the server's URL template.
+| Field Name                                  |                               Type                               | Description                                                                                                                                                                                                                                                                                 |
+|---------------------------------------------|:----------------------------------------------------------------:|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| <a name="serverUrl"></a>url                 |                             `string`                             | **REQUIRED**. A URL to the target host.  This URL supports Server Variables and MAY be relative, to indicate that the host location is relative to the location where the OpenAPI document is being served. Variable substitutions will be made when a variable is named in `{`brackets`}`. |
+| <a name="serverDescription"></a>description |                             `string`                             | An optional string describing the host designated by the URL. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.                                                                                                                                   |
+| <a name="serverVariables"></a>variables     | Map[`string`, [Server Variable Object](#server-variable-object)] | A map between a variable name and its value.  The value is used for substitution in the server's URL template.                                                                                                                                                                              |
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Server Object Example
 
@@ -428,21 +426,21 @@ servers:
 ```
 
 
-#### <a name="serverVariableObject"></a>Server Variable Object
+#### Server Variable Object
 
 An object representing a Server Variable for server URL template substitution.
 
 ##### Fixed Fields
 
-Field Name | Type | Description
----|:---:|---
-<a name="serverVariableEnum"></a>enum | [`string`] | An enumeration of string values to be used if the substitution options are from a limited set. The array MUST NOT be empty.
-<a name="serverVariableDefault"></a>default | `string` |  **REQUIRED**. The default value to use for substitution, which SHALL be sent if an alternate value is _not_ supplied. Note this behavior is different than the [Schema Object's](#schemaObject) treatment of default values, because in those cases parameter values are optional. If the [`enum`](#serverVariableEnum) is defined, the value MUST exist in the enum's values.
-<a name="serverVariableDescription"></a>description | `string` | An optional description for the server variable. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
+| Field Name                                          |    Type    | Description                                                                                                                                                                                                                                                                                                                                                                     |
+|-----------------------------------------------------|:----------:|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| <a name="serverVariableEnum"></a>enum               | [`string`] | An enumeration of string values to be used if the substitution options are from a limited set. The array MUST NOT be empty.                                                                                                                                                                                                                                                     |
+| <a name="serverVariableDefault"></a>default         |  `string`  | **REQUIRED**. The default value to use for substitution, which SHALL be sent if an alternate value is _not_ supplied. Note this behavior is different than the [Schema Object's](#schema-object) treatment of default values, because in those cases parameter values are optional. If the [`enum`](#serverVariableEnum) is defined, the value MUST exist in the enum's values. |
+| <a name="serverVariableDescription"></a>description |  `string`  | An optional description for the server variable. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.                                                                                                                                                                                                                                    |
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
-#### <a name="componentsObject"></a>Components Object
+#### Components Object
 
 Holds a set of reusable objects for different aspects of the OAS.
 All objects defined within the components object will have no effect on the API unless they are explicitly referenced from properties outside the components object.
@@ -450,21 +448,20 @@ All objects defined within the components object will have no effect on the API 
 
 ##### Fixed Fields
 
-Field Name | Type | Description
----|:---|---
-<a name="componentsSchemas"></a> schemas | Map[`string`, [Schema Object](#schemaObject)] | An object to hold reusable [Schema Objects](#schemaObject).
-<a name="componentsResponses"></a> responses | Map[`string`, [Response Object](#responseObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Response Objects](#responseObject).
-<a name="componentsParameters"></a> parameters | Map[`string`, [Parameter Object](#parameterObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Parameter Objects](#parameterObject).
-<a name="componentsExamples"></a> examples | Map[`string`, [Example Object](#exampleObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Example Objects](#exampleObject).
-<a name="componentsRequestBodies"></a> requestBodies | Map[`string`, [Request Body Object](#requestBodyObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Request Body Objects](#requestBodyObject).
-<a name="componentsHeaders"></a> headers | Map[`string`, [Header Object](#headerObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Header Objects](#headerObject).
-<a name="componentsSecuritySchemes"></a> securitySchemes| Map[`string`, [Security Scheme Object](#securitySchemeObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Security Scheme Objects](#securitySchemeObject).
-<a name="componentsLinks"></a> links | Map[`string`, [Link Object](#linkObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Link Objects](#linkObject).
-<a name="componentsCallbacks"></a> callbacks | Map[`string`, [Callback Object](#callbackObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Callback Objects](#callbackObject).
-<a name="componentsPathItems"></a> pathItems | Map[`string`, [Path Item Object](#pathItemObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Path Item Object](#pathItemObject).
+| Field Name                                               | Type                                                                                                      | Description                                                                    |
+|----------------------------------------------------------|:----------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------|
+| <a name="componentsSchemas"></a> schemas                 | Map[`string`, [Schema Object](#schema-object)]                                                            | An object to hold reusable [Schema Objects](#schema-object).                   |
+| <a name="componentsResponses"></a> responses             | Map[`string`, [Response Object](#response-object) \| [Reference Object](#reference-object)]               | An object to hold reusable [Response Objects](#response-object).               |
+| <a name="componentsParameters"></a> parameters           | Map[`string`, [Parameter Object](#parameter-object) \| [Reference Object](#reference-object)]             | An object to hold reusable [Parameter Objects](#parameter-object).             |
+| <a name="componentsExamples"></a> examples               | Map[`string`, [Example Object](#example-object) \| [Reference Object](#reference-object)]                 | An object to hold reusable [Example Objects](#example-object).                 |
+| <a name="componentsRequestBodies"></a> requestBodies     | Map[`string`, [Request Body Object](#request-body-object) \| [Reference Object](#reference-object)]       | An object to hold reusable [Request Body Objects](#request-body-object).       |
+| <a name="componentsHeaders"></a> headers                 | Map[`string`, [Header Object](#header-object) \| [Reference Object](#reference-object)]                   | An object to hold reusable [Header Objects](#header-object).                   |
+| <a name="componentsSecuritySchemes"></a> securitySchemes | Map[`string`, [Security Scheme Object](#security-scheme-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Security Scheme Objects](#security-scheme-object). |
+| <a name="componentsLinks"></a> links                     | Map[`string`, [Link Object](#link-object) \| [Reference Object](#reference-object)]                       | An object to hold reusable [Link Objects](#link-object).                       |
+| <a name="componentsCallbacks"></a> callbacks             | Map[`string`, [Callback Object](#callback-object) \| [Reference Object](#reference-object)]               | An object to hold reusable [Callback Objects](#callback-object).               |
+| <a name="componentsPathItems"></a> pathItems             | Map[`string`, [Path Item Object](#path-item-object) \| [Reference Object](#reference-object)]             | An object to hold reusable [Path Item Object](#path-item-object).              |
 
-
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 All the fixed fields declared above are objects that MUST use keys that match the regular expression: `^[a-zA-Z0-9\.\-_]+$`.
 
@@ -652,18 +649,18 @@ components:
             read:pets: read your pets
 ```
 
-#### <a name="pathsObject"></a>Paths Object
+#### Paths Object
 
 Holds the relative paths to the individual endpoints and their operations.
-The path is appended to the URL from the [`Server Object`](#serverObject) in order to construct the full URL.  The Paths MAY be empty, due to [Access Control List (ACL) constraints](#securityFiltering).
+The path is appended to the URL from the [`Server Object`](#server-object) in order to construct the full URL.  The Paths MAY be empty, due to [Access Control List (ACL) constraints](#security-filtering).
 
 ##### Patterned Fields
 
-Field Pattern | Type | Description
----|:---:|---
-<a name="pathsPath"></a>/{path} | [Path Item Object](#pathItemObject) | A relative path to an individual endpoint. The field name MUST begin with a forward slash (`/`). The path is **appended** (no relative URL resolution) to the expanded URL from the [`Server Object`](#serverObject)'s `url` field in order to construct the full URL. [Path templating](#pathTemplating) is allowed. When matching URLs, concrete (non-templated) paths would be matched before their templated counterparts. Templated paths with the same hierarchy but different templated names MUST NOT exist as they are identical. In case of ambiguous matching, it's up to the tooling to decide which one to use.
+| Field Pattern                   |                 Type                  | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+|---------------------------------|:-------------------------------------:|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| <a name="pathsPath"></a>/{path} | [Path Item Object](#path-item-object) | A relative path to an individual endpoint. The field name MUST begin with a forward slash (`/`). The path is **appended** (no relative URL resolution) to the expanded URL from the [`Server Object`](#server-object)'s `url` field in order to construct the full URL. [Path templating](#path-templating) is allowed. When matching URLs, concrete (non-templated) paths would be matched before their templated counterparts. Templated paths with the same hierarchy but different templated names MUST NOT exist as they are identical. In case of ambiguous matching, it's up to the tooling to decide which one to use. |
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Path Templating Matching
 
@@ -730,32 +727,31 @@ The following may lead to ambiguous resolution:
                 $ref: '#/components/schemas/pet'
 ```
 
-#### <a name="pathItemObject"></a>Path Item Object
+#### Path Item Object
 
 Describes the operations available on a single path.
-A Path Item MAY be empty, due to [ACL constraints](#securityFiltering).
+A Path Item MAY be empty, due to [ACL constraints](#security-filtering).
 The path itself is still exposed to the documentation viewer but they will not know which operations and parameters are available.
 
 ##### Fixed Fields
 
-Field Name | Type | Description
----|:---:|---
-<a name="pathItemRef"></a>$ref | `string` | Allows for a referenced definition of this path item. The referenced structure MUST be in the form of a [Path Item Object](#pathItemObject).  In case a Path Item Object field appears both in the defined object and the referenced object, the behavior is undefined. See the rules for resolving [Relative References](#relativeReferencesURI).
-<a name="pathItemSummary"></a>summary| `string` | An optional, string summary, intended to apply to all operations in this path.
-<a name="pathItemDescription"></a>description | `string` | An optional, string description, intended to apply to all operations in this path. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="pathItemGet"></a>get | [Operation Object](#operationObject) | A definition of a GET operation on this path.
-<a name="pathItemPut"></a>put | [Operation Object](#operationObject) | A definition of a PUT operation on this path.
-<a name="pathItemPost"></a>post | [Operation Object](#operationObject) | A definition of a POST operation on this path.
-<a name="pathItemDelete"></a>delete | [Operation Object](#operationObject) | A definition of a DELETE operation on this path.
-<a name="pathItemOptions"></a>options | [Operation Object](#operationObject) | A definition of a OPTIONS operation on this path.
-<a name="pathItemHead"></a>head | [Operation Object](#operationObject) | A definition of a HEAD operation on this path.
-<a name="pathItemPatch"></a>patch | [Operation Object](#operationObject) | A definition of a PATCH operation on this path.
-<a name="pathItemTrace"></a>trace | [Operation Object](#operationObject) | A definition of a TRACE operation on this path.
-<a name="pathItemServers"></a>servers | [[Server Object](#serverObject)] | An alternative `server` array to service all operations in this path.
-<a name="pathItemParameters"></a>parameters | [[Parameter Object](#parameterObject) \| [Reference Object](#referenceObject)] | A list of parameters that are applicable for all the operations described under this path. These parameters can be overridden at the operation level, but cannot be removed there. The list MUST NOT include duplicated parameters. A unique parameter is defined by a combination of a [name](#parameterName) and [location](#parameterIn). The list can use the [Reference Object](#referenceObject) to link to parameters that are defined at the [OpenAPI Object's components/parameters](#componentsParameters). 
+| Field Name                                    |                                       Type                                       | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+|-----------------------------------------------|:--------------------------------------------------------------------------------:|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| <a name="pathItemRef"></a>$ref                |                                     `string`                                     | Allows for a referenced definition of this path item. The referenced structure MUST be in the form of a [Path Item Object](#path-item-object).  In case a Path Item Object field appears both in the defined object and the referenced object, the behavior is undefined. See the rules for resolving [Relative References](#relative-references-in-uris).                                                                                                                                                             |
+| <a name="pathItemSummary"></a>summary         |                                     `string`                                     | An optional, string summary, intended to apply to all operations in this path.                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| <a name="pathItemDescription"></a>description |                                     `string`                                     | An optional, string description, intended to apply to all operations in this path. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.                                                                                                                                                                                                                                                                                                                                         |
+| <a name="pathItemGet"></a>get                 |                      [Operation Object](#operation-object)                       | A definition of a GET operation on this path.                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| <a name="pathItemPut"></a>put                 |                      [Operation Object](#operation-object)                       | A definition of a PUT operation on this path.                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| <a name="pathItemPost"></a>post               |                      [Operation Object](#operation-object)                       | A definition of a POST operation on this path.                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| <a name="pathItemDelete"></a>delete           |                      [Operation Object](#operation-object)                       | A definition of a DELETE operation on this path.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| <a name="pathItemOptions"></a>options         |                      [Operation Object](#operation-object)                       | A definition of a OPTIONS operation on this path.                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| <a name="pathItemHead"></a>head               |                      [Operation Object](#operation-object)                       | A definition of a HEAD operation on this path.                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| <a name="pathItemPatch"></a>patch             |                      [Operation Object](#operation-object)                       | A definition of a PATCH operation on this path.                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| <a name="pathItemTrace"></a>trace             |                      [Operation Object](#operation-object)                       | A definition of a TRACE operation on this path.                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| <a name="pathItemServers"></a>servers         |                        [[Server Object](#server-object)]                         | An alternative `server` array to service all operations in this path.                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| <a name="pathItemParameters"></a>parameters   | [[Parameter Object](#parameter-object) \| [Reference Object](#reference-object)] | A list of parameters that are applicable for all the operations described under this path. These parameters can be overridden at the operation level, but cannot be removed there. The list MUST NOT include duplicated parameters. A unique parameter is defined by a combination of a [name](#parameterName) and [location](#parameterIn). The list can use the [Reference Object](#reference-object) to link to parameters that are defined at the [OpenAPI Object's components/parameters](#componentsParameters). |
 
-
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Path Item Object Example
 
@@ -841,28 +837,28 @@ parameters:
   style: simple
 ```
 
-#### <a name="operationObject"></a>Operation Object
+#### Operation Object
 
 Describes a single API operation on a path.
 
 ##### Fixed Fields
 
-Field Name | Type | Description
----|:---:|---
-<a name="operationTags"></a>tags | [`string`] | A list of tags for API documentation control. Tags can be used for logical grouping of operations by resources or any other qualifier.
-<a name="operationSummary"></a>summary | `string` | A short summary of what the operation does.
-<a name="operationDescription"></a>description | `string` | A verbose explanation of the operation behavior. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="operationExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation for this operation.
-<a name="operationId"></a>operationId | `string` | Unique string used to identify the operation. The id MUST be unique among all operations described in the API. The operationId value is **case-sensitive**. Tools and libraries MAY use the operationId to uniquely identify an operation, therefore, it is RECOMMENDED to follow common programming naming conventions.
-<a name="operationParameters"></a>parameters | [[Parameter Object](#parameterObject) \| [Reference Object](#referenceObject)] | A list of parameters that are applicable for this operation. If a parameter is already defined at the [Path Item](#pathItemParameters), the new definition will override it but can never remove it. The list MUST NOT include duplicated parameters. A unique parameter is defined by a combination of a [name](#parameterName) and [location](#parameterIn). The list can use the [Reference Object](#referenceObject) to link to parameters that are defined at the [OpenAPI Object's components/parameters](#componentsParameters).
-<a name="operationRequestBody"></a>requestBody | [Request Body Object](#requestBodyObject) \| [Reference Object](#referenceObject) | The request body applicable for this operation.  The `requestBody` is fully supported in HTTP methods where the HTTP 1.1 specification [RFC7231](https://tools.ietf.org/html/rfc7231#section-4.3.1) has explicitly defined semantics for request bodies.  In other cases where the HTTP spec is vague (such as [GET](https://tools.ietf.org/html/rfc7231#section-4.3.1), [HEAD](https://tools.ietf.org/html/rfc7231#section-4.3.2) and [DELETE](https://tools.ietf.org/html/rfc7231#section-4.3.5)), `requestBody` is permitted but does not have well-defined semantics and SHOULD be avoided if possible.
-<a name="operationResponses"></a>responses | [Responses Object](#responsesObject) | The list of possible responses as they are returned from executing this operation.
-<a name="operationCallbacks"></a>callbacks | Map[`string`, [Callback Object](#callbackObject) \| [Reference Object](#referenceObject)] | A map of possible out-of band callbacks related to the parent operation. The key is a unique identifier for the Callback Object. Each value in the map is a [Callback Object](#callbackObject) that describes a request that may be initiated by the API provider and the expected responses.
-<a name="operationDeprecated"></a>deprecated | `boolean` | Declares this operation to be deprecated. Consumers SHOULD refrain from usage of the declared operation. Default value is `false`.
-<a name="operationSecurity"></a>security | [[Security Requirement Object](#securityRequirementObject)] | A declaration of which security mechanisms can be used for this operation. The list of values includes alternative security requirement objects that can be used. Only one of the security requirement objects need to be satisfied to authorize a request. To make security optional, an empty security requirement (`{}`) can be included in the array. This definition overrides any declared top-level [`security`](#oasSecurity). To remove a top-level security declaration, an empty array can be used.
-<a name="operationServers"></a>servers | [[Server Object](#serverObject)] | An alternative `server` array to service this operation. If an alternative `server` object is specified at the Path Item Object or Root level, it will be overridden by this value.
+| Field Name                                       |                                            Type                                             | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+|--------------------------------------------------|:-------------------------------------------------------------------------------------------:|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| <a name="operationTags"></a>tags                 |                                         [`string`]                                          | A list of tags for API documentation control. Tags can be used for logical grouping of operations by resources or any other qualifier.                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| <a name="operationSummary"></a>summary           |                                          `string`                                           | A short summary of what the operation does.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| <a name="operationDescription"></a>description   |                                          `string`                                           | A verbose explanation of the operation behavior. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| <a name="operationExternalDocs"></a>externalDocs |               [External Documentation Object](#external-documentation-object)               | Additional external documentation for this operation.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| <a name="operationId"></a>operationId            |                                          `string`                                           | Unique string used to identify the operation. The id MUST be unique among all operations described in the API. The operationId value is **case-sensitive**. Tools and libraries MAY use the operationId to uniquely identify an operation, therefore, it is RECOMMENDED to follow common programming naming conventions.                                                                                                                                                                                                                                                                                    |
+| <a name="operationParameters"></a>parameters     |      [[Parameter Object](#parameter-object) \| [Reference Object](#reference-object)]       | A list of parameters that are applicable for this operation. If a parameter is already defined at the [Path Item](#pathItemParameters), the new definition will override it but can never remove it. The list MUST NOT include duplicated parameters. A unique parameter is defined by a combination of a [name](#parameterName) and [location](#parameterIn). The list can use the [Reference Object](#reference-object) to link to parameters that are defined at the [OpenAPI Object's components/parameters](#componentsParameters).                                                                    |
+| <a name="operationRequestBody"></a>requestBody   |    [Request Body Object](#request-body-object) \| [Reference Object](#reference-object)     | The request body applicable for this operation.  The `requestBody` is fully supported in HTTP methods where the HTTP 1.1 specification [RFC7231](https://tools.ietf.org/html/rfc7231#section-4.3.1) has explicitly defined semantics for request bodies.  In other cases where the HTTP spec is vague (such as [GET](https://tools.ietf.org/html/rfc7231#section-4.3.1), [HEAD](https://tools.ietf.org/html/rfc7231#section-4.3.2) and [DELETE](https://tools.ietf.org/html/rfc7231#section-4.3.5)), `requestBody` is permitted but does not have well-defined semantics and SHOULD be avoided if possible. |
+| <a name="operationResponses"></a>responses       |                            [Responses Object](#responses-object)                            | The list of possible responses as they are returned from executing this operation.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| <a name="operationCallbacks"></a>callbacks       | Map[`string`, [Callback Object](#callback-object) \| [Reference Object](#reference-object)] | A map of possible out-of band callbacks related to the parent operation. The key is a unique identifier for the Callback Object. Each value in the map is a [Callback Object](#callback-object) that describes a request that may be initiated by the API provider and the expected responses.                                                                                                                                                                                                                                                                                                              |
+| <a name="operationDeprecated"></a>deprecated     |                                          `boolean`                                          | Declares this operation to be deprecated. Consumers SHOULD refrain from usage of the declared operation. Default value is `false`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| <a name="operationSecurity"></a>security         |                [[Security Requirement Object](#security-requirement-object)]                | A declaration of which security mechanisms can be used for this operation. The list of values includes alternative security requirement objects that can be used. Only one of the security requirement objects need to be satisfied to authorize a request. To make security optional, an empty security requirement (`{}`) can be included in the array. This definition overrides any declared top-level [`security`](#oasSecurity). To remove a top-level security declaration, an empty array can be used.                                                                                              |
+| <a name="operationServers"></a>servers           |                              [[Server Object](#server-object)]                              | An alternative `server` array to service this operation. If an alternative `server` object is specified at the Path Item Object or Root level, it will be overridden by this value.                                                                                                                                                                                                                                                                                                                                                                                                                         |
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Operation Object Example
 
@@ -975,18 +971,18 @@ security:
 ```
 
 
-#### <a name="externalDocumentationObject"></a>External Documentation Object
+#### External Documentation Object
 
 Allows referencing an external resource for extended documentation.
 
 ##### Fixed Fields
 
-Field Name | Type | Description
----|:---:|---
-<a name="externalDocDescription"></a>description | `string` | A description of the target documentation. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="externalDocUrl"></a>url | `string` | **REQUIRED**. The URL for the target documentation. This MUST be in the form of a URL.
+| Field Name                                       |   Type   | Description                                                                                                                            |
+|--------------------------------------------------|:--------:|----------------------------------------------------------------------------------------------------------------------------------------|
+| <a name="externalDocDescription"></a>description | `string` | A description of the target documentation. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation. |
+| <a name="externalDocUrl"></a>url                 | `string` | **REQUIRED**. The URL for the target documentation. This MUST be in the form of a URL.                                                 |
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### External Documentation Object Example
 
@@ -1002,7 +998,7 @@ description: Find more info here
 url: https://example.com
 ```
 
-#### <a name="parameterObject"></a>Parameter Object
+#### Parameter Object
 
 Describes a single operation parameter.
 
@@ -1010,57 +1006,56 @@ A unique parameter is defined by a combination of a [name](#parameterName) and [
 
 ##### Parameter Locations
 There are four possible parameter locations specified by the `in` field:
-* path - Used together with [Path Templating](#pathTemplating), where the parameter value is actually part of the operation's URL. This does not include the host or base path of the API. For example, in `/items/{itemId}`, the path parameter is `itemId`.
+* path - Used together with [Path Templating](#path-templating), where the parameter value is actually part of the operation's URL. This does not include the host or base path of the API. For example, in `/items/{itemId}`, the path parameter is `itemId`.
 * query - Parameters that are appended to the URL. For example, in `/items?id=###`, the query parameter is `id`.
 * header - Custom headers that are expected as part of the request. Note that [RFC7230](https://tools.ietf.org/html/rfc7230#page-22) states header names are case insensitive.
 * cookie - Used to pass a specific cookie value to the API.
 
 
 ##### Fixed Fields
-Field Name | Type | Description
----|:---:|---
-<a name="parameterName"></a>name | `string` | **REQUIRED**. The name of the parameter. Parameter names are *case sensitive*. <ul><li>If [`in`](#parameterIn) is `"path"`, the `name` field MUST correspond to a template expression occurring within the [path](#pathsPath) field in the [Paths Object](#pathsObject). See [Path Templating](#pathTemplating) for further information.<li>If [`in`](#parameterIn) is `"header"` and the `name` field is `"Accept"`, `"Content-Type"` or `"Authorization"`, the parameter definition SHALL be ignored.<li>For all other cases, the `name` corresponds to the parameter name used by the [`in`](#parameterIn) property.</ul>
-<a name="parameterIn"></a>in | `string` | **REQUIRED**. The location of the parameter. Possible values are `"query"`, `"header"`, `"path"` or `"cookie"`.
-<a name="parameterDescription"></a>description | `string` | A brief description of the parameter. This could contain examples of use. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="parameterRequired"></a>required | `boolean` | Determines whether this parameter is mandatory. If the [parameter location](#parameterIn) is `"path"`, this property is **REQUIRED** and its value MUST be `true`. Otherwise, the property MAY be included and its default value is `false`.
-<a name="parameterDeprecated"></a> deprecated | `boolean` | Specifies that a parameter is deprecated and SHOULD be transitioned out of usage. Default value is `false`.
-<a name="parameterAllowEmptyValue"></a> allowEmptyValue | `boolean` | Sets the ability to pass empty-valued parameters. This is valid only for `query` parameters and allows sending a parameter with an empty value. Default value is `false`. If [`style`](#parameterStyle) is used, and if behavior is `n/a` (cannot be serialized), the value of `allowEmptyValue` SHALL be ignored. Use of this property is NOT RECOMMENDED, as it is likely to be removed in a later revision.
+| Field Name                                              |   Type    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+|---------------------------------------------------------|:---------:|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| <a name="parameterName"></a>name                        | `string`  | **REQUIRED**. The name of the parameter. Parameter names are *case sensitive*. <ul><li>If [`in`](#parameterIn) is `"path"`, the `name` field MUST correspond to a template expression occurring within the [path](#pathsPath) field in the [Paths Object](#paths-object). See [Path Templating](#path-templating) for further information.<li>If [`in`](#parameterIn) is `"header"` and the `name` field is `"Accept"`, `"Content-Type"` or `"Authorization"`, the parameter definition SHALL be ignored.<li>For all other cases, the `name` corresponds to the parameter name used by the [`in`](#parameterIn) property.</ul> |
+| <a name="parameterIn"></a>in                            | `string`  | **REQUIRED**. The location of the parameter. Possible values are `"query"`, `"header"`, `"path"` or `"cookie"`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| <a name="parameterDescription"></a>description          | `string`  | A brief description of the parameter. This could contain examples of use. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| <a name="parameterRequired"></a>required                | `boolean` | Determines whether this parameter is mandatory. If the [parameter location](#parameterIn) is `"path"`, this property is **REQUIRED** and its value MUST be `true`. Otherwise, the property MAY be included and its default value is `false`.                                                                                                                                                                                                                                                                                                                                                                                   |
+| <a name="parameterDeprecated"></a> deprecated           | `boolean` | Specifies that a parameter is deprecated and SHOULD be transitioned out of usage. Default value is `false`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| <a name="parameterAllowEmptyValue"></a> allowEmptyValue | `boolean` | Sets the ability to pass empty-valued parameters. This is valid only for `query` parameters and allows sending a parameter with an empty value. Default value is `false`. If [`style`](#parameterStyle) is used, and if behavior is `n/a` (cannot be serialized), the value of `allowEmptyValue` SHALL be ignored. Use of this property is NOT RECOMMENDED, as it is likely to be removed in a later revision.                                                                                                                                                                                                                 |
 
 The rules for serialization of the parameter are specified in one of two ways.
 For simpler scenarios, a [`schema`](#parameterSchema) and [`style`](#parameterStyle) can describe the structure and syntax of the parameter.
 
-Field Name | Type | Description
----|:---:|---
-<a name="parameterStyle"></a>style | `string` | Describes how the parameter value will be serialized depending on the type of the parameter value. Default values (based on value of `in`): for `query` - `form`; for `path` - `simple`; for `header` - `simple`; for `cookie` - `form`.
-<a name="parameterExplode"></a>explode | `boolean` | When this is true, parameter values of type `array` or `object` generate separate parameters for each value of the array or key-value pair of the map. For other types of parameters this property has no effect. When [`style`](#parameterStyle) is `form`, the default value is `true`. For all other styles, the default value is `false`.
-<a name="parameterAllowReserved"></a>allowReserved | `boolean` | Determines whether the parameter value SHOULD allow reserved characters, as defined by [RFC3986](https://tools.ietf.org/html/rfc3986#section-2.2) `:/?#[]@!$&'()*+,;=` to be included without percent-encoding. This property only applies to parameters with an `in` value of `query`. The default value is `false`.
-<a name="parameterSchema"></a>schema | [Schema Object](#schemaObject) | The schema defining the type used for the parameter.
-<a name="parameterExample"></a>example | Any | Example of the parameter's potential value. The example SHOULD match the specified schema and encoding properties if present. The `example` field is mutually exclusive of the `examples` field. Furthermore, if referencing a `schema` that contains an example, the `example` value SHALL _override_ the example provided by the schema. To represent examples of media types that cannot naturally be represented in JSON or YAML, a string value can contain the example with escaping where necessary.
-<a name="parameterExamples"></a>examples | Map[ `string`, [Example Object](#exampleObject) \| [Reference Object](#referenceObject)] | Examples of the parameter's potential value. Each example SHOULD contain a value in the correct format as specified in the parameter encoding. The `examples` field is mutually exclusive of the `example` field. Furthermore, if referencing a `schema` that contains an example, the `examples` value SHALL _override_ the example provided by the schema.
+| Field Name                                         |                                            Type                                            | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+|----------------------------------------------------|:------------------------------------------------------------------------------------------:|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| <a name="parameterStyle"></a>style                 |                                          `string`                                          | Describes how the parameter value will be serialized depending on the type of the parameter value. Default values (based on value of `in`): for `query` - `form`; for `path` - `simple`; for `header` - `simple`; for `cookie` - `form`.                                                                                                                                                                                                                                                                    |
+| <a name="parameterExplode"></a>explode             |                                         `boolean`                                          | When this is true, parameter values of type `array` or `object` generate separate parameters for each value of the array or key-value pair of the map. For other types of parameters this property has no effect. When [`style`](#parameterStyle) is `form`, the default value is `true`. For all other styles, the default value is `false`.                                                                                                                                                               |
+| <a name="parameterAllowReserved"></a>allowReserved |                                         `boolean`                                          | Determines whether the parameter value SHOULD allow reserved characters, as defined by [RFC3986](https://tools.ietf.org/html/rfc3986#section-2.2) `:/?#[]@!$&'()*+,;=` to be included without percent-encoding. This property only applies to parameters with an `in` value of `query`. The default value is `false`.                                                                                                                                                                                       |
+| <a name="parameterSchema"></a>schema               |                              [Schema Object](#schema-object)                               | The schema defining the type used for the parameter.                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| <a name="parameterExample"></a>example             |                                            Any                                             | Example of the parameter's potential value. The example SHOULD match the specified schema and encoding properties if present. The `example` field is mutually exclusive of the `examples` field. Furthermore, if referencing a `schema` that contains an example, the `example` value SHALL _override_ the example provided by the schema. To represent examples of media types that cannot naturally be represented in JSON or YAML, a string value can contain the example with escaping where necessary. |
+| <a name="parameterExamples"></a>examples           | Map[ `string`, [Example Object](#example-object) \| [Reference Object](#reference-object)] | Examples of the parameter's potential value. Each example SHOULD contain a value in the correct format as specified in the parameter encoding. The `examples` field is mutually exclusive of the `example` field. Furthermore, if referencing a `schema` that contains an example, the `examples` value SHALL _override_ the example provided by the schema.                                                                                                                                                |
 
 For more complex scenarios, the [`content`](#parameterContent) property can define the media type and schema of the parameter.
 A parameter MUST contain either a `schema` property, or a `content` property, but not both.
 When `example` or `examples` are provided in conjunction with the `schema` object, the example MUST follow the prescribed serialization strategy for the parameter.
 
 
-Field Name | Type | Description
----|:---:|---
-<a name="parameterContent"></a>content | Map[`string`, [Media Type Object](#mediaTypeObject)] | A map containing the representations for the parameter. The key is the media type and the value describes it. The map MUST only contain one entry.
+| Field Name                             |                          Type                          | Description                                                                                                                                        |
+|----------------------------------------|:------------------------------------------------------:|----------------------------------------------------------------------------------------------------------------------------------------------------|
+| <a name="parameterContent"></a>content | Map[`string`, [Media Type Object](#media-type-object)] | A map containing the representations for the parameter. The key is the media type and the value describes it. The map MUST only contain one entry. |
 
-##### <a name="styleValues"></a>Style Values
+##### Style Values
 
 In order to support common ways of serializing simple parameters, a set of `style` values are defined.
 
-`style` | [`type`](#dataTypes) |  `in` | Comments
------------ | ------ | -------- | --------
-matrix |  `primitive`, `array`, `object` |  `path` | Path-style parameters defined by [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.7) 
-label | `primitive`, `array`, `object` |  `path` | Label style parameters defined by [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.5)
-form |  `primitive`, `array`, `object` |  `query`, `cookie` | Form style parameters defined by [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.8). This option replaces `collectionFormat` with a `csv` (when `explode` is false) or `multi` (when `explode` is true) value from OpenAPI 2.0.
-simple | `array` | `path`, `header` | Simple style parameters defined by [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.2).  This option replaces `collectionFormat` with a `csv` value from OpenAPI 2.0.
-spaceDelimited | `array`, `object` | `query` | Space separated array or object values. This option replaces `collectionFormat` equal to `ssv` from OpenAPI 2.0. 
-pipeDelimited | `array`, `object` | `query` | Pipe separated array or object values. This option replaces `collectionFormat` equal to `pipes` from OpenAPI 2.0.
-deepObject | `object` | `query` | Provides a simple way of rendering nested objects using form parameters.
-
+| `style`        | [`type`](#data-types)          | `in`              | Comments                                                                                                                                                                                                                                  |
+|----------------|--------------------------------|-------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| matrix         | `primitive`, `array`, `object` | `path`            | Path-style parameters defined by [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.7)                                                                                                                                             |
+| label          | `primitive`, `array`, `object` | `path`            | Label style parameters defined by [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.5)                                                                                                                                            |
+| form           | `primitive`, `array`, `object` | `query`, `cookie` | Form style parameters defined by [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.8). This option replaces `collectionFormat` with a `csv` (when `explode` is false) or `multi` (when `explode` is true) value from OpenAPI 2.0. |
+| simple         | `array`                        | `path`, `header`  | Simple style parameters defined by [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.2).  This option replaces `collectionFormat` with a `csv` value from OpenAPI 2.0.                                                            |
+| spaceDelimited | `array`, `object`              | `query`           | Space separated array or object values. This option replaces `collectionFormat` equal to `ssv` from OpenAPI 2.0.                                                                                                                          |
+| pipeDelimited  | `array`, `object`              | `query`           | Pipe separated array or object values. This option replaces `collectionFormat` equal to `pipes` from OpenAPI 2.0.                                                                                                                         |
+| deepObject     | `object`                       | `query`           | Provides a simple way of rendering nested objects using form parameters.                                                                                                                                                                  |
 
 ##### Style Examples
 
@@ -1073,21 +1068,21 @@ Assume a parameter named `color` has one of the following values:
 ```
 The following table shows examples of rendering differences for each value.
 
-[`style`](#styleValues) | `explode` | `empty` | `string` | `array` | `object`
------------ | ------ | -------- | -------- | -------- | -------
-matrix | false | ;color | ;color=blue | ;color=blue,black,brown | ;color=R,100,G,200,B,150
-matrix | true | ;color | ;color=blue | ;color=blue;color=black;color=brown | ;R=100;G=200;B=150
-label | false | .  | .blue |  .blue.black.brown | .R.100.G.200.B.150
-label | true | . | .blue |  .blue.black.brown | .R=100.G=200.B=150
-form | false | color= | color=blue | color=blue,black,brown | color=R,100,G,200,B,150
-form | true | color= | color=blue | color=blue&color=black&color=brown | R=100&G=200&B=150
-simple | false | n/a | blue | blue,black,brown | R,100,G,200,B,150
-simple | true | n/a | blue | blue,black,brown | R=100,G=200,B=150
-spaceDelimited | false | n/a | n/a | blue%20black%20brown | R%20100%20G%20200%20B%20150
-pipeDelimited | false | n/a | n/a | blue\|black\|brown | R\|100\|G\|200\|B\|150
-deepObject | true | n/a | n/a | n/a | color[R]=100&color[G]=200&color[B]=150
+| [`style`](#styleValues) | `explode` | `empty` | `string`    | `array`                             | `object`                               |
+|-------------------------|-----------|---------|-------------|-------------------------------------|----------------------------------------|
+| matrix                  | false     | ;color  | ;color=blue | ;color=blue,black,brown             | ;color=R,100,G,200,B,150               |
+| matrix                  | true      | ;color  | ;color=blue | ;color=blue;color=black;color=brown | ;R=100;G=200;B=150                     |
+| label                   | false     | .       | .blue       | .blue.black.brown                   | .R.100.G.200.B.150                     |
+| label                   | true      | .       | .blue       | .blue.black.brown                   | .R=100.G=200.B=150                     |
+| form                    | false     | color=  | color=blue  | color=blue,black,brown              | color=R,100,G,200,B,150                |
+| form                    | true      | color=  | color=blue  | color=blue&color=black&color=brown  | R=100&G=200&B=150                      |
+| simple                  | false     | n/a     | blue        | blue,black,brown                    | R,100,G,200,B,150                      |
+| simple                  | true      | n/a     | blue        | blue,black,brown                    | R=100,G=200,B=150                      |
+| spaceDelimited          | false     | n/a     | n/a         | blue%20black%20brown                | R%20100%20G%20200%20B%20150            |
+| pipeDelimited           | false     | n/a     | n/a         | blue\|black\|brown                  | R\|100\|G\|200\|B\|150                 |
+| deepObject              | true      | n/a     | n/a         | n/a                                 | color[R]=100&color[G]=200&color[B]=150 |
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Parameter Object Examples
 
@@ -1246,19 +1241,18 @@ content:
           type: number
 ```
 
-#### <a name="requestBodyObject"></a>Request Body Object
+#### Request Body Object
 
 Describes a single request body.
 
 ##### Fixed Fields
-Field Name | Type | Description
----|:---:|---
-<a name="requestBodyDescription"></a>description | `string` | A brief description of the request body. This could contain examples of use.  [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="requestBodyContent"></a>content | Map[`string`, [Media Type Object](#mediaTypeObject)] | **REQUIRED**. The content of the request body. The key is a media type or [media type range](https://tools.ietf.org/html/rfc7231#appendix-D) and the value describes it.  For requests that match multiple keys, only the most specific key is applicable. e.g. text/plain overrides text/*
-<a name="requestBodyRequired"></a>required | `boolean` | Determines if the request body is required in the request. Defaults to `false`.
+| Field Name                                       |                          Type                          | Description                                                                                                                                                                                                                                                                                 |
+|--------------------------------------------------|:------------------------------------------------------:|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| <a name="requestBodyDescription"></a>description |                        `string`                        | A brief description of the request body. This could contain examples of use.  [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.                                                                                                                   |
+| <a name="requestBodyContent"></a>content         | Map[`string`, [Media Type Object](#media-type-object)] | **REQUIRED**. The content of the request body. The key is a media type or [media type range](https://tools.ietf.org/html/rfc7231#appendix-D) and the value describes it.  For requests that match multiple keys, only the most specific key is applicable. e.g. text/plain overrides text/* |
+| <a name="requestBodyRequired"></a>required       |                       `boolean`                        | Determines if the request body is required in the request. Defaults to `false`.                                                                                                                                                                                                             |
 
-
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Request Body Examples
 
@@ -1368,18 +1362,18 @@ content:
 ```
 
 
-#### <a name="mediaTypeObject"></a>Media Type Object
+#### Media Type Object
 Each Media Type Object provides schema and examples for the media type identified by its key.
 
 ##### Fixed Fields
-Field Name | Type | Description
----|:---:|---
-<a name="mediaTypeSchema"></a>schema | [Schema Object](#schemaObject) | The schema defining the content of the request, response, or parameter.
-<a name="mediaTypeExample"></a>example | Any | Example of the media type.  The example object SHOULD be in the correct format as specified by the media type.  The `example` field is mutually exclusive of the `examples` field.  Furthermore, if referencing a `schema` which contains an example, the `example` value SHALL _override_ the example provided by the schema.
-<a name="mediaTypeExamples"></a>examples | Map[ `string`, [Example Object](#exampleObject) \| [Reference Object](#referenceObject)] | Examples of the media type.  Each example object SHOULD  match the media type and specified schema if present.  The `examples` field is mutually exclusive of the `example` field.  Furthermore, if referencing a `schema` which contains an example, the `examples` value SHALL _override_ the example provided by the schema.
-<a name="mediaTypeEncoding"></a>encoding | Map[`string`, [Encoding Object](#encodingObject)] | A map between a property name and its encoding information. The key, being the property name, MUST exist in the schema as a property. The encoding object SHALL only apply to `requestBody` objects when the media type is `multipart` or `application/x-www-form-urlencoded`.
+| Field Name                               |                                            Type                                            | Description                                                                                                                                                                                                                                                                                                                     |
+|------------------------------------------|:------------------------------------------------------------------------------------------:|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| <a name="mediaTypeSchema"></a>schema     |                              [Schema Object](#schema-object)                               | The schema defining the content of the request, response, or parameter.                                                                                                                                                                                                                                                         |
+| <a name="mediaTypeExample"></a>example   |                                            Any                                             | Example of the media type.  The example object SHOULD be in the correct format as specified by the media type.  The `example` field is mutually exclusive of the `examples` field.  Furthermore, if referencing a `schema` which contains an example, the `example` value SHALL _override_ the example provided by the schema.  |
+| <a name="mediaTypeExamples"></a>examples | Map[ `string`, [Example Object](#example-object) \| [Reference Object](#reference-object)] | Examples of the media type.  Each example object SHOULD  match the media type and specified schema if present.  The `examples` field is mutually exclusive of the `example` field.  Furthermore, if referencing a `schema` which contains an example, the `examples` value SHALL _override_ the example provided by the schema. |
+| <a name="mediaTypeEncoding"></a>encoding |                     Map[`string`, [Encoding Object](#encoding-object)]                     | A map between a property name and its encoding information. The key, being the property name, MUST exist in the schema as a property. The encoding object SHALL only apply to `requestBody` objects when the media type is `multipart` or `application/x-www-form-urlencoded`.                                                  |
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Media Type Examples
 
@@ -1450,7 +1444,7 @@ In contrast with the 2.0 specification, `file` input/output content in OpenAPI i
 
 In contrast with the 3.0 specification, the `format` keyword has no effect on the content-encoding of the schema. JSON Schema offers a `contentEncoding` keyword, which may be used to specify the `Content-Encoding` for the schema. The `contentEncoding` keyword supports all encodings defined in [RFC4648](https://tools.ietf.org/html/rfc4648), including "base64" and "base64url", as well as "quoted-printable" from [RFC2045](https://tools.ietf.org/html/rfc2045#section-6.7). The encoding specified by the `contentEncoding` keyword is independent of an encoding specified by the `Content-Type` header in the request or response or metadata of a multipart body -- when both are present, the encoding specified in the `contentEncoding` is applied first and then the encoding specified in the `Content-Type` header.
 
-JSON Schema also offers a `contentMediaType` keyword.  However, when the media type is already specified by the Media Type Object's key, or by the `contentType` field of an [Encoding Object](#encodingObject), the `contentMediaType` keyword SHALL be ignored if present.
+JSON Schema also offers a `contentMediaType` keyword.  However, when the media type is already specified by the Media Type Object's key, or by the `contentType` field of an [Encoding Object](#encoding-object), the `contentMediaType` keyword SHALL be ignored if present.
 
 Examples:
 
@@ -1541,13 +1535,13 @@ requestBody:
 
 In this example, the contents in the `requestBody` MUST be stringified per [RFC1866](https://tools.ietf.org/html/rfc1866/) when passed to the server.  In addition, the `address` field complex object will be stringified.
 
-When passing complex objects in the `application/x-www-form-urlencoded` content type, the default serialization strategy of such properties is described in the [`Encoding Object`](#encodingObject)'s [`style`](#encodingStyle) property as `form`.
+When passing complex objects in the `application/x-www-form-urlencoded` content type, the default serialization strategy of such properties is described in the [`Encoding Object`](#encoding-object)'s [`style`](#encodingStyle) property as `form`.
 
 ##### Special Considerations for `multipart` Content
 
 It is common to use `multipart/form-data` as a `Content-Type` when transferring request bodies to operations.  In contrast to 2.0, a `schema` is REQUIRED to define the input parameters to the operation when using `multipart` content.  This supports complex structures as well as supporting mechanisms for multiple file uploads.
 
-In a `multipart/form-data` request body, each schema property, or each element of a schema array property, takes a section in the payload with an internal header as defined by [RFC7578](https://tools.ietf.org/html/rfc7578). The serialization strategy for each property of a `multipart/form-data` request body can be specified in an associated [`Encoding Object`](#encodingObject).
+In a `multipart/form-data` request body, each schema property, or each element of a schema array property, takes a section in the payload with an internal header as defined by [RFC7578](https://tools.ietf.org/html/rfc7578). The serialization strategy for each property of a `multipart/form-data` request body can be specified in an associated [`Encoding Object`](#encoding-object).
 
 When passing in `multipart` types, boundaries MAY be used to separate sections of the content being transferred – thus, the following default `Content-Type`s are defined for `multipart`:
 
@@ -1593,20 +1587,20 @@ requestBody:
 
 An `encoding` attribute is introduced to give you control over the serialization of parts of `multipart` request bodies.  This attribute is _only_ applicable to `multipart` and `application/x-www-form-urlencoded` request bodies.
 
-#### <a name="encodingObject"></a>Encoding Object
+#### Encoding Object
 
 A single encoding definition applied to a single schema property.
 
 ##### Fixed Fields
-Field Name | Type | Description
----|:---:|---
-<a name="encodingContentType"></a>contentType | `string` | The Content-Type for encoding a specific property. Default value depends on the property type: for `object` - `application/json`;  for `array` – the default is defined based on the inner type; for all other cases the default is `application/octet-stream`. The value can be a specific media type (e.g. `application/json`), a wildcard media type (e.g. `image/*`), or a comma-separated list of the two types. 
-<a name="encodingHeaders"></a>headers | Map[`string`, [Header Object](#headerObject) \| [Reference Object](#referenceObject)] | A map allowing additional information to be provided as headers, for example `Content-Disposition`.  `Content-Type` is described separately and SHALL be ignored in this section. This property SHALL be ignored if the request body media type is not a `multipart`.
-<a name="encodingStyle"></a>style | `string` | Describes how a specific property value will be serialized depending on its type.  See [Parameter Object](#parameterObject) for details on the [`style`](#parameterStyle) property. The behavior follows the same values as `query` parameters, including default values. This property SHALL be ignored if the request body media type is not `application/x-www-form-urlencoded` or `multipart/form-data`. If a value is explicitly defined, then the value of [`contentType`](#encodingContentType) (implicit or explicit) SHALL be ignored.
-<a name="encodingExplode"></a>explode | `boolean` | When this is true, property values of type `array` or `object` generate separate parameters for each value of the array, or key-value-pair of the map.  For other types of properties this property has no effect. When [`style`](#encodingStyle) is `form`, the default value is `true`. For all other styles, the default value is `false`. This property SHALL be ignored if the request body media type is not `application/x-www-form-urlencoded` or `multipart/form-data`. If a value is explicitly defined, then the value of [`contentType`](#encodingContentType) (implicit or explicit) SHALL be ignored.
-<a name="encodingAllowReserved"></a>allowReserved | `boolean` | Determines whether the parameter value SHOULD allow reserved characters, as defined by [RFC3986](https://tools.ietf.org/html/rfc3986#section-2.2) `:/?#[]@!$&'()*+,;=` to be included without percent-encoding. The default value is `false`. This property SHALL be ignored if the request body media type is not `application/x-www-form-urlencoded` or `multipart/form-data`. If a value is explicitly defined, then the value of [`contentType`](#encodingContentType) (implicit or explicit) SHALL be ignored.
+| Field Name                                        |                                          Type                                           | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+|---------------------------------------------------|:---------------------------------------------------------------------------------------:|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| <a name="encodingContentType"></a>contentType     |                                        `string`                                         | The Content-Type for encoding a specific property. Default value depends on the property type: for `object` - `application/json`;  for `array` – the default is defined based on the inner type; for all other cases the default is `application/octet-stream`. The value can be a specific media type (e.g. `application/json`), a wildcard media type (e.g. `image/*`), or a comma-separated list of the two types.                                                                                                                                                                                               |
+| <a name="encodingHeaders"></a>headers             | Map[`string`, [Header Object](#header-object) \| [Reference Object](#reference-object)] | A map allowing additional information to be provided as headers, for example `Content-Disposition`.  `Content-Type` is described separately and SHALL be ignored in this section. This property SHALL be ignored if the request body media type is not a `multipart`.                                                                                                                                                                                                                                                                                                                                               |
+| <a name="encodingStyle"></a>style                 |                                        `string`                                         | Describes how a specific property value will be serialized depending on its type.  See [Parameter Object](#parameter-object) for details on the [`style`](#parameterStyle) property. The behavior follows the same values as `query` parameters, including default values. This property SHALL be ignored if the request body media type is not `application/x-www-form-urlencoded` or `multipart/form-data`. If a value is explicitly defined, then the value of [`contentType`](#encodingContentType) (implicit or explicit) SHALL be ignored.                                                                    |
+| <a name="encodingExplode"></a>explode             |                                        `boolean`                                        | When this is true, property values of type `array` or `object` generate separate parameters for each value of the array, or key-value-pair of the map.  For other types of properties this property has no effect. When [`style`](#encodingStyle) is `form`, the default value is `true`. For all other styles, the default value is `false`. This property SHALL be ignored if the request body media type is not `application/x-www-form-urlencoded` or `multipart/form-data`. If a value is explicitly defined, then the value of [`contentType`](#encodingContentType) (implicit or explicit) SHALL be ignored. |
+| <a name="encodingAllowReserved"></a>allowReserved |                                        `boolean`                                        | Determines whether the parameter value SHOULD allow reserved characters, as defined by [RFC3986](https://tools.ietf.org/html/rfc3986#section-2.2) `:/?#[]@!$&'()*+,;=` to be included without percent-encoding. The default value is `false`. This property SHALL be ignored if the request body media type is not `application/x-www-form-urlencoded` or `multipart/form-data`. If a value is explicitly defined, then the value of [`contentType`](#encodingContentType) (implicit or explicit) SHALL be ignored.                                                                                                 |
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Encoding Object Example
 
@@ -1645,7 +1639,7 @@ requestBody:
                 type: integer
 ```
 
-#### <a name="responsesObject"></a>Responses Object
+#### Responses Object
 
 A container for the expected responses of an operation.
 The container maps a HTTP response code to the expected response.
@@ -1661,17 +1655,16 @@ response code is provided it SHOULD be the response for a successful operation
 call.
 
 ##### Fixed Fields
-Field Name | Type | Description
----|:---:|---
-<a name="responsesDefault"></a>default | [Response Object](#responseObject) \| [Reference Object](#referenceObject) | The documentation of responses other than the ones declared for specific HTTP response codes. Use this field to cover undeclared responses.
+| Field Name                             |                                     Type                                     | Description                                                                                                                                 |
+|----------------------------------------|:----------------------------------------------------------------------------:|---------------------------------------------------------------------------------------------------------------------------------------------|
+| <a name="responsesDefault"></a>default | [Response Object](#response-object) \| [Reference Object](#reference-object) | The documentation of responses other than the ones declared for specific HTTP response codes. Use this field to cover undeclared responses. |
 
 ##### Patterned Fields
-Field Pattern | Type | Description
----|:---:|---
-<a name="responsesCode"></a>[HTTP Status Code](#httpCodes) | [Response Object](#responseObject) \| [Reference Object](#referenceObject) | Any [HTTP status code](#httpCodes) can be used as the property name, but only one property per code, to describe the expected response for that HTTP status code. This field MUST be enclosed in quotation marks (for example, "200") for compatibility between JSON and YAML. To define a range of response codes, this field MAY contain the uppercase wildcard character `X`. For example, `2XX` represents all response codes between `[200-299]`. Only the following range definitions are allowed: `1XX`, `2XX`, `3XX`, `4XX`, and `5XX`. If a response is defined using an explicit code, the explicit code definition takes precedence over the range definition for that code.
+| Field Pattern                                                      |                                     Type                                     | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+|--------------------------------------------------------------------|:----------------------------------------------------------------------------:|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| <a name="responsesCode"></a>[HTTP Status Code](#http-status-codes) | [Response Object](#response-object) \| [Reference Object](#reference-object) | Any [HTTP status code](#http-status-codes) can be used as the property name, but only one property per code, to describe the expected response for that HTTP status code. This field MUST be enclosed in quotation marks (for example, "200") for compatibility between JSON and YAML. To define a range of response codes, this field MAY contain the uppercase wildcard character `X`. For example, `2XX` represents all response codes between `[200-299]`. Only the following range definitions are allowed: `1XX`, `2XX`, `3XX`, `4XX`, and `5XX`. If a response is defined using an explicit code, the explicit code definition takes precedence over the range definition for that code. |
 
-
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Responses Object Example
 
@@ -1717,19 +1710,19 @@ default:
         $ref: '#/components/schemas/ErrorModel'
 ```
 
-#### <a name="responseObject"></a>Response Object
+#### Response Object
 Describes a single response from an API Operation, including design-time, static 
 `links` to operations based on the response.
 
 ##### Fixed Fields
-Field Name | Type | Description
----|:---:|---
-<a name="responseDescription"></a>description | `string` | **REQUIRED**. A description of the response. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="responseHeaders"></a>headers | Map[`string`, [Header Object](#headerObject)  \| [Reference Object](#referenceObject)] |  Maps a header name to its definition. [RFC7230](https://tools.ietf.org/html/rfc7230#page-22) states header names are case insensitive. If a response header is defined with the name `"Content-Type"`, it SHALL be ignored.
-<a name="responseContent"></a>content | Map[`string`, [Media Type Object](#mediaTypeObject)] | A map containing descriptions of potential response payloads. The key is a media type or [media type range](https://tools.ietf.org/html/rfc7231#appendix-D) and the value describes it.  For responses that match multiple keys, only the most specific key is applicable. e.g. text/plain overrides text/*
-<a name="responseLinks"></a>links | Map[`string`, [Link Object](#linkObject) \| [Reference Object](#referenceObject)] | A map of operations links that can be followed from the response. The key of the map is a short name for the link, following the naming constraints of the names for [Component Objects](#componentsObject). 
+| Field Name                                    |                                           Type                                           | Description                                                                                                                                                                                                                                                                                                 |
+|-----------------------------------------------|:----------------------------------------------------------------------------------------:|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| <a name="responseDescription"></a>description |                                         `string`                                         | **REQUIRED**. A description of the response. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.                                                                                                                                                                    |
+| <a name="responseHeaders"></a>headers         | Map[`string`, [Header Object](#header-object)  \| [Reference Object](#reference-object)] | Maps a header name to its definition. [RFC7230](https://tools.ietf.org/html/rfc7230#page-22) states header names are case insensitive. If a response header is defined with the name `"Content-Type"`, it SHALL be ignored.                                                                                 |
+| <a name="responseContent"></a>content         |                  Map[`string`, [Media Type Object](#media-type-object)]                  | A map containing descriptions of potential response payloads. The key is a media type or [media type range](https://tools.ietf.org/html/rfc7231#appendix-D) and the value describes it.  For responses that match multiple keys, only the most specific key is applicable. e.g. text/plain overrides text/* |
+| <a name="responseLinks"></a>links             |   Map[`string`, [Link Object](#link-object) \| [Reference Object](#reference-object)]    | A map of operations links that can be followed from the response. The key of the map is a short name for the link, following the naming constraints of the names for [Component Objects](#components-object).                                                                                               |
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Response Object Examples
 
@@ -1855,24 +1848,24 @@ Response with no return value:
 description: object created
 ```
 
-#### <a name="callbackObject"></a>Callback Object
+#### Callback Object
 
 A map of possible out-of band callbacks related to the parent operation.
-Each value in the map is a [Path Item Object](#pathItemObject) that describes a set of requests that may be initiated by the API provider and the expected responses.
+Each value in the map is a [Path Item Object](#path-item-object) that describes a set of requests that may be initiated by the API provider and the expected responses.
 The key value used to identify the path item object is an expression, evaluated at runtime, that identifies a URL to use for the callback operation.
 
 To describe incoming requests from the API provider independent from another API call, use the [`webhooks`](#oasWebhooks) field.
 
 ##### Patterned Fields
-Field Pattern | Type | Description
----|:---:|---
-<a name="callbackExpression"></a>{expression} | [Path Item Object](#pathItemObject) \| [Reference Object](#referenceObject) | A Path Item Object, or a reference to one, used to define a callback request and expected responses.  A [complete example](../examples/v3.0/callback-example.yaml) is available.
+| Field Pattern                                 |                                      Type                                      | Description                                                                                                                                                                      |
+|-----------------------------------------------|:------------------------------------------------------------------------------:|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| <a name="callbackExpression"></a>{expression} | [Path Item Object](#path-item-object) \| [Reference Object](#reference-object) | A Path Item Object, or a reference to one, used to define a callback request and expected responses.  A [complete example](../examples/v3.0/callback-example.yaml) is available. |
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Key Expression
 
-The key that identifies the [Path Item Object](#pathItemObject) is a [runtime expression](#runtimeExpression) that can be evaluated in the context of a runtime HTTP request/response to identify the URL to be used for the callback request.
+The key that identifies the [Path Item Object](#path-item-object) is a [runtime expression](#runtimeExpression) that can be evaluated in the context of a runtime HTTP request/response to identify the URL to be used for the callback request.
 A simple example might be `$request.body#/url`.
 However, using a [runtime expression](#runtimeExpression) the complete HTTP message can be accessed.
 This includes accessing any part of a body that a JSON Pointer [RFC6901](https://tools.ietf.org/html/rfc6901) can reference. 
@@ -1900,17 +1893,16 @@ Location: https://example.org/subscription/1
 
 The following examples show how the various expressions evaluate, assuming the callback operation has a path parameter named `eventType` and a query parameter named `queryUrl`.
 
-Expression | Value 
----|:---
-$url | https://example.org/subscribe/myevent?queryUrl=https://clientdomain.com/stillrunning
-$method | POST
-$request.path.eventType | myevent
-$request.query.queryUrl | https://clientdomain.com/stillrunning
-$request.header.content-Type | application/json
-$request.body#/failedUrl | https://clientdomain.com/failed
-$request.body#/successUrls/2 | https://clientdomain.com/medium
-$response.header.Location | https://example.org/subscription/1
-
+| Expression                   | Value                                                                                |
+|------------------------------|:-------------------------------------------------------------------------------------|
+| $url                         | https://example.org/subscribe/myevent?queryUrl=https://clientdomain.com/stillrunning |
+| $method                      | POST                                                                                 |
+| $request.path.eventType      | myevent                                                                              |
+| $request.query.queryUrl      | https://clientdomain.com/stillrunning                                                |
+| $request.header.content-Type | application/json                                                                     |
+| $request.body#/failedUrl     | https://clientdomain.com/failed                                                      |
+| $request.body#/successUrls/2 | https://clientdomain.com/medium                                                      |
+| $response.header.Location    | https://example.org/subscription/1                                                   |
 
 ##### Callback Object Examples
 
@@ -1948,17 +1940,17 @@ transactionCallback:
           description: callback successfully processed
 ```
 
-#### <a name="exampleObject"></a>Example Object
+#### Example Object
 
 ##### Fixed Fields
-Field Name | Type | Description
----|:---:|---
-<a name="exampleSummary"></a>summary | `string` | Short description for the example.
-<a name="exampleDescription"></a>description | `string` | Long description for the example. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="exampleValue"></a>value | Any | Embedded literal example. The `value` field and `externalValue` field are mutually exclusive. To represent examples of media types that cannot naturally represented in JSON or YAML, use a string value to contain the example, escaping where necessary.
-<a name="exampleExternalValue"></a>externalValue | `string` | A URI that points to the literal example. This provides the capability to reference examples that cannot easily be included in JSON or YAML documents.  The `value` field and `externalValue` field are mutually exclusive. See the rules for resolving [Relative References](#relativeReferencesURI).
+| Field Name                                       |   Type   | Description                                                                                                                                                                                                                                                                                                  |
+|--------------------------------------------------|:--------:|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| <a name="exampleSummary"></a>summary             | `string` | Short description for the example.                                                                                                                                                                                                                                                                           |
+| <a name="exampleDescription"></a>description     | `string` | Long description for the example. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.                                                                                                                                                                                |
+| <a name="exampleValue"></a>value                 |   Any    | Embedded literal example. The `value` field and `externalValue` field are mutually exclusive. To represent examples of media types that cannot naturally represented in JSON or YAML, use a string value to contain the example, escaping where necessary.                                                   |
+| <a name="exampleExternalValue"></a>externalValue | `string` | A URI that points to the literal example. This provides the capability to reference examples that cannot easily be included in JSON or YAML documents.  The `value` field and `externalValue` field are mutually exclusive. See the rules for resolving [Relative References](#relative-references-in-uris). |
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 In all cases, the example value is expected to be compatible with the type schema 
 of its associated value.  Tooling implementations MAY choose to 
@@ -2023,7 +2015,7 @@ responses:
 ```
 
 
-#### <a name="linkObject"></a>Link Object
+#### Link Object
 
 The `Link object` represents a possible design-time link for a response.
 The presence of a link does not guarantee the caller's ability to successfully invoke it, rather it provides a known relationship and traversal mechanism between responses and other operations.
@@ -2034,16 +2026,16 @@ For computing links, and providing instructions to execute them, a [runtime expr
 
 ##### Fixed Fields
 
-Field Name  |  Type  | Description
----|:---:|---
-<a name="linkOperationRef"></a>operationRef | `string` | A relative or absolute URI reference to an OAS operation. This field is mutually exclusive of the `operationId` field, and MUST point to an [Operation Object](#operationObject). Relative `operationRef` values MAY be used to locate an existing [Operation Object](#operationObject) in the OpenAPI definition. See the rules for resolving [Relative References](#relativeReferencesURI).
-<a name="linkOperationId"></a>operationId  | `string` | The name of an _existing_, resolvable OAS operation, as defined with a unique `operationId`.  This field is mutually exclusive of the `operationRef` field.  
-<a name="linkParameters"></a>parameters   | Map[`string`, Any \| [{expression}](#runtimeExpression)] | A map representing parameters to pass to an operation as specified with `operationId` or identified via `operationRef`. The key is the parameter name to be used, whereas the value can be a constant or an expression to be evaluated and passed to the linked operation.  The parameter name can be qualified using the [parameter location](#parameterIn) `[{in}.]{name}` for operations that use the same parameter name in different locations (e.g. path.id).
-<a name="linkRequestBody"></a>requestBody | Any \| [{expression}](#runtimeExpression) | A literal value or [{expression}](#runtimeExpression) to use as a request body when calling the target operation.
-<a name="linkDescription"></a>description  | `string` | A description of the link. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="linkServer"></a>server       | [Server Object](#serverObject) | A server object to be used by the target operation.
+| Field Name                                  |                           Type                           | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+|---------------------------------------------|:--------------------------------------------------------:|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| <a name="linkOperationRef"></a>operationRef |                         `string`                         | A relative or absolute URI reference to an OAS operation. This field is mutually exclusive of the `operationId` field, and MUST point to an [Operation Object](#operation-object). Relative `operationRef` values MAY be used to locate an existing [Operation Object](#operation-object) in the OpenAPI definition. See the rules for resolving [Relative References](#relative-references-in-uris).                                                               |
+| <a name="linkOperationId"></a>operationId   |                         `string`                         | The name of an _existing_, resolvable OAS operation, as defined with a unique `operationId`.  This field is mutually exclusive of the `operationRef` field.                                                                                                                                                                                                                                                                                                         |
+| <a name="linkParameters"></a>parameters     | Map[`string`, Any \| [{expression}](#runtimeExpression)] | A map representing parameters to pass to an operation as specified with `operationId` or identified via `operationRef`. The key is the parameter name to be used, whereas the value can be a constant or an expression to be evaluated and passed to the linked operation.  The parameter name can be qualified using the [parameter location](#parameterIn) `[{in}.]{name}` for operations that use the same parameter name in different locations (e.g. path.id). |
+| <a name="linkRequestBody"></a>requestBody   |        Any \| [{expression}](#runtimeExpression)         | A literal value or [{expression}](#runtimeExpression) to use as a request body when calling the target operation.                                                                                                                                                                                                                                                                                                                                                   |
+| <a name="linkDescription"></a>description   |                         `string`                         | A description of the link. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.                                                                                                                                                                                                                                                                                                                                              |
+| <a name="linkServer"></a>server             |             [Server Object](#server-object)              | A server object to be used by the target operation.                                                                                                                                                                                                                                                                                                                                                                                                                 |
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 A linked operation MUST be identified using either an `operationRef` or `operationId`.
 In the case of an `operationId`, it MUST be unique and resolved in the scope of the OAS document.
@@ -2121,7 +2113,7 @@ solely by the existence of a relationship.
 ##### OperationRef Examples
 
 As references to `operationId` MAY NOT be possible (the `operationId` is an optional 
-field in an [Operation Object](#operationObject)), references MAY also be made through a relative `operationRef`:
+field in an [Operation Object](#operation-object)), references MAY also be made through a relative `operationRef`:
 
 ```yaml
 links:
@@ -2147,10 +2139,10 @@ Note that in the use of `operationRef`, the _escaped forward-slash_ is necessary
 using JSON references.
 
 
-##### <a name="runtimeExpression"></a>Runtime Expressions
+##### Runtime Expressions
 
 Runtime expressions allow defining values based on information that will only be available within the HTTP message in an actual API call.
-This mechanism is used by [Link Objects](#linkObject) and [Callback Objects](#callbackObject).
+This mechanism is used by [Link Objects](#link-object) and [Callback Objects](#callback-object).
 
 The runtime expression is defined by the following [ABNF](https://tools.ietf.org/html/rfc5234) syntax
 
@@ -2179,24 +2171,24 @@ The `name` identifier is case-sensitive, whereas `token` is not.
 
 The table below provides examples of runtime expressions and examples of their use in a value:
 
-##### <a name="runtimeExpressionExamples"></a>Examples
+##### Examples
 
-Source Location | example expression  | notes
----|:---|:---|
-HTTP Method            | `$method`         | The allowable values for the `$method` will be those for the HTTP operation.
-Requested media type | `$request.header.accept`        |  
-Request parameter      | `$request.path.id`        | Request parameters MUST be declared in the `parameters` section of the parent operation or they cannot be evaluated. This includes request headers.
-Request body property   | `$request.body#/user/uuid`   | In operations which accept payloads, references may be made to portions of the `requestBody` or the entire body.
-Request URL            | `$url`            |  
-Response value         | `$response.body#/status`       |  In operations which return payloads, references may be made to portions of the response body or the entire body.
-Response header        | `$response.header.Server` |  Single header values only are available
+| Source Location       | example expression         | notes                                                                                                                                               |
+|-----------------------|:---------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------|
+| HTTP Method           | `$method`                  | The allowable values for the `$method` will be those for the HTTP operation.                                                                        |
+| Requested media type  | `$request.header.accept`   |                                                                                                                                                     |
+| Request parameter     | `$request.path.id`         | Request parameters MUST be declared in the `parameters` section of the parent operation or they cannot be evaluated. This includes request headers. |
+| Request body property | `$request.body#/user/uuid` | In operations which accept payloads, references may be made to portions of the `requestBody` or the entire body.                                    |
+| Request URL           | `$url`                     |                                                                                                                                                     |
+| Response value        | `$response.body#/status`   | In operations which return payloads, references may be made to portions of the response body or the entire body.                                    |
+| Response header       | `$response.header.Server`  | Single header values only are available                                                                                                             |
 
 Runtime expressions preserve the type of the referenced value.
 Expressions can be embedded into string values by surrounding the expression with `{}` curly braces.
 
-#### <a name="headerObject"></a>Header Object
+#### Header Object
 
-The Header Object follows the structure of the [Parameter Object](#parameterObject) with the following changes:
+The Header Object follows the structure of the [Parameter Object](#parameter-object) with the following changes:
 
 1. `name` MUST NOT be specified, it is given in the corresponding `headers` map.
 1. `in` MUST NOT be specified, it is implicitly in `header`.
@@ -2221,19 +2213,19 @@ schema:
   type: integer
 ```
 
-#### <a name="tagObject"></a>Tag Object
+#### Tag Object
 
-Adds metadata to a single tag that is used by the [Operation Object](#operationObject).
+Adds metadata to a single tag that is used by the [Operation Object](#operation-object).
 It is not mandatory to have a Tag Object per tag defined in the Operation Object instances.
 
 ##### Fixed Fields
-Field Name | Type | Description
----|:---:|---
-<a name="tagName"></a>name | `string` | **REQUIRED**. The name of the tag.
-<a name="tagDescription"></a>description | `string` | A description for the tag. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="tagExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation for this tag.
+| Field Name                                 |                              Type                               | Description                                                                                                            |
+|--------------------------------------------|:---------------------------------------------------------------:|------------------------------------------------------------------------------------------------------------------------|
+| <a name="tagName"></a>name                 |                            `string`                             | **REQUIRED**. The name of the tag.                                                                                     |
+| <a name="tagDescription"></a>description   |                            `string`                             | A description for the tag. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation. |
+| <a name="tagExternalDocs"></a>externalDocs | [External Documentation Object](#external-documentation-object) | Additional external documentation for this tag.                                                                        |
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Tag Object Example
 
@@ -2250,24 +2242,24 @@ description: Pets operations
 ```
 
 
-#### <a name="referenceObject"></a>Reference Object
+#### Reference Object
 
 A simple object to allow referencing other components in the OpenAPI document, internally and externally.
 
 The `$ref` string value contains a URI [RFC3986](https://tools.ietf.org/html/rfc3986), which identifies the location of the value being referenced.
 
-See the rules for resolving [Relative References](#relativeReferencesURI).
+See the rules for resolving [Relative References](#relative-references-in-uris).
 
 ##### Fixed Fields
-Field Name | Type | Description
----|:---:|---
-<a name="referenceRef"></a>$ref | `string` | **REQUIRED**. The reference identifier. This MUST be in the form of a URI.
-<a name="referenceSummary"></a>summary | `string` | A short summary which by default SHOULD override that of the referenced component. If the referenced object-type does not allow a `summary` field, then this field has no effect.
-<a name="referenceDescription"></a>description | `string` | A description which by default SHOULD override that of the referenced component. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation. If the referenced object-type does not allow a `description` field, then this field has no effect.
+| Field Name                                     |   Type   | Description                                                                                                                                                                                                                                                                     |
+|------------------------------------------------|:--------:|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| <a name="referenceRef"></a>$ref                | `string` | **REQUIRED**. The reference identifier. This MUST be in the form of a URI.                                                                                                                                                                                                      |
+| <a name="referenceSummary"></a>summary         | `string` | A short summary which by default SHOULD override that of the referenced component. If the referenced object-type does not allow a `summary` field, then this field has no effect.                                                                                               |
+| <a name="referenceDescription"></a>description | `string` | A description which by default SHOULD override that of the referenced component. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation. If the referenced object-type does not allow a `description` field, then this field has no effect. |
 
 This object cannot be extended with additional properties and any properties added SHALL be ignored.
 
-Note that this restriction on additional properties is a difference between Reference Objects and [`Schema Objects`](#schemaObject) that contain a `$ref` keyword.
+Note that this restriction on additional properties is a difference between Reference Objects and [`Schema Objects`](#schema-object) that contain a `$ref` keyword.
 
 ##### Reference Object Example
 
@@ -2303,7 +2295,7 @@ $ref: Pet.yaml
 $ref: definitions.yaml#/Pet
 ```
 
-#### <a name="schemaObject"></a>Schema Object
+#### Schema Object
 
 The Schema Object allows the definition of input and output data types.
 These types can be objects, but also primitives and arrays. This object is a superset of the [JSON Schema Specification Draft 2020-12](https://tools.ietf.org/html/draft-bhutton-json-schema-00).
@@ -2328,16 +2320,16 @@ In addition to the JSON Schema properties comprising the OAS dialect, the Schema
 
 The OpenAPI Specification's base vocabulary is comprised of the following keywords:
 
-##### <a name="baseVocabulary"></a>Fixed Fields
+##### Fixed Fields
 
-Field Name | Type | Description
----|:---:|---
-<a name="schemaDiscriminator"></a>discriminator | [Discriminator Object](#discriminatorObject) | Adds support for polymorphism. The discriminator is an object name that is used to differentiate between other schemas which may satisfy the payload description. See [Composition and Inheritance](#schemaComposition) for more details.
-<a name="schemaXml"></a>xml | [XML Object](#xmlObject) | This MAY be used only on properties schemas. It has no effect on root schemas. Adds additional metadata to describe the XML representation of this property.
-<a name="schemaExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation for this schema.
-<a name="schemaExample"></a>example | Any | A free-form property to include an example of an instance for this schema. To represent examples that cannot be naturally represented in JSON or YAML, a string value can be used to contain the example with escaping where necessary.<br><br>**Deprecated:** The `example` property has been deprecated in favor of the JSON Schema `examples` keyword. Use of `example` is discouraged, and later versions of this specification may remove it.
+| Field Name                                      |                              Type                               | Description                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+|-------------------------------------------------|:---------------------------------------------------------------:|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| <a name="schemaDiscriminator"></a>discriminator |          [Discriminator Object](#discriminator-object)          | Adds support for polymorphism. The discriminator is an object name that is used to differentiate between other schemas which may satisfy the payload description. See [Composition and Inheritance](#schemaComposition) for more details.                                                                                                                                                                                                          |
+| <a name="schemaXml"></a>xml                     |                    [XML Object](#xml-object)                    | This MAY be used only on properties schemas. It has no effect on root schemas. Adds additional metadata to describe the XML representation of this property.                                                                                                                                                                                                                                                                                       |
+| <a name="schemaExternalDocs"></a>externalDocs   | [External Documentation Object](#external-documentation-object) | Additional external documentation for this schema.                                                                                                                                                                                                                                                                                                                                                                                                 |
+| <a name="schemaExample"></a>example             |                               Any                               | A free-form property to include an example of an instance for this schema. To represent examples that cannot be naturally represented in JSON or YAML, a string value can be used to contain the example with escaping where necessary.<br><br>**Deprecated:** The `example` property has been deprecated in favor of the JSON Schema `examples` keyword. Use of `example` is discouraged, and later versions of this specification may remove it. |
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions), though as noted, additional properties MAY omit the `x-` prefix within this object.
+This object MAY be extended with [Specification Extensions](#specification-extensions), though as noted, additional properties MAY omit the `x-` prefix within this object.
 
 ###### <a name="schemaComposition"></a>Composition and Inheritance (Polymorphism)
 
@@ -2356,7 +2348,7 @@ As such, inline schema definitions, which do not have a given id, *cannot* be us
 ###### XML Modeling
 
 The [xml](#schemaXml) property allows extra definitions when translating the JSON definition to XML.
-The [XML Object](#xmlObject) contains additional information about the available options.
+The [XML Object](#xml-object) contains additional information about the available options.
 
 ###### Specifying Schema Dialects
 
@@ -2364,7 +2356,7 @@ It is important for tooling to be able to determine which dialect or meta-schema
 
 The `$schema` keyword MAY be present in any root Schema Object, and if present MUST be used to determine which dialect should be used when processing the schema. This allows use of Schema Objects which comply with other drafts of JSON Schema than the default Draft 2020-12 support. Tooling MUST support the <a href="#dialectSchemaId">OAS dialect schema id</a>, and MAY support additional values of `$schema`.
 
-To allow use of a different default `$schema` value for all Schema Objects contained within an OAS document, a `jsonSchemaDialect` value may be set within the <a href="#oasObject">OpenAPI Object</a>. If this default is not set, then the OAS dialect schema id MUST be used for these Schema Objects. The value of `$schema` within a Schema Object always overrides any default.
+To allow use of a different default `$schema` value for all Schema Objects contained within an OAS document, a `jsonSchemaDialect` value may be set within the <a href="#openapi-object">OpenAPI Object</a>. If this default is not set, then the OAS dialect schema id MUST be used for these Schema Objects. The value of `$schema` within a Schema Object always overrides any default.
 
 When a Schema Object is referenced from an external resource which is not an OAS document (e.g. a bare JSON Schema resource), then the value of the `$schema` keyword for schemas within that resource MUST follow [JSON Schema rules](https://tools.ietf.org/html/draft-bhutton-json-schema-00#section-8.1.1).
 
@@ -2696,19 +2688,19 @@ components:
         - packSize
 ```
 
-#### <a name="discriminatorObject"></a>Discriminator Object
+#### Discriminator Object
 
 When request bodies or response payloads may be one of a number of different schemas, a `discriminator` object can be used to aid in serialization, deserialization, and validation.  The discriminator is a specific object in a schema which is used to inform the consumer of the document of an alternative schema based on the value associated with it.
 
 When using the discriminator, _inline_ schemas will not be considered.
 
 ##### Fixed Fields
-Field Name | Type | Description
----|:---:|---
-<a name="propertyName"></a>propertyName | `string` | **REQUIRED**. The name of the property in the payload that will hold the discriminator value.
-<a name="discriminatorMapping"></a> mapping | Map[`string`, `string`] | An object to hold mappings between payload values and schema names or references.
+| Field Name                                  |          Type           | Description                                                                                   |
+|---------------------------------------------|:-----------------------:|-----------------------------------------------------------------------------------------------|
+| <a name="propertyName"></a>propertyName     |        `string`         | **REQUIRED**. The name of the property in the payload that will hold the discriminator value. |
+| <a name="discriminatorMapping"></a> mapping | Map[`string`, `string`] | An object to hold mappings between payload values and schema names or references.             |
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 The discriminator object is legal only when using one of the composite keywords `oneOf`, `anyOf`, `allOf`.
 
@@ -2831,7 +2823,7 @@ will indicate that the `Cat` schema be used.  Likewise this schema:
 will map to `Dog` because of the definition in the `mapping` element.
 
 
-#### <a name="xmlObject"></a>XML Object
+#### XML Object
 
 A metadata object that allows for more fine-tuned XML model definitions.
 
@@ -2839,19 +2831,19 @@ When using arrays, XML element names are *not* inferred (for singular/plural for
 See examples for expected behavior.
 
 ##### Fixed Fields
-Field Name | Type | Description
----|:---:|---
-<a name="xmlName"></a>name | `string` | Replaces the name of the element/attribute used for the described schema property. When defined within `items`, it will affect the name of the individual XML elements within the list. When defined alongside `type` being `array` (outside the `items`), it will affect the wrapping element and only if `wrapped` is `true`. If `wrapped` is `false`, it will be ignored.
-<a name="xmlNamespace"></a>namespace | `string` | The URI of the namespace definition. This MUST be in the form of an absolute URI.
-<a name="xmlPrefix"></a>prefix | `string` | The prefix to be used for the [name](#xmlName).
-<a name="xmlAttribute"></a>attribute | `boolean` | Declares whether the property definition translates to an attribute instead of an element. Default value is `false`.
-<a name="xmlWrapped"></a>wrapped | `boolean` | MAY be used only for an array definition. Signifies whether the array is wrapped (for example, `<books><book/><book/></books>`) or unwrapped (`<book/><book/>`). Default value is `false`. The definition takes effect only when defined alongside `type` being `array` (outside the `items`).
+| Field Name                           |   Type    | Description                                                                                                                                                                                                                                                                                                                                                                  |
+|--------------------------------------|:---------:|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| <a name="xmlName"></a>name           | `string`  | Replaces the name of the element/attribute used for the described schema property. When defined within `items`, it will affect the name of the individual XML elements within the list. When defined alongside `type` being `array` (outside the `items`), it will affect the wrapping element and only if `wrapped` is `true`. If `wrapped` is `false`, it will be ignored. |
+| <a name="xmlNamespace"></a>namespace | `string`  | The URI of the namespace definition. This MUST be in the form of an absolute URI.                                                                                                                                                                                                                                                                                            |
+| <a name="xmlPrefix"></a>prefix       | `string`  | The prefix to be used for the [name](#xmlName).                                                                                                                                                                                                                                                                                                                              |
+| <a name="xmlAttribute"></a>attribute | `boolean` | Declares whether the property definition translates to an attribute instead of an element. Default value is `false`.                                                                                                                                                                                                                                                         |
+| <a name="xmlWrapped"></a>wrapped     | `boolean` | MAY be used only for an array definition. Signifies whether the array is wrapped (for example, `<books><book/><book/></books>`) or unwrapped (`<book/><book/>`). Default value is `false`. The definition takes effect only when defined alongside `type` being `array` (outside the `items`).                                                                               |
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### XML Object Examples
 
-The examples of the XML object definitions are included inside a property definition of a [Schema Object](#schemaObject) with a sample of the XML representation of it.
+The examples of the XML object definitions are included inside a property definition of a [Schema Object](#schema-object) with a sample of the XML representation of it.
 
 ###### No XML Element
 
@@ -3184,7 +3176,7 @@ animals:
 </aliens>
 ```
 
-#### <a name="securitySchemeObject"></a>Security Scheme Object
+#### Security Scheme Object
 
 Defines a security scheme that can be used by the operations.
 
@@ -3192,18 +3184,18 @@ Supported schemes are HTTP authentication, an API key (either as a header, a coo
 Please note that as of 2020, the implicit flow is about to be deprecated by [OAuth 2.0 Security Best Current Practice](https://tools.ietf.org/html/draft-ietf-oauth-security-topics). Recommended for most use case is Authorization Code Grant flow with PKCE.
 
 ##### Fixed Fields
-Field Name | Type | Applies To | Description
----|:---:|---|---
-<a name="securitySchemeType"></a>type | `string` | Any | **REQUIRED**. The type of the security scheme. Valid values are `"apiKey"`, `"http"`, `"mutualTLS"`, `"oauth2"`, `"openIdConnect"`.
-<a name="securitySchemeDescription"></a>description | `string` | Any | A description for security scheme. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="securitySchemeName"></a>name | `string` | `apiKey` | **REQUIRED**. The name of the header, query or cookie parameter to be used.
-<a name="securitySchemeIn"></a>in | `string` | `apiKey` | **REQUIRED**. The location of the API key. Valid values are `"query"`, `"header"` or `"cookie"`.
-<a name="securitySchemeScheme"></a>scheme | `string` | `http` | **REQUIRED**. The name of the HTTP Authorization scheme to be used in the [Authorization header as defined in RFC7235](https://tools.ietf.org/html/rfc7235#section-5.1).  The values used SHOULD be registered in the [IANA Authentication Scheme registry](https://www.iana.org/assignments/http-authschemes/http-authschemes.xhtml).
-<a name="securitySchemeBearerFormat"></a>bearerFormat | `string` | `http` (`"bearer"`) | A hint to the client to identify how the bearer token is formatted.  Bearer tokens are usually generated by an authorization server, so this information is primarily for documentation purposes.
-<a name="securitySchemeFlows"></a>flows | [OAuth Flows Object](#oauthFlowsObject) | `oauth2` | **REQUIRED**. An object containing configuration information for the flow types supported.
-<a name="securitySchemeOpenIdConnectUrl"></a>openIdConnectUrl | `string` | `openIdConnect` | **REQUIRED**. OpenId Connect URL to discover OAuth2 configuration values. This MUST be in the form of a URL. The OpenID Connect standard requires the use of TLS.
+| Field Name                                                    |                   Type                    | Applies To          | Description                                                                                                                                                                                                                                                                                                                            |
+|---------------------------------------------------------------|:-----------------------------------------:|---------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| <a name="securitySchemeType"></a>type                         |                 `string`                  | Any                 | **REQUIRED**. The type of the security scheme. Valid values are `"apiKey"`, `"http"`, `"mutualTLS"`, `"oauth2"`, `"openIdConnect"`.                                                                                                                                                                                                    |
+| <a name="securitySchemeDescription"></a>description           |                 `string`                  | Any                 | A description for security scheme. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.                                                                                                                                                                                                         |
+| <a name="securitySchemeName"></a>name                         |                 `string`                  | `apiKey`            | **REQUIRED**. The name of the header, query or cookie parameter to be used.                                                                                                                                                                                                                                                            |
+| <a name="securitySchemeIn"></a>in                             |                 `string`                  | `apiKey`            | **REQUIRED**. The location of the API key. Valid values are `"query"`, `"header"` or `"cookie"`.                                                                                                                                                                                                                                       |
+| <a name="securitySchemeScheme"></a>scheme                     |                 `string`                  | `http`              | **REQUIRED**. The name of the HTTP Authorization scheme to be used in the [Authorization header as defined in RFC7235](https://tools.ietf.org/html/rfc7235#section-5.1).  The values used SHOULD be registered in the [IANA Authentication Scheme registry](https://www.iana.org/assignments/http-authschemes/http-authschemes.xhtml). |
+| <a name="securitySchemeBearerFormat"></a>bearerFormat         |                 `string`                  | `http` (`"bearer"`) | A hint to the client to identify how the bearer token is formatted.  Bearer tokens are usually generated by an authorization server, so this information is primarily for documentation purposes.                                                                                                                                      |
+| <a name="securitySchemeFlows"></a>flows                       | [OAuth Flows Object](#oauth-flows-object) | `oauth2`            | **REQUIRED**. An object containing configuration information for the flow types supported.                                                                                                                                                                                                                                             |
+| <a name="securitySchemeOpenIdConnectUrl"></a>openIdConnectUrl |                 `string`                  | `openIdConnect`     | **REQUIRED**. OpenId Connect URL to discover OAuth2 configuration values. This MUST be in the form of a URL. The OpenID Connect standard requires the use of TLS.                                                                                                                                                                      |
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Security Scheme Object Example
 
@@ -3280,33 +3272,33 @@ flows:
       read:pets: read your pets
 ```
 
-#### <a name="oauthFlowsObject"></a>OAuth Flows Object
+#### OAuth Flows Object
 
 Allows configuration of the supported OAuth Flows.
 
 ##### Fixed Fields
-Field Name | Type | Description
----|:---:|---
-<a name="oauthFlowsImplicit"></a>implicit| [OAuth Flow Object](#oauthFlowObject) | Configuration for the OAuth Implicit flow 
-<a name="oauthFlowsPassword"></a>password| [OAuth Flow Object](#oauthFlowObject) | Configuration for the OAuth Resource Owner Password flow 
-<a name="oauthFlowsClientCredentials"></a>clientCredentials| [OAuth Flow Object](#oauthFlowObject) | Configuration for the OAuth Client Credentials flow.  Previously called `application` in OpenAPI 2.0.
-<a name="oauthFlowsAuthorizationCode"></a>authorizationCode| [OAuth Flow Object](#oauthFlowObject) | Configuration for the OAuth Authorization Code flow.  Previously called `accessCode` in OpenAPI 2.0.
+| Field Name                                                  |                  Type                   | Description                                                                                           |
+|-------------------------------------------------------------|:---------------------------------------:|-------------------------------------------------------------------------------------------------------|
+| <a name="oauthFlowsImplicit"></a>implicit                   | [OAuth Flow Object](#oauth-flow-object) | Configuration for the OAuth Implicit flow                                                             |
+| <a name="oauthFlowsPassword"></a>password                   | [OAuth Flow Object](#oauth-flow-object) | Configuration for the OAuth Resource Owner Password flow                                              |
+| <a name="oauthFlowsClientCredentials"></a>clientCredentials | [OAuth Flow Object](#oauth-flow-object) | Configuration for the OAuth Client Credentials flow.  Previously called `application` in OpenAPI 2.0. |
+| <a name="oauthFlowsAuthorizationCode"></a>authorizationCode | [OAuth Flow Object](#oauth-flow-object) | Configuration for the OAuth Authorization Code flow.  Previously called `accessCode` in OpenAPI 2.0.  |
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
-#### <a name="oauthFlowObject"></a>OAuth Flow Object
+#### OAuth Flow Object
 
 Configuration details for a supported OAuth Flow
 
 ##### Fixed Fields
-Field Name | Type | Applies To | Description
----|:---:|---|---
-<a name="oauthFlowAuthorizationUrl"></a>authorizationUrl | `string` | `oauth2` (`"implicit"`, `"authorizationCode"`) | **REQUIRED**. The authorization URL to be used for this flow. This MUST be in the form of a URL. The OAuth2 standard requires the use of TLS.
-<a name="oauthFlowTokenUrl"></a>tokenUrl | `string` | `oauth2` (`"password"`, `"clientCredentials"`, `"authorizationCode"`) | **REQUIRED**. The token URL to be used for this flow. This MUST be in the form of a URL. The OAuth2 standard requires the use of TLS.
-<a name="oauthFlowRefreshUrl"></a>refreshUrl | `string` | `oauth2` | The URL to be used for obtaining refresh tokens. This MUST be in the form of a URL. The OAuth2 standard requires the use of TLS.
-<a name="oauthFlowScopes"></a>scopes | Map[`string`, `string`] | `oauth2` | **REQUIRED**. The available scopes for the OAuth2 security scheme. A map between the scope name and a short description for it. The map MAY be empty.
+| Field Name                                               |          Type           | Applies To                                                            | Description                                                                                                                                           |
+|----------------------------------------------------------|:-----------------------:|-----------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
+| <a name="oauthFlowAuthorizationUrl"></a>authorizationUrl |        `string`         | `oauth2` (`"implicit"`, `"authorizationCode"`)                        | **REQUIRED**. The authorization URL to be used for this flow. This MUST be in the form of a URL. The OAuth2 standard requires the use of TLS.         |
+| <a name="oauthFlowTokenUrl"></a>tokenUrl                 |        `string`         | `oauth2` (`"password"`, `"clientCredentials"`, `"authorizationCode"`) | **REQUIRED**. The token URL to be used for this flow. This MUST be in the form of a URL. The OAuth2 standard requires the use of TLS.                 |
+| <a name="oauthFlowRefreshUrl"></a>refreshUrl             |        `string`         | `oauth2`                                                              | The URL to be used for obtaining refresh tokens. This MUST be in the form of a URL. The OAuth2 standard requires the use of TLS.                      |
+| <a name="oauthFlowScopes"></a>scopes                     | Map[`string`, `string`] | `oauth2`                                                              | **REQUIRED**. The available scopes for the OAuth2 security scheme. A map between the scope name and a short description for it. The map MAY be empty. |
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### OAuth Flow Object Examples
 
@@ -3349,21 +3341,21 @@ flows:
       read:pets: read your pets 
 ```
 
-#### <a name="securityRequirementObject"></a>Security Requirement Object
+#### Security Requirement Object
 
 Lists the required security schemes to execute this operation.
-The name used for each property MUST correspond to a security scheme declared in the [Security Schemes](#componentsSecuritySchemes) under the [Components Object](#componentsObject).
+The name used for each property MUST correspond to a security scheme declared in the [Security Schemes](#componentsSecuritySchemes) under the [Components Object](#components-object).
 
 Security Requirement Objects that contain multiple schemes require that all schemes MUST be satisfied for a request to be authorized.
 This enables support for scenarios where multiple query parameters or HTTP headers are required to convey security information.
 
-When a list of Security Requirement Objects is defined on the [OpenAPI Object](#oasObject) or [Operation Object](#operationObject), only one of the Security Requirement Objects in the list needs to be satisfied to authorize the request.
+When a list of Security Requirement Objects is defined on the [OpenAPI Object](#openapi-object) or [Operation Object](#operation-object), only one of the Security Requirement Objects in the list needs to be satisfied to authorize the request.
 
 ##### Patterned Fields
 
-Field Pattern | Type | Description
----|:---:|---
-<a name="securityRequirementsName"></a>{name} | [`string`] | Each name MUST correspond to a security scheme which is declared in the [Security Schemes](#componentsSecuritySchemes) under the [Components Object](#componentsObject). If the security scheme is of type `"oauth2"` or `"openIdConnect"`, then the value is a list of scope names required for the execution, and the list MAY be empty if authorization does not require a specified scope. For other security scheme types, the array MAY contain a list of role names which are required for the execution, but are not otherwise defined or exchanged in-band.
+| Field Pattern                                 |    Type    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+|-----------------------------------------------|:----------:|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| <a name="securityRequirementsName"></a>{name} | [`string`] | Each name MUST correspond to a security scheme which is declared in the [Security Schemes](#componentsSecuritySchemes) under the [Components Object](#components-object). If the security scheme is of type `"oauth2"` or `"openIdConnect"`, then the value is a list of scope names required for the execution, and the list MAY be empty if authorization does not require a specified scope. For other security scheme types, the array MAY contain a list of role names which are required for the execution, but are not otherwise defined or exchanged in-band. |
 
 ##### Security Requirement Object Examples
 
@@ -3422,19 +3414,19 @@ security:
     - read:pets
 ```
 
-### <a name="specificationExtensions"></a>Specification Extensions
+### Specification Extensions
 
 While the OpenAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.
 
 The extensions properties are implemented as patterned fields that are always prefixed by `"x-"`.
 
-Field Pattern | Type | Description
----|:---:|---
-<a name="infoExtensions"></a>^x- | Any | Allows extensions to the OpenAPI Schema. The field name MUST begin with `x-`, for example, `x-internal-id`. Field names beginning `x-oai-` and `x-oas-` are reserved for uses defined by the [OpenAPI Initiative](https://www.openapis.org/). The value can be `null`, a primitive, an array or an object.
+| Field Pattern                    | Type | Description                                                                                                                                                                                                                                                                                                |
+|----------------------------------|:----:|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| <a name="infoExtensions"></a>^x- | Any  | Allows extensions to the OpenAPI Schema. The field name MUST begin with `x-`, for example, `x-internal-id`. Field names beginning `x-oai-` and `x-oas-` are reserved for uses defined by the [OpenAPI Initiative](https://www.openapis.org/). The value can be `null`, a primitive, an array or an object. |
 
 The extensions may or may not be supported by the available tooling, but those may be extended as well to add requested support (if tools are internal or open-sourced).
 
-### <a name="securityFiltering"></a>Security Filtering
+### Security Filtering
 
 Some objects in the OpenAPI Specification MAY be declared and remain empty, or be completely removed, even though they are inherently the core of the API documentation. 
 
@@ -3443,26 +3435,26 @@ While not part of the specification itself, certain libraries MAY choose to allo
 
 Two examples of this:
 
-1. The [Paths Object](#pathsObject) MAY be present but empty. It may be counterintuitive, but this may tell the viewer that they got to the right place, but can't access any documentation. They would still have access to at least the [Info Object](#infoObject) which may contain additional information regarding authentication.
-2. The [Path Item Object](#pathItemObject) MAY be empty. In this case, the viewer will be aware that the path exists, but will not be able to see any of its operations or parameters. This is different from hiding the path itself from the [Paths Object](#pathsObject), because the user will be aware of its existence. This allows the documentation provider to finely control what the viewer can see.
+1. The [Paths Object](#paths-object) MAY be present but empty. It may be counterintuitive, but this may tell the viewer that they got to the right place, but can't access any documentation. They would still have access to at least the [Info Object](#info-object) which may contain additional information regarding authentication.
+2. The [Path Item Object](#path-item-object) MAY be empty. In this case, the viewer will be aware that the path exists, but will not be able to see any of its operations or parameters. This is different from hiding the path itself from the [Paths Object](#paths-object), because the user will be aware of its existence. This allows the documentation provider to finely control what the viewer can see.
 
 
-## <a name="revisionHistory"></a>Appendix A: Revision History
+## Appendix A: Revision History
 
-Version   | Date       | Notes
----       | ---        | ---
-3.1.0     | 2021-02-15 | Release of the OpenAPI Specification 3.1.0 
-3.1.0-rc1 | 2020-10-08 | rc1 of the 3.1 specification
-3.1.0-rc0 | 2020-06-18 | rc0 of the 3.1 specification
-3.0.3     | 2020-02-20 | Patch release of the OpenAPI Specification 3.0.3
-3.0.2     | 2018-10-08 | Patch release of the OpenAPI Specification 3.0.2
-3.0.1     | 2017-12-06 | Patch release of the OpenAPI Specification 3.0.1
-3.0.0     | 2017-07-26 | Release of the OpenAPI Specification 3.0.0
-3.0.0-rc2 | 2017-06-16 | rc2 of the 3.0 specification
-3.0.0-rc1 | 2017-04-27 | rc1 of the 3.0 specification
-3.0.0-rc0 | 2017-02-28 | Implementer's Draft of the 3.0 specification
-2.0       | 2015-12-31 | Donation of Swagger 2.0 to the OpenAPI Initiative
-2.0       | 2014-09-08 | Release of Swagger 2.0
-1.2       | 2014-03-14 | Initial release of the formal document.
-1.1       | 2012-08-22 | Release of Swagger 1.1
-1.0       | 2011-08-10 | First release of the Swagger Specification
+| Version   | Date       | Notes                                             |
+|-----------|------------|---------------------------------------------------|
+| 3.1.0     | 2021-02-15 | Release of the OpenAPI Specification 3.1.0        |
+| 3.1.0-rc1 | 2020-10-08 | rc1 of the 3.1 specification                      |
+| 3.1.0-rc0 | 2020-06-18 | rc0 of the 3.1 specification                      |
+| 3.0.3     | 2020-02-20 | Patch release of the OpenAPI Specification 3.0.3  |
+| 3.0.2     | 2018-10-08 | Patch release of the OpenAPI Specification 3.0.2  |
+| 3.0.1     | 2017-12-06 | Patch release of the OpenAPI Specification 3.0.1  |
+| 3.0.0     | 2017-07-26 | Release of the OpenAPI Specification 3.0.0        |
+| 3.0.0-rc2 | 2017-06-16 | rc2 of the 3.0 specification                      |
+| 3.0.0-rc1 | 2017-04-27 | rc1 of the 3.0 specification                      |
+| 3.0.0-rc0 | 2017-02-28 | Implementer's Draft of the 3.0 specification      |
+| 2.0       | 2015-12-31 | Donation of Swagger 2.0 to the OpenAPI Initiative |
+| 2.0       | 2014-09-08 | Release of Swagger 2.0                            |
+| 1.2       | 2014-03-14 | Initial release of the formal document.           |
+| 1.1       | 2012-08-22 | Release of Swagger 1.1                            |
+| 1.0       | 2011-08-10 | First release of the Swagger Specification        |


### PR DESCRIPTION
Improve navigation of the document with markdown compatible header anchor fragments. Markdown parsers "kebab-case" headers for navigation.

While some internal navigation support of named anchors remain, e.g., `<a name="fooBar" ></a>`, Markdown parsers generally auto-expand heading elements, e.g., `h1, h2` in kebab-case. As such the "in GitHub navigation" doesn't work very well. This PR

refactor: update tables to improve markdown compatibility

Markdown parsers have varied table support. The use of "open-ended boundaries" over "pipe-ended boundaries" can lead to issues with visual rendering of tables. IDE support for tables is better supported as well, though visually, header rows are not attractive in the source code, IDEs manage this formatting very effectively.

chore: add macOS Desktop Services file to Git exclusions

Update .gitignore with the macOS .DS_Store file.