### PR TITLE
Revert "punctuation fix"

### DIFF
--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -741,8 +741,8 @@ The path itself is still exposed to the documentation viewer but they will not k
 Field Name | Type | Description
 ---|:---:|---
 <a name="pathItemRef"></a>$ref | `string` | Allows for a referenced definition of this path item. The referenced structure MUST be in the form of a [Path Item Object](#pathItemObject).  In case a Path Item Object field appears both in the defined object and the referenced object, the behavior is undefined. See the rules for resolving [Relative References](#relativeReferencesURI).
-<a name="pathItemSummary"></a>summary| `string` | An optional string summary, intended to apply to all operations in this path.
-<a name="pathItemDescription"></a>description | `string` | An optional string description, intended to apply to all operations in this path. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
+<a name="pathItemSummary"></a>summary| `string` | An optional, string summary, intended to apply to all operations in this path.
+<a name="pathItemDescription"></a>description | `string` | An optional, string description, intended to apply to all operations in this path. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
 <a name="pathItemGet"></a>get | [Operation Object](#operationObject) | A definition of a GET operation on this path.
 <a name="pathItemPut"></a>put | [Operation Object](#operationObject) | A definition of a PUT operation on this path.
 <a name="pathItemPost"></a>post | [Operation Object](#operationObject) | A definition of a POST operation on this path.


### PR DESCRIPTION
Need to revert as it changes the text in a published version of the spec. We need to make this grammatical fix in a patch version.... unfortunately.