### PR TITLE
Revert enforce existence of composite applicator keyword adjacent to "discriminator" #3137

### DIFF
--- a/schemas/v3.1/meta/base.schema.json
+++ b/schemas/v3.1/meta/base.schema.json
@@ -18,15 +18,6 @@
         "externalDocs": { "$ref": "#/$defs/external-docs" },
         "xml": { "$ref": "#/$defs/xml" }
     },
-    "dependentSchemas": {
-      "discriminator": {
-        "anyOf": [
-          { "required": [ "oneOf" ] },
-          { "required": [ "anyOf" ] },
-          { "required": [ "allOf" ] }
-        ]
-      }
-    },
 
     "$defs": {
         "extensible": {

--- a/schemas/v3.1/meta/base.schema.yaml
+++ b/schemas/v3.1/meta/base.schema.yaml
@@ -20,12 +20,6 @@ properties:
     $ref: '#/$defs/external-docs'
   xml:
     $ref: '#/$defs/xml'
-dependentSchemas:
-  discriminator:
-    anyOf:
-    - required: [oneOf]
-    - required: [anyOf]
-    - required: [allOf]
 
 $defs:
   discriminator:


### PR DESCRIPTION
This PR reverts changes from #3137 

According to 3.1.x version of the spec the `discriminator` keyword MAY be added to a parent schema definition, example from the spec:

```yml
components:
  schemas:
    Pet:
      type: object
      required:
      - petType
      properties:
        petType:
          type: string
      discriminator:
        propertyName: petType
        mapping:
          dog: Dog
    Cat:
      allOf:
      - $ref: '#/components/schemas/Pet'
      - type: object
        # all other properties specific to a `Cat`
        properties:
          name:
            type: string
    Dog:
      allOf:
      - $ref: '#/components/schemas/Pet'
      - type: object
        # all other properties specific to a `Dog`
        properties:
          bark:
            type: string
    Lizard:
      allOf:
      - $ref: '#/components/schemas/Pet'
      - type: object
        # all other properties specific to a `Lizard`
        properties:
          lovesRocks:
            type: boolean
```

See comment: https://github.com/OAI/OpenAPI-Specification/pull/2618#discussion_r1362595509

