### PR TITLE
Add double-int to formats registry

### DIFF
--- a/registries/_format/double-int.md
+++ b/registries/_format/double-int.md
@@ -1,0 +1,29 @@
+---
+owner: mikekistler
+issue: 
+description: an integer that can be stored in an IEEE 754 double-precision number without loss of precision
+base_type: integer
+layout: default
+---
+
+# <a href="..">{{ page.collection }}</a>
+
+## {{ page.slug }} - {{ page.description }}
+
+Base type: `{{ page.base_type }}`.
+
+The `{{page.slug}}` format represents an integer that can be stored in an IEEE 754 double-precision number without loss of precision. The range of values is -(2<sup>53</sup>)+1 to (2<sup>53</sup>)-1.
+
+This format is useful for systems that need to support languages (such as JavaScript) that store all numeric values as IEEE 754 double-precision numbers.
+
+{% if page.issue %}
+### GitHub Issue
+
+* [#{{ page.issue }}](https://github.com/OAI/OpenAPI-Specification/issues/{{ page.issue }})
+{% endif %}
+
+{% if page.remarks %}
+### Remarks
+
+{{ page.remarks }}
+{% endif %}


### PR DESCRIPTION
This PR adds a new format, "double-int" to the OAI formats registry.

The double-int format should be used to specify an integer that can be stored in an IEEE 754 double-precision number without loss of precision.

Naming is one of the hardest problems in computer science. We considered many names other than "double-int" -- "int53", "jsonint", "safest", others. We even asked ChatGPT for suggestions.

In the end "double-int" seems most descriptive and accurate.