### PR TITLE
Describe OpenAPI entry point in OpenAPI description docs

### DIFF
--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -69,7 +69,7 @@ An OpenAPI definition can then be used by documentation generation tools to disp
 ## Definitions
 
 ##### <a name="oasDocument"></a>OpenAPI Description
-An OpenAPI description describes an API, and is composed of an [entry document](#documentStructure), and all transitively-referenced documents. An OpenAPI Description (OAD) uses and conforms to the OpenAPI Specification, and MUST contain at least one [paths](#pathsObject) field, [components](#oasComponents) field, or [webhooks](#oasWebhooks) field.
+An OpenAPI description describes an API, and is composed of an [entry document](#documentStructure), and all its referenced documents. An OpenAPI Description (OAD) uses and conforms to the OpenAPI Specification, and MUST contain at least one [paths](#pathsObject) field, [components](#oasComponents) field, or [webhooks](#oasWebhooks) field.
 
 ##### <a name="pathTemplating"></a>Path Templating
 Path templating refers to the usage of template expressions, delimited by curly braces ({}), to mark a section of a URL path as replaceable using path parameters.

--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -69,7 +69,7 @@ An OpenAPI definition can then be used by documentation generation tools to disp
 ## Definitions
 
 ##### <a name="oasDocument"></a>OpenAPI Description
-An OpenAPI Description (OAD) describes an API, and is composed of an [entry document](#documentStructure) and all its referenced documents. An OAD uses and conforms to the OpenAPI Specification, and MUST contain at least one [paths](#pathsObject) field, [components](#oasComponents) field, or [webhooks](#oasWebhooks) field.
+An OpenAPI Description (OAD) formally describes the surface of an API and its semantics. It is composed of an [entry document](#documentStructure) and any/all of its referenced documents. An OAD uses and conforms to the OpenAPI Specification, and MUST contain at least one [paths](#pathsObject) field, [components](#oasComponents) field, or [webhooks](#oasWebhooks) field.
 
 ##### <a name="pathTemplating"></a>Path Templating
 Path templating refers to the usage of template expressions, delimited by curly braces (`{}`), to mark a section of a URL path as replaceable using path parameters.

--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -69,7 +69,7 @@ An OpenAPI definition can then be used by documentation generation tools to disp
 ## Definitions
 
 ##### <a name="oasDocument"></a>OpenAPI Description
-An OpenAPI description describes an API, and is composed of an [entry document](#documentStructure), and all its referenced documents. An OpenAPI Description (OAD) uses and conforms to the OpenAPI Specification, and MUST contain at least one [paths](#pathsObject) field, [components](#oasComponents) field, or [webhooks](#oasWebhooks) field.
+An OpenAPI Description (OAD) describes an API, and is composed of an [entry document](#documentStructure) and all its referenced documents. An OAD uses and conforms to the OpenAPI Specification, and MUST contain at least one [paths](#pathsObject) field, [components](#oasComponents) field, or [webhooks](#oasWebhooks) field.
 
 ##### <a name="pathTemplating"></a>Path Templating
 Path templating refers to the usage of template expressions, delimited by curly braces ({}), to mark a section of a URL path as replaceable using path parameters.

--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -72,7 +72,7 @@ An OpenAPI definition can then be used by documentation generation tools to disp
 An OpenAPI Description (OAD) describes an API, and is composed of an [entry document](#documentStructure) and all its referenced documents. An OAD uses and conforms to the OpenAPI Specification, and MUST contain at least one [paths](#pathsObject) field, [components](#oasComponents) field, or [webhooks](#oasWebhooks) field.
 
 ##### <a name="pathTemplating"></a>Path Templating
-Path templating refers to the usage of template expressions, delimited by curly braces ({}), to mark a section of a URL path as replaceable using path parameters.
+Path templating refers to the usage of template expressions, delimited by curly braces (`{}`), to mark a section of a URL path as replaceable using path parameters.
 
 Each template expression in the path MUST correspond to a path parameter that is included in the [Path Item](#path-item-object) itself and/or in each of the Path Item's [Operations](#operation-object). An exception is if the path item is empty, for example due to ACL constraints, matching path parameters are not required.
 

--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -69,7 +69,7 @@ An OpenAPI definition can then be used by documentation generation tools to disp
 ## Definitions
 
 ##### <a name="oasDocument"></a>OpenAPI Description
-A document (or set of documents) that describes an API. An OpenAPI Description (OAD) uses and conforms to the OpenAPI Specification, and MUST contain at least one [paths](#pathsObject) field, [components](#oasComponents) field, or [webhooks](#oasWebhooks) field.
+An OpenAPI description describes an API, and is composed of an [entry document](#documentStructure), and all transitively-referenced documents. An OpenAPI Description (OAD) uses and conforms to the OpenAPI Specification, and MUST contain at least one [paths](#pathsObject) field, [components](#oasComponents) field, or [webhooks](#oasWebhooks) field.
 
 ##### <a name="pathTemplating"></a>Path Templating
 Path templating refers to the usage of template expressions, delimited by curly braces ({}), to mark a section of a URL path as replaceable using path parameters.


### PR DESCRIPTION
Per discussion during the [Sep 28 TDC](https://github.com/OAI/OpenAPI-Specification/issues/3374) meeting, this PR attempts to tease apart the *identity* of an OpenAPI description from the document(s) which comprise it.

It also references+links the *entry point* nomenclature, also settled-upon in same meeting.

💡 ❤️  I want to thank @handrews for their feedback during and after the meeting today. What I thought might be a trivial change is clearly a bit more nuanced than I expected and the space to think and refine the wording aided in my own understanding (and hopefully others' as well!)
