### PR TITLE
Add structured fields primitive types to format registry

### DIFF
--- a/registries/_format/sf-binary.md
+++ b/registries/_format/sf-binary.md
@@ -2,6 +2,8 @@
 owner: mikekistler
 issue: 
 description: structured fields byte sequence as defined in [RFC 8941]
+source: https://www.rfc-editor.org/rfc/rfc8941#name-byte-sequences
+source_label: RFC 8941
 base_type: string
 layout: default
 ---

--- a/registries/_format/sf-binary.md
+++ b/registries/_format/sf-binary.md
@@ -1,0 +1,37 @@
+---
+owner: mikekistler
+issue: 
+description: structured fields byte sequence as defined by `sf-binary` in [RFC 8941]
+base_type: string
+layout: default
+---
+
+# <a href="..">{{ page.collection }}</a>
+
+## {{ page.slug }} - {{ page.description }}
+
+Base type: `{{ page.base_type }}`.
+
+The `{{page.slug}}` format represents a structured fields byte sequence as defined by `sf-binary` in [RFC 8941].
+
+```abnf
+sf-binary = ":" *(base64) ":"
+base64    = ALPHA / DIGIT / "+" / "/" / "="
+```
+
+A Byte Sequence is delimited with colons and encoded using base64 ([RFC 4648], Section 4).
+
+{% if page.issue %}
+### GitHub Issue
+
+* [#{{ page.issue }}](https://github.com/OAI/OpenAPI-Specification/issues/{{ page.issue }})
+{% endif %}
+
+{% if page.remarks %}
+### Remarks
+
+{{ page.remarks }}
+{% endif %}
+
+[RFC 8941]: https://www.rfc-editor.org/rfc/rfc8941#name-byte-sequences
+[RFC 4648]: https://www.rfc-editor.org/rfc/rfc4648#section-4

--- a/registries/_format/sf-binary.md
+++ b/registries/_format/sf-binary.md
@@ -1,7 +1,7 @@
 ---
 owner: mikekistler
-issue: 
-description: structured fields byte sequence as defined in [RFC 8941]
+issue:
+description: structured fields byte sequence as defined in [RFC8941]
 source: https://www.rfc-editor.org/rfc/rfc8941#name-byte-sequences
 source_label: RFC 8941
 base_type: string
@@ -14,14 +14,16 @@ layout: default
 
 Base type: `{{ page.base_type }}`.
 
-The `{{page.slug}}` format represents a structured fields byte sequence as defined in [RFC 8941].
+The `{{page.slug}}` format represents a structured fields byte sequence as defined in [RFC8941].
 
 ```abnf
 sf-binary = ":" *(base64) ":"
 base64    = ALPHA / DIGIT / "+" / "/" / "="
 ```
 
-A Byte Sequence is delimited with colons and encoded using base64 ([RFC 4648], Section 4).
+A Byte Sequence is delimited with colons and encoded using base64 ([RFC4648], Section 4).
+
+This format is appropriate for a header value that must conform to the {{page.slug}} structured field definition.
 
 {% if page.issue %}
 ### GitHub Issue
@@ -35,5 +37,5 @@ A Byte Sequence is delimited with colons and encoded using base64 ([RFC 4648], S
 {{ page.remarks }}
 {% endif %}
 
-[RFC 8941]: https://www.rfc-editor.org/rfc/rfc8941#name-byte-sequences
-[RFC 4648]: https://www.rfc-editor.org/rfc/rfc4648#section-4
+[RFC8941]: https://www.rfc-editor.org/rfc/rfc8941#name-byte-sequences
+[RFC4648]: https://www.rfc-editor.org/rfc/rfc4648#section-4

--- a/registries/_format/sf-binary.md
+++ b/registries/_format/sf-binary.md
@@ -1,7 +1,7 @@
 ---
 owner: mikekistler
 issue: 
-description: structured fields byte sequence as defined by `sf-binary` in [RFC 8941]
+description: structured fields byte sequence as defined in [RFC 8941]
 base_type: string
 layout: default
 ---
@@ -12,7 +12,7 @@ layout: default
 
 Base type: `{{ page.base_type }}`.
 
-The `{{page.slug}}` format represents a structured fields byte sequence as defined by `sf-binary` in [RFC 8941].
+The `{{page.slug}}` format represents a structured fields byte sequence as defined in [RFC 8941].
 
 ```abnf
 sf-binary = ":" *(base64) ":"

--- a/registries/_format/sf-boolean.md
+++ b/registries/_format/sf-boolean.md
@@ -1,0 +1,36 @@
+---
+owner: mikekistler
+issue: 
+description: structured fields boolean as defined by `sf-boolean` in [RFC 8941]
+base_type: string
+layout: default
+---
+
+# <a href="..">{{ page.collection }}</a>
+
+## {{ page.slug }} - {{ page.description }}
+
+Base type: `{{ page.base_type }}`.
+
+The `{{page.slug}}` format represents a structured fields boolean as defined by `sf-boolean` in [RFC 8941].
+
+```abnf
+sf-boolean = "?" boolean
+boolean    = "0" / "1"
+```
+
+A Boolean is indicated with a leading "?" character followed by a "1" for a true value or "0" for false.
+
+{% if page.issue %}
+### GitHub Issue
+
+* [#{{ page.issue }}](https://github.com/OAI/OpenAPI-Specification/issues/{{ page.issue }})
+{% endif %}
+
+{% if page.remarks %}
+### Remarks
+
+{{ page.remarks }}
+{% endif %}
+
+[RFC 8941]: https://www.rfc-editor.org/rfc/rfc8941#name-booleans

--- a/registries/_format/sf-boolean.md
+++ b/registries/_format/sf-boolean.md
@@ -1,7 +1,7 @@
 ---
 owner: mikekistler
 issue: 
-description: structured fields boolean as defined by `sf-boolean` in [RFC 8941]
+description: structured fields boolean as defined in [RFC 8941]
 base_type: string
 layout: default
 ---
@@ -12,7 +12,7 @@ layout: default
 
 Base type: `{{ page.base_type }}`.
 
-The `{{page.slug}}` format represents a structured fields boolean as defined by `sf-boolean` in [RFC 8941].
+The `{{page.slug}}` format represents a structured fields boolean as defined in [RFC 8941].
 
 ```abnf
 sf-boolean = "?" boolean

--- a/registries/_format/sf-boolean.md
+++ b/registries/_format/sf-boolean.md
@@ -2,6 +2,8 @@
 owner: mikekistler
 issue: 
 description: structured fields boolean as defined in [RFC 8941]
+source: https://www.rfc-editor.org/rfc/rfc8941#name-booleans
+source_label: RFC 8941
 base_type: string
 layout: default
 ---

--- a/registries/_format/sf-boolean.md
+++ b/registries/_format/sf-boolean.md
@@ -1,7 +1,7 @@
 ---
 owner: mikekistler
-issue: 
-description: structured fields boolean as defined in [RFC 8941]
+issue:
+description: structured fields boolean as defined in [RFC8941]
 source: https://www.rfc-editor.org/rfc/rfc8941#name-booleans
 source_label: RFC 8941
 base_type: string
@@ -14,7 +14,7 @@ layout: default
 
 Base type: `{{ page.base_type }}`.
 
-The `{{page.slug}}` format represents a structured fields boolean as defined in [RFC 8941].
+The `{{page.slug}}` format represents a structured fields boolean as defined in [RFC8941].
 
 ```abnf
 sf-boolean = "?" boolean
@@ -22,6 +22,8 @@ boolean    = "0" / "1"
 ```
 
 A Boolean is indicated with a leading "?" character followed by a "1" for a true value or "0" for false.
+
+This format is appropriate for a header value that must conform to the {{page.slug}} structured field definition.
 
 {% if page.issue %}
 ### GitHub Issue
@@ -35,4 +37,4 @@ A Boolean is indicated with a leading "?" character followed by a "1" for a true
 {{ page.remarks }}
 {% endif %}
 
-[RFC 8941]: https://www.rfc-editor.org/rfc/rfc8941#name-booleans
+[RFC8941]: https://www.rfc-editor.org/rfc/rfc8941#name-booleans

--- a/registries/_format/sf-decimal.md
+++ b/registries/_format/sf-decimal.md
@@ -1,7 +1,7 @@
 ---
 owner: mikekistler
 issue: 
-description: structured fields decimal as defined by `sf-decimal` in [RFC 8941]
+description: structured fields decimal as defined in [RFC 8941]
 base_type: integer
 layout: default
 ---
@@ -12,7 +12,7 @@ layout: default
 
 Base type: `{{ page.base_type }}`.
 
-The `{{page.slug}}` format represents a structured fields decimal as defined by `sf-decimal` in [RFC 8941].
+The `{{page.slug}}` format represents a structured fields decimal as defined in [RFC 8941].
 
 ```abnf
 sf-decimal  = ["-"] 1*12DIGIT "." 1*3DIGIT

--- a/registries/_format/sf-decimal.md
+++ b/registries/_format/sf-decimal.md
@@ -2,7 +2,9 @@
 owner: mikekistler
 issue: 
 description: structured fields decimal as defined in [RFC 8941]
-base_type: integer
+source: https://www.rfc-editor.org/rfc/rfc8941#name-decimals
+source_label: RFC 8941
+base_type: number
 layout: default
 ---
 

--- a/registries/_format/sf-decimal.md
+++ b/registries/_format/sf-decimal.md
@@ -1,7 +1,7 @@
 ---
 owner: mikekistler
-issue: 
-description: structured fields decimal as defined in [RFC 8941]
+issue:
+description: structured fields decimal as defined in [RFC8941]
 source: https://www.rfc-editor.org/rfc/rfc8941#name-decimals
 source_label: RFC 8941
 base_type: number
@@ -14,7 +14,7 @@ layout: default
 
 Base type: `{{ page.base_type }}`.
 
-The `{{page.slug}}` format represents a structured fields decimal as defined in [RFC 8941].
+The `{{page.slug}}` format represents a structured fields decimal as defined in [RFC8941].
 
 ```abnf
 sf-decimal  = ["-"] 1*12DIGIT "." 1*3DIGIT
@@ -22,6 +22,8 @@ sf-decimal  = ["-"] 1*12DIGIT "." 1*3DIGIT
 
 Decimals are numbers with an integer and a fractional component.
 The integer component has at most 12 digits; the fractional component has at most three digits.
+
+This format is appropriate for a header value that must conform to the {{page.slug}} structured field definition.
 
 {% if page.issue %}
 ### GitHub Issue
@@ -35,4 +37,4 @@ The integer component has at most 12 digits; the fractional component has at mos
 {{ page.remarks }}
 {% endif %}
 
-[RFC 8941]: https://www.rfc-editor.org/rfc/rfc8941#name-decimals
+[RFC8941]: https://www.rfc-editor.org/rfc/rfc8941#name-decimals

--- a/registries/_format/sf-decimal.md
+++ b/registries/_format/sf-decimal.md
@@ -1,0 +1,36 @@
+---
+owner: mikekistler
+issue: 
+description: structured fields decimal as defined by `sf-decimal` in [RFC 8941]
+base_type: integer
+layout: default
+---
+
+# <a href="..">{{ page.collection }}</a>
+
+## {{ page.slug }} - {{ page.description }}
+
+Base type: `{{ page.base_type }}`.
+
+The `{{page.slug}}` format represents a structured fields decimal as defined by `sf-decimal` in [RFC 8941].
+
+```abnf
+sf-decimal  = ["-"] 1*12DIGIT "." 1*3DIGIT
+```
+
+Decimals are numbers with an integer and a fractional component.
+The integer component has at most 12 digits; the fractional component has at most three digits.
+
+{% if page.issue %}
+### GitHub Issue
+
+* [#{{ page.issue }}](https://github.com/OAI/OpenAPI-Specification/issues/{{ page.issue }})
+{% endif %}
+
+{% if page.remarks %}
+### Remarks
+
+{{ page.remarks }}
+{% endif %}
+
+[RFC 8941]: https://www.rfc-editor.org/rfc/rfc8941#name-decimals

--- a/registries/_format/sf-integer.md
+++ b/registries/_format/sf-integer.md
@@ -1,0 +1,37 @@
+---
+owner: mikekistler
+issue: 
+description: structured fields integer as defined by `sf-integer` in [RFC 8941]
+base_type: integer
+layout: default
+---
+
+# <a href="..">{{ page.collection }}</a>
+
+## {{ page.slug }} - {{ page.description }}
+
+Base type: `{{ page.base_type }}`.
+
+The `{{page.slug}}` format represents a structured fields integer as defined by `sf-integer` in [RFC 8941].
+
+```abnf
+sf-integer = ["-"] 1*15DIGIT
+```
+
+Integers have a range of -999,999,999,999,999 to 999,999,999,999,999 inclusive (i.e., up to fifteen digits, signed),
+for IEEE 754 compatibility [IEEE754].
+
+{% if page.issue %}
+### GitHub Issue
+
+* [#{{ page.issue }}](https://github.com/OAI/OpenAPI-Specification/issues/{{ page.issue }})
+{% endif %}
+
+{% if page.remarks %}
+### Remarks
+
+{{ page.remarks }}
+{% endif %}
+
+[RFC 8941]: https://www.rfc-editor.org/rfc/rfc8941#name-integers
+[IEEE754]: https://ieeexplore.ieee.org/document/8766229

--- a/registries/_format/sf-integer.md
+++ b/registries/_format/sf-integer.md
@@ -2,7 +2,9 @@
 owner: mikekistler
 issue: 
 description: structured fields integer as defined in [RFC 8941]
-base_type: integer
+source: https://www.rfc-editor.org/rfc/rfc8941#name-integers
+source_label: RFC 8941
+base_type: integer, number
 layout: default
 ---
 

--- a/registries/_format/sf-integer.md
+++ b/registries/_format/sf-integer.md
@@ -1,7 +1,7 @@
 ---
 owner: mikekistler
 issue: 
-description: structured fields integer as defined by `sf-integer` in [RFC 8941]
+description: structured fields integer as defined in [RFC 8941]
 base_type: integer
 layout: default
 ---
@@ -12,7 +12,7 @@ layout: default
 
 Base type: `{{ page.base_type }}`.
 
-The `{{page.slug}}` format represents a structured fields integer as defined by `sf-integer` in [RFC 8941].
+The `{{page.slug}}` format represents a structured fields integer as defined in [RFC 8941].
 
 ```abnf
 sf-integer = ["-"] 1*15DIGIT

--- a/registries/_format/sf-integer.md
+++ b/registries/_format/sf-integer.md
@@ -1,7 +1,7 @@
 ---
 owner: mikekistler
-issue: 
-description: structured fields integer as defined in [RFC 8941]
+issue:
+description: structured fields integer as defined in [RFC8941]
 source: https://www.rfc-editor.org/rfc/rfc8941#name-integers
 source_label: RFC 8941
 base_type: integer, number
@@ -14,7 +14,7 @@ layout: default
 
 Base type: `{{ page.base_type }}`.
 
-The `{{page.slug}}` format represents a structured fields integer as defined in [RFC 8941].
+The `{{page.slug}}` format represents a structured fields integer as defined in [RFC8941].
 
 ```abnf
 sf-integer = ["-"] 1*15DIGIT
@@ -22,6 +22,8 @@ sf-integer = ["-"] 1*15DIGIT
 
 Integers have a range of -999,999,999,999,999 to 999,999,999,999,999 inclusive (i.e., up to fifteen digits, signed),
 for IEEE 754 compatibility [IEEE754].
+
+This format is appropriate for a header value that must conform to the {{page.slug}} structured field definition.
 
 {% if page.issue %}
 ### GitHub Issue
@@ -35,5 +37,5 @@ for IEEE 754 compatibility [IEEE754].
 {{ page.remarks }}
 {% endif %}
 
-[RFC 8941]: https://www.rfc-editor.org/rfc/rfc8941#name-integers
+[RFC8941]: https://www.rfc-editor.org/rfc/rfc8941#name-integers
 [IEEE754]: https://ieeexplore.ieee.org/document/8766229

--- a/registries/_format/sf-string.md
+++ b/registries/_format/sf-string.md
@@ -1,7 +1,7 @@
 ---
 owner: mikekistler
-issue: 
-description: structured fields string as defined in [RFC 8941]
+issue:
+description: structured fields string as defined in [RFC8941]
 source: https://www.rfc-editor.org/rfc/rfc8941#name-strings
 source_label: RFC 8941
 base_type: string
@@ -14,7 +14,7 @@ layout: default
 
 Base type: `{{ page.base_type }}`.
 
-The `{{page.slug}}` format represents a structured fields string as defined in [RFC 8941].
+The `{{page.slug}}` format represents a structured fields string as defined in [RFC8941].
 
 ```abnf
 sf-string = DQUOTE *chr DQUOTE
@@ -28,6 +28,8 @@ Note that this excludes tabs, newlines, carriage returns, etc.
 
 Strings are delimited with double quotes, using a backslash ("\") to escape double quotes and backslashes.
 
+This format is appropriate for a header value that must conform to the {{page.slug}} structured field definition.
+
 {% if page.issue %}
 ### GitHub Issue
 
@@ -40,4 +42,4 @@ Strings are delimited with double quotes, using a backslash ("\") to escape doub
 {{ page.remarks }}
 {% endif %}
 
-[RFC 8941]: https://www.rfc-editor.org/rfc/rfc8941#name-strings
+[RFC8941]: https://www.rfc-editor.org/rfc/rfc8941#name-strings

--- a/registries/_format/sf-string.md
+++ b/registries/_format/sf-string.md
@@ -2,6 +2,8 @@
 owner: mikekistler
 issue: 
 description: structured fields string as defined in [RFC 8941]
+source: https://www.rfc-editor.org/rfc/rfc8941#name-strings
+source_label: RFC 8941
 base_type: string
 layout: default
 ---

--- a/registries/_format/sf-string.md
+++ b/registries/_format/sf-string.md
@@ -1,0 +1,41 @@
+---
+owner: mikekistler
+issue: 
+description: structured fields string as defined by `sf-string` in [RFC 8941]
+base_type: string
+layout: default
+---
+
+# <a href="..">{{ page.collection }}</a>
+
+## {{ page.slug }} - {{ page.description }}
+
+Base type: `{{ page.base_type }}`.
+
+The `{{page.slug}}` format represents a structured fields string as defined by `sf-string` in [RFC 8941].
+
+```abnf
+sf-string = DQUOTE *chr DQUOTE
+chr       = unescaped / escaped
+unescaped = %x20-21 / %x23-5B / %x5D-7E
+escaped   = "\" ( DQUOTE / "\" )
+```
+
+Strings are zero or more printable ASCII [RFC0020] characters (i.e., the range %x20 to %x7E).
+Note that this excludes tabs, newlines, carriage returns, etc.
+
+Strings are delimited with double quotes, using a backslash ("\") to escape double quotes and backslashes.
+
+{% if page.issue %}
+### GitHub Issue
+
+* [#{{ page.issue }}](https://github.com/OAI/OpenAPI-Specification/issues/{{ page.issue }})
+{% endif %}
+
+{% if page.remarks %}
+### Remarks
+
+{{ page.remarks }}
+{% endif %}
+
+[RFC 8941]: https://www.rfc-editor.org/rfc/rfc8941#name-strings

--- a/registries/_format/sf-string.md
+++ b/registries/_format/sf-string.md
@@ -1,7 +1,7 @@
 ---
 owner: mikekistler
 issue: 
-description: structured fields string as defined by `sf-string` in [RFC 8941]
+description: structured fields string as defined in [RFC 8941]
 base_type: string
 layout: default
 ---
@@ -12,7 +12,7 @@ layout: default
 
 Base type: `{{ page.base_type }}`.
 
-The `{{page.slug}}` format represents a structured fields string as defined by `sf-string` in [RFC 8941].
+The `{{page.slug}}` format represents a structured fields string as defined in [RFC 8941].
 
 ```abnf
 sf-string = DQUOTE *chr DQUOTE

--- a/registries/_format/sf-token.md
+++ b/registries/_format/sf-token.md
@@ -2,6 +2,8 @@
 owner: mikekistler
 issue: 
 description: structured fields token as defined in [RFC 8941]
+source: https://www.rfc-editor.org/rfc/rfc8941#name-tokens
+source_label: RFC 8941
 base_type: string
 layout: default
 ---

--- a/registries/_format/sf-token.md
+++ b/registries/_format/sf-token.md
@@ -1,0 +1,35 @@
+---
+owner: mikekistler
+issue: 
+description: structured fields token as defined by `sf-token` in [RFC 8941]
+base_type: string
+layout: default
+---
+
+# <a href="..">{{ page.collection }}</a>
+
+## {{ page.slug }} - {{ page.description }}
+
+Base type: `{{ page.base_type }}`.
+
+The `{{page.slug}}` format represents a structured fields token as defined by `sf-token` in [RFC 8941].
+
+```abnf
+sf-token = ( ALPHA / "*" ) *( tchar / ":" / "/" )
+```
+
+Tokens are short textual words; their abstract model is identical to their expression in the HTTP field value serialization.
+
+{% if page.issue %}
+### GitHub Issue
+
+* [#{{ page.issue }}](https://github.com/OAI/OpenAPI-Specification/issues/{{ page.issue }})
+{% endif %}
+
+{% if page.remarks %}
+### Remarks
+
+{{ page.remarks }}
+{% endif %}
+
+[RFC 8941]: https://www.rfc-editor.org/rfc/rfc8941#name-tokens

--- a/registries/_format/sf-token.md
+++ b/registries/_format/sf-token.md
@@ -1,7 +1,7 @@
 ---
 owner: mikekistler
-issue: 
-description: structured fields token as defined in [RFC 8941]
+issue:
+description: structured fields token as defined in [RFC8941]
 source: https://www.rfc-editor.org/rfc/rfc8941#name-tokens
 source_label: RFC 8941
 base_type: string
@@ -14,13 +14,15 @@ layout: default
 
 Base type: `{{ page.base_type }}`.
 
-The `{{page.slug}}` format represents a structured fields token as defined in [RFC 8941].
+The `{{page.slug}}` format represents a structured fields token as defined in [RFC8941].
 
 ```abnf
 sf-token = ( ALPHA / "*" ) *( tchar / ":" / "/" )
 ```
 
 Tokens are short textual words; their abstract model is identical to their expression in the HTTP field value serialization.
+
+This format is appropriate for a header value that must conform to the {{page.slug}} structured field definition.
 
 {% if page.issue %}
 ### GitHub Issue
@@ -34,4 +36,4 @@ Tokens are short textual words; their abstract model is identical to their expre
 {{ page.remarks }}
 {% endif %}
 
-[RFC 8941]: https://www.rfc-editor.org/rfc/rfc8941#name-tokens
+[RFC8941]: https://www.rfc-editor.org/rfc/rfc8941#name-tokens

--- a/registries/_format/sf-token.md
+++ b/registries/_format/sf-token.md
@@ -1,7 +1,7 @@
 ---
 owner: mikekistler
 issue: 
-description: structured fields token as defined by `sf-token` in [RFC 8941]
+description: structured fields token as defined in [RFC 8941]
 base_type: string
 layout: default
 ---
@@ -12,7 +12,7 @@ layout: default
 
 Base type: `{{ page.base_type }}`.
 
-The `{{page.slug}}` format represents a structured fields token as defined by `sf-token` in [RFC 8941].
+The `{{page.slug}}` format represents a structured fields token as defined in [RFC 8941].
 
 ```abnf
 sf-token = ( ALPHA / "*" ) *( tchar / ":" / "/" )


### PR DESCRIPTION
This PR adds six new formats to the format registry for the primitive types defined in [RFC 8641] Structured Field Values for HTTP.

[RCF 8641]: https://www.rfc-editor.org/rfc/rfc8941