### PR TITLE
fix: GitHub changed markdown rendering for headings/anchors

### DIFF
--- a/versions/2.0.md
+++ b/versions/2.0.md
@@ -24,10 +24,10 @@ Version | Date | Notes
 
 ## Definitions
 
-##### <a name="pathTemplating"></a>Path Templating
+##### Path Templating
 Path templating refers to the usage of curly braces ({}) to mark a section of a URL path as replaceable using path parameters.
 
-##### <a name="mimeTypes"></a>Mime Types
+##### Mime Types
 Mime type definitions are spread across several resources. The mime type definitions should be in compliance with [RFC 6838](http://tools.ietf.org/html/rfc6838).
 
 Some examples of possible mime type definitions:
@@ -43,14 +43,14 @@ Some examples of possible mime type definitions:
   application/vnd.github.v3.diff
   application/vnd.github.v3.patch
 ```
-##### <a name="httpCodes"></a>HTTP Status Codes
+##### HTTP Status Codes
 The HTTP Status Codes are used to indicate the status of the executed operation. The available status codes are described by [RFC 7231](http://tools.ietf.org/html/rfc7231#section-6) and in the [IANA Status Code Registry](http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml).
 
 ## Specification
 
 ### Format
 
-The files describing the RESTful API in accordance with the Swagger specification are represented as JSON objects and conform to the JSON standards. YAML, being a superset of JSON, can be used as well to 
+The files describing the RESTful API in accordance with the Swagger specification are represented as JSON objects and conform to the JSON standards. YAML, being a superset of JSON, can be used as well to
 represent a Swagger specification file.
 
 For example, if a field is said to have an array value, the JSON array representation will be used:
@@ -65,7 +65,7 @@ While the API is described using JSON it does not impose a JSON input/output to 
 
 All field names in the specification are **case sensitive**.
 
-The schema exposes two types of fields. Fixed fields, which have a declared name, and Patterned fields, which declare a regex pattern for the field name. Patterned fields can have multiple occurrences as long as each has a unique name. 
+The schema exposes two types of fields. Fixed fields, which have a declared name, and Patterned fields, which declare a regex pattern for the field name. Patterned fields can have multiple occurrences as long as each has a unique name.
 
 ### File Structure
 
@@ -75,9 +75,9 @@ By convention, the Swagger specification file is named `swagger.json`.
 
 ### Data Types
 
-Primitive data types in the Swagger Specification are based on the types supported by the [JSON-Schema Draft 4](https://tools.ietf.org/html/draft-zyp-json-schema-04#section-3.5). Models are described using the [Schema Object](#schemaObject) which is a subset of JSON Schema Draft 4.
+Primitive data types in the Swagger Specification are based on the types supported by the [JSON-Schema Draft 4](https://tools.ietf.org/html/draft-zyp-json-schema-04#section-3.5). Models are described using the [Schema Object](#schema-object) which is a subset of JSON Schema Draft 4.
 
-An additional primitive data type `"file"` is used by the [Parameter Object](#parameterObject) and the [Response Object](#responseObject) to set the parameter type or the response as being a file.
+An additional primitive data type `"file"` is used by the [Parameter Object](#parameter-object) and the [Response Object](#response-object) to set the parameter type or the response as being a file.
 
 <a name="dataTypeFormat"></a>Primitives have an optional modifier property `format`. Swagger uses several known formats to more finely define the data type being used. However, the `format` property is an open `string`-valued property, and can have any value to support documentation needs. Formats such as `"email"`, `"uuid"`, etc., can be used even though they are not defined by this specification. Types that are not accompanied by a `format` property follow their definition from the JSON Schema (except for `file` type which is defined above). The formats defined by the Swagger Specification are:
 
@@ -98,7 +98,7 @@ password | `string` | `password` | Used to hint UIs the input needs to be obscur
 
 ### Schema
 
-#### <a name="swaggerObject"></a>Swagger Object
+#### Swagger Object
 
 This is the root document object for the API specification. It combines what previously was the Resource Listing and API Declaration (version 1.2 and earlier) together into one document.
 
@@ -107,28 +107,28 @@ This is the root document object for the API specification. It combines what pre
 Field Name | Type | Description
 ---|:---:|---
 <a name="swaggerSwagger"></a>swagger | `string` | **Required.** Specifies the Swagger Specification version being used. It can be used by the Swagger UI and other clients to interpret the API listing. The value MUST be `"2.0"`.
-<a name="swaggerInfo"></a>info | [Info Object](#infoObject) | **Required.** Provides metadata about the API. The metadata can be used by the clients if needed.
-<a name="swaggerHost"></a>host | `string` | The host (name or ip) serving the API. This MUST be the host only and does not include the scheme nor sub-paths. It MAY include a port. If the `host` is not included, the host serving the documentation is to be used (including the port). The `host` does not support [path templating](#pathTemplating).
-<a name="swaggerBasePath"></a>basePath | `string` | The base path on which the API is served, which is relative to the [`host`](#swaggerHost). If it is not included, the API is served directly under the `host`. The value MUST start with a leading slash (`/`). The `basePath` does not support [path templating](#pathTemplating). 
+<a name="swaggerInfo"></a>info | [Info Object](#info-object) | **Required.** Provides metadata about the API. The metadata can be used by the clients if needed.
+<a name="swaggerHost"></a>host | `string` | The host (name or ip) serving the API. This MUST be the host only and does not include the scheme nor sub-paths. It MAY include a port. If the `host` is not included, the host serving the documentation is to be used (including the port). The `host` does not support [path templating](#path-templating).
+<a name="swaggerBasePath"></a>basePath | `string` | The base path on which the API is served, which is relative to the [`host`](#swaggerHost). If it is not included, the API is served directly under the `host`. The value MUST start with a leading slash (`/`). The `basePath` does not support [path templating](#path-templating).
 <a name="swaggerSchemes"></a>schemes | [`string`] | The transfer protocol of the API. Values MUST be from the list: `"http"`, `"https"`, `"ws"`, `"wss"`. If the `schemes` is not included, the default scheme to be used is the one used to access the Swagger definition itself.
-<a name="swaggerConsumes"></a>consumes | [`string`] | A list of MIME types the APIs can consume. This is global to all APIs but can be overridden on specific API calls. Value MUST be as described under [Mime Types](#mimeTypes).
-<a name="swaggerProduces"></a>produces | [`string`] | A list of MIME types the APIs can produce. This is global to all APIs but can be overridden on specific API calls. Value MUST be as described under [Mime Types](#mimeTypes).
-<a name="swaggerPaths"></a>paths | [Paths Object](#pathsObject) | **Required.** The available paths and operations for the API.
-<a name="swaggerDefinitions"></a>definitions | [Definitions Object](#definitionsObject) | An object to hold data types produced and consumed by operations.
-<a name="swaggerParameters"></a>parameters | [Parameters Definitions Object](#parametersDefinitionsObject) | An object to hold parameters that can be used across operations. This property *does not* define global parameters for all operations.
-<a name="swaggerResponses"></a>responses | [Responses Definitions Object](#responsesDefinitionsObject) | An object to hold responses that can be used across operations. This property *does not* define global responses for all operations.
-<a name="swaggerSecurityDefinitions"></a>securityDefinitions | [Security Definitions Object](#securityDefinitionsObject) | Security scheme definitions that can be used across the specification.
-<a name="swaggerSecurity"></a>security | [[Security Requirement Object](#securityRequirementObject)] | A declaration of which security schemes are applied for the API as a whole. The list of values describes alternative security schemes that can be used (that is, there is a logical OR between the security requirements). Individual operations can override this definition.
-<a name="swaggerTags"></a>tags | [[Tag Object](#tagObject)] | A list of tags used by the specification with additional metadata. The order of the tags can be used to reflect on their order by the parsing tools. Not all tags that are used by the [Operation Object](#operationObject) must be declared. The tags that are not declared may be organized randomly or based on the tools' logic. Each tag name in the list MUST be unique.
-<a name="swaggerExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation.
+<a name="swaggerConsumes"></a>consumes | [`string`] | A list of MIME types the APIs can consume. This is global to all APIs but can be overridden on specific API calls. Value MUST be as described under [Mime Types](#mime-types).
+<a name="swaggerProduces"></a>produces | [`string`] | A list of MIME types the APIs can produce. This is global to all APIs but can be overridden on specific API calls. Value MUST be as described under [Mime Types](#mime-types).
+<a name="swaggerPaths"></a>paths | [Paths Object](#paths-object) | **Required.** The available paths and operations for the API.
+<a name="swaggerDefinitions"></a>definitions | [Definitions Object](#definitions-object) | An object to hold data types produced and consumed by operations.
+<a name="swaggerParameters"></a>parameters | [Parameters Definitions Object](#parameters-definitions-object) | An object to hold parameters that can be used across operations. This property *does not* define global parameters for all operations.
+<a name="swaggerResponses"></a>responses | [Responses Definitions Object](#responses-definitions-object) | An object to hold responses that can be used across operations. This property *does not* define global responses for all operations.
+<a name="swaggerSecurityDefinitions"></a>securityDefinitions | [Security Definitions Object](#security-definitions-object) | Security scheme definitions that can be used across the specification.
+<a name="swaggerSecurity"></a>security | [[Security Requirement Object](#security-requirement-object)] | A declaration of which security schemes are applied for the API as a whole. The list of values describes alternative security schemes that can be used (that is, there is a logical OR between the security requirements). Individual operations can override this definition.
+<a name="swaggerTags"></a>tags | [[Tag Object](#tag-object)] | A list of tags used by the specification with additional metadata. The order of the tags can be used to reflect on their order by the parsing tools. Not all tags that are used by the [Operation Object](#operation-object) must be declared. The tags that are not declared may be organized randomly or based on the tools' logic. Each tag name in the list MUST be unique.
+<a name="swaggerExternalDocs"></a>externalDocs | [External Documentation Object](#external-documentation-object) | Additional external documentation.
 
-##### Patterned Objects 
+##### Patterned Objects
 
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="swaggerExtensions"></a>^x- | Any | Allows extensions to the Swagger Schema. The field name MUST begin with `x-`, for example, `x-internal-id`. The value can be `null`, a primitive, an array or an object. See [Vendor Extensions](#vendorExtensions) for further details.
+<a name="swaggerExtensions"></a>^x- | Any | Allows extensions to the Swagger Schema. The field name MUST begin with `x-`, for example, `x-internal-id`. The value can be `null`, a primitive, an array or an object. See [Vendor Extensions](#specification-extensions) for further details.
 
-#### <a name="infoObject"></a>Info Object
+#### Info Object
 
 The object provides metadata about the API. The metadata can be used by the clients if needed, and can be presented in the Swagger-UI for convenience.
 
@@ -139,15 +139,15 @@ Field Name | Type | Description
 <a name="infoTitle"></a>title | `string` | **Required.** The title of the application.
 <a name="infoDescription"></a>description | `string` | A short description of the application. [GFM syntax](https://guides.github.com/features/mastering-markdown/#GitHub-flavored-markdown) can be used for rich text representation.
 <a name="infoTermsOfService"></a>termsOfService | `string` | The Terms of Service for the API.
-<a name="infoContact"></a>contact | [Contact Object](#contactObject) | The contact information for the exposed API.
-<a name="infoLicense"></a>license | [License Object](#licenseObject) | The license information for the exposed API.
+<a name="infoContact"></a>contact | [Contact Object](#contact-object) | The contact information for the exposed API.
+<a name="infoLicense"></a>license | [License Object](#license-object) | The license information for the exposed API.
 <a name="infoVersion"></a>version | `string` | **Required** Provides the version of the application API (not to be confused with the specification version).
 
-##### Patterned Objects 
+##### Patterned Objects
 
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="infoExtensions"></a>^x- | Any | Allows extensions to the Swagger Schema. The field name MUST begin with `x-`, for example, `x-internal-id`. The value can be `null`, a primitive, an array or an object. See [Vendor Extensions](#vendorExtensions) for further details.
+<a name="infoExtensions"></a>^x- | Any | Allows extensions to the Swagger Schema. The field name MUST begin with `x-`, for example, `x-internal-id`. The value can be `null`, a primitive, an array or an object. See [Vendor Extensions](#specification-extensions) for further details.
 
 ##### Info Object Example:
 
@@ -183,7 +183,7 @@ license:
 version: 1.0.1
 ```
 
-#### <a name="contactObject"></a>Contact Object
+#### Contact Object
 
 Contact information for the exposed API.
 
@@ -195,11 +195,11 @@ Field Name | Type | Description
 <a name="contactUrl"></a>url | `string` | The URL pointing to the contact information. MUST be in the format of a URL.
 <a name="contactEmail"></a>email | `string` | The email address of the contact person/organization. MUST be in the format of an email address.
 
-##### Patterned Objects 
+##### Patterned Objects
 
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="contactExtensions"></a>^x- | Any | Allows extensions to the Swagger Schema. The field name MUST begin with `x-`, for example, `x-internal-id`. The value can be `null`, a primitive, an array or an object. See [Vendor Extensions](#vendorExtensions) for further details.
+<a name="contactExtensions"></a>^x- | Any | Allows extensions to the Swagger Schema. The field name MUST begin with `x-`, for example, `x-internal-id`. The value can be `null`, a primitive, an array or an object. See [Vendor Extensions](#specification-extensions) for further details.
 
 ##### Contact Object Example:
 
@@ -217,7 +217,7 @@ url: http://www.swagger.io/support
 email: support@swagger.io
 ```
 
-#### <a name="licenseObject"></a>License Object
+#### License Object
 
 License information for the exposed API.
 
@@ -228,11 +228,11 @@ Field Name | Type | Description
 <a name="licenseName"></a>name | `string` | **Required.** The license name used for the API.
 <a name="licenseUrl"></a>url | `string` | A URL to the license used for the API. MUST be in the format of a URL.
 
-##### Patterned Objects 
+##### Patterned Objects
 
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="licenseExtensions"></a>^x- | Any | Allows extensions to the Swagger Schema. The field name MUST begin with `x-`, for example, `x-internal-id`. The value can be `null`, a primitive, an array or an object. See [Vendor Extensions](#vendorExtensions) for further details.
+<a name="licenseExtensions"></a>^x- | Any | Allows extensions to the Swagger Schema. The field name MUST begin with `x-`, for example, `x-internal-id`. The value can be `null`, a primitive, an array or an object. See [Vendor Extensions](#specification-extensions) for further details.
 
 ##### License Object Example:
 
@@ -248,17 +248,17 @@ name: Apache 2.0
 url: http://www.apache.org/licenses/LICENSE-2.0.html
 ```
 
-#### <a name="pathsObject"></a>Paths Object
+#### Paths Object
 
 Holds the relative paths to the individual endpoints. The path is appended to the [`basePath`](#swaggerBasePath) in order to construct the full URL.
-The Paths may be empty, due to [ACL constraints](#securityFiltering).
+The Paths may be empty, due to [ACL constraints](#security-filtering).
 
 ##### Patterned Fields
 
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="pathsPath"></a>/{path} | [Path Item Object](#pathItemObject) | A relative path to an individual endpoint. The field name MUST begin with a slash. The path is appended to the [`basePath`](#swaggerBasePath) in order to construct the full URL. [Path templating](#pathTemplating) is allowed.
-<a name="pathsExtensions"></a>^x- | Any | Allows extensions to the Swagger Schema. The field name MUST begin with `x-`, for example, `x-internal-id`. The value can be `null`, a primitive, an array or an object. See [Vendor Extensions](#vendorExtensions) for further details. 
+<a name="pathsPath"></a>/{path} | [Path Item Object](#path-item-object) | A relative path to an individual endpoint. The field name MUST begin with a slash. The path is appended to the [`basePath`](#swaggerBasePath) in order to construct the full URL. [Path templating](#path-templating) is allowed.
+<a name="pathsExtensions"></a>^x- | Any | Allows extensions to the Swagger Schema. The field name MUST begin with `x-`, for example, `x-internal-id`. The value can be `null`, a primitive, an array or an object. See [Vendor Extensions](#specification-extensions) for further details.
 
 ##### Paths Object Example
 
@@ -301,30 +301,30 @@ Field Pattern | Type | Description
             $ref: '#/definitions/pet'
 ```
 
-#### <a name="pathItemObject"></a>Path Item Object
+#### Path Item Object
 
 Describes the operations available on a single path.
-A Path Item may be empty, due to [ACL constraints](#securityFiltering). The path itself is still exposed to the documentation viewer but they will not know which operations and parameters are available.
+A Path Item may be empty, due to [ACL constraints](#security-filtering). The path itself is still exposed to the documentation viewer but they will not know which operations and parameters are available.
 
 ##### Fixed Fields
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="pathItemRef"></a>$ref | `string` | Allows for an external definition of this path item. The referenced structure MUST be in the format of a [Path Item Object](#pathItemObject). If there are conflicts between the referenced definition and this Path Item's definition, the behavior is *undefined*.
-<a name="pathItemGet"></a>get | [Operation Object](#operationObject) | A definition of a GET operation on this path.
-<a name="pathItemPut"></a>put | [Operation Object](#operationObject) | A definition of a PUT operation on this path.
-<a name="pathItemPost"></a>post | [Operation Object](#operationObject) | A definition of a POST operation on this path.
-<a name="pathItemDelete"></a>delete | [Operation Object](#operationObject) | A definition of a DELETE operation on this path.
-<a name="pathItemOptions"></a>options | [Operation Object](#operationObject) | A definition of a OPTIONS operation on this path.
-<a name="pathItemHead"></a>head | [Operation Object](#operationObject) | A definition of a HEAD operation on this path.
-<a name="pathItemPatch"></a>patch | [Operation Object](#operationObject) | A definition of a PATCH operation on this path.
-<a name="pathItemParameters"></a>parameters | [[Parameter Object](#parameterObject) \| [Reference Object](#referenceObject)] | A list of parameters that are applicable for all the operations described under this path. These parameters can be overridden at the operation level, but cannot be removed there. The list MUST NOT include duplicated parameters. A unique parameter is defined by a combination of a [name](#parameterName) and [location](#parameterIn). The list can use the [Reference Object](#referenceObject) to link to parameters that are defined at the [Swagger Object's parameters](#swaggerParameters). There can be one "body" parameter at most.
+<a name="pathItemRef"></a>$ref | `string` | Allows for an external definition of this path item. The referenced structure MUST be in the format of a [Path Item Object](#path-item-object). If there are conflicts between the referenced definition and this Path Item's definition, the behavior is *undefined*.
+<a name="pathItemGet"></a>get | [Operation Object](#operation-object) | A definition of a GET operation on this path.
+<a name="pathItemPut"></a>put | [Operation Object](#operation-object) | A definition of a PUT operation on this path.
+<a name="pathItemPost"></a>post | [Operation Object](#operation-object) | A definition of a POST operation on this path.
+<a name="pathItemDelete"></a>delete | [Operation Object](#operation-object) | A definition of a DELETE operation on this path.
+<a name="pathItemOptions"></a>options | [Operation Object](#operation-object) | A definition of a OPTIONS operation on this path.
+<a name="pathItemHead"></a>head | [Operation Object](#operation-object) | A definition of a HEAD operation on this path.
+<a name="pathItemPatch"></a>patch | [Operation Object](#operation-object) | A definition of a PATCH operation on this path.
+<a name="pathItemParameters"></a>parameters | [[Parameter Object](#parameter-object) \| [Reference Object](#reference-object)] | A list of parameters that are applicable for all the operations described under this path. These parameters can be overridden at the operation level, but cannot be removed there. The list MUST NOT include duplicated parameters. A unique parameter is defined by a combination of a [name](#parameterName) and [location](#parameterIn). The list can use the [Reference Object](#reference-object) to link to parameters that are defined at the [Swagger Object's parameters](#swaggerParameters). There can be one "body" parameter at most.
 
 ##### Patterned Fields
 
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="pathItemExtensions"></a>^x- | Any | Allows extensions to the Swagger Schema. The field name MUST begin with `x-`, for example, `x-internal-id`. The value can be `null`, a primitive, an array or an object. See [Vendor Extensions](#vendorExtensions) for further details. 
+<a name="pathItemExtensions"></a>^x- | Any | Allows extensions to the Swagger Schema. The field name MUST begin with `x-`, for example, `x-internal-id`. The value can be `null`, a primitive, an array or an object. See [Vendor Extensions](#specification-extensions) for further details.
 
 ##### Path Item Object Example
 
@@ -402,7 +402,7 @@ parameters:
   collectionFormat: csv
 ```
 
-#### <a name="operationObject"></a>Operation Object
+#### Operation Object
 
 Describes a single API operation on a path.
 
@@ -413,21 +413,21 @@ Field Name | Type | Description
 <a name="operationTags"></a>tags | [`string`] | A list of tags for API documentation control. Tags can be used for logical grouping of operations by resources or any other qualifier.
 <a name="operationSummary"></a>summary | `string` | A short summary of what the operation does. For maximum readability in the swagger-ui, this field SHOULD be less than 120 characters.
 <a name="operationDescription"></a>description | `string` | A verbose explanation of the operation behavior. [GFM syntax](https://guides.github.com/features/mastering-markdown/#GitHub-flavored-markdown) can be used for rich text representation.
-<a name="operationExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation for this operation.
+<a name="operationExternalDocs"></a>externalDocs | [External Documentation Object](#external-documentation-object) | Additional external documentation for this operation.
 <a name="operationId"></a>operationId | `string` | Unique string used to identify the operation. The id MUST be unique among all operations described in the API. Tools and libraries MAY use the operationId to uniquely identify an operation, therefore, it is recommended to follow common programming naming conventions.
-<a name="operationConsumes"></a>consumes | [`string`] | A list of MIME types the operation can consume. This overrides the [`consumes`](#swaggerConsumes) definition at the Swagger Object. An empty value MAY be used to clear the global definition. Value MUST be as described under [Mime Types](#mimeTypes).
-<a name="operationProduces"></a>produces | [`string`] | A list of MIME types the operation can produce. This overrides the [`produces`](#swaggerProduces) definition at the Swagger Object. An empty value MAY be used to clear the global definition. Value MUST be as described under [Mime Types](#mimeTypes).
-<a name="operationParameters"></a>parameters | [[Parameter Object](#parameterObject) \| [Reference Object](#referenceObject)] | A list of parameters that are applicable for this operation. If a parameter is already defined at the [Path Item](#pathItemParameters), the new definition will override it, but can never remove it. The list MUST NOT include duplicated parameters. A unique parameter is defined by a combination of a [name](#parameterName) and [location](#parameterIn). The list can use the [Reference Object](#referenceObject) to link to parameters that are defined at the [Swagger Object's parameters](#swaggerParameters). There can be one "body" parameter at most.
-<a name="operationResponses"></a>responses | [Responses Object](#responsesObject) | **Required.** The list of possible responses as they are returned from executing this operation.
-<a name="operationSchemes"></a>schemes | [`string`] | The transfer protocol for the operation. Values MUST be from the list: `"http"`, `"https"`, `"ws"`, `"wss"`. The value overrides the Swagger Object [`schemes`](#swaggerSchemes) definition. 
+<a name="operationConsumes"></a>consumes | [`string`] | A list of MIME types the operation can consume. This overrides the [`consumes`](#swaggerConsumes) definition at the Swagger Object. An empty value MAY be used to clear the global definition. Value MUST be as described under [Mime Types](#mime-types).
+<a name="operationProduces"></a>produces | [`string`] | A list of MIME types the operation can produce. This overrides the [`produces`](#swaggerProduces) definition at the Swagger Object. An empty value MAY be used to clear the global definition. Value MUST be as described under [Mime Types](#mime-types).
+<a name="operationParameters"></a>parameters | [[Parameter Object](#parameter-object) \| [Reference Object](#reference-object)] | A list of parameters that are applicable for this operation. If a parameter is already defined at the [Path Item](#pathItemParameters), the new definition will override it, but can never remove it. The list MUST NOT include duplicated parameters. A unique parameter is defined by a combination of a [name](#parameterName) and [location](#parameterIn). The list can use the [Reference Object](#reference-object) to link to parameters that are defined at the [Swagger Object's parameters](#swaggerParameters). There can be one "body" parameter at most.
+<a name="operationResponses"></a>responses | [Responses Object](#responses-object) | **Required.** The list of possible responses as they are returned from executing this operation.
+<a name="operationSchemes"></a>schemes | [`string`] | The transfer protocol for the operation. Values MUST be from the list: `"http"`, `"https"`, `"ws"`, `"wss"`. The value overrides the Swagger Object [`schemes`](#swaggerSchemes) definition.
 <a name="operationDeprecated"></a>deprecated | `boolean` | Declares this operation to be deprecated. Usage of the declared operation should be refrained. Default value is `false`.
-<a name="operationSecurity"></a>security | [[Security Requirement Object](#securityRequirementObject)] | A declaration of which security schemes are applied for this operation. The list of values describes alternative security schemes that can be used (that is, there is a logical OR between the security requirements). This definition overrides any declared top-level [`security`](#swaggerSecurity). To remove a top-level security declaration, an empty array can be used.
+<a name="operationSecurity"></a>security | [[Security Requirement Object](#security-requirement-object)] | A declaration of which security schemes are applied for this operation. The list of values describes alternative security schemes that can be used (that is, there is a logical OR between the security requirements). This definition overrides any declared top-level [`security`](#swaggerSecurity). To remove a top-level security declaration, an empty array can be used.
 
-##### Patterned Objects 
+##### Patterned Objects
 
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="operationExtensions"></a>^x- | Any | Allows extensions to the Swagger Schema. The field name MUST begin with `x-`, for example, `x-internal-id`. The value can be `null`, a primitive, an array or an object. See [Vendor Extensions](#vendorExtensions) for further details.
+<a name="operationExtensions"></a>^x- | Any | Allows extensions to the Swagger Schema. The field name MUST begin with `x-`, for example, `x-internal-id`. The value can be `null`, a primitive, an array or an object. See [Vendor Extensions](#specification-extensions) for further details.
 
 ##### Operation Object Example
 
@@ -527,7 +527,7 @@ security:
 ```
 
 
-#### <a name="externalDocumentationObject"></a>External Documentation Object
+#### External Documentation Object
 
 Allows referencing an external resource for extended documentation.
 
@@ -538,11 +538,11 @@ Field Name | Type | Description
 <a name="externalDocDescription"></a>description | `string` | A short description of the target documentation. [GFM syntax](https://guides.github.com/features/mastering-markdown/#GitHub-flavored-markdown) can be used for rich text representation.
 <a name="externalDocUrl"></a>url | `string` | **Required.** The URL for the target documentation. Value MUST be in the format of a URL.
 
-##### Patterned Objects 
+##### Patterned Objects
 
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="externalDocExtensions"></a>^x- | Any | Allows extensions to the Swagger Schema. The field name MUST begin with `x-`, for example, `x-internal-id`. The value can be `null`, a primitive, an array or an object. See [Vendor Extensions](#vendorExtensions) for further details.
+<a name="externalDocExtensions"></a>^x- | Any | Allows extensions to the Swagger Schema. The field name MUST begin with `x-`, for example, `x-internal-id`. The value can be `null`, a primitive, an array or an object. See [Vendor Extensions](#specification-extensions) for further details.
 
 ##### External Documentation Object Example
 
@@ -558,14 +558,14 @@ description: Find more info here
 url: https://swagger.io
 ```
 
-#### <a name="parameterObject"></a>Parameter Object
+#### Parameter Object
 
 Describes a single operation parameter.
 
 A unique parameter is defined by a combination of a [name](#parameterName) and [location](#parameterIn).
 
 There are five possible parameter types.
-* Path - Used together with [Path Templating](#pathTemplating), where the parameter value is actually part of the operation's URL. This does not include the host or base path of the API. For example, in `/items/{itemId}`, the path parameter is `itemId`.
+* Path - Used together with [Path Templating](#path-templating), where the parameter value is actually part of the operation's URL. This does not include the host or base path of the API. For example, in `/items/{itemId}`, the path parameter is `itemId`.
 * Query - Parameters that are appended to the URL. For example, in `/items?id=###`, the query parameter is `id`.
 * Header - Custom headers that are expected as part of the request.
 * Body - The payload that's appended to the HTTP request. Since there can only be one payload, there can only be *one* body parameter. The name of the body parameter has no effect on the parameter itself and is used for documentation purposes only. Since Form parameters are also in the payload, body and form parameters cannot exist together for the same operation.
@@ -576,16 +576,16 @@ There are five possible parameter types.
 ##### Fixed Fields
 Field Name | Type | Description
 ---|:---:|---
-<a name="parameterName"></a>name | `string` | **Required.** The name of the parameter. Parameter names are *case sensitive*. <ul><li>If [`in`](#parameterIn) is `"path"`, the `name` field MUST correspond to the associated path segment from the [path](#pathsPath) field in the [Paths Object](#pathsObject). See [Path Templating](#pathTemplating) for further information.<li>For all other cases, the `name` corresponds to the parameter name used based on the [`in`](#parameterIn) property.</ul>
+<a name="parameterName"></a>name | `string` | **Required.** The name of the parameter. Parameter names are *case sensitive*. <ul><li>If [`in`](#parameterIn) is `"path"`, the `name` field MUST correspond to the associated path segment from the [path](#pathsPath) field in the [Paths Object](#paths-object). See [Path Templating](#path-templating) for further information.<li>For all other cases, the `name` corresponds to the parameter name used based on the [`in`](#parameterIn) property.</ul>
 <a name="parameterIn"></a>in | `string` | **Required.** The location of the parameter. Possible values are "query", "header", "path", "formData" or "body".
 <a name="parameterDescription"></a>description | `string` | A brief description of the parameter. This could contain examples of use.  [GFM syntax](https://guides.github.com/features/mastering-markdown/#GitHub-flavored-markdown) can be used for rich text representation.
-<a name="parameterRequired"></a>required | `boolean` | Determines whether this parameter is mandatory. If the parameter is [`in`](#parameterIn) "path", this property is **required** and its value MUST be `true`. Otherwise, the property MAY be included and its default value is `false`. 
+<a name="parameterRequired"></a>required | `boolean` | Determines whether this parameter is mandatory. If the parameter is [`in`](#parameterIn) "path", this property is **required** and its value MUST be `true`. Otherwise, the property MAY be included and its default value is `false`.
 
 If [`in`](#parameterIn) is `"body"`:
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="parameterSchema"></a>schema | [Schema Object](#schemaObject) | **Required.** The schema defining the type used for the body parameter.
+<a name="parameterSchema"></a>schema | [Schema Object](#schema-object) | **Required.** The schema defining the type used for the body parameter.
 
 If [`in`](#parameterIn) is any value other than `"body"`:
 
@@ -594,7 +594,7 @@ Field Name | Type | Description
 <a name="parameterType"></a>type | `string` | **Required.** The type of the parameter. Since the parameter is not located at the request body, it is limited to simple types (that is, not an object). The value MUST be one of `"string"`, `"number"`, `"integer"`, `"boolean"`, `"array"` or `"file"`. If `type` is `"file"`, the [`consumes`](#operationConsumes) MUST be either `"multipart/form-data"`, `" application/x-www-form-urlencoded"` or both and the parameter MUST be [`in`](#parameterIn) `"formData"`.
 <a name="parameterFormat"></a>format | `string` | The extending format for the previously mentioned [`type`](#parameterType). See [Data Type Formats](#dataTypeFormat) for further details.
 <a name="parameterAllowEmptyValue"/>allowEmptyValue | `boolean` | Sets the ability to pass empty-valued parameters. This is valid only for either `query` or `formData` parameters and allows you to send a parameter with a name only or  an empty value. Default value is `false`.
-<a name="parameterItems"></a>items | [Items Object](#itemsObject) | **Required if [`type`](#parameterType) is "array".** Describes the type of items in the array.
+<a name="parameterItems"></a>items | [Items Object](#items-object) | **Required if [`type`](#parameterType) is "array".** Describes the type of items in the array.
 <a name="parameterCollectionFormat"></a>collectionFormat | `string` | Determines the format of the array if type array is used. Possible values are: <ul><li>`csv` - comma separated values `foo,bar`. <li>`ssv` - space separated values `foo bar`. <li>`tsv` - tab separated values `foo\tbar`. <li>`pipes` - pipe separated values <code>foo&#124;bar</code>. <li>`multi` - corresponds to multiple parameter instances instead of multiple values for a single instance `foo=bar&foo=baz`. This is valid only for parameters [`in`](#parameterIn) "query" or "formData". </ul> Default value is `csv`.
 <a name="parameterDefault"></a>default | * | Declares the value of the parameter that the server will use if none is provided, for example a "count" to control the number of results per page might default to 100 if not supplied by the client in the request. (Note: "default" has no meaning for required parameters.)  See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-6.2. Unlike JSON Schema this value MUST conform to the defined [`type`](#parameterType) for this parameter.
 <a name="parameterMaximum"></a>maximum | `number` | See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.1.2.
@@ -614,7 +614,7 @@ Field Name | Type | Description
 ##### Patterned Fields
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="parameterExtensions"></a>^x- | Any | Allows extensions to the Swagger Schema. The field name MUST begin with `x-`, for example, `x-internal-id`. The value can be `null`, a primitive, an array or an object. See [Vendor Extensions](#vendorExtensions) for further details.
+<a name="parameterExtensions"></a>^x- | Any | Allows extensions to the Swagger Schema. The field name MUST begin with `x-`, for example, `x-internal-id`. The value can be `null`, a primitive, an array or an object. See [Vendor Extensions](#specification-extensions) for further details.
 
 
 ##### Parameter Object Examples
@@ -765,7 +765,7 @@ required: true
 type: file
 ```
 
-#### <a name="itemsObject"></a>Items Object
+#### Items Object
 
 A limited subset of JSON-Schema's items object. It is used by parameter definitions that are not located [`in`](#parameterIn) `"body"`.
 
@@ -774,7 +774,7 @@ Field Name | Type | Description
 ---|:---:|---
 <a name="itemsType"></a>type | `string` | **Required.** The internal type of the array. The value MUST be one of `"string"`, `"number"`, `"integer"`, `"boolean"`, or `"array"`. Files and models are not allowed.
 <a name="itemsFormat"></a>format | `string` | The extending format for the previously mentioned [`type`](#parameterType). See [Data Type Formats](#dataTypeFormat) for further details.
-<a name="itemsItems"></a>items | [Items Object](#itemsObject) | **Required if [`type`](#itemsType) is "array".** Describes the type of items in the array.
+<a name="itemsItems"></a>items | [Items Object](#items-object) | **Required if [`type`](#itemsType) is "array".** Describes the type of items in the array.
 <a name="itemsCollectionFormat"></a>collectionFormat | `string` | Determines the format of the array if type array is used. Possible values are: <ul><li>`csv` - comma separated values `foo,bar`. <li>`ssv` - space separated values `foo bar`. <li>`tsv` - tab separated values `foo\tbar`. <li>`pipes` - pipe separated values <code>foo&#124;bar</code>. </ul> Default value is `csv`.
 <a name="itemsDefault"></a>default | * | Declares the value of the item that the server will use if none is provided. (Note: "default" has no meaning for required items.) See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-6.2. Unlike JSON Schema this value MUST conform to the defined [`type`](#itemsType) for the data type.
 <a name="itemsMaximum"></a>maximum | `number` | See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.1.2.
@@ -790,11 +790,11 @@ Field Name | Type | Description
 <a name="itemsEnum"></a>enum | [*] | See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.5.1.
 <a name="itemsMultipleOf"></a>multipleOf | `number` | See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.1.1.
 
-##### Patterned Objects 
+##### Patterned Objects
 
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="itemsExtensions"></a>^x- | Any | Allows extensions to the Swagger Schema. The field name MUST begin with `x-`, for example, `x-internal-id`. The value can be `null`, a primitive, an array or an object. See [Vendor Extensions](#vendorExtensions) for further details.
+<a name="itemsExtensions"></a>^x- | Any | Allows extensions to the Swagger Schema. The field name MUST begin with `x-`, for example, `x-internal-id`. The value can be `null`, a primitive, an array or an object. See [Vendor Extensions](#specification-extensions) for further details.
 
 ##### Items Object Examples
 
@@ -833,7 +833,7 @@ items:
   maximum: 63
 ```
 
-#### <a name="responsesObject"></a>Responses Object
+#### Responses Object
 
 A container for the expected responses of an operation. The container maps a HTTP response code to the expected response. It is not expected from the documentation to necessarily cover all possible HTTP response codes, since they may not be known in advance. However, it is expected from the documentation to cover a successful operation response and any known errors.
 
@@ -844,13 +844,13 @@ The `Responses Object` MUST contain at least one response code, and it SHOULD be
 ##### Fixed Fields
 Field Name | Type | Description
 ---|:---:|---
-<a name="responsesDefault"></a>default | [Response Object](#responseObject) \| [Reference Object](#referenceObject) | The documentation of responses other than the ones declared for specific HTTP response codes. It can be used to cover undeclared responses. [Reference Object](#referenceObject) can be used to link to a response that is defined at the [Swagger Object's responses](#swaggerResponses) section.
+<a name="responsesDefault"></a>default | [Response Object](#response-object) \| [Reference Object](#reference-object) | The documentation of responses other than the ones declared for specific HTTP response codes. It can be used to cover undeclared responses. [Reference Object](#reference-object) can be used to link to a response that is defined at the [Swagger Object's responses](#swaggerResponses) section.
 
 ##### Patterned Fields
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="responsesCode"></a>{[HTTP Status Code](#httpCodes)} | [Response Object](#responseObject) \| [Reference Object](#referenceObject) | Any [HTTP status code](#httpCodes) can be used as the property name (one property per HTTP status code). Describes the expected response for that HTTP status code.  [Reference Object](#referenceObject) can be used to link to a response that is defined at the [Swagger Object's responses](#swaggerResponses) section.
-<a name="responsesExtensions"></a>^x- | Any | Allows extensions to the Swagger Schema. The field name MUST begin with `x-`, for example, `x-internal-id`. The value can be `null`, a primitive, an array or an object. See [Vendor Extensions](#vendorExtensions) for further details.
+<a name="responsesCode"></a>{[HTTP Status Code](#http-status-codes)} | [Response Object](#response-object) \| [Reference Object](#reference-object) | Any [HTTP status code](#http-status-codes) can be used as the property name (one property per HTTP status code). Describes the expected response for that HTTP status code.  [Reference Object](#reference-object) can be used to link to a response that is defined at the [Swagger Object's responses](#swaggerResponses) section.
+<a name="responsesExtensions"></a>^x- | Any | Allows extensions to the Swagger Schema. The field name MUST begin with `x-`, for example, `x-internal-id`. The value can be `null`, a primitive, an array or an object. See [Vendor Extensions](#specification-extensions) for further details.
 
 
 ##### Responses Object Example
@@ -885,22 +885,22 @@ default:
     $ref: '#/definitions/ErrorModel'
 ```
 
-#### <a name="responseObject"></a>Response Object
+#### Response Object
 Describes a single response from an API Operation.
 
 ##### Fixed Fields
 Field Name | Type | Description
 ---|:---:|---
 <a name="responseDescription"></a>description | `string` | **Required.** A short description of the response. [GFM syntax](https://guides.github.com/features/mastering-markdown/#GitHub-flavored-markdown) can be used for rich text representation.
-<a name="responseSchema"></a>schema | [Schema Object](#schemaObject) | A definition of the response structure. It can be a primitive, an array or an object. If this field does not exist, it means no content is returned as part of the response. As an extension to the [Schema Object](#schemaObject), its root `type` value may also be `"file"`. This SHOULD be accompanied by a relevant `produces` mime-type.
-<a name="responseHeaders"></a>headers | [Headers Object](#headersObject) | A list of headers that are sent with the response.
-<a name="responseExamples"></a>examples | [Example Object](#exampleObject) | An example of the response message.
+<a name="responseSchema"></a>schema | [Schema Object](#schema-object) | A definition of the response structure. It can be a primitive, an array or an object. If this field does not exist, it means no content is returned as part of the response. As an extension to the [Schema Object](#schema-object), its root `type` value may also be `"file"`. This SHOULD be accompanied by a relevant `produces` mime-type.
+<a name="responseHeaders"></a>headers | [Headers Object](#headers-object) | A list of headers that are sent with the response.
+<a name="responseExamples"></a>examples | [Example Object](#example-object) | An example of the response message.
 
-##### Patterned Objects 
+##### Patterned Objects
 
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="responseExtensions"></a>^x- | Any | Allows extensions to the Swagger Schema. The field name MUST begin with `x-`, for example, `x-internal-id`. The value can be `null`, a primitive, an array or an object. See [Vendor Extensions](#vendorExtensions) for further details.
+<a name="responseExtensions"></a>^x- | Any | Allows extensions to the Swagger Schema. The field name MUST begin with `x-`, for example, `x-internal-id`. The value can be `null`, a primitive, an array or an object. See [Vendor Extensions](#specification-extensions) for further details.
 
 ##### Response Object Examples
 
@@ -996,13 +996,13 @@ Response with no return value:
 description: object created
 ```
 
-#### <a name="headersObject"></a>Headers Object
+#### Headers Object
 Lists the headers that can be sent as part of a response.
 
 ##### Patterned Fields
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="headersName"></a>{name} | [Header Object](#headerObject) | The name of the property corresponds to the name of the header. The value describes the type of the header.
+<a name="headersName"></a>{name} | [Header Object](#header-object) | The name of the property corresponds to the name of the header. The value describes the type of the header.
 
 ##### Headers Object Example
 
@@ -1037,14 +1037,14 @@ X-Rate-Limit-Reset:
   type: integer
 ```
 
-#### <a name="exampleObject"></a>Example Object
+#### Example Object
 
 Allows sharing examples for operation responses.
 
 ##### Patterned Fields
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="exampleMimeType"></a>{[mime type](#mimeTypes)} | Any | The name of the property MUST be one of the Operation `produces` values (either implicit or inherited). The value SHOULD be an example of what such a response would look like. 
+<a name="exampleMimeType"></a>{[mime type](#mime-types)} | Any | The name of the property MUST be one of the Operation `produces` values (either implicit or inherited). The value SHOULD be an example of what such a response would look like.
 
 ##### Example Object Example
 
@@ -1071,14 +1071,14 @@ application/json:
   breed: Mixed
 ```
 
-#### <a name="headerObject"></a>Header Object
+#### Header Object
 
 Field Name | Type | Description
 ---|:---:|---
 <a name="headerDescription"></a>description | `string` | A short description of the header.
 <a name="headerType"></a>type | `string` | **Required.** The type of the object. The value MUST be one of `"string"`, `"number"`, `"integer"`, `"boolean"`, or `"array"`.
 <a name="headerFormat"></a>format | `string` | The extending format for the previously mentioned [`type`](#stType). See [Data Type Formats](#dataTypeFormat) for further details.
-<a name="headerItems"></a>items | [Items Object](#itemsObject) | **Required if [`type`](#stType) is "array".** Describes the type of items in the array.
+<a name="headerItems"></a>items | [Items Object](#items-object) | **Required if [`type`](#stType) is "array".** Describes the type of items in the array.
 <a name="headerCollectionFormat"></a>collectionFormat | `string` | Determines the format of the array if type array is used. Possible values are: <ul><li>`csv` - comma separated values `foo,bar`. <li>`ssv` - space separated values `foo bar`. <li>`tsv` - tab separated values `foo\tbar`. <li>`pipes` - pipe separated values <code>foo&#124;bar</code>. </ul> Default value is `csv`.
 <a name="headerDefault"></a>default | * | Declares the value of the header that the server will use if none is provided. (Note: "default" has no meaning for required headers.) See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-6.2. Unlike JSON Schema this value MUST conform to the defined [`type`](#headerDefault) for the header.
 <a name="headerMaximum"></a>maximum | `number` | See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.1.2.
@@ -1094,11 +1094,11 @@ Field Name | Type | Description
 <a name="headerEnum"></a>enum | [*] | See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.5.1.
 <a name="headerMultipleOf"></a>multipleOf | `number` | See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.1.1.
 
-##### Patterned Objects 
+##### Patterned Objects
 
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="headerExtensions"></a>^x- | Any | Allows extensions to the Swagger Schema. The field name MUST begin with `x-`, for example, `x-internal-id`. The value can be `null`, a primitive, an array or an object. See [Vendor Extensions](#vendorExtensions) for further details.
+<a name="headerExtensions"></a>^x- | Any | Allows extensions to the Swagger Schema. The field name MUST begin with `x-`, for example, `x-internal-id`. The value can be `null`, a primitive, an array or an object. See [Vendor Extensions](#specification-extensions) for further details.
 
 ##### Header Object Example
 
@@ -1116,21 +1116,21 @@ description: The number of allowed requests in the current period
 type: integer
 ```
 
-#### <a name="tagObject"></a>Tag Object
+#### Tag Object
 
-Allows adding meta data to a single tag that is used by the [Operation Object](#operationObject). It is not mandatory to have a Tag Object per tag used there.
+Allows adding meta data to a single tag that is used by the [Operation Object](#operation-object). It is not mandatory to have a Tag Object per tag used there.
 
 ##### Fixed Fields
 Field Name | Type | Description
 ---|:---:|---
 <a name="tagName"></a>name | `string` | **Required.** The name of the tag.
 <a name="tagDescription"></a>description | `string` | A short description for the tag. [GFM syntax](https://guides.github.com/features/mastering-markdown/#GitHub-flavored-markdown) can be used for rich text representation.
-<a name="tagExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation for this tag.
+<a name="tagExternalDocs"></a>externalDocs | [External Documentation Object](#external-documentation-object) | Additional external documentation for this tag.
 
 ##### Patterned Fields
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="tagExtensions"></a>^x- | Any | Allows extensions to the Swagger Schema. The field name MUST begin with `x-`, for example, `x-internal-id`. The value can be `null`, a primitive, an array or an object. See [Vendor Extensions](#vendorExtensions) for further details.
+<a name="tagExtensions"></a>^x- | Any | Allows extensions to the Swagger Schema. The field name MUST begin with `x-`, for example, `x-internal-id`. The value can be `null`, a primitive, an array or an object. See [Vendor Extensions](#specification-extensions) for further details.
 
 ##### Tag Object Example
 
@@ -1146,7 +1146,7 @@ name: pet
 description: Pets operations
 ```
 
-#### <a name="referenceObject"></a>Reference Object
+#### Reference Object
 
 A simple object to allow referencing other definitions in the specification. It can be used to reference parameters and responses that are defined at the top level for reuse.
 
@@ -1155,7 +1155,7 @@ The Reference Object is a [JSON Reference](http://tools.ietf.org/html/draft-pbry
 ##### Fixed Fields
 Field Name | Type | Description
 ---|:---:|---
-<a name="referenceRef"></a>$ref | `string` | **Required.** The reference string. 
+<a name="referenceRef"></a>$ref | `string` | **Required.** The reference string.
 
 ##### Reference Object Example
 
@@ -1191,7 +1191,7 @@ $ref: 'Pet.yaml'
 $ref: 'definitions.yaml#/Pet'
 ```
 
-#### <a name="schemaObject"></a>Schema Object
+#### Schema Object
 
 The Schema Object allows the definition of input and output data types. These types can be objects, but also primitives and arrays. This object is based on the [JSON Schema Specification Draft 4](http://json-schema.org/) and uses a predefined subset of it. On top of this subset, there are extensions provided by this specification to allow for more complete documentation.
 
@@ -1220,7 +1220,7 @@ The following properties are taken directly from the JSON Schema definition and 
 - enum
 - type
 
-The following properties are taken from the JSON Schema definition but their definitions were adjusted to the Swagger Specification. Their definition is the same as the one from JSON Schema, only where the original definition references the JSON Schema definition, the [Schema Object](#schemaObject) definition is used instead.
+The following properties are taken from the JSON Schema definition but their definitions were adjusted to the Swagger Specification. Their definition is the same as the one from JSON Schema, only where the original definition references the JSON Schema definition, the [Schema Object](#schema-object) definition is used instead.
 - items
 - allOf
 - properties
@@ -1233,25 +1233,25 @@ Field Name | Type | Description
 ---|:---:|---
 <a name="schemaDiscriminator"></a>discriminator | `string` | Adds support for polymorphism. The discriminator is the schema property name that is used to differentiate between other schema that inherit this schema. The property name used MUST be defined at this schema and it MUST be in the `required` property list. When used, the value MUST be the name of this schema or any schema that inherits it.
 <a name="schemaReadOnly"></a>readOnly | `boolean` | Relevant only for Schema `"properties"` definitions. Declares the property as "read only". This means that it MAY be sent as part of a response but MUST NOT be sent as part of the request. Properties marked as `readOnly` being `true` SHOULD NOT be in the `required` list of the defined schema. Default value is `false`.
-<a name="schemaXml"></a>xml | [XML Object](#xmlObject) | This MAY be used only on properties schemas. It has no effect on root schemas. Adds Additional metadata to describe the XML representation format of this property.
-<a name="schemaExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation for this schema. 
+<a name="schemaXml"></a>xml | [XML Object](#xml-object) | This MAY be used only on properties schemas. It has no effect on root schemas. Adds Additional metadata to describe the XML representation format of this property.
+<a name="schemaExternalDocs"></a>externalDocs | [External Documentation Object](#external-documentation-object) | Additional external documentation for this schema.
 <a name="schemaExample"></a>example | Any | A free-form property to include an example of an instance for this schema.
 
-##### Patterned Objects 
+##### Patterned Objects
 
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="schemaExtensions"></a>^x- | Any | Allows extensions to the Swagger Schema. The field name MUST begin with `x-`, for example, `x-internal-id`. The value can be `null`, a primitive, an array or an object. See [Vendor Extensions](#vendorExtensions) for further details.
+<a name="schemaExtensions"></a>^x- | Any | Allows extensions to the Swagger Schema. The field name MUST begin with `x-`, for example, `x-internal-id`. The value can be `null`, a primitive, an array or an object. See [Vendor Extensions](#specification-extensions) for further details.
 
 ###### Composition and Inheritance (Polymorphism)
 
-Swagger allows combining and extending model definitions using the `allOf` property of JSON Schema, in effect offering model composition. `allOf` takes in an array of object definitions that are validated *independently* but together compose a single object. 
+Swagger allows combining and extending model definitions using the `allOf` property of JSON Schema, in effect offering model composition. `allOf` takes in an array of object definitions that are validated *independently* but together compose a single object.
 
 While composition offers model extensibility, it does not imply a hierarchy between the models. To support polymorphism, Swagger adds the support of the `discriminator` field. When used, the `discriminator` will be the name of the property used to decide which schema definition is used to validate the structure of the model. As such, the `discriminator` field MUST be a required field. The value of the chosen property has to be the friendly name given to the model under the `definitions` property. As such, inline schema definitions, which do not have a given id, *cannot* be used in polymorphism.
 
 ###### XML Modeling
 
-The [xml](#schemaXml) property allows extra definitions when translating the JSON definition to XML. The [XML Object](#xmlObject) contains additional information about the available options.
+The [xml](#schemaXml) property allows extra definitions when translating the JSON definition to XML. The [XML Object](#xml-object) contains additional information about the available options.
 
 ##### Schema Object Examples
 
@@ -1575,7 +1575,7 @@ definitions:
       - packSize
 ```
 
-#### <a name="xmlObject"></a>XML Object
+#### XML Object
 
 A metadata object that allows for more fine-tuned XML model definitions.
 
@@ -1590,15 +1590,15 @@ Field Name | Type | Description
 <a name="xmlAttribute"></a>attribute | `boolean` | Declares whether the property definition translates to an attribute instead of an element. Default value is `false`.
 <a name="xmlWrapped"></a>wrapped | `boolean` | MAY be used only for an array definition. Signifies whether the array is wrapped (for example, `<books><book/><book/></books>`) or unwrapped (`<book/><book/>`). Default value is `false`. The definition takes effect only when defined alongside `type` being `array` (outside the `items`).
 
-##### Patterned Objects 
+##### Patterned Objects
 
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="xmlExtensions"></a>^x- | Any | Allows extensions to the Swagger Schema. The field name MUST begin with `x-`, for example, `x-internal-id`. The value can be `null`, a primitive, an array or an object. See [Vendor Extensions](#vendorExtensions) for further details.
+<a name="xmlExtensions"></a>^x- | Any | Allows extensions to the Swagger Schema. The field name MUST begin with `x-`, for example, `x-internal-id`. The value can be `null`, a primitive, an array or an object. See [Vendor Extensions](#specification-extensions) for further details.
 
 ##### XML Object Examples
 
-The examples of the XML object definitions are included inside a property definition of a [Schema Object](#schemaObject) with a sample of the XML representation of it.
+The examples of the XML object definitions are included inside a property definition of a [Schema Object](#schema-object) with a sample of the XML representation of it.
 
 ###### No XML Element
 
@@ -1931,7 +1931,7 @@ animals:
 </aliens>
 ```
 
-#### <a name="definitionsObject"></a>Definitions Object
+#### Definitions Object
 
 An object to hold data types that can be consumed and produced by operations. These data types can be primitives, arrays or models.
 
@@ -1939,7 +1939,7 @@ An object to hold data types that can be consumed and produced by operations. Th
 
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="definitionsName"></a>{name} | [Schema Object](#schemaObject) | A single definition, mapping a "name" to the schema it defines.
+<a name="definitionsName"></a>{name} | [Schema Object](#schema-object) | A single definition, mapping a "name" to the schema it defines.
 
 ##### Definitions Object Example
 
@@ -1991,7 +1991,7 @@ Tag:
       type: string
 ```
 
-#### <a name="parametersDefinitionsObject"></a>Parameters Definitions Object
+#### Parameters Definitions Object
 
 An object to hold parameters to be reused across operations. Parameter definitions can be referenced to the ones defined here.
 
@@ -2001,7 +2001,7 @@ This does *not* define global operation parameters.
 
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="pdName"></a>{name} | [Parameter Object](#parameterObject) | A single parameter definition, mapping a "name" to the parameter it defines.
+<a name="pdName"></a>{name} | [Parameter Object](#parameter-object) | A single parameter definition, mapping a "name" to the parameter it defines.
 
 ##### Parameters Definition Object Example
 
@@ -2044,7 +2044,7 @@ limitParam:
 ```
 
 
-#### <a name="responsesDefinitionsObject"></a>Responses Definitions Object
+#### Responses Definitions Object
 
 An object to hold responses to be reused across operations. Response definitions can be referenced to the ones defined here.
 
@@ -2054,7 +2054,7 @@ This does *not* define global operation responses.
 
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="rdName"></a>{name} | [Response Object](#responseObject) | A single response definition, mapping a "name" to the response it defines.
+<a name="rdName"></a>{name} | [Response Object](#response-object) | A single response definition, mapping a "name" to the response it defines.
 
 ##### Responses Definitions Object Example
 
@@ -2086,14 +2086,14 @@ GeneralError:
     $ref: '#/definitions/GeneralError'
 ```
 
-#### <a name="securityDefinitionsObject"></a>Security Definitions Object
+#### Security Definitions Object
 
 A declaration of the security schemes available to be used in the specification. This does not enforce the security schemes on the operations and only serves to provide the relevant details for each scheme.
 
 ##### Patterned Fields
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="sdName"></a>{name} | [Security Scheme Object](#securitySchemeObject) | A single security scheme definition, mapping a "name" to the scheme it defines.
+<a name="sdName"></a>{name} | [Security Scheme Object](#security-scheme-object) | A single security scheme definition, mapping a "name" to the scheme it defines.
 
 ##### Security Definitions Object Example
 
@@ -2130,7 +2130,7 @@ petstore_auth:
     read:pets: read your pets
 ```
 
-#### <a name="securitySchemeObject"></a>Security Scheme Object
+#### Security Scheme Object
 
 Allows the definition of a security scheme that can be used by the operations. Supported schemes are basic authentication, an API key (either as a header or as a query parameter) and OAuth2's common flows (implicit, password, application and access code).
 
@@ -2144,13 +2144,13 @@ Field Name | Type | Validity | Description
 <a name="securitySchemeFlow"></a>flow | `string` | `oauth2` | **Required.** The flow used by the OAuth2 security scheme. Valid values are `"implicit"`, `"password"`, `"application"` or `"accessCode"`.
 <a name="securitySchemeAuthorizationUrl"></a>authorizationUrl | `string` | `oauth2` (`"implicit"`, `"accessCode"`) | **Required.** The authorization URL to be used for this flow. This SHOULD be in the form of a URL.
 <a name="securitySchemeTokenUrl"></a>tokenUrl | `string` | `oauth2` (`"password"`, `"application"`, `"accessCode"`) | **Required.** The token URL to be used for this flow. This SHOULD be in the form of a URL.
-<a name="securitySchemeScopes"></a>scopes | [Scopes Object](#scopesObject) | `oauth2` | **Required.** The available scopes for the OAuth2 security scheme.
+<a name="securitySchemeScopes"></a>scopes | [Scopes Object](#scopes-object) | `oauth2` | **Required.** The available scopes for the OAuth2 security scheme.
 
 ##### Patterned Fields
 
-Field Name | Type | Description 
+Field Name | Type | Description
 ---|:---:|---
-<a name="securitySchemeExtensions"></a>^x- | Any | Allows extensions to the Swagger Schema. The field name MUST begin with `x-`, for example, `x-internal-id`. The value can be `null`, a primitive, an array or an object. See [Vendor Extensions](#vendorExtensions) for further details.
+<a name="securitySchemeExtensions"></a>^x- | Any | Allows extensions to the Swagger Schema. The field name MUST begin with `x-`, for example, `x-internal-id`. The value can be `null`, a primitive, an array or an object. See [Vendor Extensions](#specification-extensions) for further details.
 
 ##### Security Scheme Object Example
 
@@ -2205,7 +2205,7 @@ scopes:
   read:pets: read your pets
 ```
 
-#### <a name="scopesObject"></a>Scopes Object
+#### Scopes Object
 
 Lists the available scopes for an OAuth2 security scheme.
 
@@ -2215,11 +2215,11 @@ Field Pattern | Type | Description
 ---|:---:|---
 <a name="scopesName"></a>{name} | `string` | Maps between a name of a scope to a short description of it (as the value of the property).
 
-##### Patterned Objects 
+##### Patterned Objects
 
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="scopesExtensions"></a>^x- | Any | Allows extensions to the Swagger Schema. The field name MUST begin with `x-`, for example, `x-internal-id`. The value can be `null`, a primitive, an array or an object. See [Vendor Extensions](#vendorExtensions) for further details.
+<a name="scopesExtensions"></a>^x- | Any | Allows extensions to the Swagger Schema. The field name MUST begin with `x-`, for example, `x-internal-id`. The value can be `null`, a primitive, an array or an object. See [Vendor Extensions](#specification-extensions) for further details.
 
 ##### Scopes Object Example
 
@@ -2235,11 +2235,11 @@ write:pets: modify pets in your account
 read:pets: read your pets
 ```
 
-#### <a name="securityRequirementObject"></a>Security Requirement Object
+#### Security Requirement Object
 
 Lists the required security schemes to execute this operation. The object can have multiple security schemes declared in it which are all required (that is, there is a logical AND between the schemes).
 
-The name used for each property MUST correspond to a security scheme declared in the [Security Definitions](#securityDefinitionsObject).
+The name used for each property MUST correspond to a security scheme declared in the [Security Definitions](#security-definitions-object).
 
 ##### Patterned Fields
 
@@ -2278,7 +2278,7 @@ petstore_auth:
 - read:pets
 ```
 
-### <a name="vendorExtensions"></a>Specification Extensions
+### Specification Extensions
 
 While the Swagger Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.
 
@@ -2286,13 +2286,13 @@ The extensions properties are always prefixed by `"x-"` and can have any valid J
 
 The extensions may or may not be supported by the available tooling, but those may be extended as well to add requested support (if tools are internal or open-sourced).
 
-### <a name="securityFiltering"></a>Security Filtering
+### Security Filtering
 
-Some objects in the Swagger specification may be declared and remain empty, or completely be removed, even though they are inherently the core of the API documentation. 
+Some objects in the Swagger specification may be declared and remain empty, or completely be removed, even though they are inherently the core of the API documentation.
 
 The reasoning behind it is to allow an additional layer of access control over the documentation itself. While not part of the specification itself, certain libraries may choose to allow access to parts of the documentation based on some form of authentication/authorization.
 
 Two examples for this:
 
-1. The [Paths Object](#pathsObject) may be empty. It may be counterintuitive, but this may tell the viewer that they got to the right place, but can't access any documentation. They'd still have access to the [Info Object](#infoObject) which may contain additional information regarding authentication.
-2. The [Path Item Object](#pathItemObject) may be empty. In this case, the viewer will be aware that the path exists, but will not be able to see any of its operations or parameters. This is different than hiding the path itself from the [Paths Object](#pathsObject) so the user will not be aware of its existence. This allows the documentation provider a finer control over what the viewer can see.
+1. The [Paths Object](#paths-object) may be empty. It may be counterintuitive, but this may tell the viewer that they got to the right place, but can't access any documentation. They'd still have access to the [Info Object](#info-object) which may contain additional information regarding authentication.
+2. The [Path Item Object](#path-item-object) may be empty. In this case, the viewer will be aware that the path exists, but will not be able to see any of its operations or parameters. This is different than hiding the path itself from the [Paths Object](#paths-object) so the user will not be aware of its existence. This allows the documentation provider a finer control over what the viewer can see.

--- a/versions/3.0.0.md
+++ b/versions/3.0.0.md
@@ -16,64 +16,64 @@ An OpenAPI definition can then be used by documentation generation tools to disp
 <!-- TOC depthFrom:1 depthTo:3 withLinks:1 updateOnSave:1 orderedList:0 -->
 
 - [Definitions](#definitions)
-	- [OpenAPI Document](#oasDocument)
-	- [Path Templating](#pathTemplating)
-	- [Media Types](#mediaTypes)
-	- [HTTP Status Codes](#httpCodes)
+	- [OpenAPI Document](#openapi-document)
+	- [Path Templating](#path-templating)
+	- [Media Types](#media-types)
+	- [HTTP Status Codes](#http-status-codes)
 - [Specification](#specification)
 	- [Versions](#versions)
 	- [Format](#format)
-	- [Document Structure](#documentStructure)
-	- [Data Types](#dataTypes)
-	- [Rich Text Formatting](#richText)
-	- [Relative References In URLs](#relativeReferences)
+	- [Document Structure](#document-structure)
+	- [Data Types](#data-types)
+	- [Rich Text Formatting](#rich-text-formatting)
+	- [Relative References In URLs](#relative-references-in-urls)
 	- [Schema](#schema)
-		- [OpenAPI Object](#oasObject)
-		- [Info Object](#infoObject)
-		- [Contact Object](#contactObject)
-		- [License Object](#licenseObject)
-		- [Server Object](#serverObject)
-		- [Server Variable Object](#serverVariableObject)
-		- [Components Object](#componentsObject)
-		- [Paths Object](#pathsObject)
-		- [Path Item Object](#pathItemObject)
-		- [Operation Object](#operationObject)
-		- [External Documentation Object](#externalDocumentationObject)
-		- [Parameter Object](#parameterObject)
-		- [Request Body Object](#requestBodyObject)
-		- [Media Type Object](#mediaTypeObject)
-		- [Encoding Object](#encodingObject)
-		- [Responses Object](#responsesObject)
-		- [Response Object](#responseObject)
-		- [Callback Object](#callbackObject)
-		- [Example Object](#exampleObject)
-		- [Link Object](#linkObject)
-		- [Header Object](#headerObject)
-		- [Tag Object](#tagObject)
-		- [Reference Object](#referenceObject)
-		- [Schema Object](#schemaObject)
-		- [Discriminator Object](#discriminatorObject)
-		- [XML Object](#xmlObject)
-		- [Security Scheme Object](#securitySchemeObject)
-		- [OAuth Flows Object](#oauthFlowsObject)
-		- [OAuth Flow Object](#oauthFlowObject)
-		- [Security Requirement Object](#securityRequirementObject)
-	- [Specification Extensions](#specificationExtensions)
-	- [Security Filtering](#securityFiltering)
-- [Appendix A: Revision History](#revisionHistory)
+		- [OpenAPI Object](#openapi-object)
+		- [Info Object](#info-object)
+		- [Contact Object](#contact-object)
+		- [License Object](#license-object)
+		- [Server Object](#server-object)
+		- [Server Variable Object](#server-variable-object)
+		- [Components Object](#components-object)
+		- [Paths Object](#paths-object)
+		- [Path Item Object](#path-item-object)
+		- [Operation Object](#operation-object)
+		- [External Documentation Object](#external-documentation-object)
+		- [Parameter Object](#parameter-object)
+		- [Request Body Object](#request-body-object)
+		- [Media Type Object](#media-type-object)
+		- [Encoding Object](#encoding-object)
+		- [Responses Object](#responses-object)
+		- [Response Object](#response-object)
+		- [Callback Object](#callback-object)
+		- [Example Object](#example-object)
+		- [Link Object](#link-object)
+		- [Header Object](#header-object)
+		- [Tag Object](#tag-object)
+		- [Reference Object](#reference-object)
+		- [Schema Object](#schema-object)
+		- [Discriminator Object](#discriminator-object)
+		- [XML Object](#xml-object)
+		- [Security Scheme Object](#security-scheme-object)
+		- [OAuth Flows Object](#oauth-flows-object)
+		- [OAuth Flow Object](#oauth-flow-object)
+		- [Security Requirement Object](#security-requirement-object)
+	- [Specification Extensions](#specification-extensions)
+	- [Security Filtering](#security-filtering)
+- [Appendix A: Revision History](#appendix-a-revision-history)
 	
 
 <!-- /TOC -->
 
 ## Definitions
 
-##### <a name="oasDocument"></a>OpenAPI Document
+##### OpenAPI Document
 A document (or set of documents) that defines or describes an API. An OpenAPI definition uses and conforms to the OpenAPI Specification.
 
-##### <a name="pathTemplating"></a>Path Templating
+##### Path Templating
 Path templating refers to the usage of curly braces ({}) to mark a section of a URL path as replaceable using path parameters.
 
-##### <a name="mediaTypes"></a>Media Types
+##### Media Types
 Media type definitions are spread across several resources.
 The media type definitions SHOULD be in compliance with [RFC6838](http://tools.ietf.org/html/rfc6838).
 
@@ -90,8 +90,8 @@ Some examples of possible media type definitions:
   application/vnd.github.v3.diff
   application/vnd.github.v3.patch
 ```
-##### <a name="httpCodes"></a>HTTP Status Codes
-The HTTP Status Codes are used to indicate the status of the executed operation. 
+##### HTTP Status Codes
+The HTTP Status Codes are used to indicate the status of the executed operation.
 The available status codes are defined by [RFC7231](http://tools.ietf.org/html/rfc7231#section-6) and registered status codes are listed in the [IANA Status Code Registry](http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml).
 
 ## Specification
@@ -121,7 +121,7 @@ All field names in the specification are **case sensitive**.
 
 The schema exposes two types of fields: Fixed fields, which have a declared name, and Patterned fields, which declare a regex pattern for the field name.
 
-Patterned fields MUST have unique names within the containing object. 
+Patterned fields MUST have unique names within the containing object.
 
 In order to preserve the ability to round-trip between YAML and JSON formats, YAML version [1.2](http://www.yaml.org/spec/1.2/spec.html) is RECOMMENDED along with some additional constraints:
 
@@ -130,18 +130,18 @@ In order to preserve the ability to round-trip between YAML and JSON formats, YA
 
 **Note:** While APIs may be defined by OpenAPI documents in either YAML or JSON format, the API request and response bodies and other content are not required to be JSON or YAML.
 
-### <a name="documentStructure"></a>Document Structure
+### Document Structure
 
 An OpenAPI document MAY be made up of a single document or be divided into multiple, connected parts at the discretion of the user. In the latter case, `$ref` fields MUST be used in the specification to reference those parts as follows from the [JSON Schema](http://json-schema.org) definitions.
 
 It is RECOMMENDED that the root OpenAPI document be named: `openapi.json` or `openapi.yaml`.
 
-### <a name="dataTypes"></a>Data Types
+### Data Types
 
-Primitive data types in the OAS are based on the types supported by the [JSON Schema Specification Wright Draft 00](https://tools.ietf.org/html/draft-wright-json-schema-00#section-4.2). 
-Note that `integer` as a type is also supported and is defined as a JSON number without a fraction or exponent part. 
+Primitive data types in the OAS are based on the types supported by the [JSON Schema Specification Wright Draft 00](https://tools.ietf.org/html/draft-wright-json-schema-00#section-4.2).
+Note that `integer` as a type is also supported and is defined as a JSON number without a fraction or exponent part.
 `null` is not supported as a type (see [`nullable`](#schemaNullable) for an alternative solution).
-Models are defined using the [Schema Object](#schemaObject), which is an extended subset of JSON Schema Specification Wright Draft 00.
+Models are defined using the [Schema Object](#schema-object), which is an extended subset of JSON Schema Specification Wright Draft 00.
 
 <a name="dataTypeFormat"></a>Primitives have an optional modifier property: `format`.
 OAS uses several known formats to define in fine detail the data type being used.
@@ -151,7 +151,7 @@ Types that are not accompanied by a `format` property follow the type definition
 
 The formats defined by the OAS are:
 
-Common Name | [`type`](#dataTypes) | [`format`](#dataTypeFormat) | Comments
+Common Name | [`type`](#data-types) | [`format`](#dataTypeFormat) | Comments
 ----------- | ------ | -------- | --------
 integer | `integer` | `int32` | signed 32 bits
 long | `integer` | `int64` | signed 64 bits
@@ -165,41 +165,41 @@ date | `string` | `date` | As defined by `full-date` - [RFC3339](http://xml2rfc.
 dateTime | `string` | `date-time` | As defined by `date-time` - [RFC3339](http://xml2rfc.ietf.org/public/rfc/html/rfc3339.html#anchor14)
 password | `string` | `password` | A hint to UIs to obscure input.
 
-### <a name="richText"></a>Rich Text Formatting
+### Rich Text Formatting
 Throughout the specification `description` fields are noted as supporting CommonMark markdown formatting.
-Where OpenAPI tooling renders rich text it MUST support, at a minimum, markdown syntax as described by [CommonMark 0.27](http://spec.commonmark.org/0.27/). Tooling MAY choose to ignore some CommonMark features to address security concerns. 
+Where OpenAPI tooling renders rich text it MUST support, at a minimum, markdown syntax as described by [CommonMark 0.27](http://spec.commonmark.org/0.27/). Tooling MAY choose to ignore some CommonMark features to address security concerns.
 
-### <a name="relativeReferences"></a>Relative References in URLs
+### Relative References in URLs
 
 Unless specified otherwise, all properties that are URLs MAY be relative references as defined by [RFC3986](https://tools.ietf.org/html/rfc3986#section-4.2).
-Relative references are resolved using the URLs defined in the [`Server Object`](#serverObject) as a Base URI.
+Relative references are resolved using the URLs defined in the [`Server Object`](#server-object) as a Base URI.
 
-Relative references used in `$ref` are processed as per [JSON Reference](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03), using the URL of the current document as the base URI. See also the [Reference Object](#referenceObject).
+Relative references used in `$ref` are processed as per [JSON Reference](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03), using the URL of the current document as the base URI. See also the [Reference Object](#reference-object).
 
 ### Schema
 
 In the following description, if a field is not explicitly **REQUIRED** or described with a MUST or SHALL, it can be considered OPTIONAL.
 
-#### <a name="oasObject"></a>OpenAPI Object
+#### OpenAPI Object
 
-This is the root document object of the [OpenAPI document](#oasDocument).
+This is the root document object of the [OpenAPI document](#openapi-document).
 
 ##### Fixed Fields
 
 Field Name | Type | Description
 ---|:---:|---
 <a name="oasVersion"></a>openapi | `string` | **REQUIRED**. This string MUST be the [semantic version number](http://semver.org/spec/v2.0.0.html) of the [OpenAPI Specification version](#versions) that the OpenAPI document uses. The `openapi` field SHOULD be used by tooling specifications and clients to interpret the OpenAPI document. This is *not* related to the API [`info.version`](#infoVersion) string.
-<a name="oasInfo"></a>info | [Info Object](#infoObject) | **REQUIRED**. Provides metadata about the API. The metadata MAY be used by tooling as required.
-<a name="oasServers"></a>servers | [[Server Object](#serverObject)] | An array of Server Objects, which provide connectivity information to a target server. If the `servers` property is not provided, or is an empty array, the default value would be a [Server Object](#serverObject) with a [url](#serverUrl) value of `/`.
-<a name="oasPaths"></a>paths | [Paths Object](#pathsObject) | **REQUIRED**. The available paths and operations for the API.
-<a name="oasComponents"></a>components | [Components Object](#componentsObject) | An element to hold various schemas for the specification.
-<a name="oasSecurity"></a>security | [[Security Requirement Object](#securityRequirementObject)] | A declaration of which security mechanisms can be used across the API. The list of values includes alternative security requirement objects that can be used. Only one of the security requirement objects need to be satisfied to authorize a request. Individual operations can override this definition.
-<a name="oasTags"></a>tags | [[Tag Object](#tagObject)] | A list of tags used by the specification with additional metadata. The order of the tags can be used to reflect on their order by the parsing tools. Not all tags that are used by the [Operation Object](#operationObject) must be declared. The tags that are not declared MAY be organized randomly or based on the tools' logic. Each tag name in the list MUST be unique.
-<a name="oasExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation.
+<a name="oasInfo"></a>info | [Info Object](#info-object) | **REQUIRED**. Provides metadata about the API. The metadata MAY be used by tooling as required.
+<a name="oasServers"></a>servers | [[Server Object](#server-object)] | An array of Server Objects, which provide connectivity information to a target server. If the `servers` property is not provided, or is an empty array, the default value would be a [Server Object](#server-object) with a [url](#serverUrl) value of `/`.
+<a name="oasPaths"></a>paths | [Paths Object](#paths-object) | **REQUIRED**. The available paths and operations for the API.
+<a name="oasComponents"></a>components | [Components Object](#components-object) | An element to hold various schemas for the specification.
+<a name="oasSecurity"></a>security | [[Security Requirement Object](#security-requirement-object)] | A declaration of which security mechanisms can be used across the API. The list of values includes alternative security requirement objects that can be used. Only one of the security requirement objects need to be satisfied to authorize a request. Individual operations can override this definition.
+<a name="oasTags"></a>tags | [[Tag Object](#tag-object)] | A list of tags used by the specification with additional metadata. The order of the tags can be used to reflect on their order by the parsing tools. Not all tags that are used by the [Operation Object](#operation-object) must be declared. The tags that are not declared MAY be organized randomly or based on the tools' logic. Each tag name in the list MUST be unique.
+<a name="oasExternalDocs"></a>externalDocs | [External Documentation Object](#external-documentation-object) | Additional external documentation.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
-#### <a name="infoObject"></a>Info Object
+#### Info Object
 
 The object provides metadata about the API.
 The metadata MAY be used by the clients if needed, and MAY be presented in editing or documentation generation tools for convenience.
@@ -211,12 +211,12 @@ Field Name | Type | Description
 <a name="infoTitle"></a>title | `string` | **REQUIRED**. The title of the application.
 <a name="infoDescription"></a>description | `string` | A short description of the application. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
 <a name="infoTermsOfService"></a>termsOfService | `string` | A URL to the Terms of Service for the API. MUST be in the format of a URL.
-<a name="infoContact"></a>contact | [Contact Object](#contactObject) | The contact information for the exposed API.
-<a name="infoLicense"></a>license | [License Object](#licenseObject) | The license information for the exposed API.
+<a name="infoContact"></a>contact | [Contact Object](#contact-object) | The contact information for the exposed API.
+<a name="infoLicense"></a>license | [License Object](#license-object) | The license information for the exposed API.
 <a name="infoVersion"></a>version | `string` | **REQUIRED**. The version of the OpenAPI document (which is distinct from the [OpenAPI Specification version](#oasVersion) or the API implementation version).
 
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Info Object Example:
 
@@ -252,7 +252,7 @@ license:
 version: 1.0.1
 ```
 
-#### <a name="contactObject"></a>Contact Object
+#### Contact Object
 
 Contact information for the exposed API.
 
@@ -264,7 +264,7 @@ Field Name | Type | Description
 <a name="contactUrl"></a>url | `string` | The URL pointing to the contact information. MUST be in the format of a URL.
 <a name="contactEmail"></a>email | `string` | The email address of the contact person/organization. MUST be in the format of an email address.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Contact Object Example:
 
@@ -282,7 +282,7 @@ url: http://www.example.com/support
 email: support@example.com
 ```
 
-#### <a name="licenseObject"></a>License Object
+#### License Object
 
 License information for the exposed API.
 
@@ -293,7 +293,7 @@ Field Name | Type | Description
 <a name="licenseName"></a>name | `string` | **REQUIRED**. The license name used for the API.
 <a name="licenseUrl"></a>url | `string` | A URL to the license used for the API. MUST be in the format of a URL.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### License Object Example:
 
@@ -309,7 +309,7 @@ name: Apache 2.0
 url: http://www.apache.org/licenses/LICENSE-2.0.html
 ```
 
-#### <a name="serverObject"></a>Server Object
+#### Server Object
 
 An object representing a Server.
 
@@ -319,9 +319,9 @@ Field Name | Type | Description
 ---|:---:|---
 <a name="serverUrl"></a>url | `string` | **REQUIRED**. A URL to the target host.  This URL supports Server Variables and MAY be relative, to indicate that the host location is relative to the location where the OpenAPI document is being served. Variable substitutions will be made when a variable is named in `{`brackets`}`.
 <a name="serverDescription"></a>description | `string` | An optional string describing the host designated by the URL. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="serverVariables"></a>variables | Map[`string`, [Server Variable Object](#serverVariableObject)] | A map between a variable name and its value.  The value is used for substitution in the server's URL template.
+<a name="serverVariables"></a>variables | Map[`string`, [Server Variable Object](#server-variable-object)] | A map between a variable name and its value.  The value is used for substitution in the server's URL template.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Server Object Example
 
@@ -419,7 +419,7 @@ servers:
 ```
 
 
-#### <a name="serverVariableObject"></a>Server Variable Object
+#### Server Variable Object
 
 An object representing a Server Variable for server URL template substitution.
 
@@ -428,12 +428,12 @@ An object representing a Server Variable for server URL template substitution.
 Field Name | Type | Description
 ---|:---:|---
 <a name="serverVariableEnum"></a>enum | [`string`] | An enumeration of string values to be used if the substitution options are from a limited set.
-<a name="serverVariableDefault"></a>default | `string` |  **REQUIRED**. The default value to use for substitution, and to send, if an alternate value is _not_ supplied. Unlike the [Schema Object's](#schemaObject) `default`, this value MUST be provided by the consumer.
+<a name="serverVariableDefault"></a>default | `string` |  **REQUIRED**. The default value to use for substitution, and to send, if an alternate value is _not_ supplied. Unlike the [Schema Object's](#schema-object) `default`, this value MUST be provided by the consumer.
 <a name="serverVariableDescription"></a>description | `string` | An optional description for the server variable. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
-#### <a name="componentsObject"></a>Components Object
+#### Components Object
 
 Holds a set of reusable objects for different aspects of the OAS.
 All objects defined within the components object will have no effect on the API unless they are explicitly referenced from properties outside the components object.
@@ -443,17 +443,17 @@ All objects defined within the components object will have no effect on the API 
 
 Field Name | Type | Description
 ---|:---|---
-<a name="componentsSchemas"></a> schemas | Map[`string`, [Schema Object](#schemaObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Schema Objects](#schemaObject).
-<a name="componentsResponses"></a> responses | Map[`string`, [Response Object](#responseObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Response Objects](#responseObject).
-<a name="componentsParameters"></a> parameters | Map[`string`, [Parameter Object](#parameterObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Parameter Objects](#parameterObject).
-<a name="componentsExamples"></a> examples | Map[`string`, [Example Object](#exampleObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Example Objects](#exampleObject).
-<a name="componentsRequestBodies"></a> requestBodies | Map[`string`, [Request Body Object](#requestBodyObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Request Body Objects](#requestBodyObject).
-<a name="componentsHeaders"></a> headers | Map[`string`, [Header Object](#headerObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Header Objects](#headerObject).
-<a name="componentsSecuritySchemes"></a> securitySchemes| Map[`string`, [Security Scheme Object](#securitySchemeObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Security Scheme Objects](#securitySchemeObject).
-<a name="componentsLinks"></a> links | Map[`string`, [Link Object](#linkObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Link Objects](#linkObject).
-<a name="componentsCallbacks"></a> callbacks | Map[`string`, [Callback Object](#callbackObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Callback Objects](#callbackObject).
+<a name="componentsSchemas"></a> schemas | Map[`string`, [Schema Object](#schema-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Schema Objects](#schema-object).
+<a name="componentsResponses"></a> responses | Map[`string`, [Response Object](#response-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Response Objects](#response-object).
+<a name="componentsParameters"></a> parameters | Map[`string`, [Parameter Object](#parameter-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Parameter Objects](#parameter-object).
+<a name="componentsExamples"></a> examples | Map[`string`, [Example Object](#example-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Example Objects](#example-object).
+<a name="componentsRequestBodies"></a> requestBodies | Map[`string`, [Request Body Object](#request-body-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Request Body Objects](#request-body-object).
+<a name="componentsHeaders"></a> headers | Map[`string`, [Header Object](#header-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Header Objects](#header-object).
+<a name="componentsSecuritySchemes"></a> securitySchemes| Map[`string`, [Security Scheme Object](#security-scheme-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Security Scheme Objects](#security-scheme-object).
+<a name="componentsLinks"></a> links | Map[`string`, [Link Object](#link-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Link Objects](#link-object).
+<a name="componentsCallbacks"></a> callbacks | Map[`string`, [Callback Object](#callback-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Callback Objects](#callback-object).
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 All the fixed fields declared above are objects that MUST use keys that match the regular expression: `^[a-zA-Z0-9\.\-_]+$`.
 
@@ -613,7 +613,7 @@ components:
       in: header
     petstore_auth:
       type: oauth2
-      flows: 
+      flows:
         implicit:
           authorizationUrl: http://example.org/api/oauth/dialog
           scopes:
@@ -622,18 +622,18 @@ components:
 ```
 
 
-#### <a name="pathsObject"></a>Paths Object
+#### Paths Object
 
 Holds the relative paths to the individual endpoints and their operations.
-The path is appended to the URL from the [`Server Object`](#serverObject) in order to construct the full URL.  The Paths MAY be empty, due to [ACL constraints](#securityFiltering).
+The path is appended to the URL from the [`Server Object`](#server-object) in order to construct the full URL.  The Paths MAY be empty, due to [ACL constraints](#security-filtering).
 
 ##### Patterned Fields
 
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="pathsPath"></a>/{path} | [Path Item Object](#pathItemObject) | A relative path to an individual endpoint. The field name MUST begin with a slash. The path is **appended** (no relative URL resolution) to the expanded URL from the [`Server Object`](#serverObject)'s `url` field in order to construct the full URL. [Path templating](#pathTemplating) is allowed. When matching URLs, concrete (non-templated) paths would be matched before their templated counterparts. Templated paths with the same hierarchy but different templated names MUST NOT exist as they are identical. In case of ambiguous matching, it's up to the tooling to decide which one to use.
+<a name="pathsPath"></a>/{path} | [Path Item Object](#path-item-object) | A relative path to an individual endpoint. The field name MUST begin with a slash. The path is **appended** (no relative URL resolution) to the expanded URL from the [`Server Object`](#server-object)'s `url` field in order to construct the full URL. [Path templating](#path-templating) is allowed. When matching URLs, concrete (non-templated) paths would be matched before their templated counterparts. Templated paths with the same hierarchy but different templated names MUST NOT exist as they are identical. In case of ambiguous matching, it's up to the tooling to decide which one to use.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Path Templating Matching
 
@@ -666,7 +666,7 @@ The following may lead to ambiguous resolution:
     "get": {
       "description": "Returns all pets from the system that the user has access to",
       "responses": {
-        "200": {          
+        "200": {         
           "description": "A list of pets.",
           "content": {
             "application/json": {
@@ -700,32 +700,32 @@ The following may lead to ambiguous resolution:
                 $ref: '#/components/schemas/pet'
 ```
 
-#### <a name="pathItemObject"></a>Path Item Object
+#### Path Item Object
 
 Describes the operations available on a single path.
-A Path Item MAY be empty, due to [ACL constraints](#securityFiltering).
+A Path Item MAY be empty, due to [ACL constraints](#security-filtering).
 The path itself is still exposed to the documentation viewer but they will not know which operations and parameters are available.
 
 ##### Fixed Fields
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="pathItemRef"></a>$ref | `string` | Allows for an external definition of this path item. The referenced structure MUST be in the format of a [Path Item Object](#pathItemObject). If there are conflicts between the referenced definition and this Path Item's definition, the behavior is *undefined*.
+<a name="pathItemRef"></a>$ref | `string` | Allows for an external definition of this path item. The referenced structure MUST be in the format of a [Path Item Object](#path-item-object). If there are conflicts between the referenced definition and this Path Item's definition, the behavior is *undefined*.
 <a name="pathItemSummary"></a>summary| `string` | An optional, string summary, intended to apply to all operations in this path.
 <a name="pathItemDescription"></a>description | `string` | An optional, string description, intended to apply to all operations in this path. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="pathItemGet"></a>get | [Operation Object](#operationObject) | A definition of a GET operation on this path.
-<a name="pathItemPut"></a>put | [Operation Object](#operationObject) | A definition of a PUT operation on this path.
-<a name="pathItemPost"></a>post | [Operation Object](#operationObject) | A definition of a POST operation on this path.
-<a name="pathItemDelete"></a>delete | [Operation Object](#operationObject) | A definition of a DELETE operation on this path.
-<a name="pathItemOptions"></a>options | [Operation Object](#operationObject) | A definition of a OPTIONS operation on this path.
-<a name="pathItemHead"></a>head | [Operation Object](#operationObject) | A definition of a HEAD operation on this path.
-<a name="pathItemPatch"></a>patch | [Operation Object](#operationObject) | A definition of a PATCH operation on this path.
-<a name="pathItemTrace"></a>trace | [Operation Object](#operationObject) | A definition of a TRACE operation on this path.
-<a name="pathItemServers"></a>servers | [[Server Object](#serverObject)] | An alternative `server` array to service all operations in this path.
-<a name="pathItemParameters"></a>parameters | [[Parameter Object](#parameterObject) \| [Reference Object](#referenceObject)] | A list of parameters that are applicable for all the operations described under this path. These parameters can be overridden at the operation level, but cannot be removed there. The list MUST NOT include duplicated parameters. A unique parameter is defined by a combination of a [name](#parameterName) and [location](#parameterIn). The list can use the [Reference Object](#referenceObject) to link to parameters that are defined at the [OpenAPI Object's components/parameters](#componentsParameters). 
+<a name="pathItemGet"></a>get | [Operation Object](#operation-object) | A definition of a GET operation on this path.
+<a name="pathItemPut"></a>put | [Operation Object](#operation-object) | A definition of a PUT operation on this path.
+<a name="pathItemPost"></a>post | [Operation Object](#operation-object) | A definition of a POST operation on this path.
+<a name="pathItemDelete"></a>delete | [Operation Object](#operation-object) | A definition of a DELETE operation on this path.
+<a name="pathItemOptions"></a>options | [Operation Object](#operation-object) | A definition of a OPTIONS operation on this path.
+<a name="pathItemHead"></a>head | [Operation Object](#operation-object) | A definition of a HEAD operation on this path.
+<a name="pathItemPatch"></a>patch | [Operation Object](#operation-object) | A definition of a PATCH operation on this path.
+<a name="pathItemTrace"></a>trace | [Operation Object](#operation-object) | A definition of a TRACE operation on this path.
+<a name="pathItemServers"></a>servers | [[Server Object](#server-object)] | An alternative `server` array to service all operations in this path.
+<a name="pathItemParameters"></a>parameters | [[Parameter Object](#parameter-object) \| [Reference Object](#reference-object)] | A list of parameters that are applicable for all the operations described under this path. These parameters can be overridden at the operation level, but cannot be removed there. The list MUST NOT include duplicated parameters. A unique parameter is defined by a combination of a [name](#parameterName) and [location](#parameterIn). The list can use the [Reference Object](#reference-object) to link to parameters that are defined at the [OpenAPI Object's components/parameters](#componentsParameters).
 
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Path Item Object Example
 
@@ -808,10 +808,10 @@ parameters:
     type: array
     style: simple
     items:
-      type: string  
+      type: string 
 ```
 
-#### <a name="operationObject"></a>Operation Object
+#### Operation Object
 
 Describes a single API operation on a path.
 
@@ -822,17 +822,17 @@ Field Name | Type | Description
 <a name="operationTags"></a>tags | [`string`] | A list of tags for API documentation control. Tags can be used for logical grouping of operations by resources or any other qualifier.
 <a name="operationSummary"></a>summary | `string` | A short summary of what the operation does.
 <a name="operationDescription"></a>description | `string` | A verbose explanation of the operation behavior. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="operationExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation for this operation.
+<a name="operationExternalDocs"></a>externalDocs | [External Documentation Object](#external-documentation-object) | Additional external documentation for this operation.
 <a name="operationId"></a>operationId | `string` | Unique string used to identify the operation. The id MUST be unique among all operations described in the API. Tools and libraries MAY use the operationId to uniquely identify an operation, therefore, it is RECOMMENDED to follow common programming naming conventions.
-<a name="operationParameters"></a>parameters | [[Parameter Object](#parameterObject) \| [Reference Object](#referenceObject)] | A list of parameters that are applicable for this operation. If a parameter is already defined at the [Path Item](#pathItemParameters), the new definition will override it but can never remove it. The list MUST NOT include duplicated parameters. A unique parameter is defined by a combination of a [name](#parameterName) and [location](#parameterIn). The list can use the [Reference Object](#referenceObject) to link to parameters that are defined at the [OpenAPI Object's components/parameters](#componentsParameters).
-<a name="operationRequestBody"></a>requestBody | [Request Body Object](#requestBodyObject) \| [Reference Object](#referenceObject) | The request body applicable for this operation.  The `requestBody` is only supported in HTTP methods where the HTTP 1.1 specification [RFC7231](https://tools.ietf.org/html/rfc7231#section-4.3.1) has explicitly defined semantics for request bodies.  In other cases where the HTTP spec is vague, `requestBody` SHALL be ignored by consumers.
-<a name="operationResponses"></a>responses | [Responses Object](#responsesObject) | **REQUIRED**. The list of possible responses as they are returned from executing this operation.
-<a name="operationCallbacks"></a>callbacks | Map[`string`, [Callback Object](#callbackObject) \| [Reference Object](#referenceObject)] | A map of possible out-of band callbacks related to the parent operation. The key is a unique identifier for the Callback Object. Each value in the map is a [Callback Object](#callbackObject) that describes a request that may be initiated by the API provider and the expected responses. The key value used to identify the callback object is an expression, evaluated at runtime, that identifies a URL to use for the callback operation.
+<a name="operationParameters"></a>parameters | [[Parameter Object](#parameter-object) \| [Reference Object](#reference-object)] | A list of parameters that are applicable for this operation. If a parameter is already defined at the [Path Item](#pathItemParameters), the new definition will override it but can never remove it. The list MUST NOT include duplicated parameters. A unique parameter is defined by a combination of a [name](#parameterName) and [location](#parameterIn). The list can use the [Reference Object](#reference-object) to link to parameters that are defined at the [OpenAPI Object's components/parameters](#componentsParameters).
+<a name="operationRequestBody"></a>requestBody | [Request Body Object](#request-body-object) \| [Reference Object](#reference-object) | The request body applicable for this operation.  The `requestBody` is only supported in HTTP methods where the HTTP 1.1 specification [RFC7231](https://tools.ietf.org/html/rfc7231#section-4.3.1) has explicitly defined semantics for request bodies.  In other cases where the HTTP spec is vague, `requestBody` SHALL be ignored by consumers.
+<a name="operationResponses"></a>responses | [Responses Object](#responses-object) | **REQUIRED**. The list of possible responses as they are returned from executing this operation.
+<a name="operationCallbacks"></a>callbacks | Map[`string`, [Callback Object](#callback-object) \| [Reference Object](#reference-object)] | A map of possible out-of band callbacks related to the parent operation. The key is a unique identifier for the Callback Object. Each value in the map is a [Callback Object](#callback-object) that describes a request that may be initiated by the API provider and the expected responses. The key value used to identify the callback object is an expression, evaluated at runtime, that identifies a URL to use for the callback operation.
 <a name="operationDeprecated"></a>deprecated | `boolean` | Declares this operation to be deprecated. Consumers SHOULD refrain from usage of the declared operation. Default value is `false`.
-<a name="operationSecurity"></a>security | [[Security Requirement Object](#securityRequirementObject)] | A declaration of which security mechanisms can be used for this operation. The list of values includes alternative security requirement objects that can be used. Only one of the security requirement objects need to be satisfied to authorize a request. This definition overrides any declared top-level [`security`](#oasSecurity). To remove a top-level security declaration, an empty array can be used.
-<a name="operationServers"></a>servers | [[Server Object](#serverObject)] | An alternative `server` array to service this operation. If an alternative `server` object is specified at the Path Item Object or Root level, it will be overridden by this value.
+<a name="operationSecurity"></a>security | [[Security Requirement Object](#security-requirement-object)] | A declaration of which security mechanisms can be used for this operation. The list of values includes alternative security requirement objects that can be used. Only one of the security requirement objects need to be satisfied to authorize a request. This definition overrides any declared top-level [`security`](#oasSecurity). To remove a top-level security declaration, an empty array can be used.
+<a name="operationServers"></a>servers | [[Server Object](#server-object)] | An alternative `server` array to service this operation. If an alternative `server` object is specified at the Path Item Object or Root level, it will be overridden by this value.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Operation Object Example
 
@@ -860,7 +860,7 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
         "schema": {
           "type": "object",
            "properties": {
-              "name": { 
+              "name": {
                 "description": "Updated name of the pet",
                 "type": "string"
               },
@@ -869,7 +869,7 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
                 "type": "string"
              }
            },
-        "required": ["status"] 
+        "required": ["status"]
         }
       }
     }
@@ -918,7 +918,7 @@ requestBody:
     'application/x-www-form-urlencoded':
       schema:
        properties:
-          name: 
+          name:
             description: Updated name of the pet
             type: string
           status:
@@ -929,12 +929,12 @@ requestBody:
 responses:
   '200':
     description: Pet updated.
-    content: 
+    content:
       'application/json': {}
       'application/xml': {}
   '405':
     description: Invalid input
-    content: 
+    content:
       'application/json': {}
       'application/xml': {}
 security:
@@ -944,7 +944,7 @@ security:
 ```
 
 
-#### <a name="externalDocumentationObject"></a>External Documentation Object
+#### External Documentation Object
 
 Allows referencing an external resource for extended documentation.
 
@@ -955,7 +955,7 @@ Field Name | Type | Description
 <a name="externalDocDescription"></a>description | `string` | A short description of the target documentation. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
 <a name="externalDocUrl"></a>url | `string` | **REQUIRED**. The URL for the target documentation. Value MUST be in the format of a URL.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### External Documentation Object Example
 
@@ -971,7 +971,7 @@ description: Find more info here
 url: https://example.com
 ```
 
-#### <a name="parameterObject"></a>Parameter Object
+#### Parameter Object
 
 Describes a single operation parameter.
 
@@ -979,7 +979,7 @@ A unique parameter is defined by a combination of a [name](#parameterName) and [
 
 ##### Parameter Locations
 There are four possible parameter locations specified by the `in` field:
-* path - Used together with [Path Templating](#pathTemplating), where the parameter value is actually part of the operation's URL. This does not include the host or base path of the API. For example, in `/items/{itemId}`, the path parameter is `itemId`.
+* path - Used together with [Path Templating](#path-templating), where the parameter value is actually part of the operation's URL. This does not include the host or base path of the API. For example, in `/items/{itemId}`, the path parameter is `itemId`.
 * query - Parameters that are appended to the URL. For example, in `/items?id=###`, the query parameter is `id`.
 * header - Custom headers that are expected as part of the request. Note that [RFC7230](https://tools.ietf.org/html/rfc7230#page-22) states header names are case insensitive.
 * cookie - Used to pass a specific cookie value to the API.
@@ -988,7 +988,7 @@ There are four possible parameter locations specified by the `in` field:
 ##### Fixed Fields
 Field Name | Type | Description
 ---|:---:|---
-<a name="parameterName"></a>name | `string` | **REQUIRED**. The name of the parameter. Parameter names are *case sensitive*. <ul><li>If [`in`](#parameterIn) is `"path"`, the `name` field MUST correspond to the associated path segment from the [path](#pathsPath) field in the [Paths Object](#pathsObject). See [Path Templating](#pathTemplating) for further information.<li>If [`in`](#parameterIn) is `"header"` and the `name` field is `"Accept"`, `"Content-Type"` or `"Authorization"`, the parameter definition SHALL be ignored.<li>For all other cases, the `name` corresponds to the parameter name used by the [`in`](#parameterIn) property.</ul>
+<a name="parameterName"></a>name | `string` | **REQUIRED**. The name of the parameter. Parameter names are *case sensitive*. <ul><li>If [`in`](#parameterIn) is `"path"`, the `name` field MUST correspond to the associated path segment from the [path](#pathsPath) field in the [Paths Object](#paths-object). See [Path Templating](#path-templating) for further information.<li>If [`in`](#parameterIn) is `"header"` and the `name` field is `"Accept"`, `"Content-Type"` or `"Authorization"`, the parameter definition SHALL be ignored.<li>For all other cases, the `name` corresponds to the parameter name used by the [`in`](#parameterIn) property.</ul>
 <a name="parameterIn"></a>in | `string` | **REQUIRED**. The location of the parameter. Possible values are "query", "header", "path" or "cookie".
 <a name="parameterDescription"></a>description | `string` | A brief description of the parameter. This could contain examples of use.  [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
 <a name="parameterRequired"></a>required | `boolean` | Determines whether this parameter is mandatory. If the [parameter location](#parameterIn) is "path", this property is **REQUIRED** and its value MUST be `true`. Otherwise, the property MAY be included and its default value is `false`.
@@ -1003,9 +1003,9 @@ Field Name | Type | Description
 <a name="parameterStyle"></a>style | `string` | Describes how the parameter value will be serialized depending on the type of the parameter value. Default values (based on value of `in`): for `query` - `form`; for `path` - `simple`; for `header` - `simple`; for `cookie` - `form`.
 <a name="parameterExplode"></a>explode | `boolean` | When this is true, parameter values of type `array` or `object` generate separate parameters for each value of the array or key-value pair of the map.  For other types of parameters this property has no effect. When [`style`](#parameterStyle) is `form`, the default value is `true`. For all other styles, the default value is `false`.
 <a name="parameterAllowReserved"></a>allowReserved | `boolean` | Determines whether the parameter value SHOULD allow reserved characters, as defined by [RFC3986](https://tools.ietf.org/html/rfc3986#section-2.2) `:/?#[]@!$&'()*+,;=` to be included without percent-encoding. This property only applies to parameters with an `in` value of `query`. The default value is `false`.
-<a name="parameterSchema"></a>schema | [Schema Object](#schemaObject) \| [Reference Object](#referenceObject) | The schema defining the type used for the parameter.
+<a name="parameterSchema"></a>schema | [Schema Object](#schema-object) \| [Reference Object](#reference-object) | The schema defining the type used for the parameter.
 <a name="parameterExample"></a>example | Any | Example of the media type.  The example SHOULD match the specified schema and encoding properties if present.  The `example` object is mutually exclusive of the `examples` object.  Furthermore, if referencing a `schema` which contains an example, the `example` value SHALL _override_ the example provided by the schema. To represent examples of media types that cannot naturally be represented in JSON or YAML, a string value can contain the example with escaping where necessary.
-<a name="parameterExamples"></a>examples | Map[ `string`, [Example Object](#exampleObject) \| [Reference Object](#referenceObject)] | Examples of the media type.  Each example SHOULD contain a value in the correct format as specified in the parameter encoding.  The `examples` object is mutually exclusive of the `example` object.  Furthermore, if referencing a `schema` which contains an example, the `examples` value SHALL _override_ the example provided by the schema.
+<a name="parameterExamples"></a>examples | Map[ `string`, [Example Object](#example-object) \| [Reference Object](#reference-object)] | Examples of the media type.  Each example SHOULD contain a value in the correct format as specified in the parameter encoding.  The `examples` object is mutually exclusive of the `example` object.  Furthermore, if referencing a `schema` which contains an example, the `examples` value SHALL _override_ the example provided by the schema.
 
 For more complex scenarios, the [`content`](#parameterContent) property can define the media type and schema of the parameter.
 A parameter MUST contain either a `schema` property, or a `content` property, but not both.
@@ -1014,19 +1014,19 @@ When `example` or `examples` are provided in conjunction with the `schema` objec
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="parameterContent"></a>content | Map[`string`, [Media Type Object](#mediaTypeObject)] | A map containing the representations for the parameter. The key is the media type and the value describes it.  The map MUST only contain one entry.
+<a name="parameterContent"></a>content | Map[`string`, [Media Type Object](#media-type-object)] | A map containing the representations for the parameter. The key is the media type and the value describes it.  The map MUST only contain one entry.
 
 ##### Style Values
 
 In order to support common ways of serializing simple parameters, a set of `style` values are defined.
 
-`style` | [`type`](#dataTypes) |  `in` | Comments
+`style` | [`type`](#data-types) |  `in` | Comments
 ----------- | ------ | -------- | --------
-matrix |  `primitive`, `array`, `object` |  `path` | Path-style parameters defined by [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.7) 
+matrix |  `primitive`, `array`, `object` |  `path` | Path-style parameters defined by [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.7)
 label | `primitive`, `array`, `object` |  `path` | Label style parameters defined by [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.5)
 form |  `primitive`, `array`, `object` |  `query`, `cookie` | Form style parameters defined by [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.8). This option replaces `collectionFormat` with a `csv` (when `explode` is false) or `multi` (when `explode` is true) value from OpenAPI 2.0.
 simple | `array` | `path`, `header` | Simple style parameters defined by [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.2).  This option replaces `collectionFormat` with a `csv` value from OpenAPI 2.0.
-spaceDelimited | `array` | `query` | Space separated array values. This option replaces `collectionFormat` equal to `ssv` from OpenAPI 2.0. 
+spaceDelimited | `array` | `query` | Space separated array values. This option replaces `collectionFormat` equal to `ssv` from OpenAPI 2.0.
 pipeDelimited | `array` | `query` | Pipe separated array values. This option replaces `collectionFormat` equal to `pipes` from OpenAPI 2.0.
 deepObject | `object` | `query` | Provides a simple way of rendering nested objects using form parameters.
 
@@ -1056,7 +1056,7 @@ spaceDelimited | false | n/a | n/a | blue%20black%20brown | R%20100%20G%20200%20
 pipeDelimited | false | n/a | n/a | blue\|black\|brown | R\|100\|G\|200|G\|150
 deepObject | true | n/a | n/a | n/a | color[R]=100&color[G]=200&color[B]=150
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Parameter Object Examples
 
@@ -1215,7 +1215,7 @@ content:
           type: number
 ```
 
-#### <a name="requestBodyObject"></a>Request Body Object
+#### Request Body Object
 
 Describes a single request body.
 
@@ -1223,11 +1223,11 @@ Describes a single request body.
 Field Name | Type | Description
 ---|:---:|---
 <a name="requestBodyDescription"></a>description | `string` | A brief description of the request body. This could contain examples of use.  [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="requestBodyContent"></a>content | Map[`string`, [Media Type Object](#mediaTypeObject)] | **REQUIRED**. The content of the request body. The key is a media type or [media type range](https://tools.ietf.org/html/rfc7231#appendix-D) and the value describes it.  For requests that match multiple keys, only the most specific key is applicable. e.g. text/plain overrides text/*
+<a name="requestBodyContent"></a>content | Map[`string`, [Media Type Object](#media-type-object)] | **REQUIRED**. The content of the request body. The key is a media type or [media type range](https://tools.ietf.org/html/rfc7231#appendix-D) and the value describes it.  For requests that match multiple keys, only the most specific key is applicable. e.g. text/plain overrides text/*
 <a name="requestBodyRequired"></a>required | `boolean` | Determines if the request body is required in the request. Defaults to `false`.
 
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Request Body Examples
 
@@ -1242,9 +1242,9 @@ A request body with a referenced model definition.
       },
       "examples": {
           "user" : {
-            "summary": "User Example", 
+            "summary": "User Example",
             "externalValue": "http://foo.bar/examples/user-example.json"
-          } 
+          }
         }
     },
     "application/xml": {
@@ -1262,9 +1262,9 @@ A request body with a referenced model definition.
       "examples": {
         "user" : {
             "summary": "User example in Plain text",
-            "externalValue": "http://foo.bar/examples/user-example.txt" 
+            "externalValue": "http://foo.bar/examples/user-example.txt"
         }
-      } 
+      }
     },
     "*/*": {
       "examples": {
@@ -1280,7 +1280,7 @@ A request body with a referenced model definition.
 
 ```yaml
 description: user to add to the system
-content: 
+content:
   'application/json':
     schema:
       $ref: '#/components/schemas/User'
@@ -1302,7 +1302,7 @@ content:
         externalValue: 'http://foo.bar/examples/user-example.txt'
   '*/*':
     examples:
-      user: 
+      user:
         summary: User example in other format
         externalValue: 'http://foo.bar/examples/user-example.whatever'
 ```
@@ -1336,18 +1336,18 @@ content:
 ```
 
 
-#### <a name="mediaTypeObject"></a>Media Type Object
+#### Media Type Object
 Each Media Type Object provides schema and examples for the media type identified by its key.
 
 ##### Fixed Fields
 Field Name | Type | Description
 ---|:---:|---
-<a name="mediaTypeSchema"></a>schema | [Schema Object](#schemaObject) \| [Reference Object](#referenceObject) | The schema defining the type used for the request body.
+<a name="mediaTypeSchema"></a>schema | [Schema Object](#schema-object) \| [Reference Object](#reference-object) | The schema defining the type used for the request body.
 <a name="mediaTypeExample"></a>example | Any | Example of the media type.  The example object SHOULD be in the correct format as specified by the media type.  The `example` object is mutually exclusive of the `examples` object.  Furthermore, if referencing a `schema` which contains an example, the `example` value SHALL _override_ the example provided by the schema.
-<a name="mediaTypeExamples"></a>examples | Map[ `string`, [Example Object](#exampleObject) \| [Reference Object](#referenceObject)] | Examples of the media type.  Each example object SHOULD  match the media type and specified schema if present.  The `examples` object is mutually exclusive of the `example` object.  Furthermore, if referencing a `schema` which contains an example, the `examples` value SHALL _override_ the example provided by the schema.
-<a name="mediaTypeEncoding"></a>encoding | Map[`string`, [Encoding Object](#encodingObject)] | A map between a property name and its encoding information. The key, being the property name, MUST exist in the schema as a property. The encoding object SHALL only apply to `requestBody` objects when the media type is `multipart` or `application/x-www-form-urlencoded`.
+<a name="mediaTypeExamples"></a>examples | Map[ `string`, [Example Object](#example-object) \| [Reference Object](#reference-object)] | Examples of the media type.  Each example object SHOULD  match the media type and specified schema if present.  The `examples` object is mutually exclusive of the `example` object.  Furthermore, if referencing a `schema` which contains an example, the `examples` value SHALL _override_ the example provided by the schema.
+<a name="mediaTypeEncoding"></a>encoding | Map[`string`, [Encoding Object](#encoding-object)] | A map between a property name and its encoding information. The key, being the property name, MUST exist in the schema as a property. The encoding object SHALL only apply to `requestBody` objects when the media type is `multipart` or `application/x-www-form-urlencoded`.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Media Type Examples
 
@@ -1360,7 +1360,7 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
     "examples": {
       "cat" : {
         "summary": "An example of a cat",
-        "value": 
+        "value":
           {
             "name": "Fluffy",
             "petType": "Cat",
@@ -1371,7 +1371,7 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
       },
       "dog": {
         "summary": "An example of a dog with a cat's name",
-        "value" :  { 
+        "value" :  {
           "name": "Puma",
           "petType": "Dog",
           "color": "Black",
@@ -1388,7 +1388,7 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
 ```
 
 ```yaml
-application/json: 
+application/json:
   schema:
     $ref: "#/components/schemas/Pet"
   examples:
@@ -1459,7 +1459,7 @@ requestBody:
     'image/png':
       schema:
         type: string
-        format: binary        
+        format: binary       
 ```
 
 To upload multiple files, a `multipart` media type MUST be used:
@@ -1502,7 +1502,7 @@ requestBody:
 
 In this example, the contents in the `requestBody` MUST be stringified per [RFC1866](https://tools.ietf.org/html/rfc1866/) when passed to the server.  In addition, the `address` field complex object will be stringified.
 
-When passing complex objects in the `application/x-www-form-urlencoded` content type, the default serialization strategy of such properties is described in the [`Encoding Object`](#encodingObject)'s [`style`](#encodingStyle) property as `form`.
+When passing complex objects in the `application/x-www-form-urlencoded` content type, the default serialization strategy of such properties is described in the [`Encoding Object`](#encoding-object)'s [`style`](#encodingStyle) property as `form`.
 
 ##### Special Considerations for `multipart` Content
 
@@ -1549,7 +1549,7 @@ requestBody:
 
 An `encoding` attribute is introduced to give you control over the serialization of parts of `multipart` request bodies.  This attribute is _only_ applicable to `multipart` and `application/x-www-form-urlencoded` request bodies.
 
-#### <a name="encodingObject"></a>Encoding Object
+#### Encoding Object
 
 A single encoding definition applied to a single schema property.
 
@@ -1557,12 +1557,12 @@ A single encoding definition applied to a single schema property.
 Field Name | Type | Description
 ---|:---:|---
 <a name="encodingContentType"></a>contentType | `string` | The Content-Type for encoding a specific property. Default value depends on the property type: for `string` with `format` being `binary` – `application/octet-stream`; for other primitive types – `text/plain`; for `object` - `application/json`; for `array` – the default is defined based on the inner type. The value can be a specific media type (e.g. `application/json`), a wildcard media type (e.g. `image/*`), or a comma-separated list of the two types.
-<a name="encodingHeaders"></a>headers | Map[`string`, [Header Object](#headerObject) \| [Reference Object](#referenceObject)] | A map allowing additional information to be provided as headers, for example `Content-Disposition`.  `Content-Type` is described separately and SHALL be ignored in this section. This property SHALL be ignored if the request body media type is not a `multipart`.
-<a name="encodingStyle"></a>style | `string` | Describes how a specific property value will be serialized depending on its type.  See [Parameter Object](#parameterObject) for details on the [`style`](#parameterStyle) property. The behavior follows the same values as `query` parameters, including default values. This property SHALL be ignored if the request body media type is not `application/x-www-form-urlencoded`.
+<a name="encodingHeaders"></a>headers | Map[`string`, [Header Object](#header-object) \| [Reference Object](#reference-object)] | A map allowing additional information to be provided as headers, for example `Content-Disposition`.  `Content-Type` is described separately and SHALL be ignored in this section. This property SHALL be ignored if the request body media type is not a `multipart`.
+<a name="encodingStyle"></a>style | `string` | Describes how a specific property value will be serialized depending on its type.  See [Parameter Object](#parameter-object) for details on the [`style`](#parameterStyle) property. The behavior follows the same values as `query` parameters, including default values. This property SHALL be ignored if the request body media type is not `application/x-www-form-urlencoded`.
 <a name="encodingExplode"></a>explode | `boolean` | When this is true, property values of type `array` or `object` generate separate parameters for each value of the array, or key-value-pair of the map.  For other types of properties this property has no effect. When [`style`](#encodingStyle) is `form`, the default value is `true`. For all other styles, the default value is `false`. This property SHALL be ignored if the request body media type is not `application/x-www-form-urlencoded`.
 <a name="encodingAllowReserved"></a>allowReserved | `boolean` | Determines whether the parameter value SHOULD allow reserved characters, as defined by [RFC3986](https://tools.ietf.org/html/rfc3986#section-2.2) `:/?#[]@!$&'()*+,;=` to be included without percent-encoding. The default value is `false`. This property SHALL be ignored if the request body media type is not `application/x-www-form-urlencoded`.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Encoding Object Example
 
@@ -1604,7 +1604,7 @@ requestBody:
                 type: integer
 ```
 
-#### <a name="responsesObject"></a>Responses Object
+#### Responses Object
 
 A container for the expected responses of an operation.
 The container maps a HTTP response code to the expected response.
@@ -1612,24 +1612,24 @@ The container maps a HTTP response code to the expected response.
 The documentation is not necessarily expected to cover all possible HTTP response codes because they may not be known in advance.
 However, documentation is expected to cover a successful operation response and any known errors.
 
-The `default` MAY be used as a default response object for all HTTP codes 
+The `default` MAY be used as a default response object for all HTTP codes
 that are not covered individually by the specification.
 
-The `Responses Object` MUST contain at least one response code, and it 
+The `Responses Object` MUST contain at least one response code, and it
 SHOULD be the response for a successful operation call.
 
 ##### Fixed Fields
 Field Name | Type | Description
 ---|:---:|---
-<a name="responsesDefault"></a>default | [Response Object](#responseObject) \| [Reference Object](#referenceObject) | The documentation of responses other than the ones declared for specific HTTP response codes. Use this field to cover undeclared responses. A [Reference Object](#referenceObject) can link to a response that the [OpenAPI Object's components/responses](#componentsResponses) section defines.
+<a name="responsesDefault"></a>default | [Response Object](#response-object) \| [Reference Object](#reference-object) | The documentation of responses other than the ones declared for specific HTTP response codes. Use this field to cover undeclared responses. A [Reference Object](#reference-object) can link to a response that the [OpenAPI Object's components/responses](#componentsResponses) section defines.
 
 ##### Patterned Fields
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="responsesCode"></a>[HTTP Status Code](#httpCodes) | [Response Object](#responseObject) \| [Reference Object](#referenceObject) | Any [HTTP status code](#httpCodes) can be used as the property name, but only one property per code, to describe the expected response for that HTTP status code.  A [Reference Object](#referenceObject) can link to a response that is defined in the [OpenAPI Object's components/responses](#componentsResponses) section. This field MUST be enclosed in quotation marks (for example, "200") for compatibility between JSON and YAML. To define a range of response codes, this field MAY contain the uppercase wildcard character `X`. For example, `2XX` represents all response codes between `[200-299]`. The following range definitions are allowed: `1XX`, `2XX`, `3XX`, `4XX`, and `5XX`. If a response range is defined using an explicit code, the explicit code definition takes precedence over the range definition for that code.
+<a name="responsesCode"></a>[HTTP Status Code](#http-status-codes) | [Response Object](#response-object) \| [Reference Object](#reference-object) | Any [HTTP status code](#http-status-codes) can be used as the property name, but only one property per code, to describe the expected response for that HTTP status code.  A [Reference Object](#reference-object) can link to a response that is defined in the [OpenAPI Object's components/responses](#componentsResponses) section. This field MUST be enclosed in quotation marks (for example, "200") for compatibility between JSON and YAML. To define a range of response codes, this field MAY contain the uppercase wildcard character `X`. For example, `2XX` represents all response codes between `[200-299]`. The following range definitions are allowed: `1XX`, `2XX`, `3XX`, `4XX`, and `5XX`. If a response range is defined using an explicit code, the explicit code definition takes precedence over the range definition for that code.
 
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Responses Object Example
 
@@ -1663,7 +1663,7 @@ A 200 response for a successful operation and a default response for others (imp
 ```yaml
 '200':
   description: a pet to be returned
-  content: 
+  content:
     application/json:
       schema:
         $ref: '#/components/schemas/Pet'
@@ -1675,19 +1675,19 @@ default:
         $ref: '#/components/schemas/ErrorModel'
 ```
 
-#### <a name="responseObject"></a>Response Object
-Describes a single response from an API Operation, including design-time, static 
+#### Response Object
+Describes a single response from an API Operation, including design-time, static
 `links` to operations based on the response.
 
 ##### Fixed Fields
 Field Name | Type | Description
 ---|:---:|---
 <a name="responseDescription"></a>description | `string` | **REQUIRED**. A short description of the response. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="responseHeaders"></a>headers | Map[`string`, [Header Object](#headerObject)  \| [Reference Object](#referenceObject)] |  Maps a header name to its definition. [RFC7230](https://tools.ietf.org/html/rfc7230#page-22) states header names are case insensitive. If a response header is defined with the name `"Content-Type"`, it SHALL be ignored.
-<a name="responseContent"></a>content | Map[`string`, [Media Type Object](#mediaTypeObject)] | A map containing descriptions of potential response payloads. The key is a media type or [media type range](https://tools.ietf.org/html/rfc7231#appendix-D) and the value describes it.  For responses that match multiple keys, only the most specific key is applicable. e.g. text/plain overrides text/*
-<a name="responseLinks"></a>links | Map[`string`, [Link Object](#linkObject) \| [Reference Object](#referenceObject)] | A map of operations links that can be followed from the response. The key of the map is a short name for the link, following the naming constraints of the names for [Component Objects](#componentsObject). 
+<a name="responseHeaders"></a>headers | Map[`string`, [Header Object](#header-object)  \| [Reference Object](#reference-object)] |  Maps a header name to its definition. [RFC7230](https://tools.ietf.org/html/rfc7230#page-22) states header names are case insensitive. If a response header is defined with the name `"Content-Type"`, it SHALL be ignored.
+<a name="responseContent"></a>content | Map[`string`, [Media Type Object](#media-type-object)] | A map containing descriptions of potential response payloads. The key is a media type or [media type range](https://tools.ietf.org/html/rfc7231#appendix-D) and the value describes it.  For responses that match multiple keys, only the most specific key is applicable. e.g. text/plain overrides text/*
+<a name="responseLinks"></a>links | Map[`string`, [Link Object](#link-object) \| [Reference Object](#reference-object)] | A map of operations links that can be followed from the response. The key of the map is a short name for the link, following the naming constraints of the names for [Component Objects](#components-object).
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Response Object Examples
 
@@ -1711,9 +1711,9 @@ Response of an array of a complex type:
 
 ```yaml
 description: A complex object array response
-content: 
+content:
   application/json:
-    schema: 
+    schema:
       type: array
       items:
         $ref: '#/components/schemas/VeryComplexType'
@@ -1812,25 +1812,25 @@ Response with no return value:
 description: object created
 ```
 
-#### <a name="callbackObject"></a>Callback Object
+#### Callback Object
 
 A map of possible out-of band callbacks related to the parent operation.
-Each value in the map is a [Path Item Object](#pathItemObject) that describes a set of requests that may be initiated by the API provider and the expected responses.
+Each value in the map is a [Path Item Object](#path-item-object) that describes a set of requests that may be initiated by the API provider and the expected responses.
 The key value used to identify the callback object is an expression, evaluated at runtime, that identifies a URL to use for the callback operation.
 
 ##### Patterned Fields
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="callbackExpression"></a>{expression} | [Path Item Object](#pathItemObject) | A Path Item Object used to define a callback request and expected responses.  A [complete example](../examples/v3.0/callback-example.yaml) is available.
+<a name="callbackExpression"></a>{expression} | [Path Item Object](#path-item-object) | A Path Item Object used to define a callback request and expected responses.  A [complete example](../examples/v3.0/callback-example.yaml) is available.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Key Expression
 
-The key that identifies the [Path Item Object](#pathItemObject) is a [runtime expression](#runtimeExpression) that can be evaluated in the context of a runtime HTTP request/response to identify the URL to be used for the callback request.
+The key that identifies the [Path Item Object](#path-item-object) is a [runtime expression](#runtime-expressions) that can be evaluated in the context of a runtime HTTP request/response to identify the URL to be used for the callback request.
 A simple example might be `$request.body#/url`.
-However, using a [runtime expression](#runtimeExpression) the complete HTTP message can be accessed.
-This includes accessing any part of a body that a JSON Pointer [RFC6901](https://tools.ietf.org/html/rfc6901) can reference. 
+However, using a [runtime expression](#runtime-expressions) the complete HTTP message can be accessed.
+This includes accessing any part of a body that a JSON Pointer [RFC6901](https://tools.ietf.org/html/rfc6901) can reference.
 
 For example, given the following HTTP request:
 
@@ -1846,7 +1846,7 @@ Content-Length: 187
     "http://clientdomain.com/fast",
     "http://clientdomain.com/medium",
     "http://clientdomain.com/slow"
-  ] 
+  ]
 }
 
 201 Created
@@ -1855,7 +1855,7 @@ Location: http://example.org/subscription/1
 
 The following examples show how the various expressions evaluate, assuming the callback operation has a path parameter named `eventType` and a query parameter named `queryUrl`.
 
-Expression | Value 
+Expression | Value
 ---|:---
 $url | http://example.org/subscribe/myevent?queryUrl=http://clientdomain.com/stillrunning
 $method | POST
@@ -1877,7 +1877,7 @@ myWebhook:
     post:
       requestBody:
         description: Callback payload
-        content: 
+        content:
           'application/json':
             schema:
               $ref: '#/components/schemas/SomePayload'
@@ -1887,7 +1887,7 @@ myWebhook:
 ```
 
 
-#### <a name="exampleObject"></a>Example Object
+#### Example Object
 
 ##### Fixed Fields
 Field Name | Type | Description
@@ -1895,12 +1895,12 @@ Field Name | Type | Description
 <a name="exampleSummary"></a>summary | `string` | Short description for the example.
 <a name="exampleDescription"></a>description | `string` | Long description for the example. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
 <a name="exampleValue"></a>value | Any | Embedded literal example. The `value` field and `externalValue` field are mutually exclusive. To represent examples of media types that cannot naturally represented in JSON or YAML, use a string value to contain the example, escaping where necessary.
-<a name="exampleExternalValue"></a>externalValue | `string` | A URL that points to the literal example. This provides the capability to reference examples that cannot easily be included in JSON or YAML documents.  The `value` field and `externalValue` field are mutually exclusive. 
+<a name="exampleExternalValue"></a>externalValue | `string` | A URL that points to the literal example. This provides the capability to reference examples that cannot easily be included in JSON or YAML documents.  The `value` field and `externalValue` field are mutually exclusive.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
-In all cases, the example value is expected to be compatible with the type schema 
-of its associated value.  Tooling implementations MAY choose to 
+In all cases, the example value is expected to be compatible with the type schema
+of its associated value.  Tooling implementations MAY choose to
 validate compatibility automatically, and reject the example value(s) if incompatible.
 
 ##### Example Object Example
@@ -1921,7 +1921,7 @@ schemas:
       'application/json':
         schema:
           $ref: '#/components/schemas/Address'
-        examples: 
+        examples:
           foo:
             summary: A foo example
             value: {"foo": "bar"}
@@ -1929,15 +1929,15 @@ schemas:
             summary: A bar example
             value: {"bar": "baz"}
       'application/xml':
-        examples: 
+        examples:
           xmlExample:
             summary: This is an example in XML
             externalValue: 'http://example.org/examples/address-example.xml'
       'text/plain':
         examples:
-          textExample: 
+          textExample:
             summary: This is a text example
-            externalValue: 'http://foo.bar/examples/address-example.txt' 
+            externalValue: 'http://foo.bar/examples/address-example.txt'
 
 
 # in a parameter
@@ -1948,14 +1948,14 @@ schemas:
         type: 'string'
         format: 'zip-code'
         examples:
-          zip-example: 
+          zip-example:
             $ref: '#/components/examples/zip-example'
 
 # in a response
   responses:
     '200':
       description: your car appointment has been booked
-      content: 
+      content:
         application/json:
           schema:
             $ref: '#/components/schemas/SuccessResponse'
@@ -1965,31 +1965,31 @@ schemas:
 ```
 
 
-#### <a name="linkObject"></a>Link Object
+#### Link Object
 
 The `Link object` represents a possible design-time link for a response.
 The presence of a link does not guarantee the caller's ability to successfully invoke it, rather it provides a known relationship and traversal mechanism between responses and other operations.
 
 Unlike _dynamic_ links (i.e. links provided **in** the response payload), the OAS linking mechanism does not require link information in the runtime response.
 
-For computing links, and providing instructions to execute them, a [runtime expression](#runtimeExpression) is used for accessing values in an operation and using them as parameters while invoking the linked operation.  
+For computing links, and providing instructions to execute them, a [runtime expression](#runtime-expressions) is used for accessing values in an operation and using them as parameters while invoking the linked operation. 
 
 ##### Fixed Fields
 
 Field Name  |  Type  | Description
 ---|:---:|---
-<a name="linkOperationRef"></a>operationRef | `string` | A relative or absolute reference to an OAS operation. This field is mutually exclusive of the `operationId` field, and MUST point to an [Operation Object](#operationObject). Relative `operationRef` values MAY be used to locate an existing [Operation Object](#operationObject) in the OpenAPI definition.
-<a name="linkOperationId"></a>operationId  | `string` | The name of an _existing_, resolvable OAS operation, as defined with a unique `operationId`.  This field is mutually exclusive of the `operationRef` field.  
-<a name="linkParameters"></a>parameters   | Map[`string`, Any \| [{expression}](#runtimeExpression)] | A map representing parameters to pass to an operation as specified with `operationId` or identified via `operationRef`. The key is the parameter name to be used, whereas the value can be a constant or an expression to be evaluated and passed to the linked operation.  The parameter name can be qualified using the [parameter location](#parameterIn) `[{in}.]{name}` for operations that use the same parameter name in different locations (e.g. path.id).
-<a name="linkRequestBody"></a>requestBody | Any \| [{expression}](#runtimeExpression) | A literal value or [{expression}](#runtimeExpression) to use as a request body when calling the target operation.
+<a name="linkOperationRef"></a>operationRef | `string` | A relative or absolute reference to an OAS operation. This field is mutually exclusive of the `operationId` field, and MUST point to an [Operation Object](#operation-object). Relative `operationRef` values MAY be used to locate an existing [Operation Object](#operation-object) in the OpenAPI definition.
+<a name="linkOperationId"></a>operationId  | `string` | The name of an _existing_, resolvable OAS operation, as defined with a unique `operationId`.  This field is mutually exclusive of the `operationRef` field. 
+<a name="linkParameters"></a>parameters   | Map[`string`, Any \| [{expression}](#runtime-expressions)] | A map representing parameters to pass to an operation as specified with `operationId` or identified via `operationRef`. The key is the parameter name to be used, whereas the value can be a constant or an expression to be evaluated and passed to the linked operation.  The parameter name can be qualified using the [parameter location](#parameterIn) `[{in}.]{name}` for operations that use the same parameter name in different locations (e.g. path.id).
+<a name="linkRequestBody"></a>requestBody | Any \| [{expression}](#runtime-expressions) | A literal value or [{expression}](#runtime-expressions) to use as a request body when calling the target operation.
 <a name="linkDescription"></a>description  | `string` | A description of the link. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="linkServer"></a>server       | [Server Object](#serverObject) | A server object to be used by the target operation.
+<a name="linkServer"></a>server       | [Server Object](#server-object) | A server object to be used by the target operation.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 A linked operation MUST be identified using either an `operationRef` or `operationId`.
 In the case of an `operationId`, it MUST be unique and resolved in the scope of the OAS document.
-Because of the potential for name clashes, the `operationRef` syntax is preferred 
+Because of the potential for name clashes, the `operationRef` syntax is preferred
 for specifications with external references.
 
 ##### Examples
@@ -2003,7 +2003,7 @@ paths:
     - name: id
       in: path
       required: true
-      description: the user identifier, as userId 
+      description: the user identifier, as userId
       schema:
         type: string
     get:
@@ -2031,7 +2031,7 @@ paths:
     - name: userid
       in: path
       required: true
-      description: the user identifier, as userId 
+      description: the user identifier, as userId
       schema:
         type: string
       # linked operation
@@ -2055,14 +2055,14 @@ links:
       userUuid: $response.body#/uuid
 ```
 
-Clients follow all links at their discretion. 
-Neither permissions, nor the capability to make a successful call to that link, is guaranteed 
+Clients follow all links at their discretion.
+Neither permissions, nor the capability to make a successful call to that link, is guaranteed
 solely by the existence of a relationship.
 
 
 ##### OperationRef Examples
 
-As references to `operationId` MAY NOT be possible (the `operationId` is an optional 
+As references to `operationId` MAY NOT be possible (the `operationId` is an optional
 value), references MAY also be made through a relative `operationRef`:
 
 ```yaml
@@ -2085,52 +2085,52 @@ links:
       username: $response.body#/username
 ```
 
-Note that in the use of `operationRef`, the _escaped forward-slash_ is necessary when 
+Note that in the use of `operationRef`, the _escaped forward-slash_ is necessary when
 using JSON references.
 
 
-##### <a name="runtimeExpression"></a>Runtime Expressions
+##### Runtime Expressions
 
 Runtime expressions allow defining values based on information that will only be available within the HTTP message in an actual API call.
-This mechanism is used by [Link Objects](#linkObject) and [Callback Objects](#callbackObject).
+This mechanism is used by [Link Objects](#link-object) and [Callback Objects](#callback-object).
 
 The runtime expression is defined by the following [ABNF](https://tools.ietf.org/html/rfc5234) syntax
 
 ```
       expression = ( "$url" | "$method" | "$statusCode" | "$request." source | "$response." source )
-      source = ( header-reference | query-reference | path-reference | body-reference )  
+      source = ( header-reference | query-reference | path-reference | body-reference ) 
       header-reference = "header." token
-      query-reference = "query." name  
+      query-reference = "query." name 
       path-reference = "path." name
       body-reference = "body" ["#" fragment]
-      fragment = a JSON Pointer [RFC 6901](https://tools.ietf.org/html/rfc6901)  
+      fragment = a JSON Pointer [RFC 6901](https://tools.ietf.org/html/rfc6901) 
       name = *( char )
       char = as per RFC [7159](https://tools.ietf.org/html/rfc7159#section-7)
       token = as per RFC [7230](https://tools.ietf.org/html/rfc7230#section-3.2.6)
 ```
 
-The `name` identifier is case-sensitive, whereas `token` is not. 
+The `name` identifier is case-sensitive, whereas `token` is not.
 
 The table below provides examples of runtime expressions and examples of their use in a value:
 
-##### <a name="runtimeExpressionExamples"></a>Examples
+##### Examples
 
 Source Location | example expression  | notes
 ---|:---|:---|
 HTTP Method            | `$method`         | The allowable values for the `$method` will be those for the HTTP operation.
-Requested media type | `$request.header.accept`        |  
+Requested media type | `$request.header.accept`        | 
 Request parameter      | `$request.path.id`        | Request parameters MUST be declared in the `parameters` section of the parent operation or they cannot be evaluated. This includes request headers.
 Request body property   | `$request.body#/user/uuid`   | In operations which accept payloads, references may be made to portions of the `requestBody` or the entire body.
-Request URL            | `$url`            |  
+Request URL            | `$url`            | 
 Response value         | `$response.body#/status`       |  In operations which return payloads, references may be made to portions of the response body or the entire body.
 Response header        | `$response.header.Server` |  Single header values only are available
 
 Runtime expressions preserve the type of the referenced value.
 Expressions can be embedded into string values by surrounding the expression with `{}` curly braces.
 
-#### <a name="headerObject"></a>Header Object
+#### Header Object
 
-The Header Object follows the structure of the [Parameter Object](#parameterObject) with the following changes:
+The Header Object follows the structure of the [Parameter Object](#parameter-object) with the following changes:
 
 1. `name` MUST NOT be specified, it is given in the corresponding `headers` map.
 1. `in` MUST NOT be specified, it is implicitly in `header`.
@@ -2155,9 +2155,9 @@ schema:
   type: integer
 ```
 
-#### <a name="tagObject"></a>Tag Object
+#### Tag Object
 
-Adds metadata to a single tag that is used by the [Operation Object](#operationObject).
+Adds metadata to a single tag that is used by the [Operation Object](#operation-object).
 It is not mandatory to have a Tag Object per tag defined in the Operation Object instances.
 
 ##### Fixed Fields
@@ -2165,9 +2165,9 @@ Field Name | Type | Description
 ---|:---:|---
 <a name="tagName"></a>name | `string` | **REQUIRED**. The name of the tag.
 <a name="tagDescription"></a>description | `string` | A short description for the tag. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="tagExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation for this tag.
+<a name="tagExternalDocs"></a>externalDocs | [External Documentation Object](#external-documentation-object) | Additional external documentation for this tag.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Tag Object Example
 
@@ -2183,16 +2183,16 @@ name: pet
 description: Pets operations
 ```
 
-#### <a name="examplesObject"></a>Examples Object
+#### Examples Object
 
-In an `example`, a JSON Reference MAY be used, with the 
-explicit restriction that examples having a JSON format with object named 
-`$ref` are not allowed. Therefore, that `example`, structurally, can be 
+In an `example`, a JSON Reference MAY be used, with the
+explicit restriction that examples having a JSON format with object named
+`$ref` are not allowed. Therefore, that `example`, structurally, can be
 either a string primitive or an object, similar to `additionalProperties`.
 
-In all cases, the payload is expected to be compatible with the type schema 
-for the associated value.  Tooling implementations MAY choose to 
-validate compatibility automatically, and reject the example value(s) if they 
+In all cases, the payload is expected to be compatible with the type schema
+for the associated value.  Tooling implementations MAY choose to
+validate compatibility automatically, and reject the example value(s) if they
 are incompatible.
 
 ```yaml
@@ -2223,7 +2223,7 @@ schemas:
         examples:
           text:
             externalValue: 'http://foo.bar/examples/address-example.txt'
-        
+       
 # in a parameter
   parameters:
     - name: 'zipCode'
@@ -2231,14 +2231,14 @@ schemas:
       schema:
         type: 'string'
         format: 'zip-code'
-        example: 
+        example:
           $ref: 'http://foo.bar#/examples/zip-example'
 
 # in a response, note the singular `example`:
   responses:
     '200':
       description: your car appointment has been booked
-      content: 
+      content:
         application/json:
           schema:
             $ref: '#/components/schemas/SuccessResponse'
@@ -2246,11 +2246,11 @@ schemas:
             $ref: http://foo.bar#/examples/address-example.json
 ```
 
-#### <a name="referenceObject"></a>Reference Object
+#### Reference Object
 
 A simple object to allow referencing other components in the specification, internally and externally.
 
-The Reference Object is defined by [JSON Reference](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03) and follows the same structure, behavior and rules. 
+The Reference Object is defined by [JSON Reference](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03) and follows the same structure, behavior and rules.
 
 For this specification, reference resolution is accomplished as defined by the JSON Reference specification and not by the JSON Schema specification.
 
@@ -2295,7 +2295,7 @@ $ref: Pet.yaml
 $ref: definitions.yaml#/Pet
 ```
 
-#### <a name="schemaObject"></a>Schema Object
+#### Schema Object
 
 The Schema Object allows the definition of input and output data types.
 These types can be objects, but also primitives and arrays.
@@ -2304,7 +2304,7 @@ This object is an extended subset of the [JSON Schema Specification Wright Draft
 For more information about the properties, see [JSON Schema Core](https://tools.ietf.org/html/draft-wright-json-schema-00) and [JSON Schema Validation](https://tools.ietf.org/html/draft-wright-json-schema-validation-00).
 Unless stated otherwise, the property definitions follow the JSON Schema.
 
-##### Properties 
+##### Properties
 
 The following properties are taken directly from the JSON Schema definition and follow the same specifications:
 
@@ -2325,20 +2325,20 @@ The following properties are taken directly from the JSON Schema definition and 
 - required
 - enum
 
-The following properties are taken from the JSON Schema definition but their definitions were adjusted to the OpenAPI Specification. 
+The following properties are taken from the JSON Schema definition but their definitions were adjusted to the OpenAPI Specification.
 - type - Value MUST be a string. Multiple types via an array are not supported.
-- allOf - Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard JSON Schema.
-- oneOf - Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard JSON Schema.
-- anyOf - Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard JSON Schema.
-- not - Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard JSON Schema.
-- items - Value MUST be an object and not an array. Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard JSON Schema. `items` MUST be present if the `type` is `array`.
-- properties - Property definitions MUST be a [Schema Object](#schemaObject) and not a standard JSON Schema (inline or referenced).
-- additionalProperties - Value can be boolean or object. Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard JSON Schema.
+- allOf - Inline or referenced schema MUST be of a [Schema Object](#schema-object) and not a standard JSON Schema.
+- oneOf - Inline or referenced schema MUST be of a [Schema Object](#schema-object) and not a standard JSON Schema.
+- anyOf - Inline or referenced schema MUST be of a [Schema Object](#schema-object) and not a standard JSON Schema.
+- not - Inline or referenced schema MUST be of a [Schema Object](#schema-object) and not a standard JSON Schema.
+- items - Value MUST be an object and not an array. Inline or referenced schema MUST be of a [Schema Object](#schema-object) and not a standard JSON Schema. `items` MUST be present if the `type` is `array`.
+- properties - Property definitions MUST be a [Schema Object](#schema-object) and not a standard JSON Schema (inline or referenced).
+- additionalProperties - Value can be boolean or object. Inline or referenced schema MUST be of a [Schema Object](#schema-object) and not a standard JSON Schema.
 - description - [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
 - format - See [Data Type Formats](#dataTypeFormat) for further details. While relying on JSON Schema's defined formats, the OAS offers a few additional predefined formats.
 - default - The default value represents what would be assumed by the consumer of the input as the value of the schema if one is not provided. Unlike JSON Schema, the value MUST conform to the defined type for the Schema Object defined at the same level. For example, if `type` is `string`, then `default` can be `"foo"` but cannot be `1`.
 
-Alternatively, any time a Schema Object can be used, a [Reference Object](#referenceObject) can be used in its place. This allows referencing definitions instead of defining them inline.
+Alternatively, any time a Schema Object can be used, a [Reference Object](#reference-object) can be used in its place. This allows referencing definitions instead of defining them inline.
 
 Additional properties defined by the JSON Schema specification that are not mentioned here are strictly unsupported.
 
@@ -2348,20 +2348,20 @@ Other than the JSON Schema subset fields, the following fields MAY be used for f
 Field Name | Type | Description
 ---|:---:|---
 <a name="schemaNullable"></a>nullable | `boolean` | Allows sending a `null` value for the defined schema. Default value is `false`.
-<a name="schemaDiscriminator"></a>discriminator | [Discriminator Object](#discriminatorObject) | Adds support for polymorphism. The discriminator is an object name that is used to differentiate between other schemas which may satisfy the payload description. See [Composition and Inheritance](#schemaComposition) for more details.
+<a name="schemaDiscriminator"></a>discriminator | [Discriminator Object](#discriminator-object) | Adds support for polymorphism. The discriminator is an object name that is used to differentiate between other schemas which may satisfy the payload description. See [Composition and Inheritance](#composition-and-inheritance-polymorphism) for more details.
 <a name="schemaReadOnly"></a>readOnly | `boolean` | Relevant only for Schema `"properties"` definitions. Declares the property as "read only". This means that it MAY be sent as part of a response but SHOULD NOT be sent as part of the request. If the property is marked as `readOnly` being `true` and is in the `required` list, the `required` will take effect on the response only. A property MUST NOT be marked as both `readOnly` and `writeOnly` being `true`. Default value is `false`.
 <a name="schemaWriteOnly"></a>writeOnly | `boolean` | Relevant only for Schema `"properties"` definitions. Declares the property as "write only". Therefore, it MAY be sent as part of a request but SHOULD NOT be sent as part of the response. If the property is marked as `writeOnly` being `true` and is in the `required` list, the `required` will take effect on the request only. A property MUST NOT be marked as both `readOnly` and `writeOnly` being `true`. Default value is `false`.
-<a name="schemaXml"></a>xml | [XML Object](#xmlObject) | This MAY be used only on properties schemas. It has no effect on root schemas. Adds additional metadata to describe the XML representation of this property.
-<a name="schemaExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation for this schema. 
+<a name="schemaXml"></a>xml | [XML Object](#xml-object) | This MAY be used only on properties schemas. It has no effect on root schemas. Adds additional metadata to describe the XML representation of this property.
+<a name="schemaExternalDocs"></a>externalDocs | [External Documentation Object](#external-documentation-object) | Additional external documentation for this schema.
 <a name="schemaExample"></a>example | Any | A free-form property to include an example of an instance for this schema. To represent examples that cannot be naturally represented in JSON or YAML, a string value can be used to contain the example with escaping where necessary.
 <a name="schemaDeprecated"></a> deprecated | `boolean` | Specifies that a schema is deprecated and SHOULD be transitioned out of usage. Default value is `false`.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
-###### <a name="schemaComposition"></a>Composition and Inheritance (Polymorphism)
+###### Composition and Inheritance (Polymorphism)
 
 The OpenAPI Specification allows combining and extending model definitions using the `allOf` property of JSON Schema, in effect offering model composition.
-`allOf` takes an array of object definitions that are validated *independently* but together compose a single object. 
+`allOf` takes an array of object definitions that are validated *independently* but together compose a single object.
 
 While composition offers model extensibility, it does not imply a hierarchy between the models.
 To support polymorphism, the OpenAPI Specification adds the `discriminator` field.
@@ -2375,7 +2375,7 @@ As such, inline schema definitions, which do not have a given id, *cannot* be us
 ###### XML Modeling
 
 The [xml](#schemaXml) property allows extra definitions when translating the JSON definition to XML.
-The [XML Object](#xmlObject) contains additional information about the available options.
+The [XML Object](#xml-object) contains additional information about the available options.
 
 ##### Schema Object Examples
 
@@ -2705,7 +2705,7 @@ components:
         - packSize
 ```
 
-#### <a name="discriminatorObject"></a>Discriminator Object
+#### Discriminator Object
 
 When request bodies or response payloads may be one of a number of different schemas, a `discriminator` object can be used to aid in serialization, deserialization, and validation.  The discriminator is a specific object in a schema which is used to inform the consumer of the specification of an alternative schema based on the value associated with it.
 
@@ -2838,7 +2838,7 @@ will indicate that the `Cat` schema be used.  Likewise this schema:
 will map to `Dog` because of the definition in the `mappings` element.
 
 
-#### <a name="xmlObject"></a>XML Object
+#### XML Object
 
 A metadata object that allows for more fine-tuned XML model definitions.
 
@@ -2854,11 +2854,11 @@ Field Name | Type | Description
 <a name="xmlAttribute"></a>attribute | `boolean` | Declares whether the property definition translates to an attribute instead of an element. Default value is `false`.
 <a name="xmlWrapped"></a>wrapped | `boolean` | MAY be used only for an array definition. Signifies whether the array is wrapped (for example, `<books><book/><book/></books>`) or unwrapped (`<book/><book/>`). Default value is `false`. The definition takes effect only when defined alongside `type` being `array` (outside the `items`).
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### XML Object Examples
 
-The examples of the XML object definitions are included inside a property definition of a [Schema Object](#schemaObject) with a sample of the XML representation of it.
+The examples of the XML object definitions are included inside a property definition of a [Schema Object](#schema-object) with a sample of the XML representation of it.
 
 ###### No XML Element
 
@@ -3191,7 +3191,7 @@ animals:
 </aliens>
 ```
 
-#### <a name="securitySchemeObject"></a>Security Scheme Object
+#### Security Scheme Object
 
 Defines a security scheme that can be used by the operations.
 Supported schemes are HTTP authentication, an API key (either as a header or as a query parameter), OAuth2's common flows (implicit, password, application and access code) as defined in [RFC6749](https://tools.ietf.org/html/rfc6749), and [OpenID Connect Discovery](https://tools.ietf.org/html/draft-ietf-oauth-discovery-06).
@@ -3205,10 +3205,10 @@ Field Name | Type | Applies To | Description
 <a name="securitySchemeIn"></a>in | `string` | `apiKey` | **REQUIRED**. The location of the API key. Valid values are `"query"`, `"header"` or `"cookie"`.
 <a name="securitySchemeScheme"></a>scheme | `string` | `http` | **REQUIRED**. The name of the HTTP Authorization scheme to be used in the [Authorization header as defined in RFC7235](https://tools.ietf.org/html/rfc7235#section-5.1).
 <a name="securitySchemeBearerFormat"></a>bearerFormat | `string` | `http` (`"bearer"`) | A hint to the client to identify how the bearer token is formatted.  Bearer tokens are usually generated by an authorization server, so this information is primarily for documentation purposes.
-<a name="securitySchemeFlows"></a>flows | [OAuth Flows Object](#oauthFlowsObject) | `oauth2` | **REQUIRED**. An object containing configuration information for the flow types supported.
+<a name="securitySchemeFlows"></a>flows | [OAuth Flows Object](#oauth-flows-object) | `oauth2` | **REQUIRED**. An object containing configuration information for the flow types supported.
 <a name="securitySchemeOpenIdConnectUrl"></a>openIdConnectUrl | `string` | `openIdConnect` | **REQUIRED**. OpenId Connect URL to discover OAuth2 configuration values. This MUST be in the form of a URL.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Security Scheme Object Example
 
@@ -3277,7 +3277,7 @@ bearerFormat: JWT
 
 ```yaml
 type: oauth2
-flows: 
+flows:
   implicit:
     authorizationUrl: https://example.com/api/oauth/dialog
     scopes:
@@ -3285,21 +3285,21 @@ flows:
       read:pets: read your pets
 ```
 
-#### <a name="oauthFlowsObject"></a>OAuth Flows Object
+#### OAuth Flows Object
 
 Allows configuration of the supported OAuth Flows.
 
 ##### Fixed Fields
 Field Name | Type | Description
 ---|:---:|---
-<a name="oauthFlowsImplicit"></a>implicit| [OAuth Flow Object](#oauthFlowObject) | Configuration for the OAuth Implicit flow 
-<a name="oauthFlowsPassword"></a>password| [OAuth Flow Object](#oauthFlowObject) | Configuration for the OAuth Resource Owner Password flow 
-<a name="oauthFlowsClientCredentials"></a>clientCredentials| [OAuth Flow Object](#oauthFlowObject) | Configuration for the OAuth Client Credentials flow.  Previously called `application` in OpenAPI 2.0.
-<a name="oauthFlowsAuthorizationCode"></a>authorizationCode| [OAuth Flow Object](#oauthFlowObject) | Configuration for the OAuth Authorization Code flow.  Previously called `accessCode` in OpenAPI 2.0.
+<a name="oauthFlowsImplicit"></a>implicit| [OAuth Flow Object](#oauth-flow-object) | Configuration for the OAuth Implicit flow
+<a name="oauthFlowsPassword"></a>password| [OAuth Flow Object](#oauth-flow-object) | Configuration for the OAuth Resource Owner Password flow
+<a name="oauthFlowsClientCredentials"></a>clientCredentials| [OAuth Flow Object](#oauth-flow-object) | Configuration for the OAuth Client Credentials flow.  Previously called `application` in OpenAPI 2.0.
+<a name="oauthFlowsAuthorizationCode"></a>authorizationCode| [OAuth Flow Object](#oauth-flow-object) | Configuration for the OAuth Authorization Code flow.  Previously called `accessCode` in OpenAPI 2.0.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
-#### <a name="oauthFlowObject"></a>OAuth Flow Object
+#### OAuth Flow Object
 
 Configuration details for a supported OAuth Flow
 
@@ -3311,7 +3311,7 @@ Field Name | Type | Applies To | Description
 <a name="oauthFlowRefreshUrl"></a>refreshUrl | `string` | `oauth2` | The URL to be used for obtaining refresh tokens. This MUST be in the form of a URL.
 <a name="oauthFlowScopes"></a>scopes | Map[`string`, `string`] | `oauth2` | **REQUIRED**. The available scopes for the OAuth2 security scheme. A map between the scope name and a short description for it.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### OAuth Flow Object Examples
 
@@ -3340,7 +3340,7 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
 
 ```YAML
 type: oauth2
-flows: 
+flows:
   implicit:
     authorizationUrl: https://example.com/api/oauth/dialog
     scopes:
@@ -3351,25 +3351,25 @@ flows:
     tokenUrl: https://example.com/api/oauth/token
     scopes:
       write:pets: modify pets in your account
-      read:pets: read your pets 
+      read:pets: read your pets
 ```
 
 
-#### <a name="securityRequirementObject"></a>Security Requirement Object
+#### Security Requirement Object
 
 Lists the required security schemes to execute this operation.
-The name used for each property MUST correspond to a security scheme declared in the [Security Schemes](#componentsSecuritySchemes) under the [Components Object](#componentsObject).
+The name used for each property MUST correspond to a security scheme declared in the [Security Schemes](#componentsSecuritySchemes) under the [Components Object](#components-object).
 
 Security Requirement Objects that contain multiple schemes require that all schemes MUST be satisfied for a request to be authorized.
 This enables support for scenarios where multiple query parameters or HTTP headers are required to convey security information.
 
-When a list of Security Requirement Objects is defined on the [Open API object](#oasObject) or [Operation Object](#operationObject), only one of Security Requirement Objects in the list needs to be satisfied to authorize the request.  
+When a list of Security Requirement Objects is defined on the [Open API object](#openapi-object) or [Operation Object](#operation-object), only one of Security Requirement Objects in the list needs to be satisfied to authorize the request. 
 
 ##### Patterned Fields
 
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="securityRequirementsName"></a>{name} | [`string`] | Each name MUST correspond to a security scheme which is declared in the [Security Schemes](#componentsSecuritySchemes) under the [Components Object](#componentsObject). If the security scheme is of type `"oauth2"` or `"openIdConnect"`, then the value is a list of scope names required for the execution. For other security scheme types, the array MUST be empty.
+<a name="securityRequirementsName"></a>{name} | [`string`] | Each name MUST correspond to a security scheme which is declared in the [Security Schemes](#componentsSecuritySchemes) under the [Components Object](#components-object). If the security scheme is of type `"oauth2"` or `"openIdConnect"`, then the value is a list of scope names required for the execution. For other security scheme types, the array MUST be empty.
 
 ##### Security Requirement Object Examples
 
@@ -3402,7 +3402,7 @@ petstore_auth:
 - read:pets
 ```
 
-### <a name="specificationExtensions"></a>Specification Extensions
+### Specification Extensions
 
 While the OpenAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.
 
@@ -3414,19 +3414,19 @@ Field Pattern | Type | Description
 
 The extensions may or may not be supported by the available tooling, but those may be extended as well to add requested support (if tools are internal or open-sourced).
 
-### <a name="securityFiltering"></a>Security Filtering
+### Security Filtering
 
-Some objects in the OpenAPI Specification MAY be declared and remain empty, or be completely removed, even though they are inherently the core of the API documentation. 
+Some objects in the OpenAPI Specification MAY be declared and remain empty, or be completely removed, even though they are inherently the core of the API documentation.
 
 The reasoning is to allow an additional layer of access control over the documentation.
 While not part of the specification itself, certain libraries MAY choose to allow access to parts of the documentation based on some form of authentication/authorization.
 
 Two examples of this:
 
-1. The [Paths Object](#pathsObject) MAY be empty. It may be counterintuitive, but this may tell the viewer that they got to the right place, but can't access any documentation. They'd still have access to the [Info Object](#infoObject) which may contain additional information regarding authentication.
-2. The [Path Item Object](#pathItemObject) MAY be empty. In this case, the viewer will be aware that the path exists, but will not be able to see any of its operations or parameters. This is different than hiding the path itself from the [Paths Object](#pathsObject), so the user will not be aware of its existence. This allows the documentation provider to finely control what the viewer can see.
+1. The [Paths Object](#paths-object) MAY be empty. It may be counterintuitive, but this may tell the viewer that they got to the right place, but can't access any documentation. They'd still have access to the [Info Object](#info-object) which may contain additional information regarding authentication.
+2. The [Path Item Object](#path-item-object) MAY be empty. In this case, the viewer will be aware that the path exists, but will not be able to see any of its operations or parameters. This is different than hiding the path itself from the [Paths Object](#paths-object), so the user will not be aware of its existence. This allows the documentation provider to finely control what the viewer can see.
 
-## <a name="revisionHistory"></a>Appendix A: Revision History
+## Appendix A: Revision History
 
 Version   | Date       | Notes
 ---       | ---        | ---

--- a/versions/3.0.1.md
+++ b/versions/3.0.1.md
@@ -16,64 +16,64 @@ An OpenAPI definition can then be used by documentation generation tools to disp
 <!-- TOC depthFrom:1 depthTo:3 withLinks:1 updateOnSave:1 orderedList:0 -->
 
 - [Definitions](#definitions)
-	- [OpenAPI Document](#oasDocument)
-	- [Path Templating](#pathTemplating)
-	- [Media Types](#mediaTypes)
-	- [HTTP Status Codes](#httpCodes)
+	- [OpenAPI Document](#openapi-document)
+	- [Path Templating](#path-templating)
+	- [Media Types](#media-types)
+	- [HTTP Status Codes](#http-status-codes)
 - [Specification](#specification)
 	- [Versions](#versions)
 	- [Format](#format)
-	- [Document Structure](#documentStructure)
-	- [Data Types](#dataTypes)
-	- [Rich Text Formatting](#richText)
-	- [Relative References In URLs](#relativeReferences)
+	- [Document Structure](#document-structure)
+	- [Data Types](#data-types)
+	- [Rich Text Formatting](#rich-text-formatting)
+	- [Relative References In URLs](#relative-references-in-urls)
 	- [Schema](#schema)
-		- [OpenAPI Object](#oasObject)
-		- [Info Object](#infoObject)
-		- [Contact Object](#contactObject)
-		- [License Object](#licenseObject)
-		- [Server Object](#serverObject)
-		- [Server Variable Object](#serverVariableObject)
-		- [Components Object](#componentsObject)
-		- [Paths Object](#pathsObject)
-		- [Path Item Object](#pathItemObject)
-		- [Operation Object](#operationObject)
-		- [External Documentation Object](#externalDocumentationObject)
-		- [Parameter Object](#parameterObject)
-		- [Request Body Object](#requestBodyObject)
-		- [Media Type Object](#mediaTypeObject)
-		- [Encoding Object](#encodingObject)
-		- [Responses Object](#responsesObject)
-		- [Response Object](#responseObject)
-		- [Callback Object](#callbackObject)
-		- [Example Object](#exampleObject)
-		- [Link Object](#linkObject)
-		- [Header Object](#headerObject)
-		- [Tag Object](#tagObject)
-		- [Reference Object](#referenceObject)
-		- [Schema Object](#schemaObject)
-		- [Discriminator Object](#discriminatorObject)
-		- [XML Object](#xmlObject)
-		- [Security Scheme Object](#securitySchemeObject)
-		- [OAuth Flows Object](#oauthFlowsObject)
-		- [OAuth Flow Object](#oauthFlowObject)
-		- [Security Requirement Object](#securityRequirementObject)
-	- [Specification Extensions](#specificationExtensions)
-	- [Security Filtering](#securityFiltering)
-- [Appendix A: Revision History](#revisionHistory)
+		- [OpenAPI Object](#openapi-object)
+		- [Info Object](#info-object)
+		- [Contact Object](#contact-object)
+		- [License Object](#license-object)
+		- [Server Object](#server-object)
+		- [Server Variable Object](#server-variable-object)
+		- [Components Object](#components-object)
+		- [Paths Object](#paths-object)
+		- [Path Item Object](#path-item-object)
+		- [Operation Object](#operation-object)
+		- [External Documentation Object](#external-documentation-object)
+		- [Parameter Object](#parameter-object)
+		- [Request Body Object](#request-body-object)
+		- [Media Type Object](#media-type-object)
+		- [Encoding Object](#encoding-object)
+		- [Responses Object](#responses-object)
+		- [Response Object](#response-object)
+		- [Callback Object](#callback-object)
+		- [Example Object](#example-object)
+		- [Link Object](#link-object)
+		- [Header Object](#header-object)
+		- [Tag Object](#tag-object)
+		- [Reference Object](#reference-object)
+		- [Schema Object](#schema-object)
+		- [Discriminator Object](#discriminator-object)
+		- [XML Object](#xml-object)
+		- [Security Scheme Object](#security-scheme-object)
+		- [OAuth Flows Object](#oauth-flows-object)
+		- [OAuth Flow Object](#oauth-flow-object)
+		- [Security Requirement Object](#security-requirement-object)
+	- [Specification Extensions](#specification-extensions)
+	- [Security Filtering](#security-filtering)
+- [Appendix A: Revision History](#appendix-a-revision-history)
 	
 
 <!-- /TOC -->
 
 ## Definitions
 
-##### <a name="oasDocument"></a>OpenAPI Document
+##### OpenAPI Document
 A document (or set of documents) that defines or describes an API. An OpenAPI definition uses and conforms to the OpenAPI Specification.
 
-##### <a name="pathTemplating"></a>Path Templating
+##### Path Templating
 Path templating refers to the usage of curly braces ({}) to mark a section of a URL path as replaceable using path parameters.
 
-##### <a name="mediaTypes"></a>Media Types
+##### Media Types
 Media type definitions are spread across several resources.
 The media type definitions SHOULD be in compliance with [RFC6838](https://tools.ietf.org/html/rfc6838).
 
@@ -90,8 +90,8 @@ Some examples of possible media type definitions:
   application/vnd.github.v3.diff
   application/vnd.github.v3.patch
 ```
-##### <a name="httpCodes"></a>HTTP Status Codes
-The HTTP Status Codes are used to indicate the status of the executed operation. 
+##### HTTP Status Codes
+The HTTP Status Codes are used to indicate the status of the executed operation.
 The available status codes are defined by [RFC7231](https://tools.ietf.org/html/rfc7231#section-6) and registered status codes are listed in the [IANA Status Code Registry](https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml).
 
 ## Specification
@@ -121,7 +121,7 @@ All field names in the specification are **case sensitive**.
 
 The schema exposes two types of fields: Fixed fields, which have a declared name, and Patterned fields, which declare a regex pattern for the field name.
 
-Patterned fields MUST have unique names within the containing object. 
+Patterned fields MUST have unique names within the containing object.
 
 In order to preserve the ability to round-trip between YAML and JSON formats, YAML version [1.2](http://www.yaml.org/spec/1.2/spec.html) is RECOMMENDED along with some additional constraints:
 
@@ -130,18 +130,18 @@ In order to preserve the ability to round-trip between YAML and JSON formats, YA
 
 **Note:** While APIs may be defined by OpenAPI documents in either YAML or JSON format, the API request and response bodies and other content are not required to be JSON or YAML.
 
-### <a name="documentStructure"></a>Document Structure
+### Document Structure
 
 An OpenAPI document MAY be made up of a single document or be divided into multiple, connected parts at the discretion of the user. In the latter case, `$ref` fields MUST be used in the specification to reference those parts as follows from the [JSON Schema](http://json-schema.org) definitions.
 
 It is RECOMMENDED that the root OpenAPI document be named: `openapi.json` or `openapi.yaml`.
 
-### <a name="dataTypes"></a>Data Types
+### Data Types
 
-Primitive data types in the OAS are based on the types supported by the [JSON Schema Specification Wright Draft 00](https://tools.ietf.org/html/draft-wright-json-schema-00#section-4.2). 
-Note that `integer` as a type is also supported and is defined as a JSON number without a fraction or exponent part. 
+Primitive data types in the OAS are based on the types supported by the [JSON Schema Specification Wright Draft 00](https://tools.ietf.org/html/draft-wright-json-schema-00#section-4.2).
+Note that `integer` as a type is also supported and is defined as a JSON number without a fraction or exponent part.
 `null` is not supported as a type (see [`nullable`](#schemaNullable) for an alternative solution).
-Models are defined using the [Schema Object](#schemaObject), which is an extended subset of JSON Schema Specification Wright Draft 00.
+Models are defined using the [Schema Object](#schema-object), which is an extended subset of JSON Schema Specification Wright Draft 00.
 
 <a name="dataTypeFormat"></a>Primitives have an optional modifier property: `format`.
 OAS uses several known formats to define in fine detail the data type being used.
@@ -151,7 +151,7 @@ Types that are not accompanied by a `format` property follow the type definition
 
 The formats defined by the OAS are:
 
-Common Name | [`type`](#dataTypes) | [`format`](#dataTypeFormat) | Comments
+Common Name | [`type`](#data-types) | [`format`](#dataTypeFormat) | Comments
 ----------- | ------ | -------- | --------
 integer | `integer` | `int32` | signed 32 bits
 long | `integer` | `int64` | signed 64 bits
@@ -165,41 +165,41 @@ date | `string` | `date` | As defined by `full-date` - [RFC3339](https://xml2rfc
 dateTime | `string` | `date-time` | As defined by `date-time` - [RFC3339](https://xml2rfc.ietf.org/public/rfc/html/rfc3339.html#anchor14)
 password | `string` | `password` | A hint to UIs to obscure input.
 
-### <a name="richText"></a>Rich Text Formatting
+### Rich Text Formatting
 Throughout the specification `description` fields are noted as supporting CommonMark markdown formatting.
-Where OpenAPI tooling renders rich text it MUST support, at a minimum, markdown syntax as described by [CommonMark 0.27](http://spec.commonmark.org/0.27/). Tooling MAY choose to ignore some CommonMark features to address security concerns. 
+Where OpenAPI tooling renders rich text it MUST support, at a minimum, markdown syntax as described by [CommonMark 0.27](http://spec.commonmark.org/0.27/). Tooling MAY choose to ignore some CommonMark features to address security concerns.
 
-### <a name="relativeReferences"></a>Relative References in URLs
+### Relative References in URLs
 
 Unless specified otherwise, all properties that are URLs MAY be relative references as defined by [RFC3986](https://tools.ietf.org/html/rfc3986#section-4.2).
-Relative references are resolved using the URLs defined in the [`Server Object`](#serverObject) as a Base URI.
+Relative references are resolved using the URLs defined in the [`Server Object`](#server-object) as a Base URI.
 
-Relative references used in `$ref` are processed as per [JSON Reference](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03), using the URL of the current document as the base URI. See also the [Reference Object](#referenceObject).
+Relative references used in `$ref` are processed as per [JSON Reference](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03), using the URL of the current document as the base URI. See also the [Reference Object](#reference-object).
 
 ### Schema
 
 In the following description, if a field is not explicitly **REQUIRED** or described with a MUST or SHALL, it can be considered OPTIONAL.
 
-#### <a name="oasObject"></a>OpenAPI Object
+#### OpenAPI Object
 
-This is the root document object of the [OpenAPI document](#oasDocument).
+This is the root document object of the [OpenAPI document](#openapi-document).
 
 ##### Fixed Fields
 
 Field Name | Type | Description
 ---|:---:|---
 <a name="oasVersion"></a>openapi | `string` | **REQUIRED**. This string MUST be the [semantic version number](https://semver.org/spec/v2.0.0.html) of the [OpenAPI Specification version](#versions) that the OpenAPI document uses. The `openapi` field SHOULD be used by tooling specifications and clients to interpret the OpenAPI document. This is *not* related to the API [`info.version`](#infoVersion) string.
-<a name="oasInfo"></a>info | [Info Object](#infoObject) | **REQUIRED**. Provides metadata about the API. The metadata MAY be used by tooling as required.
-<a name="oasServers"></a>servers | [[Server Object](#serverObject)] | An array of Server Objects, which provide connectivity information to a target server. If the `servers` property is not provided, or is an empty array, the default value would be a [Server Object](#serverObject) with a [url](#serverUrl) value of `/`.
-<a name="oasPaths"></a>paths | [Paths Object](#pathsObject) | **REQUIRED**. The available paths and operations for the API.
-<a name="oasComponents"></a>components | [Components Object](#componentsObject) | An element to hold various schemas for the specification.
-<a name="oasSecurity"></a>security | [[Security Requirement Object](#securityRequirementObject)] | A declaration of which security mechanisms can be used across the API. The list of values includes alternative security requirement objects that can be used. Only one of the security requirement objects need to be satisfied to authorize a request. Individual operations can override this definition.
-<a name="oasTags"></a>tags | [[Tag Object](#tagObject)] | A list of tags used by the specification with additional metadata. The order of the tags can be used to reflect on their order by the parsing tools. Not all tags that are used by the [Operation Object](#operationObject) must be declared. The tags that are not declared MAY be organized randomly or based on the tools' logic. Each tag name in the list MUST be unique.
-<a name="oasExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation.
+<a name="oasInfo"></a>info | [Info Object](#info-object) | **REQUIRED**. Provides metadata about the API. The metadata MAY be used by tooling as required.
+<a name="oasServers"></a>servers | [[Server Object](#server-object)] | An array of Server Objects, which provide connectivity information to a target server. If the `servers` property is not provided, or is an empty array, the default value would be a [Server Object](#server-object) with a [url](#serverUrl) value of `/`.
+<a name="oasPaths"></a>paths | [Paths Object](#paths-object) | **REQUIRED**. The available paths and operations for the API.
+<a name="oasComponents"></a>components | [Components Object](#components-object) | An element to hold various schemas for the specification.
+<a name="oasSecurity"></a>security | [[Security Requirement Object](#security-requirement-object)] | A declaration of which security mechanisms can be used across the API. The list of values includes alternative security requirement objects that can be used. Only one of the security requirement objects need to be satisfied to authorize a request. Individual operations can override this definition.
+<a name="oasTags"></a>tags | [[Tag Object](#tag-object)] | A list of tags used by the specification with additional metadata. The order of the tags can be used to reflect on their order by the parsing tools. Not all tags that are used by the [Operation Object](#operation-object) must be declared. The tags that are not declared MAY be organized randomly or based on the tools' logic. Each tag name in the list MUST be unique.
+<a name="oasExternalDocs"></a>externalDocs | [External Documentation Object](#external-documentation-object) | Additional external documentation.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
-#### <a name="infoObject"></a>Info Object
+#### Info Object
 
 The object provides metadata about the API.
 The metadata MAY be used by the clients if needed, and MAY be presented in editing or documentation generation tools for convenience.
@@ -211,12 +211,12 @@ Field Name | Type | Description
 <a name="infoTitle"></a>title | `string` | **REQUIRED**. The title of the application.
 <a name="infoDescription"></a>description | `string` | A short description of the application. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
 <a name="infoTermsOfService"></a>termsOfService | `string` | A URL to the Terms of Service for the API. MUST be in the format of a URL.
-<a name="infoContact"></a>contact | [Contact Object](#contactObject) | The contact information for the exposed API.
-<a name="infoLicense"></a>license | [License Object](#licenseObject) | The license information for the exposed API.
+<a name="infoContact"></a>contact | [Contact Object](#contact-object) | The contact information for the exposed API.
+<a name="infoLicense"></a>license | [License Object](#license-object) | The license information for the exposed API.
 <a name="infoVersion"></a>version | `string` | **REQUIRED**. The version of the OpenAPI document (which is distinct from the [OpenAPI Specification version](#oasVersion) or the API implementation version).
 
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Info Object Example:
 
@@ -252,7 +252,7 @@ license:
 version: 1.0.1
 ```
 
-#### <a name="contactObject"></a>Contact Object
+#### Contact Object
 
 Contact information for the exposed API.
 
@@ -264,7 +264,7 @@ Field Name | Type | Description
 <a name="contactUrl"></a>url | `string` | The URL pointing to the contact information. MUST be in the format of a URL.
 <a name="contactEmail"></a>email | `string` | The email address of the contact person/organization. MUST be in the format of an email address.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Contact Object Example:
 
@@ -282,7 +282,7 @@ url: http://www.example.com/support
 email: support@example.com
 ```
 
-#### <a name="licenseObject"></a>License Object
+#### License Object
 
 License information for the exposed API.
 
@@ -293,7 +293,7 @@ Field Name | Type | Description
 <a name="licenseName"></a>name | `string` | **REQUIRED**. The license name used for the API.
 <a name="licenseUrl"></a>url | `string` | A URL to the license used for the API. MUST be in the format of a URL.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### License Object Example:
 
@@ -309,7 +309,7 @@ name: Apache 2.0
 url: https://www.apache.org/licenses/LICENSE-2.0.html
 ```
 
-#### <a name="serverObject"></a>Server Object
+#### Server Object
 
 An object representing a Server.
 
@@ -319,9 +319,9 @@ Field Name | Type | Description
 ---|:---:|---
 <a name="serverUrl"></a>url | `string` | **REQUIRED**. A URL to the target host.  This URL supports Server Variables and MAY be relative, to indicate that the host location is relative to the location where the OpenAPI document is being served. Variable substitutions will be made when a variable is named in `{`brackets`}`.
 <a name="serverDescription"></a>description | `string` | An optional string describing the host designated by the URL. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="serverVariables"></a>variables | Map[`string`, [Server Variable Object](#serverVariableObject)] | A map between a variable name and its value.  The value is used for substitution in the server's URL template.
+<a name="serverVariables"></a>variables | Map[`string`, [Server Variable Object](#server-variable-object)] | A map between a variable name and its value.  The value is used for substitution in the server's URL template.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Server Object Example
 
@@ -419,7 +419,7 @@ servers:
 ```
 
 
-#### <a name="serverVariableObject"></a>Server Variable Object
+#### Server Variable Object
 
 An object representing a Server Variable for server URL template substitution.
 
@@ -428,12 +428,12 @@ An object representing a Server Variable for server URL template substitution.
 Field Name | Type | Description
 ---|:---:|---
 <a name="serverVariableEnum"></a>enum | [`string`] | An enumeration of string values to be used if the substitution options are from a limited set.
-<a name="serverVariableDefault"></a>default | `string` |  **REQUIRED**. The default value to use for substitution, and to send, if an alternate value is _not_ supplied. Unlike the [Schema Object's](#schemaObject) `default`, this value MUST be provided by the consumer.
+<a name="serverVariableDefault"></a>default | `string` |  **REQUIRED**. The default value to use for substitution, and to send, if an alternate value is _not_ supplied. Unlike the [Schema Object's](#schema-object) `default`, this value MUST be provided by the consumer.
 <a name="serverVariableDescription"></a>description | `string` | An optional description for the server variable. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
-#### <a name="componentsObject"></a>Components Object
+#### Components Object
 
 Holds a set of reusable objects for different aspects of the OAS.
 All objects defined within the components object will have no effect on the API unless they are explicitly referenced from properties outside the components object.
@@ -443,17 +443,17 @@ All objects defined within the components object will have no effect on the API 
 
 Field Name | Type | Description
 ---|:---|---
-<a name="componentsSchemas"></a> schemas | Map[`string`, [Schema Object](#schemaObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Schema Objects](#schemaObject).
-<a name="componentsResponses"></a> responses | Map[`string`, [Response Object](#responseObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Response Objects](#responseObject).
-<a name="componentsParameters"></a> parameters | Map[`string`, [Parameter Object](#parameterObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Parameter Objects](#parameterObject).
-<a name="componentsExamples"></a> examples | Map[`string`, [Example Object](#exampleObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Example Objects](#exampleObject).
-<a name="componentsRequestBodies"></a> requestBodies | Map[`string`, [Request Body Object](#requestBodyObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Request Body Objects](#requestBodyObject).
-<a name="componentsHeaders"></a> headers | Map[`string`, [Header Object](#headerObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Header Objects](#headerObject).
-<a name="componentsSecuritySchemes"></a> securitySchemes| Map[`string`, [Security Scheme Object](#securitySchemeObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Security Scheme Objects](#securitySchemeObject).
-<a name="componentsLinks"></a> links | Map[`string`, [Link Object](#linkObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Link Objects](#linkObject).
-<a name="componentsCallbacks"></a> callbacks | Map[`string`, [Callback Object](#callbackObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Callback Objects](#callbackObject).
+<a name="componentsSchemas"></a> schemas | Map[`string`, [Schema Object](#schema-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Schema Objects](#schema-object).
+<a name="componentsResponses"></a> responses | Map[`string`, [Response Object](#response-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Response Objects](#response-object).
+<a name="componentsParameters"></a> parameters | Map[`string`, [Parameter Object](#parameter-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Parameter Objects](#parameter-object).
+<a name="componentsExamples"></a> examples | Map[`string`, [Example Object](#example-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Example Objects](#example-object).
+<a name="componentsRequestBodies"></a> requestBodies | Map[`string`, [Request Body Object](#request-body-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Request Body Objects](#request-body-object).
+<a name="componentsHeaders"></a> headers | Map[`string`, [Header Object](#header-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Header Objects](#header-object).
+<a name="componentsSecuritySchemes"></a> securitySchemes| Map[`string`, [Security Scheme Object](#security-scheme-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Security Scheme Objects](#security-scheme-object).
+<a name="componentsLinks"></a> links | Map[`string`, [Link Object](#link-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Link Objects](#link-object).
+<a name="componentsCallbacks"></a> callbacks | Map[`string`, [Callback Object](#callback-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Callback Objects](#callback-object).
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 All the fixed fields declared above are objects that MUST use keys that match the regular expression: `^[a-zA-Z0-9\.\-_]+$`.
 
@@ -613,7 +613,7 @@ components:
       in: header
     petstore_auth:
       type: oauth2
-      flows: 
+      flows:
         implicit:
           authorizationUrl: http://example.org/api/oauth/dialog
           scopes:
@@ -622,18 +622,18 @@ components:
 ```
 
 
-#### <a name="pathsObject"></a>Paths Object
+#### Paths Object
 
 Holds the relative paths to the individual endpoints and their operations.
-The path is appended to the URL from the [`Server Object`](#serverObject) in order to construct the full URL.  The Paths MAY be empty, due to [ACL constraints](#securityFiltering).
+The path is appended to the URL from the [`Server Object`](#server-object) in order to construct the full URL.  The Paths MAY be empty, due to [ACL constraints](#security-filtering).
 
 ##### Patterned Fields
 
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="pathsPath"></a>/{path} | [Path Item Object](#pathItemObject) | A relative path to an individual endpoint. The field name MUST begin with a slash. The path is **appended** (no relative URL resolution) to the expanded URL from the [`Server Object`](#serverObject)'s `url` field in order to construct the full URL. [Path templating](#pathTemplating) is allowed. When matching URLs, concrete (non-templated) paths would be matched before their templated counterparts. Templated paths with the same hierarchy but different templated names MUST NOT exist as they are identical. In case of ambiguous matching, it's up to the tooling to decide which one to use.
+<a name="pathsPath"></a>/{path} | [Path Item Object](#path-item-object) | A relative path to an individual endpoint. The field name MUST begin with a slash. The path is **appended** (no relative URL resolution) to the expanded URL from the [`Server Object`](#server-object)'s `url` field in order to construct the full URL. [Path templating](#path-templating) is allowed. When matching URLs, concrete (non-templated) paths would be matched before their templated counterparts. Templated paths with the same hierarchy but different templated names MUST NOT exist as they are identical. In case of ambiguous matching, it's up to the tooling to decide which one to use.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Path Templating Matching
 
@@ -666,7 +666,7 @@ The following may lead to ambiguous resolution:
     "get": {
       "description": "Returns all pets from the system that the user has access to",
       "responses": {
-        "200": {          
+        "200": {         
           "description": "A list of pets.",
           "content": {
             "application/json": {
@@ -700,32 +700,32 @@ The following may lead to ambiguous resolution:
                 $ref: '#/components/schemas/pet'
 ```
 
-#### <a name="pathItemObject"></a>Path Item Object
+#### Path Item Object
 
 Describes the operations available on a single path.
-A Path Item MAY be empty, due to [ACL constraints](#securityFiltering).
+A Path Item MAY be empty, due to [ACL constraints](#security-filtering).
 The path itself is still exposed to the documentation viewer but they will not know which operations and parameters are available.
 
 ##### Fixed Fields
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="pathItemRef"></a>$ref | `string` | Allows for an external definition of this path item. The referenced structure MUST be in the format of a [Path Item Object](#pathItemObject). If there are conflicts between the referenced definition and this Path Item's definition, the behavior is *undefined*.
+<a name="pathItemRef"></a>$ref | `string` | Allows for an external definition of this path item. The referenced structure MUST be in the format of a [Path Item Object](#path-item-object). If there are conflicts between the referenced definition and this Path Item's definition, the behavior is *undefined*.
 <a name="pathItemSummary"></a>summary| `string` | An optional, string summary, intended to apply to all operations in this path.
 <a name="pathItemDescription"></a>description | `string` | An optional, string description, intended to apply to all operations in this path. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="pathItemGet"></a>get | [Operation Object](#operationObject) | A definition of a GET operation on this path.
-<a name="pathItemPut"></a>put | [Operation Object](#operationObject) | A definition of a PUT operation on this path.
-<a name="pathItemPost"></a>post | [Operation Object](#operationObject) | A definition of a POST operation on this path.
-<a name="pathItemDelete"></a>delete | [Operation Object](#operationObject) | A definition of a DELETE operation on this path.
-<a name="pathItemOptions"></a>options | [Operation Object](#operationObject) | A definition of a OPTIONS operation on this path.
-<a name="pathItemHead"></a>head | [Operation Object](#operationObject) | A definition of a HEAD operation on this path.
-<a name="pathItemPatch"></a>patch | [Operation Object](#operationObject) | A definition of a PATCH operation on this path.
-<a name="pathItemTrace"></a>trace | [Operation Object](#operationObject) | A definition of a TRACE operation on this path.
-<a name="pathItemServers"></a>servers | [[Server Object](#serverObject)] | An alternative `server` array to service all operations in this path.
-<a name="pathItemParameters"></a>parameters | [[Parameter Object](#parameterObject) \| [Reference Object](#referenceObject)] | A list of parameters that are applicable for all the operations described under this path. These parameters can be overridden at the operation level, but cannot be removed there. The list MUST NOT include duplicated parameters. A unique parameter is defined by a combination of a [name](#parameterName) and [location](#parameterIn). The list can use the [Reference Object](#referenceObject) to link to parameters that are defined at the [OpenAPI Object's components/parameters](#componentsParameters). 
+<a name="pathItemGet"></a>get | [Operation Object](#operation-object) | A definition of a GET operation on this path.
+<a name="pathItemPut"></a>put | [Operation Object](#operation-object) | A definition of a PUT operation on this path.
+<a name="pathItemPost"></a>post | [Operation Object](#operation-object) | A definition of a POST operation on this path.
+<a name="pathItemDelete"></a>delete | [Operation Object](#operation-object) | A definition of a DELETE operation on this path.
+<a name="pathItemOptions"></a>options | [Operation Object](#operation-object) | A definition of a OPTIONS operation on this path.
+<a name="pathItemHead"></a>head | [Operation Object](#operation-object) | A definition of a HEAD operation on this path.
+<a name="pathItemPatch"></a>patch | [Operation Object](#operation-object) | A definition of a PATCH operation on this path.
+<a name="pathItemTrace"></a>trace | [Operation Object](#operation-object) | A definition of a TRACE operation on this path.
+<a name="pathItemServers"></a>servers | [[Server Object](#server-object)] | An alternative `server` array to service all operations in this path.
+<a name="pathItemParameters"></a>parameters | [[Parameter Object](#parameter-object) \| [Reference Object](#reference-object)] | A list of parameters that are applicable for all the operations described under this path. These parameters can be overridden at the operation level, but cannot be removed there. The list MUST NOT include duplicated parameters. A unique parameter is defined by a combination of a [name](#parameterName) and [location](#parameterIn). The list can use the [Reference Object](#reference-object) to link to parameters that are defined at the [OpenAPI Object's components/parameters](#componentsParameters).
 
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Path Item Object Example
 
@@ -808,10 +808,10 @@ parameters:
     type: array
     style: simple
     items:
-      type: string  
+      type: string 
 ```
 
-#### <a name="operationObject"></a>Operation Object
+#### Operation Object
 
 Describes a single API operation on a path.
 
@@ -822,17 +822,17 @@ Field Name | Type | Description
 <a name="operationTags"></a>tags | [`string`] | A list of tags for API documentation control. Tags can be used for logical grouping of operations by resources or any other qualifier.
 <a name="operationSummary"></a>summary | `string` | A short summary of what the operation does.
 <a name="operationDescription"></a>description | `string` | A verbose explanation of the operation behavior. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="operationExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation for this operation.
+<a name="operationExternalDocs"></a>externalDocs | [External Documentation Object](#external-documentation-object) | Additional external documentation for this operation.
 <a name="operationId"></a>operationId | `string` | Unique string used to identify the operation. The id MUST be unique among all operations described in the API. Tools and libraries MAY use the operationId to uniquely identify an operation, therefore, it is RECOMMENDED to follow common programming naming conventions.
-<a name="operationParameters"></a>parameters | [[Parameter Object](#parameterObject) \| [Reference Object](#referenceObject)] | A list of parameters that are applicable for this operation. If a parameter is already defined at the [Path Item](#pathItemParameters), the new definition will override it but can never remove it. The list MUST NOT include duplicated parameters. A unique parameter is defined by a combination of a [name](#parameterName) and [location](#parameterIn). The list can use the [Reference Object](#referenceObject) to link to parameters that are defined at the [OpenAPI Object's components/parameters](#componentsParameters).
-<a name="operationRequestBody"></a>requestBody | [Request Body Object](#requestBodyObject) \| [Reference Object](#referenceObject) | The request body applicable for this operation.  The `requestBody` is only supported in HTTP methods where the HTTP 1.1 specification [RFC7231](https://tools.ietf.org/html/rfc7231#section-4.3.1) has explicitly defined semantics for request bodies.  In other cases where the HTTP spec is vague, `requestBody` SHALL be ignored by consumers.
-<a name="operationResponses"></a>responses | [Responses Object](#responsesObject) | **REQUIRED**. The list of possible responses as they are returned from executing this operation.
-<a name="operationCallbacks"></a>callbacks | Map[`string`, [Callback Object](#callbackObject) \| [Reference Object](#referenceObject)] | A map of possible out-of band callbacks related to the parent operation. The key is a unique identifier for the Callback Object. Each value in the map is a [Callback Object](#callbackObject) that describes a request that may be initiated by the API provider and the expected responses. The key value used to identify the callback object is an expression, evaluated at runtime, that identifies a URL to use for the callback operation.
+<a name="operationParameters"></a>parameters | [[Parameter Object](#parameter-object) \| [Reference Object](#reference-object)] | A list of parameters that are applicable for this operation. If a parameter is already defined at the [Path Item](#pathItemParameters), the new definition will override it but can never remove it. The list MUST NOT include duplicated parameters. A unique parameter is defined by a combination of a [name](#parameterName) and [location](#parameterIn). The list can use the [Reference Object](#reference-object) to link to parameters that are defined at the [OpenAPI Object's components/parameters](#componentsParameters).
+<a name="operationRequestBody"></a>requestBody | [Request Body Object](#request-body-object) \| [Reference Object](#reference-object) | The request body applicable for this operation.  The `requestBody` is only supported in HTTP methods where the HTTP 1.1 specification [RFC7231](https://tools.ietf.org/html/rfc7231#section-4.3.1) has explicitly defined semantics for request bodies.  In other cases where the HTTP spec is vague, `requestBody` SHALL be ignored by consumers.
+<a name="operationResponses"></a>responses | [Responses Object](#responses-object) | **REQUIRED**. The list of possible responses as they are returned from executing this operation.
+<a name="operationCallbacks"></a>callbacks | Map[`string`, [Callback Object](#callback-object) \| [Reference Object](#reference-object)] | A map of possible out-of band callbacks related to the parent operation. The key is a unique identifier for the Callback Object. Each value in the map is a [Callback Object](#callback-object) that describes a request that may be initiated by the API provider and the expected responses. The key value used to identify the callback object is an expression, evaluated at runtime, that identifies a URL to use for the callback operation.
 <a name="operationDeprecated"></a>deprecated | `boolean` | Declares this operation to be deprecated. Consumers SHOULD refrain from usage of the declared operation. Default value is `false`.
-<a name="operationSecurity"></a>security | [[Security Requirement Object](#securityRequirementObject)] | A declaration of which security mechanisms can be used for this operation. The list of values includes alternative security requirement objects that can be used. Only one of the security requirement objects need to be satisfied to authorize a request. This definition overrides any declared top-level [`security`](#oasSecurity). To remove a top-level security declaration, an empty array can be used.
-<a name="operationServers"></a>servers | [[Server Object](#serverObject)] | An alternative `server` array to service this operation. If an alternative `server` object is specified at the Path Item Object or Root level, it will be overridden by this value.
+<a name="operationSecurity"></a>security | [[Security Requirement Object](#security-requirement-object)] | A declaration of which security mechanisms can be used for this operation. The list of values includes alternative security requirement objects that can be used. Only one of the security requirement objects need to be satisfied to authorize a request. This definition overrides any declared top-level [`security`](#oasSecurity). To remove a top-level security declaration, an empty array can be used.
+<a name="operationServers"></a>servers | [[Server Object](#server-object)] | An alternative `server` array to service this operation. If an alternative `server` object is specified at the Path Item Object or Root level, it will be overridden by this value.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Operation Object Example
 
@@ -860,7 +860,7 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
         "schema": {
           "type": "object",
            "properties": {
-              "name": { 
+              "name": {
                 "description": "Updated name of the pet",
                 "type": "string"
               },
@@ -869,7 +869,7 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
                 "type": "string"
              }
            },
-        "required": ["status"] 
+        "required": ["status"]
         }
       }
     }
@@ -918,7 +918,7 @@ requestBody:
     'application/x-www-form-urlencoded':
       schema:
        properties:
-          name: 
+          name:
             description: Updated name of the pet
             type: string
           status:
@@ -929,12 +929,12 @@ requestBody:
 responses:
   '200':
     description: Pet updated.
-    content: 
+    content:
       'application/json': {}
       'application/xml': {}
   '405':
     description: Invalid input
-    content: 
+    content:
       'application/json': {}
       'application/xml': {}
 security:
@@ -944,7 +944,7 @@ security:
 ```
 
 
-#### <a name="externalDocumentationObject"></a>External Documentation Object
+#### External Documentation Object
 
 Allows referencing an external resource for extended documentation.
 
@@ -955,7 +955,7 @@ Field Name | Type | Description
 <a name="externalDocDescription"></a>description | `string` | A short description of the target documentation. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
 <a name="externalDocUrl"></a>url | `string` | **REQUIRED**. The URL for the target documentation. Value MUST be in the format of a URL.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### External Documentation Object Example
 
@@ -971,7 +971,7 @@ description: Find more info here
 url: https://example.com
 ```
 
-#### <a name="parameterObject"></a>Parameter Object
+#### Parameter Object
 
 Describes a single operation parameter.
 
@@ -979,7 +979,7 @@ A unique parameter is defined by a combination of a [name](#parameterName) and [
 
 ##### Parameter Locations
 There are four possible parameter locations specified by the `in` field:
-* path - Used together with [Path Templating](#pathTemplating), where the parameter value is actually part of the operation's URL. This does not include the host or base path of the API. For example, in `/items/{itemId}`, the path parameter is `itemId`.
+* path - Used together with [Path Templating](#path-templating), where the parameter value is actually part of the operation's URL. This does not include the host or base path of the API. For example, in `/items/{itemId}`, the path parameter is `itemId`.
 * query - Parameters that are appended to the URL. For example, in `/items?id=###`, the query parameter is `id`.
 * header - Custom headers that are expected as part of the request. Note that [RFC7230](https://tools.ietf.org/html/rfc7230#page-22) states header names are case insensitive.
 * cookie - Used to pass a specific cookie value to the API.
@@ -988,7 +988,7 @@ There are four possible parameter locations specified by the `in` field:
 ##### Fixed Fields
 Field Name | Type | Description
 ---|:---:|---
-<a name="parameterName"></a>name | `string` | **REQUIRED**. The name of the parameter. Parameter names are *case sensitive*. <ul><li>If [`in`](#parameterIn) is `"path"`, the `name` field MUST correspond to the associated path segment from the [path](#pathsPath) field in the [Paths Object](#pathsObject). See [Path Templating](#pathTemplating) for further information.<li>If [`in`](#parameterIn) is `"header"` and the `name` field is `"Accept"`, `"Content-Type"` or `"Authorization"`, the parameter definition SHALL be ignored.<li>For all other cases, the `name` corresponds to the parameter name used by the [`in`](#parameterIn) property.</ul>
+<a name="parameterName"></a>name | `string` | **REQUIRED**. The name of the parameter. Parameter names are *case sensitive*. <ul><li>If [`in`](#parameterIn) is `"path"`, the `name` field MUST correspond to the associated path segment from the [path](#pathsPath) field in the [Paths Object](#paths-object). See [Path Templating](#path-templating) for further information.<li>If [`in`](#parameterIn) is `"header"` and the `name` field is `"Accept"`, `"Content-Type"` or `"Authorization"`, the parameter definition SHALL be ignored.<li>For all other cases, the `name` corresponds to the parameter name used by the [`in`](#parameterIn) property.</ul>
 <a name="parameterIn"></a>in | `string` | **REQUIRED**. The location of the parameter. Possible values are "query", "header", "path" or "cookie".
 <a name="parameterDescription"></a>description | `string` | A brief description of the parameter. This could contain examples of use.  [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
 <a name="parameterRequired"></a>required | `boolean` | Determines whether this parameter is mandatory. If the [parameter location](#parameterIn) is "path", this property is **REQUIRED** and its value MUST be `true`. Otherwise, the property MAY be included and its default value is `false`.
@@ -1003,9 +1003,9 @@ Field Name | Type | Description
 <a name="parameterStyle"></a>style | `string` | Describes how the parameter value will be serialized depending on the type of the parameter value. Default values (based on value of `in`): for `query` - `form`; for `path` - `simple`; for `header` - `simple`; for `cookie` - `form`.
 <a name="parameterExplode"></a>explode | `boolean` | When this is true, parameter values of type `array` or `object` generate separate parameters for each value of the array or key-value pair of the map.  For other types of parameters this property has no effect. When [`style`](#parameterStyle) is `form`, the default value is `true`. For all other styles, the default value is `false`.
 <a name="parameterAllowReserved"></a>allowReserved | `boolean` | Determines whether the parameter value SHOULD allow reserved characters, as defined by [RFC3986](https://tools.ietf.org/html/rfc3986#section-2.2) `:/?#[]@!$&'()*+,;=` to be included without percent-encoding. This property only applies to parameters with an `in` value of `query`. The default value is `false`.
-<a name="parameterSchema"></a>schema | [Schema Object](#schemaObject) \| [Reference Object](#referenceObject) | The schema defining the type used for the parameter.
+<a name="parameterSchema"></a>schema | [Schema Object](#schema-object) \| [Reference Object](#reference-object) | The schema defining the type used for the parameter.
 <a name="parameterExample"></a>example | Any | Example of the media type.  The example SHOULD match the specified schema and encoding properties if present.  The `example` field is mutually exclusive of the `examples` field.  Furthermore, if referencing a `schema` which contains an example, the `example` value SHALL _override_ the example provided by the schema. To represent examples of media types that cannot naturally be represented in JSON or YAML, a string value can contain the example with escaping where necessary.
-<a name="parameterExamples"></a>examples | Map[ `string`, [Example Object](#exampleObject) \| [Reference Object](#referenceObject)] | Examples of the media type.  Each example SHOULD contain a value in the correct format as specified in the parameter encoding.  The `examples` field is mutually exclusive of the `example` field.  Furthermore, if referencing a `schema` which contains an example, the `examples` value SHALL _override_ the example provided by the schema.
+<a name="parameterExamples"></a>examples | Map[ `string`, [Example Object](#example-object) \| [Reference Object](#reference-object)] | Examples of the media type.  Each example SHOULD contain a value in the correct format as specified in the parameter encoding.  The `examples` field is mutually exclusive of the `example` field.  Furthermore, if referencing a `schema` which contains an example, the `examples` value SHALL _override_ the example provided by the schema.
 
 For more complex scenarios, the [`content`](#parameterContent) property can define the media type and schema of the parameter.
 A parameter MUST contain either a `schema` property, or a `content` property, but not both.
@@ -1014,19 +1014,19 @@ When `example` or `examples` are provided in conjunction with the `schema` objec
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="parameterContent"></a>content | Map[`string`, [Media Type Object](#mediaTypeObject)] | A map containing the representations for the parameter. The key is the media type and the value describes it.  The map MUST only contain one entry.
+<a name="parameterContent"></a>content | Map[`string`, [Media Type Object](#media-type-object)] | A map containing the representations for the parameter. The key is the media type and the value describes it.  The map MUST only contain one entry.
 
 ##### Style Values
 
 In order to support common ways of serializing simple parameters, a set of `style` values are defined.
 
-`style` | [`type`](#dataTypes) |  `in` | Comments
+`style` | [`type`](#data-types) |  `in` | Comments
 ----------- | ------ | -------- | --------
-matrix |  `primitive`, `array`, `object` |  `path` | Path-style parameters defined by [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.7) 
+matrix |  `primitive`, `array`, `object` |  `path` | Path-style parameters defined by [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.7)
 label | `primitive`, `array`, `object` |  `path` | Label style parameters defined by [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.5)
 form |  `primitive`, `array`, `object` |  `query`, `cookie` | Form style parameters defined by [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.8). This option replaces `collectionFormat` with a `csv` (when `explode` is false) or `multi` (when `explode` is true) value from OpenAPI 2.0.
 simple | `array` | `path`, `header` | Simple style parameters defined by [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.2).  This option replaces `collectionFormat` with a `csv` value from OpenAPI 2.0.
-spaceDelimited | `array` | `query` | Space separated array values. This option replaces `collectionFormat` equal to `ssv` from OpenAPI 2.0. 
+spaceDelimited | `array` | `query` | Space separated array values. This option replaces `collectionFormat` equal to `ssv` from OpenAPI 2.0.
 pipeDelimited | `array` | `query` | Pipe separated array values. This option replaces `collectionFormat` equal to `pipes` from OpenAPI 2.0.
 deepObject | `object` | `query` | Provides a simple way of rendering nested objects using form parameters.
 
@@ -1056,7 +1056,7 @@ spaceDelimited | false | n/a | n/a | blue%20black%20brown | R%20100%20G%20200%20
 pipeDelimited | false | n/a | n/a | blue\|black\|brown | R\|100\|G\|200|G\|150
 deepObject | true | n/a | n/a | n/a | color[R]=100&color[G]=200&color[B]=150
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Parameter Object Examples
 
@@ -1215,7 +1215,7 @@ content:
           type: number
 ```
 
-#### <a name="requestBodyObject"></a>Request Body Object
+#### Request Body Object
 
 Describes a single request body.
 
@@ -1223,11 +1223,11 @@ Describes a single request body.
 Field Name | Type | Description
 ---|:---:|---
 <a name="requestBodyDescription"></a>description | `string` | A brief description of the request body. This could contain examples of use.  [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="requestBodyContent"></a>content | Map[`string`, [Media Type Object](#mediaTypeObject)] | **REQUIRED**. The content of the request body. The key is a media type or [media type range](https://tools.ietf.org/html/rfc7231#appendix-D) and the value describes it.  For requests that match multiple keys, only the most specific key is applicable. e.g. text/plain overrides text/*
+<a name="requestBodyContent"></a>content | Map[`string`, [Media Type Object](#media-type-object)] | **REQUIRED**. The content of the request body. The key is a media type or [media type range](https://tools.ietf.org/html/rfc7231#appendix-D) and the value describes it.  For requests that match multiple keys, only the most specific key is applicable. e.g. text/plain overrides text/*
 <a name="requestBodyRequired"></a>required | `boolean` | Determines if the request body is required in the request. Defaults to `false`.
 
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Request Body Examples
 
@@ -1242,9 +1242,9 @@ A request body with a referenced model definition.
       },
       "examples": {
           "user" : {
-            "summary": "User Example", 
+            "summary": "User Example",
             "externalValue": "http://foo.bar/examples/user-example.json"
-          } 
+          }
         }
     },
     "application/xml": {
@@ -1262,9 +1262,9 @@ A request body with a referenced model definition.
       "examples": {
         "user" : {
             "summary": "User example in Plain text",
-            "externalValue": "http://foo.bar/examples/user-example.txt" 
+            "externalValue": "http://foo.bar/examples/user-example.txt"
         }
-      } 
+      }
     },
     "*/*": {
       "examples": {
@@ -1280,7 +1280,7 @@ A request body with a referenced model definition.
 
 ```yaml
 description: user to add to the system
-content: 
+content:
   'application/json':
     schema:
       $ref: '#/components/schemas/User'
@@ -1302,7 +1302,7 @@ content:
         externalValue: 'http://foo.bar/examples/user-example.txt'
   '*/*':
     examples:
-      user: 
+      user:
         summary: User example in other format
         externalValue: 'http://foo.bar/examples/user-example.whatever'
 ```
@@ -1336,18 +1336,18 @@ content:
 ```
 
 
-#### <a name="mediaTypeObject"></a>Media Type Object
+#### Media Type Object
 Each Media Type Object provides schema and examples for the media type identified by its key.
 
 ##### Fixed Fields
 Field Name | Type | Description
 ---|:---:|---
-<a name="mediaTypeSchema"></a>schema | [Schema Object](#schemaObject) \| [Reference Object](#referenceObject) | The schema defining the type used for the request body.
+<a name="mediaTypeSchema"></a>schema | [Schema Object](#schema-object) \| [Reference Object](#reference-object) | The schema defining the type used for the request body.
 <a name="mediaTypeExample"></a>example | Any | Example of the media type.  The example object SHOULD be in the correct format as specified by the media type.  The `example` field is mutually exclusive of the `examples` field.  Furthermore, if referencing a `schema` which contains an example, the `example` value SHALL _override_ the example provided by the schema.
-<a name="mediaTypeExamples"></a>examples | Map[ `string`, [Example Object](#exampleObject) \| [Reference Object](#referenceObject)] | Examples of the media type.  Each example object SHOULD  match the media type and specified schema if present.  The `examples` field is mutually exclusive of the `example` field.  Furthermore, if referencing a `schema` which contains an example, the `examples` value SHALL _override_ the example provided by the schema.
-<a name="mediaTypeEncoding"></a>encoding | Map[`string`, [Encoding Object](#encodingObject)] | A map between a property name and its encoding information. The key, being the property name, MUST exist in the schema as a property. The encoding object SHALL only apply to `requestBody` objects when the media type is `multipart` or `application/x-www-form-urlencoded`.
+<a name="mediaTypeExamples"></a>examples | Map[ `string`, [Example Object](#example-object) \| [Reference Object](#reference-object)] | Examples of the media type.  Each example object SHOULD  match the media type and specified schema if present.  The `examples` field is mutually exclusive of the `example` field.  Furthermore, if referencing a `schema` which contains an example, the `examples` value SHALL _override_ the example provided by the schema.
+<a name="mediaTypeEncoding"></a>encoding | Map[`string`, [Encoding Object](#encoding-object)] | A map between a property name and its encoding information. The key, being the property name, MUST exist in the schema as a property. The encoding object SHALL only apply to `requestBody` objects when the media type is `multipart` or `application/x-www-form-urlencoded`.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Media Type Examples
 
@@ -1360,7 +1360,7 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
     "examples": {
       "cat" : {
         "summary": "An example of a cat",
-        "value": 
+        "value":
           {
             "name": "Fluffy",
             "petType": "Cat",
@@ -1371,7 +1371,7 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
       },
       "dog": {
         "summary": "An example of a dog with a cat's name",
-        "value" :  { 
+        "value" :  {
           "name": "Puma",
           "petType": "Dog",
           "color": "Black",
@@ -1388,7 +1388,7 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
 ```
 
 ```yaml
-application/json: 
+application/json:
   schema:
     $ref: "#/components/schemas/Pet"
   examples:
@@ -1459,7 +1459,7 @@ requestBody:
     'image/png':
       schema:
         type: string
-        format: binary        
+        format: binary       
 ```
 
 To upload multiple files, a `multipart` media type MUST be used:
@@ -1502,7 +1502,7 @@ requestBody:
 
 In this example, the contents in the `requestBody` MUST be stringified per [RFC1866](https://tools.ietf.org/html/rfc1866/) when passed to the server.  In addition, the `address` field complex object will be stringified.
 
-When passing complex objects in the `application/x-www-form-urlencoded` content type, the default serialization strategy of such properties is described in the [`Encoding Object`](#encodingObject)'s [`style`](#encodingStyle) property as `form`.
+When passing complex objects in the `application/x-www-form-urlencoded` content type, the default serialization strategy of such properties is described in the [`Encoding Object`](#encoding-object)'s [`style`](#encodingStyle) property as `form`.
 
 ##### Special Considerations for `multipart` Content
 
@@ -1549,7 +1549,7 @@ requestBody:
 
 An `encoding` attribute is introduced to give you control over the serialization of parts of `multipart` request bodies.  This attribute is _only_ applicable to `multipart` and `application/x-www-form-urlencoded` request bodies.
 
-#### <a name="encodingObject"></a>Encoding Object
+#### Encoding Object
 
 A single encoding definition applied to a single schema property.
 
@@ -1557,12 +1557,12 @@ A single encoding definition applied to a single schema property.
 Field Name | Type | Description
 ---|:---:|---
 <a name="encodingContentType"></a>contentType | `string` | The Content-Type for encoding a specific property. Default value depends on the property type: for `string` with `format` being `binary` – `application/octet-stream`; for other primitive types – `text/plain`; for `object` - `application/json`; for `array` – the default is defined based on the inner type. The value can be a specific media type (e.g. `application/json`), a wildcard media type (e.g. `image/*`), or a comma-separated list of the two types.
-<a name="encodingHeaders"></a>headers | Map[`string`, [Header Object](#headerObject) \| [Reference Object](#referenceObject)] | A map allowing additional information to be provided as headers, for example `Content-Disposition`.  `Content-Type` is described separately and SHALL be ignored in this section. This property SHALL be ignored if the request body media type is not a `multipart`.
-<a name="encodingStyle"></a>style | `string` | Describes how a specific property value will be serialized depending on its type.  See [Parameter Object](#parameterObject) for details on the [`style`](#parameterStyle) property. The behavior follows the same values as `query` parameters, including default values. This property SHALL be ignored if the request body media type is not `application/x-www-form-urlencoded`.
+<a name="encodingHeaders"></a>headers | Map[`string`, [Header Object](#header-object) \| [Reference Object](#reference-object)] | A map allowing additional information to be provided as headers, for example `Content-Disposition`.  `Content-Type` is described separately and SHALL be ignored in this section. This property SHALL be ignored if the request body media type is not a `multipart`.
+<a name="encodingStyle"></a>style | `string` | Describes how a specific property value will be serialized depending on its type.  See [Parameter Object](#parameter-object) for details on the [`style`](#parameterStyle) property. The behavior follows the same values as `query` parameters, including default values. This property SHALL be ignored if the request body media type is not `application/x-www-form-urlencoded`.
 <a name="encodingExplode"></a>explode | `boolean` | When this is true, property values of type `array` or `object` generate separate parameters for each value of the array, or key-value-pair of the map.  For other types of properties this property has no effect. When [`style`](#encodingStyle) is `form`, the default value is `true`. For all other styles, the default value is `false`. This property SHALL be ignored if the request body media type is not `application/x-www-form-urlencoded`.
 <a name="encodingAllowReserved"></a>allowReserved | `boolean` | Determines whether the parameter value SHOULD allow reserved characters, as defined by [RFC3986](https://tools.ietf.org/html/rfc3986#section-2.2) `:/?#[]@!$&'()*+,;=` to be included without percent-encoding. The default value is `false`. This property SHALL be ignored if the request body media type is not `application/x-www-form-urlencoded`.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Encoding Object Example
 
@@ -1604,7 +1604,7 @@ requestBody:
                 type: integer
 ```
 
-#### <a name="responsesObject"></a>Responses Object
+#### Responses Object
 
 A container for the expected responses of an operation.
 The container maps a HTTP response code to the expected response.
@@ -1612,24 +1612,24 @@ The container maps a HTTP response code to the expected response.
 The documentation is not necessarily expected to cover all possible HTTP response codes because they may not be known in advance.
 However, documentation is expected to cover a successful operation response and any known errors.
 
-The `default` MAY be used as a default response object for all HTTP codes 
+The `default` MAY be used as a default response object for all HTTP codes
 that are not covered individually by the specification.
 
-The `Responses Object` MUST contain at least one response code, and it 
+The `Responses Object` MUST contain at least one response code, and it
 SHOULD be the response for a successful operation call.
 
 ##### Fixed Fields
 Field Name | Type | Description
 ---|:---:|---
-<a name="responsesDefault"></a>default | [Response Object](#responseObject) \| [Reference Object](#referenceObject) | The documentation of responses other than the ones declared for specific HTTP response codes. Use this field to cover undeclared responses. A [Reference Object](#referenceObject) can link to a response that the [OpenAPI Object's components/responses](#componentsResponses) section defines.
+<a name="responsesDefault"></a>default | [Response Object](#response-object) \| [Reference Object](#reference-object) | The documentation of responses other than the ones declared for specific HTTP response codes. Use this field to cover undeclared responses. A [Reference Object](#reference-object) can link to a response that the [OpenAPI Object's components/responses](#componentsResponses) section defines.
 
 ##### Patterned Fields
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="responsesCode"></a>[HTTP Status Code](#httpCodes) | [Response Object](#responseObject) \| [Reference Object](#referenceObject) | Any [HTTP status code](#httpCodes) can be used as the property name, but only one property per code, to describe the expected response for that HTTP status code.  A [Reference Object](#referenceObject) can link to a response that is defined in the [OpenAPI Object's components/responses](#componentsResponses) section. This field MUST be enclosed in quotation marks (for example, "200") for compatibility between JSON and YAML. To define a range of response codes, this field MAY contain the uppercase wildcard character `X`. For example, `2XX` represents all response codes between `[200-299]`. The following range definitions are allowed: `1XX`, `2XX`, `3XX`, `4XX`, and `5XX`. If a response range is defined using an explicit code, the explicit code definition takes precedence over the range definition for that code.
+<a name="responsesCode"></a>[HTTP Status Code](#http-status-codes) | [Response Object](#response-object) \| [Reference Object](#reference-object) | Any [HTTP status code](#http-status-codes) can be used as the property name, but only one property per code, to describe the expected response for that HTTP status code.  A [Reference Object](#reference-object) can link to a response that is defined in the [OpenAPI Object's components/responses](#componentsResponses) section. This field MUST be enclosed in quotation marks (for example, "200") for compatibility between JSON and YAML. To define a range of response codes, this field MAY contain the uppercase wildcard character `X`. For example, `2XX` represents all response codes between `[200-299]`. The following range definitions are allowed: `1XX`, `2XX`, `3XX`, `4XX`, and `5XX`. If a response range is defined using an explicit code, the explicit code definition takes precedence over the range definition for that code.
 
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Responses Object Example
 
@@ -1663,7 +1663,7 @@ A 200 response for a successful operation and a default response for others (imp
 ```yaml
 '200':
   description: a pet to be returned
-  content: 
+  content:
     application/json:
       schema:
         $ref: '#/components/schemas/Pet'
@@ -1675,19 +1675,19 @@ default:
         $ref: '#/components/schemas/ErrorModel'
 ```
 
-#### <a name="responseObject"></a>Response Object
-Describes a single response from an API Operation, including design-time, static 
+#### Response Object
+Describes a single response from an API Operation, including design-time, static
 `links` to operations based on the response.
 
 ##### Fixed Fields
 Field Name | Type | Description
 ---|:---:|---
 <a name="responseDescription"></a>description | `string` | **REQUIRED**. A short description of the response. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="responseHeaders"></a>headers | Map[`string`, [Header Object](#headerObject)  \| [Reference Object](#referenceObject)] |  Maps a header name to its definition. [RFC7230](https://tools.ietf.org/html/rfc7230#page-22) states header names are case insensitive. If a response header is defined with the name `"Content-Type"`, it SHALL be ignored.
-<a name="responseContent"></a>content | Map[`string`, [Media Type Object](#mediaTypeObject)] | A map containing descriptions of potential response payloads. The key is a media type or [media type range](https://tools.ietf.org/html/rfc7231#appendix-D) and the value describes it.  For responses that match multiple keys, only the most specific key is applicable. e.g. text/plain overrides text/*
-<a name="responseLinks"></a>links | Map[`string`, [Link Object](#linkObject) \| [Reference Object](#referenceObject)] | A map of operations links that can be followed from the response. The key of the map is a short name for the link, following the naming constraints of the names for [Component Objects](#componentsObject). 
+<a name="responseHeaders"></a>headers | Map[`string`, [Header Object](#header-object)  \| [Reference Object](#reference-object)] |  Maps a header name to its definition. [RFC7230](https://tools.ietf.org/html/rfc7230#page-22) states header names are case insensitive. If a response header is defined with the name `"Content-Type"`, it SHALL be ignored.
+<a name="responseContent"></a>content | Map[`string`, [Media Type Object](#media-type-object)] | A map containing descriptions of potential response payloads. The key is a media type or [media type range](https://tools.ietf.org/html/rfc7231#appendix-D) and the value describes it.  For responses that match multiple keys, only the most specific key is applicable. e.g. text/plain overrides text/*
+<a name="responseLinks"></a>links | Map[`string`, [Link Object](#link-object) \| [Reference Object](#reference-object)] | A map of operations links that can be followed from the response. The key of the map is a short name for the link, following the naming constraints of the names for [Component Objects](#components-object).
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Response Object Examples
 
@@ -1711,9 +1711,9 @@ Response of an array of a complex type:
 
 ```yaml
 description: A complex object array response
-content: 
+content:
   application/json:
-    schema: 
+    schema:
       type: array
       items:
         $ref: '#/components/schemas/VeryComplexType'
@@ -1812,25 +1812,25 @@ Response with no return value:
 description: object created
 ```
 
-#### <a name="callbackObject"></a>Callback Object
+#### Callback Object
 
 A map of possible out-of band callbacks related to the parent operation.
-Each value in the map is a [Path Item Object](#pathItemObject) that describes a set of requests that may be initiated by the API provider and the expected responses.
+Each value in the map is a [Path Item Object](#path-item-object) that describes a set of requests that may be initiated by the API provider and the expected responses.
 The key value used to identify the callback object is an expression, evaluated at runtime, that identifies a URL to use for the callback operation.
 
 ##### Patterned Fields
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="callbackExpression"></a>{expression} | [Path Item Object](#pathItemObject) | A Path Item Object used to define a callback request and expected responses.  A [complete example](../examples/v3.0/callback-example.yaml) is available.
+<a name="callbackExpression"></a>{expression} | [Path Item Object](#path-item-object) | A Path Item Object used to define a callback request and expected responses.  A [complete example](../examples/v3.0/callback-example.yaml) is available.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Key Expression
 
-The key that identifies the [Path Item Object](#pathItemObject) is a [runtime expression](#runtimeExpression) that can be evaluated in the context of a runtime HTTP request/response to identify the URL to be used for the callback request.
+The key that identifies the [Path Item Object](#path-item-object) is a [runtime expression](#runtime-expressions) that can be evaluated in the context of a runtime HTTP request/response to identify the URL to be used for the callback request.
 A simple example might be `$request.body#/url`.
-However, using a [runtime expression](#runtimeExpression) the complete HTTP message can be accessed.
-This includes accessing any part of a body that a JSON Pointer [RFC6901](https://tools.ietf.org/html/rfc6901) can reference. 
+However, using a [runtime expression](#runtime-expressions) the complete HTTP message can be accessed.
+This includes accessing any part of a body that a JSON Pointer [RFC6901](https://tools.ietf.org/html/rfc6901) can reference.
 
 For example, given the following HTTP request:
 
@@ -1846,7 +1846,7 @@ Content-Length: 187
     "http://clientdomain.com/fast",
     "http://clientdomain.com/medium",
     "http://clientdomain.com/slow"
-  ] 
+  ]
 }
 
 201 Created
@@ -1855,7 +1855,7 @@ Location: http://example.org/subscription/1
 
 The following examples show how the various expressions evaluate, assuming the callback operation has a path parameter named `eventType` and a query parameter named `queryUrl`.
 
-Expression | Value 
+Expression | Value
 ---|:---
 $url | http://example.org/subscribe/myevent?queryUrl=http://clientdomain.com/stillrunning
 $method | POST
@@ -1877,7 +1877,7 @@ myWebhook:
     post:
       requestBody:
         description: Callback payload
-        content: 
+        content:
           'application/json':
             schema:
               $ref: '#/components/schemas/SomePayload'
@@ -1887,7 +1887,7 @@ myWebhook:
 ```
 
 
-#### <a name="exampleObject"></a>Example Object
+#### Example Object
 
 ##### Fixed Fields
 Field Name | Type | Description
@@ -1895,12 +1895,12 @@ Field Name | Type | Description
 <a name="exampleSummary"></a>summary | `string` | Short description for the example.
 <a name="exampleDescription"></a>description | `string` | Long description for the example. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
 <a name="exampleValue"></a>value | Any | Embedded literal example. The `value` field and `externalValue` field are mutually exclusive. To represent examples of media types that cannot naturally represented in JSON or YAML, use a string value to contain the example, escaping where necessary.
-<a name="exampleExternalValue"></a>externalValue | `string` | A URL that points to the literal example. This provides the capability to reference examples that cannot easily be included in JSON or YAML documents.  The `value` field and `externalValue` field are mutually exclusive. 
+<a name="exampleExternalValue"></a>externalValue | `string` | A URL that points to the literal example. This provides the capability to reference examples that cannot easily be included in JSON or YAML documents.  The `value` field and `externalValue` field are mutually exclusive.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
-In all cases, the example value is expected to be compatible with the type schema 
-of its associated value.  Tooling implementations MAY choose to 
+In all cases, the example value is expected to be compatible with the type schema
+of its associated value.  Tooling implementations MAY choose to
 validate compatibility automatically, and reject the example value(s) if incompatible.
 
 ##### Example Object Example
@@ -1921,7 +1921,7 @@ schemas:
       'application/json':
         schema:
           $ref: '#/components/schemas/Address'
-        examples: 
+        examples:
           foo:
             summary: A foo example
             value: {"foo": "bar"}
@@ -1929,15 +1929,15 @@ schemas:
             summary: A bar example
             value: {"bar": "baz"}
       'application/xml':
-        examples: 
+        examples:
           xmlExample:
             summary: This is an example in XML
             externalValue: 'http://example.org/examples/address-example.xml'
       'text/plain':
         examples:
-          textExample: 
+          textExample:
             summary: This is a text example
-            externalValue: 'http://foo.bar/examples/address-example.txt' 
+            externalValue: 'http://foo.bar/examples/address-example.txt'
 
 
 # in a parameter
@@ -1948,14 +1948,14 @@ schemas:
         type: 'string'
         format: 'zip-code'
         examples:
-          zip-example: 
+          zip-example:
             $ref: '#/components/examples/zip-example'
 
 # in a response
   responses:
     '200':
       description: your car appointment has been booked
-      content: 
+      content:
         application/json:
           schema:
             $ref: '#/components/schemas/SuccessResponse'
@@ -1965,31 +1965,31 @@ schemas:
 ```
 
 
-#### <a name="linkObject"></a>Link Object
+#### Link Object
 
 The `Link object` represents a possible design-time link for a response.
 The presence of a link does not guarantee the caller's ability to successfully invoke it, rather it provides a known relationship and traversal mechanism between responses and other operations.
 
 Unlike _dynamic_ links (i.e. links provided **in** the response payload), the OAS linking mechanism does not require link information in the runtime response.
 
-For computing links, and providing instructions to execute them, a [runtime expression](#runtimeExpression) is used for accessing values in an operation and using them as parameters while invoking the linked operation.  
+For computing links, and providing instructions to execute them, a [runtime expression](#runtime-expressions) is used for accessing values in an operation and using them as parameters while invoking the linked operation. 
 
 ##### Fixed Fields
 
 Field Name  |  Type  | Description
 ---|:---:|---
-<a name="linkOperationRef"></a>operationRef | `string` | A relative or absolute reference to an OAS operation. This field is mutually exclusive of the `operationId` field, and MUST point to an [Operation Object](#operationObject). Relative `operationRef` values MAY be used to locate an existing [Operation Object](#operationObject) in the OpenAPI definition.
-<a name="linkOperationId"></a>operationId  | `string` | The name of an _existing_, resolvable OAS operation, as defined with a unique `operationId`.  This field is mutually exclusive of the `operationRef` field.  
-<a name="linkParameters"></a>parameters   | Map[`string`, Any \| [{expression}](#runtimeExpression)] | A map representing parameters to pass to an operation as specified with `operationId` or identified via `operationRef`. The key is the parameter name to be used, whereas the value can be a constant or an expression to be evaluated and passed to the linked operation.  The parameter name can be qualified using the [parameter location](#parameterIn) `[{in}.]{name}` for operations that use the same parameter name in different locations (e.g. path.id).
-<a name="linkRequestBody"></a>requestBody | Any \| [{expression}](#runtimeExpression) | A literal value or [{expression}](#runtimeExpression) to use as a request body when calling the target operation.
+<a name="linkOperationRef"></a>operationRef | `string` | A relative or absolute reference to an OAS operation. This field is mutually exclusive of the `operationId` field, and MUST point to an [Operation Object](#operation-object). Relative `operationRef` values MAY be used to locate an existing [Operation Object](#operation-object) in the OpenAPI definition.
+<a name="linkOperationId"></a>operationId  | `string` | The name of an _existing_, resolvable OAS operation, as defined with a unique `operationId`.  This field is mutually exclusive of the `operationRef` field. 
+<a name="linkParameters"></a>parameters   | Map[`string`, Any \| [{expression}](#runtime-expressions)] | A map representing parameters to pass to an operation as specified with `operationId` or identified via `operationRef`. The key is the parameter name to be used, whereas the value can be a constant or an expression to be evaluated and passed to the linked operation.  The parameter name can be qualified using the [parameter location](#parameterIn) `[{in}.]{name}` for operations that use the same parameter name in different locations (e.g. path.id).
+<a name="linkRequestBody"></a>requestBody | Any \| [{expression}](#runtime-expressions) | A literal value or [{expression}](#runtime-expressions) to use as a request body when calling the target operation.
 <a name="linkDescription"></a>description  | `string` | A description of the link. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="linkServer"></a>server       | [Server Object](#serverObject) | A server object to be used by the target operation.
+<a name="linkServer"></a>server       | [Server Object](#server-object) | A server object to be used by the target operation.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 A linked operation MUST be identified using either an `operationRef` or `operationId`.
 In the case of an `operationId`, it MUST be unique and resolved in the scope of the OAS document.
-Because of the potential for name clashes, the `operationRef` syntax is preferred 
+Because of the potential for name clashes, the `operationRef` syntax is preferred
 for specifications with external references.
 
 ##### Examples
@@ -2003,7 +2003,7 @@ paths:
     - name: id
       in: path
       required: true
-      description: the user identifier, as userId 
+      description: the user identifier, as userId
       schema:
         type: string
     get:
@@ -2031,7 +2031,7 @@ paths:
     - name: userid
       in: path
       required: true
-      description: the user identifier, as userId 
+      description: the user identifier, as userId
       schema:
         type: string
     # linked operation
@@ -2055,14 +2055,14 @@ links:
       userUuid: $response.body#/uuid
 ```
 
-Clients follow all links at their discretion. 
-Neither permissions, nor the capability to make a successful call to that link, is guaranteed 
+Clients follow all links at their discretion.
+Neither permissions, nor the capability to make a successful call to that link, is guaranteed
 solely by the existence of a relationship.
 
 
 ##### OperationRef Examples
 
-As references to `operationId` MAY NOT be possible (the `operationId` is an optional 
+As references to `operationId` MAY NOT be possible (the `operationId` is an optional
 value), references MAY also be made through a relative `operationRef`:
 
 ```yaml
@@ -2085,52 +2085,52 @@ links:
       username: $response.body#/username
 ```
 
-Note that in the use of `operationRef`, the _escaped forward-slash_ is necessary when 
+Note that in the use of `operationRef`, the _escaped forward-slash_ is necessary when
 using JSON references.
 
 
-##### <a name="runtimeExpression"></a>Runtime Expressions
+##### Runtime Expressions
 
 Runtime expressions allow defining values based on information that will only be available within the HTTP message in an actual API call.
-This mechanism is used by [Link Objects](#linkObject) and [Callback Objects](#callbackObject).
+This mechanism is used by [Link Objects](#link-object) and [Callback Objects](#callback-object).
 
 The runtime expression is defined by the following [ABNF](https://tools.ietf.org/html/rfc5234) syntax
 
 ```
       expression = ( "$url" | "$method" | "$statusCode" | "$request." source | "$response." source )
-      source = ( header-reference | query-reference | path-reference | body-reference )  
+      source = ( header-reference | query-reference | path-reference | body-reference ) 
       header-reference = "header." token
-      query-reference = "query." name  
+      query-reference = "query." name 
       path-reference = "path." name
       body-reference = "body" ["#" fragment]
-      fragment = a JSON Pointer [RFC 6901](https://tools.ietf.org/html/rfc6901)  
+      fragment = a JSON Pointer [RFC 6901](https://tools.ietf.org/html/rfc6901) 
       name = *( char )
       char = as per RFC [7159](https://tools.ietf.org/html/rfc7159#section-7)
       token = as per RFC [7230](https://tools.ietf.org/html/rfc7230#section-3.2.6)
 ```
 
-The `name` identifier is case-sensitive, whereas `token` is not. 
+The `name` identifier is case-sensitive, whereas `token` is not.
 
 The table below provides examples of runtime expressions and examples of their use in a value:
 
-##### <a name="runtimeExpressionExamples"></a>Examples
+##### Examples
 
 Source Location | example expression  | notes
 ---|:---|:---|
 HTTP Method            | `$method`         | The allowable values for the `$method` will be those for the HTTP operation.
-Requested media type | `$request.header.accept`        |  
+Requested media type | `$request.header.accept`        | 
 Request parameter      | `$request.path.id`        | Request parameters MUST be declared in the `parameters` section of the parent operation or they cannot be evaluated. This includes request headers.
 Request body property   | `$request.body#/user/uuid`   | In operations which accept payloads, references may be made to portions of the `requestBody` or the entire body.
-Request URL            | `$url`            |  
+Request URL            | `$url`            | 
 Response value         | `$response.body#/status`       |  In operations which return payloads, references may be made to portions of the response body or the entire body.
 Response header        | `$response.header.Server` |  Single header values only are available
 
 Runtime expressions preserve the type of the referenced value.
 Expressions can be embedded into string values by surrounding the expression with `{}` curly braces.
 
-#### <a name="headerObject"></a>Header Object
+#### Header Object
 
-The Header Object follows the structure of the [Parameter Object](#parameterObject) with the following changes:
+The Header Object follows the structure of the [Parameter Object](#parameter-object) with the following changes:
 
 1. `name` MUST NOT be specified, it is given in the corresponding `headers` map.
 1. `in` MUST NOT be specified, it is implicitly in `header`.
@@ -2155,9 +2155,9 @@ schema:
   type: integer
 ```
 
-#### <a name="tagObject"></a>Tag Object
+#### Tag Object
 
-Adds metadata to a single tag that is used by the [Operation Object](#operationObject).
+Adds metadata to a single tag that is used by the [Operation Object](#operation-object).
 It is not mandatory to have a Tag Object per tag defined in the Operation Object instances.
 
 ##### Fixed Fields
@@ -2165,9 +2165,9 @@ Field Name | Type | Description
 ---|:---:|---
 <a name="tagName"></a>name | `string` | **REQUIRED**. The name of the tag.
 <a name="tagDescription"></a>description | `string` | A short description for the tag. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="tagExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation for this tag.
+<a name="tagExternalDocs"></a>externalDocs | [External Documentation Object](#external-documentation-object) | Additional external documentation for this tag.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Tag Object Example
 
@@ -2184,11 +2184,11 @@ description: Pets operations
 ```
 
 
-#### <a name="referenceObject"></a>Reference Object
+#### Reference Object
 
 A simple object to allow referencing other components in the specification, internally and externally.
 
-The Reference Object is defined by [JSON Reference](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03) and follows the same structure, behavior and rules. 
+The Reference Object is defined by [JSON Reference](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03) and follows the same structure, behavior and rules.
 
 For this specification, reference resolution is accomplished as defined by the JSON Reference specification and not by the JSON Schema specification.
 
@@ -2233,7 +2233,7 @@ $ref: Pet.yaml
 $ref: definitions.yaml#/Pet
 ```
 
-#### <a name="schemaObject"></a>Schema Object
+#### Schema Object
 
 The Schema Object allows the definition of input and output data types.
 These types can be objects, but also primitives and arrays.
@@ -2242,7 +2242,7 @@ This object is an extended subset of the [JSON Schema Specification Wright Draft
 For more information about the properties, see [JSON Schema Core](https://tools.ietf.org/html/draft-wright-json-schema-00) and [JSON Schema Validation](https://tools.ietf.org/html/draft-wright-json-schema-validation-00).
 Unless stated otherwise, the property definitions follow the JSON Schema.
 
-##### Properties 
+##### Properties
 
 The following properties are taken directly from the JSON Schema definition and follow the same specifications:
 
@@ -2263,20 +2263,20 @@ The following properties are taken directly from the JSON Schema definition and 
 - required
 - enum
 
-The following properties are taken from the JSON Schema definition but their definitions were adjusted to the OpenAPI Specification. 
+The following properties are taken from the JSON Schema definition but their definitions were adjusted to the OpenAPI Specification.
 - type - Value MUST be a string. Multiple types via an array are not supported.
-- allOf - Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard JSON Schema.
-- oneOf - Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard JSON Schema.
-- anyOf - Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard JSON Schema.
-- not - Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard JSON Schema.
-- items - Value MUST be an object and not an array. Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard JSON Schema. `items` MUST be present if the `type` is `array`.
-- properties - Property definitions MUST be a [Schema Object](#schemaObject) and not a standard JSON Schema (inline or referenced).
-- additionalProperties - Value can be boolean or object. Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard JSON Schema.
+- allOf - Inline or referenced schema MUST be of a [Schema Object](#schema-object) and not a standard JSON Schema.
+- oneOf - Inline or referenced schema MUST be of a [Schema Object](#schema-object) and not a standard JSON Schema.
+- anyOf - Inline or referenced schema MUST be of a [Schema Object](#schema-object) and not a standard JSON Schema.
+- not - Inline or referenced schema MUST be of a [Schema Object](#schema-object) and not a standard JSON Schema.
+- items - Value MUST be an object and not an array. Inline or referenced schema MUST be of a [Schema Object](#schema-object) and not a standard JSON Schema. `items` MUST be present if the `type` is `array`.
+- properties - Property definitions MUST be a [Schema Object](#schema-object) and not a standard JSON Schema (inline or referenced).
+- additionalProperties - Value can be boolean or object. Inline or referenced schema MUST be of a [Schema Object](#schema-object) and not a standard JSON Schema.
 - description - [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
 - format - See [Data Type Formats](#dataTypeFormat) for further details. While relying on JSON Schema's defined formats, the OAS offers a few additional predefined formats.
 - default - The default value represents what would be assumed by the consumer of the input as the value of the schema if one is not provided. Unlike JSON Schema, the value MUST conform to the defined type for the Schema Object defined at the same level. For example, if `type` is `string`, then `default` can be `"foo"` but cannot be `1`.
 
-Alternatively, any time a Schema Object can be used, a [Reference Object](#referenceObject) can be used in its place. This allows referencing definitions instead of defining them inline.
+Alternatively, any time a Schema Object can be used, a [Reference Object](#reference-object) can be used in its place. This allows referencing definitions instead of defining them inline.
 
 Additional properties defined by the JSON Schema specification that are not mentioned here are strictly unsupported.
 
@@ -2286,20 +2286,20 @@ Other than the JSON Schema subset fields, the following fields MAY be used for f
 Field Name | Type | Description
 ---|:---:|---
 <a name="schemaNullable"></a>nullable | `boolean` | Allows sending a `null` value for the defined schema. Default value is `false`.
-<a name="schemaDiscriminator"></a>discriminator | [Discriminator Object](#discriminatorObject) | Adds support for polymorphism. The discriminator is an object name that is used to differentiate between other schemas which may satisfy the payload description. See [Composition and Inheritance](#schemaComposition) for more details.
+<a name="schemaDiscriminator"></a>discriminator | [Discriminator Object](#discriminator-object) | Adds support for polymorphism. The discriminator is an object name that is used to differentiate between other schemas which may satisfy the payload description. See [Composition and Inheritance](#composition-and-inheritance-polymorphism) for more details.
 <a name="schemaReadOnly"></a>readOnly | `boolean` | Relevant only for Schema `"properties"` definitions. Declares the property as "read only". This means that it MAY be sent as part of a response but SHOULD NOT be sent as part of the request. If the property is marked as `readOnly` being `true` and is in the `required` list, the `required` will take effect on the response only. A property MUST NOT be marked as both `readOnly` and `writeOnly` being `true`. Default value is `false`.
 <a name="schemaWriteOnly"></a>writeOnly | `boolean` | Relevant only for Schema `"properties"` definitions. Declares the property as "write only". Therefore, it MAY be sent as part of a request but SHOULD NOT be sent as part of the response. If the property is marked as `writeOnly` being `true` and is in the `required` list, the `required` will take effect on the request only. A property MUST NOT be marked as both `readOnly` and `writeOnly` being `true`. Default value is `false`.
-<a name="schemaXml"></a>xml | [XML Object](#xmlObject) | This MAY be used only on properties schemas. It has no effect on root schemas. Adds additional metadata to describe the XML representation of this property.
-<a name="schemaExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation for this schema. 
+<a name="schemaXml"></a>xml | [XML Object](#xml-object) | This MAY be used only on properties schemas. It has no effect on root schemas. Adds additional metadata to describe the XML representation of this property.
+<a name="schemaExternalDocs"></a>externalDocs | [External Documentation Object](#external-documentation-object) | Additional external documentation for this schema.
 <a name="schemaExample"></a>example | Any | A free-form property to include an example of an instance for this schema. To represent examples that cannot be naturally represented in JSON or YAML, a string value can be used to contain the example with escaping where necessary.
 <a name="schemaDeprecated"></a> deprecated | `boolean` | Specifies that a schema is deprecated and SHOULD be transitioned out of usage. Default value is `false`.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
-###### <a name="schemaComposition"></a>Composition and Inheritance (Polymorphism)
+###### Composition and Inheritance (Polymorphism)
 
 The OpenAPI Specification allows combining and extending model definitions using the `allOf` property of JSON Schema, in effect offering model composition.
-`allOf` takes an array of object definitions that are validated *independently* but together compose a single object. 
+`allOf` takes an array of object definitions that are validated *independently* but together compose a single object.
 
 While composition offers model extensibility, it does not imply a hierarchy between the models.
 To support polymorphism, the OpenAPI Specification adds the `discriminator` field.
@@ -2313,7 +2313,7 @@ As such, inline schema definitions, which do not have a given id, *cannot* be us
 ###### XML Modeling
 
 The [xml](#schemaXml) property allows extra definitions when translating the JSON definition to XML.
-The [XML Object](#xmlObject) contains additional information about the available options.
+The [XML Object](#xml-object) contains additional information about the available options.
 
 ##### Schema Object Examples
 
@@ -2643,7 +2643,7 @@ components:
         - packSize
 ```
 
-#### <a name="discriminatorObject"></a>Discriminator Object
+#### Discriminator Object
 
 When request bodies or response payloads may be one of a number of different schemas, a `discriminator` object can be used to aid in serialization, deserialization, and validation.  The discriminator is a specific object in a schema which is used to inform the consumer of the specification of an alternative schema based on the value associated with it.
 
@@ -2776,7 +2776,7 @@ will indicate that the `Cat` schema be used.  Likewise this schema:
 will map to `Dog` because of the definition in the `mappings` element.
 
 
-#### <a name="xmlObject"></a>XML Object
+#### XML Object
 
 A metadata object that allows for more fine-tuned XML model definitions.
 
@@ -2792,11 +2792,11 @@ Field Name | Type | Description
 <a name="xmlAttribute"></a>attribute | `boolean` | Declares whether the property definition translates to an attribute instead of an element. Default value is `false`.
 <a name="xmlWrapped"></a>wrapped | `boolean` | MAY be used only for an array definition. Signifies whether the array is wrapped (for example, `<books><book/><book/></books>`) or unwrapped (`<book/><book/>`). Default value is `false`. The definition takes effect only when defined alongside `type` being `array` (outside the `items`).
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### XML Object Examples
 
-The examples of the XML object definitions are included inside a property definition of a [Schema Object](#schemaObject) with a sample of the XML representation of it.
+The examples of the XML object definitions are included inside a property definition of a [Schema Object](#schema-object) with a sample of the XML representation of it.
 
 ###### No XML Element
 
@@ -3129,7 +3129,7 @@ animals:
 </aliens>
 ```
 
-#### <a name="securitySchemeObject"></a>Security Scheme Object
+#### Security Scheme Object
 
 Defines a security scheme that can be used by the operations.
 Supported schemes are HTTP authentication, an API key (either as a header or as a query parameter), OAuth2's common flows (implicit, password, application and access code) as defined in [RFC6749](https://tools.ietf.org/html/rfc6749), and [OpenID Connect Discovery](https://tools.ietf.org/html/draft-ietf-oauth-discovery-06).
@@ -3143,10 +3143,10 @@ Field Name | Type | Applies To | Description
 <a name="securitySchemeIn"></a>in | `string` | `apiKey` | **REQUIRED**. The location of the API key. Valid values are `"query"`, `"header"` or `"cookie"`.
 <a name="securitySchemeScheme"></a>scheme | `string` | `http` | **REQUIRED**. The name of the HTTP Authorization scheme to be used in the [Authorization header as defined in RFC7235](https://tools.ietf.org/html/rfc7235#section-5.1).
 <a name="securitySchemeBearerFormat"></a>bearerFormat | `string` | `http` (`"bearer"`) | A hint to the client to identify how the bearer token is formatted.  Bearer tokens are usually generated by an authorization server, so this information is primarily for documentation purposes.
-<a name="securitySchemeFlows"></a>flows | [OAuth Flows Object](#oauthFlowsObject) | `oauth2` | **REQUIRED**. An object containing configuration information for the flow types supported.
+<a name="securitySchemeFlows"></a>flows | [OAuth Flows Object](#oauth-flows-object) | `oauth2` | **REQUIRED**. An object containing configuration information for the flow types supported.
 <a name="securitySchemeOpenIdConnectUrl"></a>openIdConnectUrl | `string` | `openIdConnect` | **REQUIRED**. OpenId Connect URL to discover OAuth2 configuration values. This MUST be in the form of a URL.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Security Scheme Object Example
 
@@ -3215,7 +3215,7 @@ bearerFormat: JWT
 
 ```yaml
 type: oauth2
-flows: 
+flows:
   implicit:
     authorizationUrl: https://example.com/api/oauth/dialog
     scopes:
@@ -3223,21 +3223,21 @@ flows:
       read:pets: read your pets
 ```
 
-#### <a name="oauthFlowsObject"></a>OAuth Flows Object
+#### OAuth Flows Object
 
 Allows configuration of the supported OAuth Flows.
 
 ##### Fixed Fields
 Field Name | Type | Description
 ---|:---:|---
-<a name="oauthFlowsImplicit"></a>implicit| [OAuth Flow Object](#oauthFlowObject) | Configuration for the OAuth Implicit flow 
-<a name="oauthFlowsPassword"></a>password| [OAuth Flow Object](#oauthFlowObject) | Configuration for the OAuth Resource Owner Password flow 
-<a name="oauthFlowsClientCredentials"></a>clientCredentials| [OAuth Flow Object](#oauthFlowObject) | Configuration for the OAuth Client Credentials flow.  Previously called `application` in OpenAPI 2.0.
-<a name="oauthFlowsAuthorizationCode"></a>authorizationCode| [OAuth Flow Object](#oauthFlowObject) | Configuration for the OAuth Authorization Code flow.  Previously called `accessCode` in OpenAPI 2.0.
+<a name="oauthFlowsImplicit"></a>implicit| [OAuth Flow Object](#oauth-flow-object) | Configuration for the OAuth Implicit flow
+<a name="oauthFlowsPassword"></a>password| [OAuth Flow Object](#oauth-flow-object) | Configuration for the OAuth Resource Owner Password flow
+<a name="oauthFlowsClientCredentials"></a>clientCredentials| [OAuth Flow Object](#oauth-flow-object) | Configuration for the OAuth Client Credentials flow.  Previously called `application` in OpenAPI 2.0.
+<a name="oauthFlowsAuthorizationCode"></a>authorizationCode| [OAuth Flow Object](#oauth-flow-object) | Configuration for the OAuth Authorization Code flow.  Previously called `accessCode` in OpenAPI 2.0.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
-#### <a name="oauthFlowObject"></a>OAuth Flow Object
+#### OAuth Flow Object
 
 Configuration details for a supported OAuth Flow
 
@@ -3249,7 +3249,7 @@ Field Name | Type | Applies To | Description
 <a name="oauthFlowRefreshUrl"></a>refreshUrl | `string` | `oauth2` | The URL to be used for obtaining refresh tokens. This MUST be in the form of a URL.
 <a name="oauthFlowScopes"></a>scopes | Map[`string`, `string`] | `oauth2` | **REQUIRED**. The available scopes for the OAuth2 security scheme. A map between the scope name and a short description for it.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### OAuth Flow Object Examples
 
@@ -3278,7 +3278,7 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
 
 ```YAML
 type: oauth2
-flows: 
+flows:
   implicit:
     authorizationUrl: https://example.com/api/oauth/dialog
     scopes:
@@ -3289,25 +3289,25 @@ flows:
     tokenUrl: https://example.com/api/oauth/token
     scopes:
       write:pets: modify pets in your account
-      read:pets: read your pets 
+      read:pets: read your pets
 ```
 
 
-#### <a name="securityRequirementObject"></a>Security Requirement Object
+#### Security Requirement Object
 
 Lists the required security schemes to execute this operation.
-The name used for each property MUST correspond to a security scheme declared in the [Security Schemes](#componentsSecuritySchemes) under the [Components Object](#componentsObject).
+The name used for each property MUST correspond to a security scheme declared in the [Security Schemes](#componentsSecuritySchemes) under the [Components Object](#components-object).
 
 Security Requirement Objects that contain multiple schemes require that all schemes MUST be satisfied for a request to be authorized.
 This enables support for scenarios where multiple query parameters or HTTP headers are required to convey security information.
 
-When a list of Security Requirement Objects is defined on the [Open API object](#oasObject) or [Operation Object](#operationObject), only one of Security Requirement Objects in the list needs to be satisfied to authorize the request.  
+When a list of Security Requirement Objects is defined on the [Open API object](#openapi-object) or [Operation Object](#operation-object), only one of Security Requirement Objects in the list needs to be satisfied to authorize the request. 
 
 ##### Patterned Fields
 
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="securityRequirementsName"></a>{name} | [`string`] | Each name MUST correspond to a security scheme which is declared in the [Security Schemes](#componentsSecuritySchemes) under the [Components Object](#componentsObject). If the security scheme is of type `"oauth2"` or `"openIdConnect"`, then the value is a list of scope names required for the execution. For other security scheme types, the array MUST be empty.
+<a name="securityRequirementsName"></a>{name} | [`string`] | Each name MUST correspond to a security scheme which is declared in the [Security Schemes](#componentsSecuritySchemes) under the [Components Object](#components-object). If the security scheme is of type `"oauth2"` or `"openIdConnect"`, then the value is a list of scope names required for the execution. For other security scheme types, the array MUST be empty.
 
 ##### Security Requirement Object Examples
 
@@ -3340,7 +3340,7 @@ petstore_auth:
 - read:pets
 ```
 
-### <a name="specificationExtensions"></a>Specification Extensions
+### Specification Extensions
 
 While the OpenAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.
 
@@ -3352,19 +3352,19 @@ Field Pattern | Type | Description
 
 The extensions may or may not be supported by the available tooling, but those may be extended as well to add requested support (if tools are internal or open-sourced).
 
-### <a name="securityFiltering"></a>Security Filtering
+### Security Filtering
 
-Some objects in the OpenAPI Specification MAY be declared and remain empty, or be completely removed, even though they are inherently the core of the API documentation. 
+Some objects in the OpenAPI Specification MAY be declared and remain empty, or be completely removed, even though they are inherently the core of the API documentation.
 
 The reasoning is to allow an additional layer of access control over the documentation.
 While not part of the specification itself, certain libraries MAY choose to allow access to parts of the documentation based on some form of authentication/authorization.
 
 Two examples of this:
 
-1. The [Paths Object](#pathsObject) MAY be empty. It may be counterintuitive, but this may tell the viewer that they got to the right place, but can't access any documentation. They'd still have access to the [Info Object](#infoObject) which may contain additional information regarding authentication.
-2. The [Path Item Object](#pathItemObject) MAY be empty. In this case, the viewer will be aware that the path exists, but will not be able to see any of its operations or parameters. This is different than hiding the path itself from the [Paths Object](#pathsObject), so the user will not be aware of its existence. This allows the documentation provider to finely control what the viewer can see.
+1. The [Paths Object](#paths-object) MAY be empty. It may be counterintuitive, but this may tell the viewer that they got to the right place, but can't access any documentation. They'd still have access to the [Info Object](#info-object) which may contain additional information regarding authentication.
+2. The [Path Item Object](#path-item-object) MAY be empty. In this case, the viewer will be aware that the path exists, but will not be able to see any of its operations or parameters. This is different than hiding the path itself from the [Paths Object](#paths-object), so the user will not be aware of its existence. This allows the documentation provider to finely control what the viewer can see.
 
-## <a name="revisionHistory"></a>Appendix A: Revision History
+## Appendix A: Revision History
 
 Version   | Date       | Notes
 ---       | ---        | ---

--- a/versions/3.0.2.md
+++ b/versions/3.0.2.md
@@ -16,64 +16,64 @@ An OpenAPI definition can then be used by documentation generation tools to disp
 <!-- TOC depthFrom:1 depthTo:3 withLinks:1 updateOnSave:1 orderedList:0 -->
 
 - [Definitions](#definitions)
-	- [OpenAPI Document](#oasDocument)
-	- [Path Templating](#pathTemplating)
-	- [Media Types](#mediaTypes)
-	- [HTTP Status Codes](#httpCodes)
+	- [OpenAPI Document](#openapi-document)
+	- [Path Templating](#path-templating)
+	- [Media Types](#media-types)
+	- [HTTP Status Codes](#http-status-codes)
 - [Specification](#specification)
 	- [Versions](#versions)
 	- [Format](#format)
-	- [Document Structure](#documentStructure)
-	- [Data Types](#dataTypes)
-	- [Rich Text Formatting](#richText)
-	- [Relative References In URLs](#relativeReferences)
+	- [Document Structure](#document-structure)
+	- [Data Types](#data-types)
+	- [Rich Text Formatting](#rich-text-formatting)
+	- [Relative References In URLs](#relative-references-in-urls)
 	- [Schema](#schema)
-		- [OpenAPI Object](#oasObject)
-		- [Info Object](#infoObject)
-		- [Contact Object](#contactObject)
-		- [License Object](#licenseObject)
-		- [Server Object](#serverObject)
-		- [Server Variable Object](#serverVariableObject)
-		- [Components Object](#componentsObject)
-		- [Paths Object](#pathsObject)
-		- [Path Item Object](#pathItemObject)
-		- [Operation Object](#operationObject)
-		- [External Documentation Object](#externalDocumentationObject)
-		- [Parameter Object](#parameterObject)
-		- [Request Body Object](#requestBodyObject)
-		- [Media Type Object](#mediaTypeObject)
-		- [Encoding Object](#encodingObject)
-		- [Responses Object](#responsesObject)
-		- [Response Object](#responseObject)
-		- [Callback Object](#callbackObject)
-		- [Example Object](#exampleObject)
-		- [Link Object](#linkObject)
-		- [Header Object](#headerObject)
-		- [Tag Object](#tagObject)
-		- [Reference Object](#referenceObject)
-		- [Schema Object](#schemaObject)
-		- [Discriminator Object](#discriminatorObject)
-		- [XML Object](#xmlObject)
-		- [Security Scheme Object](#securitySchemeObject)
-		- [OAuth Flows Object](#oauthFlowsObject)
-		- [OAuth Flow Object](#oauthFlowObject)
-		- [Security Requirement Object](#securityRequirementObject)
-	- [Specification Extensions](#specificationExtensions)
-	- [Security Filtering](#securityFiltering)
-- [Appendix A: Revision History](#revisionHistory)
+		- [OpenAPI Object](#openapi-object)
+		- [Info Object](#info-object)
+		- [Contact Object](#contact-object)
+		- [License Object](#license-object)
+		- [Server Object](#server-object)
+		- [Server Variable Object](#server-variable-object)
+		- [Components Object](#components-object)
+		- [Paths Object](#paths-object)
+		- [Path Item Object](#path-item-object)
+		- [Operation Object](#operation-object)
+		- [External Documentation Object](#external-documentation-object)
+		- [Parameter Object](#parameter-object)
+		- [Request Body Object](#request-body-object)
+		- [Media Type Object](#media-type-object)
+		- [Encoding Object](#encoding-object)
+		- [Responses Object](#responses-object)
+		- [Response Object](#response-object)
+		- [Callback Object](#callback-object)
+		- [Example Object](#example-object)
+		- [Link Object](#link-object)
+		- [Header Object](#header-object)
+		- [Tag Object](#tag-object)
+		- [Reference Object](#reference-object)
+		- [Schema Object](#schema-object)
+		- [Discriminator Object](#discriminator-object)
+		- [XML Object](#xml-object)
+		- [Security Scheme Object](#security-scheme-object)
+		- [OAuth Flows Object](#oauth-flows-object)
+		- [OAuth Flow Object](#oauth-flow-object)
+		- [Security Requirement Object](#security-requirement-object)
+	- [Specification Extensions](#specification-extensions)
+	- [Security Filtering](#security-filtering)
+- [Appendix A: Revision History](#appendix-a-revision-history)
 	
 
 <!-- /TOC -->
 
 ## Definitions
 
-##### <a name="oasDocument"></a>OpenAPI Document
+##### OpenAPI Document
 A document (or set of documents) that defines or describes an API. An OpenAPI definition uses and conforms to the OpenAPI Specification.
 
-##### <a name="pathTemplating"></a>Path Templating
+##### Path Templating
 Path templating refers to the usage of curly braces ({}) to mark a section of a URL path as replaceable using path parameters.
 
-##### <a name="mediaTypes"></a>Media Types
+##### Media Types
 Media type definitions are spread across several resources.
 The media type definitions SHOULD be in compliance with [RFC6838](https://tools.ietf.org/html/rfc6838).
 
@@ -90,8 +90,8 @@ Some examples of possible media type definitions:
   application/vnd.github.v3.diff
   application/vnd.github.v3.patch
 ```
-##### <a name="httpCodes"></a>HTTP Status Codes
-The HTTP Status Codes are used to indicate the status of the executed operation. 
+##### HTTP Status Codes
+The HTTP Status Codes are used to indicate the status of the executed operation.
 The available status codes are defined by [RFC7231](https://tools.ietf.org/html/rfc7231#section-6) and registered status codes are listed in the [IANA Status Code Registry](https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml).
 
 ## Specification
@@ -122,7 +122,7 @@ This includes all fields that are used as keys in a map, except where explicitly
 
 The schema exposes two types of fields: Fixed fields, which have a declared name, and Patterned fields, which declare a regex pattern for the field name.
 
-Patterned fields MUST have unique names within the containing object. 
+Patterned fields MUST have unique names within the containing object.
 
 In order to preserve the ability to round-trip between YAML and JSON formats, YAML version [1.2](http://www.yaml.org/spec/1.2/spec.html) is RECOMMENDED along with some additional constraints:
 
@@ -131,18 +131,18 @@ In order to preserve the ability to round-trip between YAML and JSON formats, YA
 
 **Note:** While APIs may be defined by OpenAPI documents in either YAML or JSON format, the API request and response bodies and other content are not required to be JSON or YAML.
 
-### <a name="documentStructure"></a>Document Structure
+### Document Structure
 
 An OpenAPI document MAY be made up of a single document or be divided into multiple, connected parts at the discretion of the user. In the latter case, `$ref` fields MUST be used in the specification to reference those parts as follows from the [JSON Schema](http://json-schema.org) definitions.
 
 It is RECOMMENDED that the root OpenAPI document be named: `openapi.json` or `openapi.yaml`.
 
-### <a name="dataTypes"></a>Data Types
+### Data Types
 
-Primitive data types in the OAS are based on the types supported by the [JSON Schema Specification Wright Draft 00](https://tools.ietf.org/html/draft-wright-json-schema-00#section-4.2). 
-Note that `integer` as a type is also supported and is defined as a JSON number without a fraction or exponent part. 
+Primitive data types in the OAS are based on the types supported by the [JSON Schema Specification Wright Draft 00](https://tools.ietf.org/html/draft-wright-json-schema-00#section-4.2).
+Note that `integer` as a type is also supported and is defined as a JSON number without a fraction or exponent part.
 `null` is not supported as a type (see [`nullable`](#schemaNullable) for an alternative solution).
-Models are defined using the [Schema Object](#schemaObject), which is an extended subset of JSON Schema Specification Wright Draft 00.
+Models are defined using the [Schema Object](#schema-object), which is an extended subset of JSON Schema Specification Wright Draft 00.
 
 <a name="dataTypeFormat"></a>Primitives have an optional modifier property: `format`.
 OAS uses several known formats to define in fine detail the data type being used.
@@ -152,7 +152,7 @@ Types that are not accompanied by a `format` property follow the type definition
 
 The formats defined by the OAS are:
 
-[`type`](#dataTypes) | [`format`](#dataTypeFormat) | Comments
+[`type`](#data-types) | [`format`](#dataTypeFormat) | Comments
 ------ | -------- | --------
 `integer` | `int32` | signed 32 bits
 `integer` | `int64` | signed 64 bits (a.k.a long)
@@ -167,41 +167,41 @@ The formats defined by the OAS are:
 `string` | `password` | A hint to UIs to obscure input.
 
 
-### <a name="richText"></a>Rich Text Formatting
+### Rich Text Formatting
 Throughout the specification `description` fields are noted as supporting CommonMark markdown formatting.
-Where OpenAPI tooling renders rich text it MUST support, at a minimum, markdown syntax as described by [CommonMark 0.27](http://spec.commonmark.org/0.27/). Tooling MAY choose to ignore some CommonMark features to address security concerns. 
+Where OpenAPI tooling renders rich text it MUST support, at a minimum, markdown syntax as described by [CommonMark 0.27](http://spec.commonmark.org/0.27/). Tooling MAY choose to ignore some CommonMark features to address security concerns.
 
-### <a name="relativeReferences"></a>Relative References in URLs
+### Relative References in URLs
 
 Unless specified otherwise, all properties that are URLs MAY be relative references as defined by [RFC3986](https://tools.ietf.org/html/rfc3986#section-4.2).
-Relative references are resolved using the URLs defined in the [`Server Object`](#serverObject) as a Base URI.
+Relative references are resolved using the URLs defined in the [`Server Object`](#server-object) as a Base URI.
 
-Relative references used in `$ref` are processed as per [JSON Reference](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03), using the URL of the current document as the base URI. See also the [Reference Object](#referenceObject).
+Relative references used in `$ref` are processed as per [JSON Reference](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03), using the URL of the current document as the base URI. See also the [Reference Object](#reference-object).
 
 ### Schema
 
 In the following description, if a field is not explicitly **REQUIRED** or described with a MUST or SHALL, it can be considered OPTIONAL.
 
-#### <a name="oasObject"></a>OpenAPI Object
+#### OpenAPI Object
 
-This is the root document object of the [OpenAPI document](#oasDocument).
+This is the root document object of the [OpenAPI document](#openapi-document).
 
 ##### Fixed Fields
 
 Field Name | Type | Description
 ---|:---:|---
 <a name="oasVersion"></a>openapi | `string` | **REQUIRED**. This string MUST be the [semantic version number](https://semver.org/spec/v2.0.0.html) of the [OpenAPI Specification version](#versions) that the OpenAPI document uses. The `openapi` field SHOULD be used by tooling specifications and clients to interpret the OpenAPI document. This is *not* related to the API [`info.version`](#infoVersion) string.
-<a name="oasInfo"></a>info | [Info Object](#infoObject) | **REQUIRED**. Provides metadata about the API. The metadata MAY be used by tooling as required.
-<a name="oasServers"></a>servers | [[Server Object](#serverObject)] | An array of Server Objects, which provide connectivity information to a target server. If the `servers` property is not provided, or is an empty array, the default value would be a [Server Object](#serverObject) with a [url](#serverUrl) value of `/`.
-<a name="oasPaths"></a>paths | [Paths Object](#pathsObject) | **REQUIRED**. The available paths and operations for the API.
-<a name="oasComponents"></a>components | [Components Object](#componentsObject) | An element to hold various schemas for the specification.
-<a name="oasSecurity"></a>security | [[Security Requirement Object](#securityRequirementObject)] | A declaration of which security mechanisms can be used across the API. The list of values includes alternative security requirement objects that can be used. Only one of the security requirement objects need to be satisfied to authorize a request. Individual operations can override this definition.
-<a name="oasTags"></a>tags | [[Tag Object](#tagObject)] | A list of tags used by the specification with additional metadata. The order of the tags can be used to reflect on their order by the parsing tools. Not all tags that are used by the [Operation Object](#operationObject) must be declared. The tags that are not declared MAY be organized randomly or based on the tools' logic. Each tag name in the list MUST be unique.
-<a name="oasExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation.
+<a name="oasInfo"></a>info | [Info Object](#info-object) | **REQUIRED**. Provides metadata about the API. The metadata MAY be used by tooling as required.
+<a name="oasServers"></a>servers | [[Server Object](#server-object)] | An array of Server Objects, which provide connectivity information to a target server. If the `servers` property is not provided, or is an empty array, the default value would be a [Server Object](#server-object) with a [url](#serverUrl) value of `/`.
+<a name="oasPaths"></a>paths | [Paths Object](#paths-object) | **REQUIRED**. The available paths and operations for the API.
+<a name="oasComponents"></a>components | [Components Object](#components-object) | An element to hold various schemas for the specification.
+<a name="oasSecurity"></a>security | [[Security Requirement Object](#security-requirement-object)] | A declaration of which security mechanisms can be used across the API. The list of values includes alternative security requirement objects that can be used. Only one of the security requirement objects need to be satisfied to authorize a request. Individual operations can override this definition.
+<a name="oasTags"></a>tags | [[Tag Object](#tag-object)] | A list of tags used by the specification with additional metadata. The order of the tags can be used to reflect on their order by the parsing tools. Not all tags that are used by the [Operation Object](#operation-object) must be declared. The tags that are not declared MAY be organized randomly or based on the tools' logic. Each tag name in the list MUST be unique.
+<a name="oasExternalDocs"></a>externalDocs | [External Documentation Object](#external-documentation-object) | Additional external documentation.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
-#### <a name="infoObject"></a>Info Object
+#### Info Object
 
 The object provides metadata about the API.
 The metadata MAY be used by the clients if needed, and MAY be presented in editing or documentation generation tools for convenience.
@@ -213,12 +213,12 @@ Field Name | Type | Description
 <a name="infoTitle"></a>title | `string` | **REQUIRED**. The title of the application.
 <a name="infoDescription"></a>description | `string` | A short description of the application. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
 <a name="infoTermsOfService"></a>termsOfService | `string` | A URL to the Terms of Service for the API. MUST be in the format of a URL.
-<a name="infoContact"></a>contact | [Contact Object](#contactObject) | The contact information for the exposed API.
-<a name="infoLicense"></a>license | [License Object](#licenseObject) | The license information for the exposed API.
+<a name="infoContact"></a>contact | [Contact Object](#contact-object) | The contact information for the exposed API.
+<a name="infoLicense"></a>license | [License Object](#license-object) | The license information for the exposed API.
 <a name="infoVersion"></a>version | `string` | **REQUIRED**. The version of the OpenAPI document (which is distinct from the [OpenAPI Specification version](#oasVersion) or the API implementation version).
 
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Info Object Example
 
@@ -254,7 +254,7 @@ license:
 version: 1.0.1
 ```
 
-#### <a name="contactObject"></a>Contact Object
+#### Contact Object
 
 Contact information for the exposed API.
 
@@ -266,7 +266,7 @@ Field Name | Type | Description
 <a name="contactUrl"></a>url | `string` | The URL pointing to the contact information. MUST be in the format of a URL.
 <a name="contactEmail"></a>email | `string` | The email address of the contact person/organization. MUST be in the format of an email address.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Contact Object Example
 
@@ -284,7 +284,7 @@ url: http://www.example.com/support
 email: support@example.com
 ```
 
-#### <a name="licenseObject"></a>License Object
+#### License Object
 
 License information for the exposed API.
 
@@ -295,7 +295,7 @@ Field Name | Type | Description
 <a name="licenseName"></a>name | `string` | **REQUIRED**. The license name used for the API.
 <a name="licenseUrl"></a>url | `string` | A URL to the license used for the API. MUST be in the format of a URL.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### License Object Example
 
@@ -311,7 +311,7 @@ name: Apache 2.0
 url: https://www.apache.org/licenses/LICENSE-2.0.html
 ```
 
-#### <a name="serverObject"></a>Server Object
+#### Server Object
 
 An object representing a Server.
 
@@ -321,9 +321,9 @@ Field Name | Type | Description
 ---|:---:|---
 <a name="serverUrl"></a>url | `string` | **REQUIRED**. A URL to the target host.  This URL supports Server Variables and MAY be relative, to indicate that the host location is relative to the location where the OpenAPI document is being served. Variable substitutions will be made when a variable is named in `{`brackets`}`.
 <a name="serverDescription"></a>description | `string` | An optional string describing the host designated by the URL. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="serverVariables"></a>variables | Map[`string`, [Server Variable Object](#serverVariableObject)] | A map between a variable name and its value.  The value is used for substitution in the server's URL template.
+<a name="serverVariables"></a>variables | Map[`string`, [Server Variable Object](#server-variable-object)] | A map between a variable name and its value.  The value is used for substitution in the server's URL template.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Server Object Example
 
@@ -421,7 +421,7 @@ servers:
 ```
 
 
-#### <a name="serverVariableObject"></a>Server Variable Object
+#### Server Variable Object
 
 An object representing a Server Variable for server URL template substitution.
 
@@ -430,12 +430,12 @@ An object representing a Server Variable for server URL template substitution.
 Field Name | Type | Description
 ---|:---:|---
 <a name="serverVariableEnum"></a>enum | [`string`] | An enumeration of string values to be used if the substitution options are from a limited set.
-<a name="serverVariableDefault"></a>default | `string` |  **REQUIRED**. The default value to use for substitution, which SHALL be sent if an alternate value is _not_ supplied. Note this behavior is different than the [Schema Object's](#schemaObject) treatment of default values, because in those cases parameter values are optional.
+<a name="serverVariableDefault"></a>default | `string` |  **REQUIRED**. The default value to use for substitution, which SHALL be sent if an alternate value is _not_ supplied. Note this behavior is different than the [Schema Object's](#schema-object) treatment of default values, because in those cases parameter values are optional.
 <a name="serverVariableDescription"></a>description | `string` | An optional description for the server variable. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
-#### <a name="componentsObject"></a>Components Object
+#### Components Object
 
 Holds a set of reusable objects for different aspects of the OAS.
 All objects defined within the components object will have no effect on the API unless they are explicitly referenced from properties outside the components object.
@@ -445,17 +445,17 @@ All objects defined within the components object will have no effect on the API 
 
 Field Name | Type | Description
 ---|:---|---
-<a name="componentsSchemas"></a> schemas | Map[`string`, [Schema Object](#schemaObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Schema Objects](#schemaObject).
-<a name="componentsResponses"></a> responses | Map[`string`, [Response Object](#responseObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Response Objects](#responseObject).
-<a name="componentsParameters"></a> parameters | Map[`string`, [Parameter Object](#parameterObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Parameter Objects](#parameterObject).
-<a name="componentsExamples"></a> examples | Map[`string`, [Example Object](#exampleObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Example Objects](#exampleObject).
-<a name="componentsRequestBodies"></a> requestBodies | Map[`string`, [Request Body Object](#requestBodyObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Request Body Objects](#requestBodyObject).
-<a name="componentsHeaders"></a> headers | Map[`string`, [Header Object](#headerObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Header Objects](#headerObject).
-<a name="componentsSecuritySchemes"></a> securitySchemes| Map[`string`, [Security Scheme Object](#securitySchemeObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Security Scheme Objects](#securitySchemeObject).
-<a name="componentsLinks"></a> links | Map[`string`, [Link Object](#linkObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Link Objects](#linkObject).
-<a name="componentsCallbacks"></a> callbacks | Map[`string`, [Callback Object](#callbackObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Callback Objects](#callbackObject).
+<a name="componentsSchemas"></a> schemas | Map[`string`, [Schema Object](#schema-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Schema Objects](#schema-object).
+<a name="componentsResponses"></a> responses | Map[`string`, [Response Object](#response-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Response Objects](#response-object).
+<a name="componentsParameters"></a> parameters | Map[`string`, [Parameter Object](#parameter-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Parameter Objects](#parameter-object).
+<a name="componentsExamples"></a> examples | Map[`string`, [Example Object](#example-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Example Objects](#example-object).
+<a name="componentsRequestBodies"></a> requestBodies | Map[`string`, [Request Body Object](#request-body-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Request Body Objects](#request-body-object).
+<a name="componentsHeaders"></a> headers | Map[`string`, [Header Object](#header-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Header Objects](#header-object).
+<a name="componentsSecuritySchemes"></a> securitySchemes| Map[`string`, [Security Scheme Object](#security-scheme-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Security Scheme Objects](#security-scheme-object).
+<a name="componentsLinks"></a> links | Map[`string`, [Link Object](#link-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Link Objects](#link-object).
+<a name="componentsCallbacks"></a> callbacks | Map[`string`, [Callback Object](#callback-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Callback Objects](#callback-object).
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 All the fixed fields declared above are objects that MUST use keys that match the regular expression: `^[a-zA-Z0-9\.\-_]+$`.
 
@@ -635,7 +635,7 @@ components:
       in: header
     petstore_auth:
       type: oauth2
-      flows: 
+      flows:
         implicit:
           authorizationUrl: http://example.org/api/oauth/dialog
           scopes:
@@ -644,18 +644,18 @@ components:
 ```
 
 
-#### <a name="pathsObject"></a>Paths Object
+#### Paths Object
 
 Holds the relative paths to the individual endpoints and their operations.
-The path is appended to the URL from the [`Server Object`](#serverObject) in order to construct the full URL.  The Paths MAY be empty, due to [ACL constraints](#securityFiltering).
+The path is appended to the URL from the [`Server Object`](#server-object) in order to construct the full URL.  The Paths MAY be empty, due to [ACL constraints](#security-filtering).
 
 ##### Patterned Fields
 
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="pathsPath"></a>/{path} | [Path Item Object](#pathItemObject) | A relative path to an individual endpoint. The field name MUST begin with a slash. The path is **appended** (no relative URL resolution) to the expanded URL from the [`Server Object`](#serverObject)'s `url` field in order to construct the full URL. [Path templating](#pathTemplating) is allowed. When matching URLs, concrete (non-templated) paths would be matched before their templated counterparts. Templated paths with the same hierarchy but different templated names MUST NOT exist as they are identical. In case of ambiguous matching, it's up to the tooling to decide which one to use.
+<a name="pathsPath"></a>/{path} | [Path Item Object](#path-item-object) | A relative path to an individual endpoint. The field name MUST begin with a slash. The path is **appended** (no relative URL resolution) to the expanded URL from the [`Server Object`](#server-object)'s `url` field in order to construct the full URL. [Path templating](#path-templating) is allowed. When matching URLs, concrete (non-templated) paths would be matched before their templated counterparts. Templated paths with the same hierarchy but different templated names MUST NOT exist as they are identical. In case of ambiguous matching, it's up to the tooling to decide which one to use.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Path Templating Matching
 
@@ -688,7 +688,7 @@ The following may lead to ambiguous resolution:
     "get": {
       "description": "Returns all pets from the system that the user has access to",
       "responses": {
-        "200": {          
+        "200": {         
           "description": "A list of pets.",
           "content": {
             "application/json": {
@@ -722,32 +722,32 @@ The following may lead to ambiguous resolution:
                 $ref: '#/components/schemas/pet'
 ```
 
-#### <a name="pathItemObject"></a>Path Item Object
+#### Path Item Object
 
 Describes the operations available on a single path.
-A Path Item MAY be empty, due to [ACL constraints](#securityFiltering).
+A Path Item MAY be empty, due to [ACL constraints](#security-filtering).
 The path itself is still exposed to the documentation viewer but they will not know which operations and parameters are available.
 
 ##### Fixed Fields
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="pathItemRef"></a>$ref | `string` | Allows for an external definition of this path item. The referenced structure MUST be in the format of a [Path Item Object](#pathItemObject). If there are conflicts between the referenced definition and this Path Item's definition, the behavior is *undefined*.
+<a name="pathItemRef"></a>$ref | `string` | Allows for an external definition of this path item. The referenced structure MUST be in the format of a [Path Item Object](#path-item-object). If there are conflicts between the referenced definition and this Path Item's definition, the behavior is *undefined*.
 <a name="pathItemSummary"></a>summary| `string` | An optional, string summary, intended to apply to all operations in this path.
 <a name="pathItemDescription"></a>description | `string` | An optional, string description, intended to apply to all operations in this path. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="pathItemGet"></a>get | [Operation Object](#operationObject) | A definition of a GET operation on this path.
-<a name="pathItemPut"></a>put | [Operation Object](#operationObject) | A definition of a PUT operation on this path.
-<a name="pathItemPost"></a>post | [Operation Object](#operationObject) | A definition of a POST operation on this path.
-<a name="pathItemDelete"></a>delete | [Operation Object](#operationObject) | A definition of a DELETE operation on this path.
-<a name="pathItemOptions"></a>options | [Operation Object](#operationObject) | A definition of a OPTIONS operation on this path.
-<a name="pathItemHead"></a>head | [Operation Object](#operationObject) | A definition of a HEAD operation on this path.
-<a name="pathItemPatch"></a>patch | [Operation Object](#operationObject) | A definition of a PATCH operation on this path.
-<a name="pathItemTrace"></a>trace | [Operation Object](#operationObject) | A definition of a TRACE operation on this path.
-<a name="pathItemServers"></a>servers | [[Server Object](#serverObject)] | An alternative `server` array to service all operations in this path.
-<a name="pathItemParameters"></a>parameters | [[Parameter Object](#parameterObject) \| [Reference Object](#referenceObject)] | A list of parameters that are applicable for all the operations described under this path. These parameters can be overridden at the operation level, but cannot be removed there. The list MUST NOT include duplicated parameters. A unique parameter is defined by a combination of a [name](#parameterName) and [location](#parameterIn). The list can use the [Reference Object](#referenceObject) to link to parameters that are defined at the [OpenAPI Object's components/parameters](#componentsParameters). 
+<a name="pathItemGet"></a>get | [Operation Object](#operation-object) | A definition of a GET operation on this path.
+<a name="pathItemPut"></a>put | [Operation Object](#operation-object) | A definition of a PUT operation on this path.
+<a name="pathItemPost"></a>post | [Operation Object](#operation-object) | A definition of a POST operation on this path.
+<a name="pathItemDelete"></a>delete | [Operation Object](#operation-object) | A definition of a DELETE operation on this path.
+<a name="pathItemOptions"></a>options | [Operation Object](#operation-object) | A definition of a OPTIONS operation on this path.
+<a name="pathItemHead"></a>head | [Operation Object](#operation-object) | A definition of a HEAD operation on this path.
+<a name="pathItemPatch"></a>patch | [Operation Object](#operation-object) | A definition of a PATCH operation on this path.
+<a name="pathItemTrace"></a>trace | [Operation Object](#operation-object) | A definition of a TRACE operation on this path.
+<a name="pathItemServers"></a>servers | [[Server Object](#server-object)] | An alternative `server` array to service all operations in this path.
+<a name="pathItemParameters"></a>parameters | [[Parameter Object](#parameter-object) \| [Reference Object](#reference-object)] | A list of parameters that are applicable for all the operations described under this path. These parameters can be overridden at the operation level, but cannot be removed there. The list MUST NOT include duplicated parameters. A unique parameter is defined by a combination of a [name](#parameterName) and [location](#parameterIn). The list can use the [Reference Object](#reference-object) to link to parameters that are defined at the [OpenAPI Object's components/parameters](#componentsParameters).
 
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Path Item Object Example
 
@@ -830,10 +830,10 @@ parameters:
     type: array
     style: simple
     items:
-      type: string  
+      type: string 
 ```
 
-#### <a name="operationObject"></a>Operation Object
+#### Operation Object
 
 Describes a single API operation on a path.
 
@@ -844,17 +844,17 @@ Field Name | Type | Description
 <a name="operationTags"></a>tags | [`string`] | A list of tags for API documentation control. Tags can be used for logical grouping of operations by resources or any other qualifier.
 <a name="operationSummary"></a>summary | `string` | A short summary of what the operation does.
 <a name="operationDescription"></a>description | `string` | A verbose explanation of the operation behavior. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="operationExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation for this operation.
+<a name="operationExternalDocs"></a>externalDocs | [External Documentation Object](#external-documentation-object) | Additional external documentation for this operation.
 <a name="operationId"></a>operationId | `string` | Unique string used to identify the operation. The id MUST be unique among all operations described in the API. The operationId value is **case-sensitive**. Tools and libraries MAY use the operationId to uniquely identify an operation, therefore, it is RECOMMENDED to follow common programming naming conventions.
-<a name="operationParameters"></a>parameters | [[Parameter Object](#parameterObject) \| [Reference Object](#referenceObject)] | A list of parameters that are applicable for this operation. If a parameter is already defined at the [Path Item](#pathItemParameters), the new definition will override it but can never remove it. The list MUST NOT include duplicated parameters. A unique parameter is defined by a combination of a [name](#parameterName) and [location](#parameterIn). The list can use the [Reference Object](#referenceObject) to link to parameters that are defined at the [OpenAPI Object's components/parameters](#componentsParameters).
-<a name="operationRequestBody"></a>requestBody | [Request Body Object](#requestBodyObject) \| [Reference Object](#referenceObject) | The request body applicable for this operation.  The `requestBody` is only supported in HTTP methods where the HTTP 1.1 specification [RFC7231](https://tools.ietf.org/html/rfc7231#section-4.3.1) has explicitly defined semantics for request bodies.  In other cases where the HTTP spec is vague, `requestBody` SHALL be ignored by consumers.
-<a name="operationResponses"></a>responses | [Responses Object](#responsesObject) | **REQUIRED**. The list of possible responses as they are returned from executing this operation.
-<a name="operationCallbacks"></a>callbacks | Map[`string`, [Callback Object](#callbackObject) \| [Reference Object](#referenceObject)] | A map of possible out-of band callbacks related to the parent operation. The key is a unique identifier for the Callback Object. Each value in the map is a [Callback Object](#callbackObject) that describes a request that may be initiated by the API provider and the expected responses. The key value used to identify the callback object is an expression, evaluated at runtime, that identifies a URL to use for the callback operation.
+<a name="operationParameters"></a>parameters | [[Parameter Object](#parameter-object) \| [Reference Object](#reference-object)] | A list of parameters that are applicable for this operation. If a parameter is already defined at the [Path Item](#pathItemParameters), the new definition will override it but can never remove it. The list MUST NOT include duplicated parameters. A unique parameter is defined by a combination of a [name](#parameterName) and [location](#parameterIn). The list can use the [Reference Object](#reference-object) to link to parameters that are defined at the [OpenAPI Object's components/parameters](#componentsParameters).
+<a name="operationRequestBody"></a>requestBody | [Request Body Object](#request-body-object) \| [Reference Object](#reference-object) | The request body applicable for this operation.  The `requestBody` is only supported in HTTP methods where the HTTP 1.1 specification [RFC7231](https://tools.ietf.org/html/rfc7231#section-4.3.1) has explicitly defined semantics for request bodies.  In other cases where the HTTP spec is vague, `requestBody` SHALL be ignored by consumers.
+<a name="operationResponses"></a>responses | [Responses Object](#responses-object) | **REQUIRED**. The list of possible responses as they are returned from executing this operation.
+<a name="operationCallbacks"></a>callbacks | Map[`string`, [Callback Object](#callback-object) \| [Reference Object](#reference-object)] | A map of possible out-of band callbacks related to the parent operation. The key is a unique identifier for the Callback Object. Each value in the map is a [Callback Object](#callback-object) that describes a request that may be initiated by the API provider and the expected responses. The key value used to identify the callback object is an expression, evaluated at runtime, that identifies a URL to use for the callback operation.
 <a name="operationDeprecated"></a>deprecated | `boolean` | Declares this operation to be deprecated. Consumers SHOULD refrain from usage of the declared operation. Default value is `false`.
-<a name="operationSecurity"></a>security | [[Security Requirement Object](#securityRequirementObject)] | A declaration of which security mechanisms can be used for this operation. The list of values includes alternative security requirement objects that can be used. Only one of the security requirement objects need to be satisfied to authorize a request. This definition overrides any declared top-level [`security`](#oasSecurity). To remove a top-level security declaration, an empty array can be used.
-<a name="operationServers"></a>servers | [[Server Object](#serverObject)] | An alternative `server` array to service this operation. If an alternative `server` object is specified at the Path Item Object or Root level, it will be overridden by this value.
+<a name="operationSecurity"></a>security | [[Security Requirement Object](#security-requirement-object)] | A declaration of which security mechanisms can be used for this operation. The list of values includes alternative security requirement objects that can be used. Only one of the security requirement objects need to be satisfied to authorize a request. This definition overrides any declared top-level [`security`](#oasSecurity). To remove a top-level security declaration, an empty array can be used.
+<a name="operationServers"></a>servers | [[Server Object](#server-object)] | An alternative `server` array to service this operation. If an alternative `server` object is specified at the Path Item Object or Root level, it will be overridden by this value.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Operation Object Example
 
@@ -882,7 +882,7 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
         "schema": {
           "type": "object",
            "properties": {
-              "name": { 
+              "name": {
                 "description": "Updated name of the pet",
                 "type": "string"
               },
@@ -891,7 +891,7 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
                 "type": "string"
              }
            },
-        "required": ["status"] 
+        "required": ["status"]
         }
       }
     }
@@ -940,7 +940,7 @@ requestBody:
     'application/x-www-form-urlencoded':
       schema:
        properties:
-          name: 
+          name:
             description: Updated name of the pet
             type: string
           status:
@@ -951,12 +951,12 @@ requestBody:
 responses:
   '200':
     description: Pet updated.
-    content: 
+    content:
       'application/json': {}
       'application/xml': {}
   '405':
     description: Method Not Allowed
-    content: 
+    content:
       'application/json': {}
       'application/xml': {}
 security:
@@ -966,7 +966,7 @@ security:
 ```
 
 
-#### <a name="externalDocumentationObject"></a>External Documentation Object
+#### External Documentation Object
 
 Allows referencing an external resource for extended documentation.
 
@@ -977,7 +977,7 @@ Field Name | Type | Description
 <a name="externalDocDescription"></a>description | `string` | A short description of the target documentation. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
 <a name="externalDocUrl"></a>url | `string` | **REQUIRED**. The URL for the target documentation. Value MUST be in the format of a URL.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### External Documentation Object Example
 
@@ -993,7 +993,7 @@ description: Find more info here
 url: https://example.com
 ```
 
-#### <a name="parameterObject"></a>Parameter Object
+#### Parameter Object
 
 Describes a single operation parameter.
 
@@ -1001,7 +1001,7 @@ A unique parameter is defined by a combination of a [name](#parameterName) and [
 
 ##### Parameter Locations
 There are four possible parameter locations specified by the `in` field:
-* path - Used together with [Path Templating](#pathTemplating), where the parameter value is actually part of the operation's URL. This does not include the host or base path of the API. For example, in `/items/{itemId}`, the path parameter is `itemId`.
+* path - Used together with [Path Templating](#path-templating), where the parameter value is actually part of the operation's URL. This does not include the host or base path of the API. For example, in `/items/{itemId}`, the path parameter is `itemId`.
 * query - Parameters that are appended to the URL. For example, in `/items?id=###`, the query parameter is `id`.
 * header - Custom headers that are expected as part of the request. Note that [RFC7230](https://tools.ietf.org/html/rfc7230#page-22) states header names are case insensitive.
 * cookie - Used to pass a specific cookie value to the API.
@@ -1010,7 +1010,7 @@ There are four possible parameter locations specified by the `in` field:
 ##### Fixed Fields
 Field Name | Type | Description
 ---|:---:|---
-<a name="parameterName"></a>name | `string` | **REQUIRED**. The name of the parameter. Parameter names are *case sensitive*. <ul><li>If [`in`](#parameterIn) is `"path"`, the `name` field MUST correspond to the associated path segment from the [path](#pathsPath) field in the [Paths Object](#pathsObject). See [Path Templating](#pathTemplating) for further information.<li>If [`in`](#parameterIn) is `"header"` and the `name` field is `"Accept"`, `"Content-Type"` or `"Authorization"`, the parameter definition SHALL be ignored.<li>For all other cases, the `name` corresponds to the parameter name used by the [`in`](#parameterIn) property.</ul>
+<a name="parameterName"></a>name | `string` | **REQUIRED**. The name of the parameter. Parameter names are *case sensitive*. <ul><li>If [`in`](#parameterIn) is `"path"`, the `name` field MUST correspond to the associated path segment from the [path](#pathsPath) field in the [Paths Object](#paths-object). See [Path Templating](#path-templating) for further information.<li>If [`in`](#parameterIn) is `"header"` and the `name` field is `"Accept"`, `"Content-Type"` or `"Authorization"`, the parameter definition SHALL be ignored.<li>For all other cases, the `name` corresponds to the parameter name used by the [`in`](#parameterIn) property.</ul>
 <a name="parameterIn"></a>in | `string` | **REQUIRED**. The location of the parameter. Possible values are "query", "header", "path" or "cookie".
 <a name="parameterDescription"></a>description | `string` | A brief description of the parameter. This could contain examples of use.  [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
 <a name="parameterRequired"></a>required | `boolean` | Determines whether this parameter is mandatory. If the [parameter location](#parameterIn) is "path", this property is **REQUIRED** and its value MUST be `true`. Otherwise, the property MAY be included and its default value is `false`.
@@ -1025,9 +1025,9 @@ Field Name | Type | Description
 <a name="parameterStyle"></a>style | `string` | Describes how the parameter value will be serialized depending on the type of the parameter value. Default values (based on value of `in`): for `query` - `form`; for `path` - `simple`; for `header` - `simple`; for `cookie` - `form`.
 <a name="parameterExplode"></a>explode | `boolean` | When this is true, parameter values of type `array` or `object` generate separate parameters for each value of the array or key-value pair of the map.  For other types of parameters this property has no effect. When [`style`](#parameterStyle) is `form`, the default value is `true`. For all other styles, the default value is `false`.
 <a name="parameterAllowReserved"></a>allowReserved | `boolean` | Determines whether the parameter value SHOULD allow reserved characters, as defined by [RFC3986](https://tools.ietf.org/html/rfc3986#section-2.2) `:/?#[]@!$&'()*+,;=` to be included without percent-encoding. This property only applies to parameters with an `in` value of `query`. The default value is `false`.
-<a name="parameterSchema"></a>schema | [Schema Object](#schemaObject) \| [Reference Object](#referenceObject) | The schema defining the type used for the parameter.
+<a name="parameterSchema"></a>schema | [Schema Object](#schema-object) \| [Reference Object](#reference-object) | The schema defining the type used for the parameter.
 <a name="parameterExample"></a>example | Any | Example of the media type.  The example SHOULD match the specified schema and encoding properties if present.  The `example` field is mutually exclusive of the `examples` field.  Furthermore, if referencing a `schema` which contains an example, the `example` value SHALL _override_ the example provided by the schema. To represent examples of media types that cannot naturally be represented in JSON or YAML, a string value can contain the example with escaping where necessary.
-<a name="parameterExamples"></a>examples | Map[ `string`, [Example Object](#exampleObject) \| [Reference Object](#referenceObject)] | Examples of the media type.  Each example SHOULD contain a value in the correct format as specified in the parameter encoding.  The `examples` field is mutually exclusive of the `example` field.  Furthermore, if referencing a `schema` which contains an example, the `examples` value SHALL _override_ the example provided by the schema.
+<a name="parameterExamples"></a>examples | Map[ `string`, [Example Object](#example-object) \| [Reference Object](#reference-object)] | Examples of the media type.  Each example SHOULD contain a value in the correct format as specified in the parameter encoding.  The `examples` field is mutually exclusive of the `example` field.  Furthermore, if referencing a `schema` which contains an example, the `examples` value SHALL _override_ the example provided by the schema.
 
 For more complex scenarios, the [`content`](#parameterContent) property can define the media type and schema of the parameter.
 A parameter MUST contain either a `schema` property, or a `content` property, but not both.
@@ -1036,19 +1036,19 @@ When `example` or `examples` are provided in conjunction with the `schema` objec
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="parameterContent"></a>content | Map[`string`, [Media Type Object](#mediaTypeObject)] | A map containing the representations for the parameter. The key is the media type and the value describes it.  The map MUST only contain one entry.
+<a name="parameterContent"></a>content | Map[`string`, [Media Type Object](#media-type-object)] | A map containing the representations for the parameter. The key is the media type and the value describes it.  The map MUST only contain one entry.
 
 ##### Style Values
 
 In order to support common ways of serializing simple parameters, a set of `style` values are defined.
 
-`style` | [`type`](#dataTypes) |  `in` | Comments
+`style` | [`type`](#data-types) |  `in` | Comments
 ----------- | ------ | -------- | --------
-matrix |  `primitive`, `array`, `object` |  `path` | Path-style parameters defined by [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.7) 
+matrix |  `primitive`, `array`, `object` |  `path` | Path-style parameters defined by [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.7)
 label | `primitive`, `array`, `object` |  `path` | Label style parameters defined by [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.5)
 form |  `primitive`, `array`, `object` |  `query`, `cookie` | Form style parameters defined by [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.8). This option replaces `collectionFormat` with a `csv` (when `explode` is false) or `multi` (when `explode` is true) value from OpenAPI 2.0.
 simple | `array` | `path`, `header` | Simple style parameters defined by [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.2).  This option replaces `collectionFormat` with a `csv` value from OpenAPI 2.0.
-spaceDelimited | `array` | `query` | Space separated array values. This option replaces `collectionFormat` equal to `ssv` from OpenAPI 2.0. 
+spaceDelimited | `array` | `query` | Space separated array values. This option replaces `collectionFormat` equal to `ssv` from OpenAPI 2.0.
 pipeDelimited | `array` | `query` | Pipe separated array values. This option replaces `collectionFormat` equal to `pipes` from OpenAPI 2.0.
 deepObject | `object` | `query` | Provides a simple way of rendering nested objects using form parameters.
 
@@ -1078,7 +1078,7 @@ spaceDelimited | false | n/a | n/a | blue%20black%20brown | R%20100%20G%20200%20
 pipeDelimited | false | n/a | n/a | blue\|black\|brown | R\|100\|G\|200|G\|150
 deepObject | true | n/a | n/a | n/a | color[R]=100&color[G]=200&color[B]=150
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Parameter Object Examples
 
@@ -1237,7 +1237,7 @@ content:
           type: number
 ```
 
-#### <a name="requestBodyObject"></a>Request Body Object
+#### Request Body Object
 
 Describes a single request body.
 
@@ -1245,11 +1245,11 @@ Describes a single request body.
 Field Name | Type | Description
 ---|:---:|---
 <a name="requestBodyDescription"></a>description | `string` | A brief description of the request body. This could contain examples of use.  [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="requestBodyContent"></a>content | Map[`string`, [Media Type Object](#mediaTypeObject)] | **REQUIRED**. The content of the request body. The key is a media type or [media type range](https://tools.ietf.org/html/rfc7231#appendix-D) and the value describes it.  For requests that match multiple keys, only the most specific key is applicable. e.g. text/plain overrides text/*
+<a name="requestBodyContent"></a>content | Map[`string`, [Media Type Object](#media-type-object)] | **REQUIRED**. The content of the request body. The key is a media type or [media type range](https://tools.ietf.org/html/rfc7231#appendix-D) and the value describes it.  For requests that match multiple keys, only the most specific key is applicable. e.g. text/plain overrides text/*
 <a name="requestBodyRequired"></a>required | `boolean` | Determines if the request body is required in the request. Defaults to `false`.
 
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Request Body Examples
 
@@ -1264,9 +1264,9 @@ A request body with a referenced model definition.
       },
       "examples": {
           "user" : {
-            "summary": "User Example", 
+            "summary": "User Example",
             "externalValue": "http://foo.bar/examples/user-example.json"
-          } 
+          }
         }
     },
     "application/xml": {
@@ -1284,9 +1284,9 @@ A request body with a referenced model definition.
       "examples": {
         "user" : {
             "summary": "User example in Plain text",
-            "externalValue": "http://foo.bar/examples/user-example.txt" 
+            "externalValue": "http://foo.bar/examples/user-example.txt"
         }
-      } 
+      }
     },
     "*/*": {
       "examples": {
@@ -1302,7 +1302,7 @@ A request body with a referenced model definition.
 
 ```yaml
 description: user to add to the system
-content: 
+content:
   'application/json':
     schema:
       $ref: '#/components/schemas/User'
@@ -1324,7 +1324,7 @@ content:
         externalValue: 'http://foo.bar/examples/user-example.txt'
   '*/*':
     examples:
-      user: 
+      user:
         summary: User example in other format
         externalValue: 'http://foo.bar/examples/user-example.whatever'
 ```
@@ -1358,18 +1358,18 @@ content:
 ```
 
 
-#### <a name="mediaTypeObject"></a>Media Type Object
+#### Media Type Object
 Each Media Type Object provides schema and examples for the media type identified by its key.
 
 ##### Fixed Fields
 Field Name | Type | Description
 ---|:---:|---
-<a name="mediaTypeSchema"></a>schema | [Schema Object](#schemaObject) \| [Reference Object](#referenceObject) | The schema defining the content of the request, response, or parameter.
+<a name="mediaTypeSchema"></a>schema | [Schema Object](#schema-object) \| [Reference Object](#reference-object) | The schema defining the content of the request, response, or parameter.
 <a name="mediaTypeExample"></a>example | Any | Example of the media type.  The example object SHOULD be in the correct format as specified by the media type.  The `example` field is mutually exclusive of the `examples` field.  Furthermore, if referencing a `schema` which contains an example, the `example` value SHALL _override_ the example provided by the schema.
-<a name="mediaTypeExamples"></a>examples | Map[ `string`, [Example Object](#exampleObject) \| [Reference Object](#referenceObject)] | Examples of the media type.  Each example object SHOULD  match the media type and specified schema if present.  The `examples` field is mutually exclusive of the `example` field.  Furthermore, if referencing a `schema` which contains an example, the `examples` value SHALL _override_ the example provided by the schema.
-<a name="mediaTypeEncoding"></a>encoding | Map[`string`, [Encoding Object](#encodingObject)] | A map between a property name and its encoding information. The key, being the property name, MUST exist in the schema as a property. The encoding object SHALL only apply to `requestBody` objects when the media type is `multipart` or `application/x-www-form-urlencoded`.
+<a name="mediaTypeExamples"></a>examples | Map[ `string`, [Example Object](#example-object) \| [Reference Object](#reference-object)] | Examples of the media type.  Each example object SHOULD  match the media type and specified schema if present.  The `examples` field is mutually exclusive of the `example` field.  Furthermore, if referencing a `schema` which contains an example, the `examples` value SHALL _override_ the example provided by the schema.
+<a name="mediaTypeEncoding"></a>encoding | Map[`string`, [Encoding Object](#encoding-object)] | A map between a property name and its encoding information. The key, being the property name, MUST exist in the schema as a property. The encoding object SHALL only apply to `requestBody` objects when the media type is `multipart` or `application/x-www-form-urlencoded`.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Media Type Examples
 
@@ -1382,7 +1382,7 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
     "examples": {
       "cat" : {
         "summary": "An example of a cat",
-        "value": 
+        "value":
           {
             "name": "Fluffy",
             "petType": "Cat",
@@ -1393,7 +1393,7 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
       },
       "dog": {
         "summary": "An example of a dog with a cat's name",
-        "value" :  { 
+        "value" :  {
           "name": "Puma",
           "petType": "Dog",
           "color": "Black",
@@ -1410,7 +1410,7 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
 ```
 
 ```yaml
-application/json: 
+application/json:
   schema:
     $ref: "#/components/schemas/Pet"
   examples:
@@ -1481,7 +1481,7 @@ requestBody:
     'image/png':
       schema:
         type: string
-        format: binary        
+        format: binary       
 ```
 
 To upload multiple files, a `multipart` media type MUST be used:
@@ -1524,7 +1524,7 @@ requestBody:
 
 In this example, the contents in the `requestBody` MUST be stringified per [RFC1866](https://tools.ietf.org/html/rfc1866/) when passed to the server.  In addition, the `address` field complex object will be stringified.
 
-When passing complex objects in the `application/x-www-form-urlencoded` content type, the default serialization strategy of such properties is described in the [`Encoding Object`](#encodingObject)'s [`style`](#encodingStyle) property as `form`.
+When passing complex objects in the `application/x-www-form-urlencoded` content type, the default serialization strategy of such properties is described in the [`Encoding Object`](#encoding-object)'s [`style`](#encodingStyle) property as `form`.
 
 ##### Special Considerations for `multipart` Content
 
@@ -1571,7 +1571,7 @@ requestBody:
 
 An `encoding` attribute is introduced to give you control over the serialization of parts of `multipart` request bodies.  This attribute is _only_ applicable to `multipart` and `application/x-www-form-urlencoded` request bodies.
 
-#### <a name="encodingObject"></a>Encoding Object
+#### Encoding Object
 
 A single encoding definition applied to a single schema property.
 
@@ -1579,12 +1579,12 @@ A single encoding definition applied to a single schema property.
 Field Name | Type | Description
 ---|:---:|---
 <a name="encodingContentType"></a>contentType | `string` | The Content-Type for encoding a specific property. Default value depends on the property type: for `string` with `format` being `binary` – `application/octet-stream`; for other primitive types – `text/plain`; for `object` - `application/json`; for `array` – the default is defined based on the inner type. The value can be a specific media type (e.g. `application/json`), a wildcard media type (e.g. `image/*`), or a comma-separated list of the two types.
-<a name="encodingHeaders"></a>headers | Map[`string`, [Header Object](#headerObject) \| [Reference Object](#referenceObject)] | A map allowing additional information to be provided as headers, for example `Content-Disposition`.  `Content-Type` is described separately and SHALL be ignored in this section. This property SHALL be ignored if the request body media type is not a `multipart`.
-<a name="encodingStyle"></a>style | `string` | Describes how a specific property value will be serialized depending on its type.  See [Parameter Object](#parameterObject) for details on the [`style`](#parameterStyle) property. The behavior follows the same values as `query` parameters, including default values. This property SHALL be ignored if the request body media type is not `application/x-www-form-urlencoded`.
+<a name="encodingHeaders"></a>headers | Map[`string`, [Header Object](#header-object) \| [Reference Object](#reference-object)] | A map allowing additional information to be provided as headers, for example `Content-Disposition`.  `Content-Type` is described separately and SHALL be ignored in this section. This property SHALL be ignored if the request body media type is not a `multipart`.
+<a name="encodingStyle"></a>style | `string` | Describes how a specific property value will be serialized depending on its type.  See [Parameter Object](#parameter-object) for details on the [`style`](#parameterStyle) property. The behavior follows the same values as `query` parameters, including default values. This property SHALL be ignored if the request body media type is not `application/x-www-form-urlencoded`.
 <a name="encodingExplode"></a>explode | `boolean` | When this is true, property values of type `array` or `object` generate separate parameters for each value of the array, or key-value-pair of the map.  For other types of properties this property has no effect. When [`style`](#encodingStyle) is `form`, the default value is `true`. For all other styles, the default value is `false`. This property SHALL be ignored if the request body media type is not `application/x-www-form-urlencoded`.
 <a name="encodingAllowReserved"></a>allowReserved | `boolean` | Determines whether the parameter value SHOULD allow reserved characters, as defined by [RFC3986](https://tools.ietf.org/html/rfc3986#section-2.2) `:/?#[]@!$&'()*+,;=` to be included without percent-encoding. The default value is `false`. This property SHALL be ignored if the request body media type is not `application/x-www-form-urlencoded`.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Encoding Object Example
 
@@ -1626,7 +1626,7 @@ requestBody:
                 type: integer
 ```
 
-#### <a name="responsesObject"></a>Responses Object
+#### Responses Object
 
 A container for the expected responses of an operation.
 The container maps a HTTP response code to the expected response.
@@ -1634,24 +1634,24 @@ The container maps a HTTP response code to the expected response.
 The documentation is not necessarily expected to cover all possible HTTP response codes because they may not be known in advance.
 However, documentation is expected to cover a successful operation response and any known errors.
 
-The `default` MAY be used as a default response object for all HTTP codes 
+The `default` MAY be used as a default response object for all HTTP codes
 that are not covered individually by the specification.
 
-The `Responses Object` MUST contain at least one response code, and it 
+The `Responses Object` MUST contain at least one response code, and it
 SHOULD be the response for a successful operation call.
 
 ##### Fixed Fields
 Field Name | Type | Description
 ---|:---:|---
-<a name="responsesDefault"></a>default | [Response Object](#responseObject) \| [Reference Object](#referenceObject) | The documentation of responses other than the ones declared for specific HTTP response codes. Use this field to cover undeclared responses. A [Reference Object](#referenceObject) can link to a response that the [OpenAPI Object's components/responses](#componentsResponses) section defines.
+<a name="responsesDefault"></a>default | [Response Object](#response-object) \| [Reference Object](#reference-object) | The documentation of responses other than the ones declared for specific HTTP response codes. Use this field to cover undeclared responses. A [Reference Object](#reference-object) can link to a response that the [OpenAPI Object's components/responses](#componentsResponses) section defines.
 
 ##### Patterned Fields
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="responsesCode"></a>[HTTP Status Code](#httpCodes) | [Response Object](#responseObject) \| [Reference Object](#referenceObject) | Any [HTTP status code](#httpCodes) can be used as the property name, but only one property per code, to describe the expected response for that HTTP status code.  A [Reference Object](#referenceObject) can link to a response that is defined in the [OpenAPI Object's components/responses](#componentsResponses) section. This field MUST be enclosed in quotation marks (for example, "200") for compatibility between JSON and YAML. To define a range of response codes, this field MAY contain the uppercase wildcard character `X`. For example, `2XX` represents all response codes between `[200-299]`. Only the following range definitions are allowed: `1XX`, `2XX`, `3XX`, `4XX`, and `5XX`. If a response is defined using an explicit code, the explicit code definition takes precedence over the range definition for that code.
+<a name="responsesCode"></a>[HTTP Status Code](#http-status-codes) | [Response Object](#response-object) \| [Reference Object](#reference-object) | Any [HTTP status code](#http-status-codes) can be used as the property name, but only one property per code, to describe the expected response for that HTTP status code.  A [Reference Object](#reference-object) can link to a response that is defined in the [OpenAPI Object's components/responses](#componentsResponses) section. This field MUST be enclosed in quotation marks (for example, "200") for compatibility between JSON and YAML. To define a range of response codes, this field MAY contain the uppercase wildcard character `X`. For example, `2XX` represents all response codes between `[200-299]`. Only the following range definitions are allowed: `1XX`, `2XX`, `3XX`, `4XX`, and `5XX`. If a response is defined using an explicit code, the explicit code definition takes precedence over the range definition for that code.
 
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Responses Object Example
 
@@ -1685,7 +1685,7 @@ A 200 response for a successful operation and a default response for others (imp
 ```yaml
 '200':
   description: a pet to be returned
-  content: 
+  content:
     application/json:
       schema:
         $ref: '#/components/schemas/Pet'
@@ -1697,19 +1697,19 @@ default:
         $ref: '#/components/schemas/ErrorModel'
 ```
 
-#### <a name="responseObject"></a>Response Object
-Describes a single response from an API Operation, including design-time, static 
+#### Response Object
+Describes a single response from an API Operation, including design-time, static
 `links` to operations based on the response.
 
 ##### Fixed Fields
 Field Name | Type | Description
 ---|:---:|---
 <a name="responseDescription"></a>description | `string` | **REQUIRED**. A short description of the response. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="responseHeaders"></a>headers | Map[`string`, [Header Object](#headerObject)  \| [Reference Object](#referenceObject)] |  Maps a header name to its definition. [RFC7230](https://tools.ietf.org/html/rfc7230#page-22) states header names are case insensitive. If a response header is defined with the name `"Content-Type"`, it SHALL be ignored.
-<a name="responseContent"></a>content | Map[`string`, [Media Type Object](#mediaTypeObject)] | A map containing descriptions of potential response payloads. The key is a media type or [media type range](https://tools.ietf.org/html/rfc7231#appendix-D) and the value describes it.  For responses that match multiple keys, only the most specific key is applicable. e.g. text/plain overrides text/*
-<a name="responseLinks"></a>links | Map[`string`, [Link Object](#linkObject) \| [Reference Object](#referenceObject)] | A map of operations links that can be followed from the response. The key of the map is a short name for the link, following the naming constraints of the names for [Component Objects](#componentsObject). 
+<a name="responseHeaders"></a>headers | Map[`string`, [Header Object](#header-object)  \| [Reference Object](#reference-object)] |  Maps a header name to its definition. [RFC7230](https://tools.ietf.org/html/rfc7230#page-22) states header names are case insensitive. If a response header is defined with the name `"Content-Type"`, it SHALL be ignored.
+<a name="responseContent"></a>content | Map[`string`, [Media Type Object](#media-type-object)] | A map containing descriptions of potential response payloads. The key is a media type or [media type range](https://tools.ietf.org/html/rfc7231#appendix-D) and the value describes it.  For responses that match multiple keys, only the most specific key is applicable. e.g. text/plain overrides text/*
+<a name="responseLinks"></a>links | Map[`string`, [Link Object](#link-object) \| [Reference Object](#reference-object)] | A map of operations links that can be followed from the response. The key of the map is a short name for the link, following the naming constraints of the names for [Component Objects](#components-object).
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Response Object Examples
 
@@ -1733,9 +1733,9 @@ Response of an array of a complex type:
 
 ```yaml
 description: A complex object array response
-content: 
+content:
   application/json:
-    schema: 
+    schema:
       type: array
       items:
         $ref: '#/components/schemas/VeryComplexType'
@@ -1834,25 +1834,25 @@ Response with no return value:
 description: object created
 ```
 
-#### <a name="callbackObject"></a>Callback Object
+#### Callback Object
 
 A map of possible out-of band callbacks related to the parent operation.
-Each value in the map is a [Path Item Object](#pathItemObject) that describes a set of requests that may be initiated by the API provider and the expected responses.
+Each value in the map is a [Path Item Object](#path-item-object) that describes a set of requests that may be initiated by the API provider and the expected responses.
 The key value used to identify the callback object is an expression, evaluated at runtime, that identifies a URL to use for the callback operation.
 
 ##### Patterned Fields
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="callbackExpression"></a>{expression} | [Path Item Object](#pathItemObject) | A Path Item Object used to define a callback request and expected responses.  A [complete example](../examples/v3.0/callback-example.yaml) is available.
+<a name="callbackExpression"></a>{expression} | [Path Item Object](#path-item-object) | A Path Item Object used to define a callback request and expected responses.  A [complete example](../examples/v3.0/callback-example.yaml) is available.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Key Expression
 
-The key that identifies the [Path Item Object](#pathItemObject) is a [runtime expression](#runtimeExpression) that can be evaluated in the context of a runtime HTTP request/response to identify the URL to be used for the callback request.
+The key that identifies the [Path Item Object](#path-item-object) is a [runtime expression](#runtime-expressions) that can be evaluated in the context of a runtime HTTP request/response to identify the URL to be used for the callback request.
 A simple example might be `$request.body#/url`.
-However, using a [runtime expression](#runtimeExpression) the complete HTTP message can be accessed.
-This includes accessing any part of a body that a JSON Pointer [RFC6901](https://tools.ietf.org/html/rfc6901) can reference. 
+However, using a [runtime expression](#runtime-expressions) the complete HTTP message can be accessed.
+This includes accessing any part of a body that a JSON Pointer [RFC6901](https://tools.ietf.org/html/rfc6901) can reference.
 
 For example, given the following HTTP request:
 
@@ -1868,7 +1868,7 @@ Content-Length: 187
     "http://clientdomain.com/fast",
     "http://clientdomain.com/medium",
     "http://clientdomain.com/slow"
-  ] 
+  ]
 }
 
 201 Created
@@ -1877,7 +1877,7 @@ Location: http://example.org/subscription/1
 
 The following examples show how the various expressions evaluate, assuming the callback operation has a path parameter named `eventType` and a query parameter named `queryUrl`.
 
-Expression | Value 
+Expression | Value
 ---|:---
 $url | http://example.org/subscribe/myevent?queryUrl=http://clientdomain.com/stillrunning
 $method | POST
@@ -1899,7 +1899,7 @@ myWebhook:
     post:
       requestBody:
         description: Callback payload
-        content: 
+        content:
           'application/json':
             schema:
               $ref: '#/components/schemas/SomePayload'
@@ -1909,7 +1909,7 @@ myWebhook:
 ```
 
 
-#### <a name="exampleObject"></a>Example Object
+#### Example Object
 
 ##### Fixed Fields
 Field Name | Type | Description
@@ -1917,12 +1917,12 @@ Field Name | Type | Description
 <a name="exampleSummary"></a>summary | `string` | Short description for the example.
 <a name="exampleDescription"></a>description | `string` | Long description for the example. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
 <a name="exampleValue"></a>value | Any | Embedded literal example. The `value` field and `externalValue` field are mutually exclusive. To represent examples of media types that cannot naturally represented in JSON or YAML, use a string value to contain the example, escaping where necessary.
-<a name="exampleExternalValue"></a>externalValue | `string` | A URL that points to the literal example. This provides the capability to reference examples that cannot easily be included in JSON or YAML documents.  The `value` field and `externalValue` field are mutually exclusive. 
+<a name="exampleExternalValue"></a>externalValue | `string` | A URL that points to the literal example. This provides the capability to reference examples that cannot easily be included in JSON or YAML documents.  The `value` field and `externalValue` field are mutually exclusive.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
-In all cases, the example value is expected to be compatible with the type schema 
-of its associated value.  Tooling implementations MAY choose to 
+In all cases, the example value is expected to be compatible with the type schema
+of its associated value.  Tooling implementations MAY choose to
 validate compatibility automatically, and reject the example value(s) if incompatible.
 
 ##### Example Object Examples
@@ -1947,7 +1947,7 @@ requestBody:
     'application/json':
       schema:
         $ref: '#/components/schemas/Address'
-      examples: 
+      examples:
         foo:
           summary: A foo example
           value: {"foo": "bar"}
@@ -1955,13 +1955,13 @@ requestBody:
           summary: A bar example
           value: {"bar": "baz"}
     'application/xml':
-      examples: 
+      examples:
         xmlExample:
           summary: This is an example in XML
           externalValue: 'http://example.org/examples/address-example.xml'
     'text/plain':
       examples:
-        textExample: 
+        textExample:
           summary: This is a text example
           externalValue: 'http://foo.bar/examples/address-example.txt'
 ```
@@ -1976,7 +1976,7 @@ parameters:
       type: 'string'
       format: 'zip-code'
       examples:
-        zip-example: 
+        zip-example:
           $ref: '#/components/examples/zip-example'
 ```
 
@@ -1986,7 +1986,7 @@ In a response:
 responses:
   '200':
     description: your car appointment has been booked
-    content: 
+    content:
       application/json:
         schema:
           $ref: '#/components/schemas/SuccessResponse'
@@ -1996,31 +1996,31 @@ responses:
 ```
 
 
-#### <a name="linkObject"></a>Link Object
+#### Link Object
 
 The `Link object` represents a possible design-time link for a response.
 The presence of a link does not guarantee the caller's ability to successfully invoke it, rather it provides a known relationship and traversal mechanism between responses and other operations.
 
 Unlike _dynamic_ links (i.e. links provided **in** the response payload), the OAS linking mechanism does not require link information in the runtime response.
 
-For computing links, and providing instructions to execute them, a [runtime expression](#runtimeExpression) is used for accessing values in an operation and using them as parameters while invoking the linked operation.  
+For computing links, and providing instructions to execute them, a [runtime expression](#runtime-expressions) is used for accessing values in an operation and using them as parameters while invoking the linked operation. 
 
 ##### Fixed Fields
 
 Field Name  |  Type  | Description
 ---|:---:|---
-<a name="linkOperationRef"></a>operationRef | `string` | A relative or absolute reference to an OAS operation. This field is mutually exclusive of the `operationId` field, and MUST point to an [Operation Object](#operationObject). Relative `operationRef` values MAY be used to locate an existing [Operation Object](#operationObject) in the OpenAPI definition.
-<a name="linkOperationId"></a>operationId  | `string` | The name of an _existing_, resolvable OAS operation, as defined with a unique `operationId`.  This field is mutually exclusive of the `operationRef` field.  
-<a name="linkParameters"></a>parameters   | Map[`string`, Any \| [{expression}](#runtimeExpression)] | A map representing parameters to pass to an operation as specified with `operationId` or identified via `operationRef`. The key is the parameter name to be used, whereas the value can be a constant or an expression to be evaluated and passed to the linked operation.  The parameter name can be qualified using the [parameter location](#parameterIn) `[{in}.]{name}` for operations that use the same parameter name in different locations (e.g. path.id).
-<a name="linkRequestBody"></a>requestBody | Any \| [{expression}](#runtimeExpression) | A literal value or [{expression}](#runtimeExpression) to use as a request body when calling the target operation.
+<a name="linkOperationRef"></a>operationRef | `string` | A relative or absolute reference to an OAS operation. This field is mutually exclusive of the `operationId` field, and MUST point to an [Operation Object](#operation-object). Relative `operationRef` values MAY be used to locate an existing [Operation Object](#operation-object) in the OpenAPI definition.
+<a name="linkOperationId"></a>operationId  | `string` | The name of an _existing_, resolvable OAS operation, as defined with a unique `operationId`.  This field is mutually exclusive of the `operationRef` field. 
+<a name="linkParameters"></a>parameters   | Map[`string`, Any \| [{expression}](#runtime-expressions)] | A map representing parameters to pass to an operation as specified with `operationId` or identified via `operationRef`. The key is the parameter name to be used, whereas the value can be a constant or an expression to be evaluated and passed to the linked operation.  The parameter name can be qualified using the [parameter location](#parameterIn) `[{in}.]{name}` for operations that use the same parameter name in different locations (e.g. path.id).
+<a name="linkRequestBody"></a>requestBody | Any \| [{expression}](#runtime-expressions) | A literal value or [{expression}](#runtime-expressions) to use as a request body when calling the target operation.
 <a name="linkDescription"></a>description  | `string` | A description of the link. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="linkServer"></a>server       | [Server Object](#serverObject) | A server object to be used by the target operation.
+<a name="linkServer"></a>server       | [Server Object](#server-object) | A server object to be used by the target operation.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 A linked operation MUST be identified using either an `operationRef` or `operationId`.
 In the case of an `operationId`, it MUST be unique and resolved in the scope of the OAS document.
-Because of the potential for name clashes, the `operationRef` syntax is preferred 
+Because of the potential for name clashes, the `operationRef` syntax is preferred
 for specifications with external references.
 
 ##### Examples
@@ -2034,7 +2034,7 @@ paths:
     - name: id
       in: path
       required: true
-      description: the user identifier, as userId 
+      description: the user identifier, as userId
       schema:
         type: string
     get:
@@ -2062,7 +2062,7 @@ paths:
     - name: userid
       in: path
       required: true
-      description: the user identifier, as userId 
+      description: the user identifier, as userId
       schema:
         type: string
     # linked operation
@@ -2086,14 +2086,14 @@ links:
       userUuid: $response.body#/uuid
 ```
 
-Clients follow all links at their discretion. 
-Neither permissions, nor the capability to make a successful call to that link, is guaranteed 
+Clients follow all links at their discretion.
+Neither permissions, nor the capability to make a successful call to that link, is guaranteed
 solely by the existence of a relationship.
 
 
 ##### OperationRef Examples
 
-As references to `operationId` MAY NOT be possible (the `operationId` is an optional 
+As references to `operationId` MAY NOT be possible (the `operationId` is an optional
 value), references MAY also be made through a relative `operationRef`:
 
 ```yaml
@@ -2116,52 +2116,52 @@ links:
       username: $response.body#/username
 ```
 
-Note that in the use of `operationRef`, the _escaped forward-slash_ is necessary when 
+Note that in the use of `operationRef`, the _escaped forward-slash_ is necessary when
 using JSON references.
 
 
-##### <a name="runtimeExpression"></a>Runtime Expressions
+##### Runtime Expressions
 
 Runtime expressions allow defining values based on information that will only be available within the HTTP message in an actual API call.
-This mechanism is used by [Link Objects](#linkObject) and [Callback Objects](#callbackObject).
+This mechanism is used by [Link Objects](#link-object) and [Callback Objects](#callback-object).
 
 The runtime expression is defined by the following [ABNF](https://tools.ietf.org/html/rfc5234) syntax
 
 ```
       expression = ( "$url" | "$method" | "$statusCode" | "$request." source | "$response." source )
-      source = ( header-reference | query-reference | path-reference | body-reference )  
+      source = ( header-reference | query-reference | path-reference | body-reference ) 
       header-reference = "header." token
-      query-reference = "query." name  
+      query-reference = "query." name 
       path-reference = "path." name
       body-reference = "body" ["#" fragment]
-      fragment = a JSON Pointer [RFC 6901](https://tools.ietf.org/html/rfc6901)  
+      fragment = a JSON Pointer [RFC 6901](https://tools.ietf.org/html/rfc6901) 
       name = *( char )
       char = as per RFC [7159](https://tools.ietf.org/html/rfc7159#section-7)
       token = as per RFC [7230](https://tools.ietf.org/html/rfc7230#section-3.2.6)
 ```
 
-The `name` identifier is case-sensitive, whereas `token` is not. 
+The `name` identifier is case-sensitive, whereas `token` is not.
 
 The table below provides examples of runtime expressions and examples of their use in a value:
 
-##### <a name="runtimeExpressionExamples"></a>Examples
+##### Examples
 
 Source Location | example expression  | notes
 ---|:---|:---|
 HTTP Method            | `$method`         | The allowable values for the `$method` will be those for the HTTP operation.
-Requested media type | `$request.header.accept`        |  
+Requested media type | `$request.header.accept`        | 
 Request parameter      | `$request.path.id`        | Request parameters MUST be declared in the `parameters` section of the parent operation or they cannot be evaluated. This includes request headers.
 Request body property   | `$request.body#/user/uuid`   | In operations which accept payloads, references may be made to portions of the `requestBody` or the entire body.
-Request URL            | `$url`            |  
+Request URL            | `$url`            | 
 Response value         | `$response.body#/status`       |  In operations which return payloads, references may be made to portions of the response body or the entire body.
 Response header        | `$response.header.Server` |  Single header values only are available
 
 Runtime expressions preserve the type of the referenced value.
 Expressions can be embedded into string values by surrounding the expression with `{}` curly braces.
 
-#### <a name="headerObject"></a>Header Object
+#### Header Object
 
-The Header Object follows the structure of the [Parameter Object](#parameterObject) with the following changes:
+The Header Object follows the structure of the [Parameter Object](#parameter-object) with the following changes:
 
 1. `name` MUST NOT be specified, it is given in the corresponding `headers` map.
 1. `in` MUST NOT be specified, it is implicitly in `header`.
@@ -2186,9 +2186,9 @@ schema:
   type: integer
 ```
 
-#### <a name="tagObject"></a>Tag Object
+#### Tag Object
 
-Adds metadata to a single tag that is used by the [Operation Object](#operationObject).
+Adds metadata to a single tag that is used by the [Operation Object](#operation-object).
 It is not mandatory to have a Tag Object per tag defined in the Operation Object instances.
 
 ##### Fixed Fields
@@ -2196,9 +2196,9 @@ Field Name | Type | Description
 ---|:---:|---
 <a name="tagName"></a>name | `string` | **REQUIRED**. The name of the tag.
 <a name="tagDescription"></a>description | `string` | A short description for the tag. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="tagExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation for this tag.
+<a name="tagExternalDocs"></a>externalDocs | [External Documentation Object](#external-documentation-object) | Additional external documentation for this tag.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Tag Object Example
 
@@ -2215,11 +2215,11 @@ description: Pets operations
 ```
 
 
-#### <a name="referenceObject"></a>Reference Object
+#### Reference Object
 
 A simple object to allow referencing other components in the specification, internally and externally.
 
-The Reference Object is defined by [JSON Reference](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03) and follows the same structure, behavior and rules. 
+The Reference Object is defined by [JSON Reference](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03) and follows the same structure, behavior and rules.
 
 For this specification, reference resolution is accomplished as defined by the JSON Reference specification and not by the JSON Schema specification.
 
@@ -2264,7 +2264,7 @@ $ref: Pet.yaml
 $ref: definitions.yaml#/Pet
 ```
 
-#### <a name="schemaObject"></a>Schema Object
+#### Schema Object
 
 The Schema Object allows the definition of input and output data types.
 These types can be objects, but also primitives and arrays.
@@ -2273,7 +2273,7 @@ This object is an extended subset of the [JSON Schema Specification Wright Draft
 For more information about the properties, see [JSON Schema Core](https://tools.ietf.org/html/draft-wright-json-schema-00) and [JSON Schema Validation](https://tools.ietf.org/html/draft-wright-json-schema-validation-00).
 Unless stated otherwise, the property definitions follow the JSON Schema.
 
-##### Properties 
+##### Properties
 
 The following properties are taken directly from the JSON Schema definition and follow the same specifications:
 
@@ -2294,20 +2294,20 @@ The following properties are taken directly from the JSON Schema definition and 
 - required
 - enum
 
-The following properties are taken from the JSON Schema definition but their definitions were adjusted to the OpenAPI Specification. 
+The following properties are taken from the JSON Schema definition but their definitions were adjusted to the OpenAPI Specification.
 - type - Value MUST be a string. Multiple types via an array are not supported.
-- allOf - Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard JSON Schema.
-- oneOf - Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard JSON Schema.
-- anyOf - Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard JSON Schema.
-- not - Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard JSON Schema.
-- items - Value MUST be an object and not an array. Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard JSON Schema. `items` MUST be present if the `type` is `array`.
-- properties - Property definitions MUST be a [Schema Object](#schemaObject) and not a standard JSON Schema (inline or referenced).
-- additionalProperties - Value can be boolean or object. Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard JSON Schema. Consistent with JSON Schema, `additionalProperties` defaults to `true`.
+- allOf - Inline or referenced schema MUST be of a [Schema Object](#schema-object) and not a standard JSON Schema.
+- oneOf - Inline or referenced schema MUST be of a [Schema Object](#schema-object) and not a standard JSON Schema.
+- anyOf - Inline or referenced schema MUST be of a [Schema Object](#schema-object) and not a standard JSON Schema.
+- not - Inline or referenced schema MUST be of a [Schema Object](#schema-object) and not a standard JSON Schema.
+- items - Value MUST be an object and not an array. Inline or referenced schema MUST be of a [Schema Object](#schema-object) and not a standard JSON Schema. `items` MUST be present if the `type` is `array`.
+- properties - Property definitions MUST be a [Schema Object](#schema-object) and not a standard JSON Schema (inline or referenced).
+- additionalProperties - Value can be boolean or object. Inline or referenced schema MUST be of a [Schema Object](#schema-object) and not a standard JSON Schema. Consistent with JSON Schema, `additionalProperties` defaults to `true`.
 - description - [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
 - format - See [Data Type Formats](#dataTypeFormat) for further details. While relying on JSON Schema's defined formats, the OAS offers a few additional predefined formats.
 - default - The default value represents what would be assumed by the consumer of the input as the value of the schema if one is not provided. Unlike JSON Schema, the value MUST conform to the defined type for the Schema Object defined at the same level. For example, if `type` is `string`, then `default` can be `"foo"` but cannot be `1`.
 
-Alternatively, any time a Schema Object can be used, a [Reference Object](#referenceObject) can be used in its place. This allows referencing definitions instead of defining them inline.
+Alternatively, any time a Schema Object can be used, a [Reference Object](#reference-object) can be used in its place. This allows referencing definitions instead of defining them inline.
 
 Additional properties defined by the JSON Schema specification that are not mentioned here are strictly unsupported.
 
@@ -2317,20 +2317,20 @@ Other than the JSON Schema subset fields, the following fields MAY be used for f
 Field Name | Type | Description
 ---|:---:|---
 <a name="schemaNullable"></a>nullable | `boolean` | Allows sending a `null` value for the defined schema. Default value is `false`.
-<a name="schemaDiscriminator"></a>discriminator | [Discriminator Object](#discriminatorObject) | Adds support for polymorphism. The discriminator is an object name that is used to differentiate between other schemas which may satisfy the payload description. See [Composition and Inheritance](#schemaComposition) for more details.
+<a name="schemaDiscriminator"></a>discriminator | [Discriminator Object](#discriminator-object) | Adds support for polymorphism. The discriminator is an object name that is used to differentiate between other schemas which may satisfy the payload description. See [Composition and Inheritance](#composition-and-inheritance-polymorphism) for more details.
 <a name="schemaReadOnly"></a>readOnly | `boolean` | Relevant only for Schema `"properties"` definitions. Declares the property as "read only". This means that it MAY be sent as part of a response but SHOULD NOT be sent as part of the request. If the property is marked as `readOnly` being `true` and is in the `required` list, the `required` will take effect on the response only. A property MUST NOT be marked as both `readOnly` and `writeOnly` being `true`. Default value is `false`.
 <a name="schemaWriteOnly"></a>writeOnly | `boolean` | Relevant only for Schema `"properties"` definitions. Declares the property as "write only". Therefore, it MAY be sent as part of a request but SHOULD NOT be sent as part of the response. If the property is marked as `writeOnly` being `true` and is in the `required` list, the `required` will take effect on the request only. A property MUST NOT be marked as both `readOnly` and `writeOnly` being `true`. Default value is `false`.
-<a name="schemaXml"></a>xml | [XML Object](#xmlObject) | This MAY be used only on properties schemas. It has no effect on root schemas. Adds additional metadata to describe the XML representation of this property.
-<a name="schemaExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation for this schema. 
+<a name="schemaXml"></a>xml | [XML Object](#xml-object) | This MAY be used only on properties schemas. It has no effect on root schemas. Adds additional metadata to describe the XML representation of this property.
+<a name="schemaExternalDocs"></a>externalDocs | [External Documentation Object](#external-documentation-object) | Additional external documentation for this schema.
 <a name="schemaExample"></a>example | Any | A free-form property to include an example of an instance for this schema. To represent examples that cannot be naturally represented in JSON or YAML, a string value can be used to contain the example with escaping where necessary.
 <a name="schemaDeprecated"></a> deprecated | `boolean` | Specifies that a schema is deprecated and SHOULD be transitioned out of usage. Default value is `false`.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
-###### <a name="schemaComposition"></a>Composition and Inheritance (Polymorphism)
+###### Composition and Inheritance (Polymorphism)
 
 The OpenAPI Specification allows combining and extending model definitions using the `allOf` property of JSON Schema, in effect offering model composition.
-`allOf` takes an array of object definitions that are validated *independently* but together compose a single object. 
+`allOf` takes an array of object definitions that are validated *independently* but together compose a single object.
 
 While composition offers model extensibility, it does not imply a hierarchy between the models.
 To support polymorphism, the OpenAPI Specification adds the `discriminator` field.
@@ -2344,7 +2344,7 @@ As such, inline schema definitions, which do not have a given id, *cannot* be us
 ###### XML Modeling
 
 The [xml](#schemaXml) property allows extra definitions when translating the JSON definition to XML.
-The [XML Object](#xmlObject) contains additional information about the available options.
+The [XML Object](#xml-object) contains additional information about the available options.
 
 ##### Schema Object Examples
 
@@ -2674,7 +2674,7 @@ components:
         - packSize
 ```
 
-#### <a name="discriminatorObject"></a>Discriminator Object
+#### Discriminator Object
 
 When request bodies or response payloads may be one of a number of different schemas, a `discriminator` object can be used to aid in serialization, deserialization, and validation.  The discriminator is a specific object in a schema which is used to inform the consumer of the specification of an alternative schema based on the value associated with it.
 
@@ -2807,7 +2807,7 @@ will indicate that the `Cat` schema be used.  Likewise this schema:
 will map to `Dog` because of the definition in the `mappings` element.
 
 
-#### <a name="xmlObject"></a>XML Object
+#### XML Object
 
 A metadata object that allows for more fine-tuned XML model definitions.
 
@@ -2823,11 +2823,11 @@ Field Name | Type | Description
 <a name="xmlAttribute"></a>attribute | `boolean` | Declares whether the property definition translates to an attribute instead of an element. Default value is `false`.
 <a name="xmlWrapped"></a>wrapped | `boolean` | MAY be used only for an array definition. Signifies whether the array is wrapped (for example, `<books><book/><book/></books>`) or unwrapped (`<book/><book/>`). Default value is `false`. The definition takes effect only when defined alongside `type` being `array` (outside the `items`).
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### XML Object Examples
 
-The examples of the XML object definitions are included inside a property definition of a [Schema Object](#schemaObject) with a sample of the XML representation of it.
+The examples of the XML object definitions are included inside a property definition of a [Schema Object](#schema-object) with a sample of the XML representation of it.
 
 ###### No XML Element
 
@@ -3160,7 +3160,7 @@ animals:
 </aliens>
 ```
 
-#### <a name="securitySchemeObject"></a>Security Scheme Object
+#### Security Scheme Object
 
 Defines a security scheme that can be used by the operations.
 Supported schemes are HTTP authentication, an API key (either as a header, a cookie parameter or as a query parameter), OAuth2's common flows (implicit, password, application and access code) as defined in [RFC6749](https://tools.ietf.org/html/rfc6749), and [OpenID Connect Discovery](https://tools.ietf.org/html/draft-ietf-oauth-discovery-06).
@@ -3174,10 +3174,10 @@ Field Name | Type | Applies To | Description
 <a name="securitySchemeIn"></a>in | `string` | `apiKey` | **REQUIRED**. The location of the API key. Valid values are `"query"`, `"header"` or `"cookie"`.
 <a name="securitySchemeScheme"></a>scheme | `string` | `http` | **REQUIRED**. The name of the HTTP Authorization scheme to be used in the [Authorization header as defined in RFC7235](https://tools.ietf.org/html/rfc7235#section-5.1).
 <a name="securitySchemeBearerFormat"></a>bearerFormat | `string` | `http` (`"bearer"`) | A hint to the client to identify how the bearer token is formatted.  Bearer tokens are usually generated by an authorization server, so this information is primarily for documentation purposes.
-<a name="securitySchemeFlows"></a>flows | [OAuth Flows Object](#oauthFlowsObject) | `oauth2` | **REQUIRED**. An object containing configuration information for the flow types supported.
+<a name="securitySchemeFlows"></a>flows | [OAuth Flows Object](#oauth-flows-object) | `oauth2` | **REQUIRED**. An object containing configuration information for the flow types supported.
 <a name="securitySchemeOpenIdConnectUrl"></a>openIdConnectUrl | `string` | `openIdConnect` | **REQUIRED**. OpenId Connect URL to discover OAuth2 configuration values. This MUST be in the form of a URL.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Security Scheme Object Example
 
@@ -3246,7 +3246,7 @@ bearerFormat: JWT
 
 ```yaml
 type: oauth2
-flows: 
+flows:
   implicit:
     authorizationUrl: https://example.com/api/oauth/dialog
     scopes:
@@ -3254,21 +3254,21 @@ flows:
       read:pets: read your pets
 ```
 
-#### <a name="oauthFlowsObject"></a>OAuth Flows Object
+#### OAuth Flows Object
 
 Allows configuration of the supported OAuth Flows.
 
 ##### Fixed Fields
 Field Name | Type | Description
 ---|:---:|---
-<a name="oauthFlowsImplicit"></a>implicit| [OAuth Flow Object](#oauthFlowObject) | Configuration for the OAuth Implicit flow 
-<a name="oauthFlowsPassword"></a>password| [OAuth Flow Object](#oauthFlowObject) | Configuration for the OAuth Resource Owner Password flow 
-<a name="oauthFlowsClientCredentials"></a>clientCredentials| [OAuth Flow Object](#oauthFlowObject) | Configuration for the OAuth Client Credentials flow.  Previously called `application` in OpenAPI 2.0.
-<a name="oauthFlowsAuthorizationCode"></a>authorizationCode| [OAuth Flow Object](#oauthFlowObject) | Configuration for the OAuth Authorization Code flow.  Previously called `accessCode` in OpenAPI 2.0.
+<a name="oauthFlowsImplicit"></a>implicit| [OAuth Flow Object](#oauth-flow-object) | Configuration for the OAuth Implicit flow
+<a name="oauthFlowsPassword"></a>password| [OAuth Flow Object](#oauth-flow-object) | Configuration for the OAuth Resource Owner Password flow
+<a name="oauthFlowsClientCredentials"></a>clientCredentials| [OAuth Flow Object](#oauth-flow-object) | Configuration for the OAuth Client Credentials flow.  Previously called `application` in OpenAPI 2.0.
+<a name="oauthFlowsAuthorizationCode"></a>authorizationCode| [OAuth Flow Object](#oauth-flow-object) | Configuration for the OAuth Authorization Code flow.  Previously called `accessCode` in OpenAPI 2.0.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
-#### <a name="oauthFlowObject"></a>OAuth Flow Object
+#### OAuth Flow Object
 
 Configuration details for a supported OAuth Flow
 
@@ -3280,7 +3280,7 @@ Field Name | Type | Applies To | Description
 <a name="oauthFlowRefreshUrl"></a>refreshUrl | `string` | `oauth2` | The URL to be used for obtaining refresh tokens. This MUST be in the form of a URL.
 <a name="oauthFlowScopes"></a>scopes | Map[`string`, `string`] | `oauth2` | **REQUIRED**. The available scopes for the OAuth2 security scheme. A map between the scope name and a short description for it.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### OAuth Flow Object Examples
 
@@ -3309,7 +3309,7 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
 
 ```yaml
 type: oauth2
-flows: 
+flows:
   implicit:
     authorizationUrl: https://example.com/api/oauth/dialog
     scopes:
@@ -3320,25 +3320,25 @@ flows:
     tokenUrl: https://example.com/api/oauth/token
     scopes:
       write:pets: modify pets in your account
-      read:pets: read your pets 
+      read:pets: read your pets
 ```
 
 
-#### <a name="securityRequirementObject"></a>Security Requirement Object
+#### Security Requirement Object
 
 Lists the required security schemes to execute this operation.
-The name used for each property MUST correspond to a security scheme declared in the [Security Schemes](#componentsSecuritySchemes) under the [Components Object](#componentsObject).
+The name used for each property MUST correspond to a security scheme declared in the [Security Schemes](#componentsSecuritySchemes) under the [Components Object](#components-object).
 
 Security Requirement Objects that contain multiple schemes require that all schemes MUST be satisfied for a request to be authorized.
 This enables support for scenarios where multiple query parameters or HTTP headers are required to convey security information.
 
-When a list of Security Requirement Objects is defined on the [OpenAPI Object](#oasObject) or [Operation Object](#operationObject), only one of the Security Requirement Objects in the list needs to be satisfied to authorize the request.
+When a list of Security Requirement Objects is defined on the [OpenAPI Object](#openapi-object) or [Operation Object](#operation-object), only one of the Security Requirement Objects in the list needs to be satisfied to authorize the request.
 
 ##### Patterned Fields
 
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="securityRequirementsName"></a>{name} | [`string`] | Each name MUST correspond to a security scheme which is declared in the [Security Schemes](#componentsSecuritySchemes) under the [Components Object](#componentsObject). If the security scheme is of type `"oauth2"` or `"openIdConnect"`, then the value is a list of scope names required for the execution. For other security scheme types, the array MUST be empty.
+<a name="securityRequirementsName"></a>{name} | [`string`] | Each name MUST correspond to a security scheme which is declared in the [Security Schemes](#componentsSecuritySchemes) under the [Components Object](#components-object). If the security scheme is of type `"oauth2"` or `"openIdConnect"`, then the value is a list of scope names required for the execution. For other security scheme types, the array MUST be empty.
 
 ##### Security Requirement Object Examples
 
@@ -3371,7 +3371,7 @@ petstore_auth:
 - read:pets
 ```
 
-### <a name="specificationExtensions"></a>Specification Extensions
+### Specification Extensions
 
 While the OpenAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.
 
@@ -3383,19 +3383,19 @@ Field Pattern | Type | Description
 
 The extensions may or may not be supported by the available tooling, but those may be extended as well to add requested support (if tools are internal or open-sourced).
 
-### <a name="securityFiltering"></a>Security Filtering
+### Security Filtering
 
-Some objects in the OpenAPI Specification MAY be declared and remain empty, or be completely removed, even though they are inherently the core of the API documentation. 
+Some objects in the OpenAPI Specification MAY be declared and remain empty, or be completely removed, even though they are inherently the core of the API documentation.
 
 The reasoning is to allow an additional layer of access control over the documentation.
 While not part of the specification itself, certain libraries MAY choose to allow access to parts of the documentation based on some form of authentication/authorization.
 
 Two examples of this:
 
-1. The [Paths Object](#pathsObject) MAY be empty. It may be counterintuitive, but this may tell the viewer that they got to the right place, but can't access any documentation. They'd still have access to the [Info Object](#infoObject) which may contain additional information regarding authentication.
-2. The [Path Item Object](#pathItemObject) MAY be empty. In this case, the viewer will be aware that the path exists, but will not be able to see any of its operations or parameters. This is different than hiding the path itself from the [Paths Object](#pathsObject), so the user will not be aware of its existence. This allows the documentation provider to finely control what the viewer can see.
+1. The [Paths Object](#paths-object) MAY be empty. It may be counterintuitive, but this may tell the viewer that they got to the right place, but can't access any documentation. They'd still have access to the [Info Object](#info-object) which may contain additional information regarding authentication.
+2. The [Path Item Object](#path-item-object) MAY be empty. In this case, the viewer will be aware that the path exists, but will not be able to see any of its operations or parameters. This is different than hiding the path itself from the [Paths Object](#paths-object), so the user will not be aware of its existence. This allows the documentation provider to finely control what the viewer can see.
 
-## <a name="revisionHistory"></a>Appendix A: Revision History
+## Appendix A: Revision History
 
 Version   | Date       | Notes
 ---       | ---        | ---

--- a/versions/3.0.3.md
+++ b/versions/3.0.3.md
@@ -16,66 +16,66 @@ An OpenAPI definition can then be used by documentation generation tools to disp
 <!-- TOC depthFrom:1 depthTo:3 withLinks:1 updateOnSave:1 orderedList:0 -->
 
 - [Definitions](#definitions)
-	- [OpenAPI Document](#oasDocument)
-	- [Path Templating](#pathTemplating)
-	- [Media Types](#mediaTypes)
-	- [HTTP Status Codes](#httpCodes)
+	- [OpenAPI Document](#openapi-document)
+	- [Path Templating](#path-templating)
+	- [Media Types](#media-types)
+	- [HTTP Status Codes](#http-status-codes)
 - [Specification](#specification)
 	- [Versions](#versions)
 	- [Format](#format)
-	- [Document Structure](#documentStructure)
-	- [Data Types](#dataTypes)
-	- [Rich Text Formatting](#richText)
-	- [Relative References In URLs](#relativeReferences)
+	- [Document Structure](#document-structure)
+	- [Data Types](#data-types)
+	- [Rich Text Formatting](#rich-text-formatting)
+	- [Relative References In URLs](#relative-references-in-urls)
 	- [Schema](#schema)
-		- [OpenAPI Object](#oasObject)
-		- [Info Object](#infoObject)
-		- [Contact Object](#contactObject)
-		- [License Object](#licenseObject)
-		- [Server Object](#serverObject)
-		- [Server Variable Object](#serverVariableObject)
-		- [Components Object](#componentsObject)
-		- [Paths Object](#pathsObject)
-		- [Path Item Object](#pathItemObject)
-		- [Operation Object](#operationObject)
-		- [External Documentation Object](#externalDocumentationObject)
-		- [Parameter Object](#parameterObject)
-		- [Request Body Object](#requestBodyObject)
-		- [Media Type Object](#mediaTypeObject)
-		- [Encoding Object](#encodingObject)
-		- [Responses Object](#responsesObject)
-		- [Response Object](#responseObject)
-		- [Callback Object](#callbackObject)
-		- [Example Object](#exampleObject)
-		- [Link Object](#linkObject)
-		- [Header Object](#headerObject)
-		- [Tag Object](#tagObject)
-		- [Reference Object](#referenceObject)
-		- [Schema Object](#schemaObject)
-		- [Discriminator Object](#discriminatorObject)
-		- [XML Object](#xmlObject)
-		- [Security Scheme Object](#securitySchemeObject)
-		- [OAuth Flows Object](#oauthFlowsObject)
-		- [OAuth Flow Object](#oauthFlowObject)
-		- [Security Requirement Object](#securityRequirementObject)
-	- [Specification Extensions](#specificationExtensions)
-	- [Security Filtering](#securityFiltering)
-- [Appendix A: Revision History](#revisionHistory)
+		- [OpenAPI Object](#openapi-object)
+		- [Info Object](#info-object)
+		- [Contact Object](#contact-object)
+		- [License Object](#license-object)
+		- [Server Object](#server-object)
+		- [Server Variable Object](#server-variable-object)
+		- [Components Object](#components-object)
+		- [Paths Object](#paths-object)
+		- [Path Item Object](#path-item-object)
+		- [Operation Object](#operation-object)
+		- [External Documentation Object](#external-documentation-object)
+		- [Parameter Object](#parameter-object)
+		- [Request Body Object](#request-body-object)
+		- [Media Type Object](#media-type-object)
+		- [Encoding Object](#encoding-object)
+		- [Responses Object](#responses-object)
+		- [Response Object](#response-object)
+		- [Callback Object](#callback-object)
+		- [Example Object](#example-object)
+		- [Link Object](#link-object)
+		- [Header Object](#header-object)
+		- [Tag Object](#tag-object)
+		- [Reference Object](#reference-object)
+		- [Schema Object](#schema-object)
+		- [Discriminator Object](#discriminator-object)
+		- [XML Object](#xml-object)
+		- [Security Scheme Object](#security-scheme-object)
+		- [OAuth Flows Object](#oauth-flows-object)
+		- [OAuth Flow Object](#oauth-flow-object)
+		- [Security Requirement Object](#security-requirement-object)
+	- [Specification Extensions](#specification-extensions)
+	- [Security Filtering](#security-filtering)
+- [Appendix A: Revision History](#appendix-a-revision-history)
 	
 
 <!-- /TOC -->
 
 ## Definitions
 
-##### <a name="oasDocument"></a>OpenAPI Document
+##### OpenAPI Document
 A document (or set of documents) that defines or describes an API. An OpenAPI definition uses and conforms to the OpenAPI Specification.
 
-##### <a name="pathTemplating"></a>Path Templating
+##### Path Templating
 Path templating refers to the usage of template expressions, delimited by curly braces ({}), to mark a section of a URL path as replaceable using path parameters.
 
 Each template expression in the path MUST correspond to a path parameter that is included in the [Path Item](#path-item-object) itself and/or in each of the Path Item's [Operations](#operation-object).
 
-##### <a name="mediaTypes"></a>Media Types
+##### Media Types
 Media type definitions are spread across several resources.
 The media type definitions SHOULD be in compliance with [RFC6838](https://tools.ietf.org/html/rfc6838).
 
@@ -92,8 +92,8 @@ Some examples of possible media type definitions:
   application/vnd.github.v3.diff
   application/vnd.github.v3.patch
 ```
-##### <a name="httpCodes"></a>HTTP Status Codes
-The HTTP Status Codes are used to indicate the status of the executed operation. 
+##### HTTP Status Codes
+The HTTP Status Codes are used to indicate the status of the executed operation.
 The available status codes are defined by [RFC7231](https://tools.ietf.org/html/rfc7231#section-6) and registered status codes are listed in the [IANA Status Code Registry](https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml).
 
 ## Specification
@@ -126,7 +126,7 @@ This includes all fields that are used as keys in a map, except where explicitly
 
 The schema exposes two types of fields: Fixed fields, which have a declared name, and Patterned fields, which declare a regex pattern for the field name.
 
-Patterned fields MUST have unique names within the containing object. 
+Patterned fields MUST have unique names within the containing object.
 
 In order to preserve the ability to round-trip between YAML and JSON formats, YAML version [1.2](https://yaml.org/spec/1.2/spec.html) is RECOMMENDED along with some additional constraints:
 
@@ -135,18 +135,18 @@ In order to preserve the ability to round-trip between YAML and JSON formats, YA
 
 **Note:** While APIs may be defined by OpenAPI documents in either YAML or JSON format, the API request and response bodies and other content are not required to be JSON or YAML.
 
-### <a name="documentStructure"></a>Document Structure
+### Document Structure
 
 An OpenAPI document MAY be made up of a single document or be divided into multiple, connected parts at the discretion of the user. In the latter case, `$ref` fields MUST be used in the specification to reference those parts as follows from the [JSON Schema](https://json-schema.org) definitions.
 
 It is RECOMMENDED that the root OpenAPI document be named: `openapi.json` or `openapi.yaml`.
 
-### <a name="dataTypes"></a>Data Types
+### Data Types
 
-Primitive data types in the OAS are based on the types supported by the [JSON Schema Specification Wright Draft 00](https://tools.ietf.org/html/draft-wright-json-schema-00#section-4.2). 
-Note that `integer` as a type is also supported and is defined as a JSON number without a fraction or exponent part. 
+Primitive data types in the OAS are based on the types supported by the [JSON Schema Specification Wright Draft 00](https://tools.ietf.org/html/draft-wright-json-schema-00#section-4.2).
+Note that `integer` as a type is also supported and is defined as a JSON number without a fraction or exponent part.
 `null` is not supported as a type (see [`nullable`](#schemaNullable) for an alternative solution).
-Models are defined using the [Schema Object](#schemaObject), which is an extended subset of JSON Schema Specification Wright Draft 00.
+Models are defined using the [Schema Object](#schema-object), which is an extended subset of JSON Schema Specification Wright Draft 00.
 
 <a name="dataTypeFormat"></a>Primitives have an optional modifier property: `format`.
 OAS uses several known formats to define in fine detail the data type being used.
@@ -156,7 +156,7 @@ Types that are not accompanied by a `format` property follow the type definition
 
 The formats defined by the OAS are:
 
-[`type`](#dataTypes) | [`format`](#dataTypeFormat) | Comments
+[`type`](#data-types) | [`format`](#dataTypeFormat) | Comments
 ------ | -------- | --------
 `integer` | `int32` | signed 32 bits
 `integer` | `int64` | signed 64 bits (a.k.a long)
@@ -171,41 +171,41 @@ The formats defined by the OAS are:
 `string` | `password` | A hint to UIs to obscure input.
 
 
-### <a name="richText"></a>Rich Text Formatting
+### Rich Text Formatting
 Throughout the specification `description` fields are noted as supporting CommonMark markdown formatting.
-Where OpenAPI tooling renders rich text it MUST support, at a minimum, markdown syntax as described by [CommonMark 0.27](https://spec.commonmark.org/0.27/). Tooling MAY choose to ignore some CommonMark features to address security concerns. 
+Where OpenAPI tooling renders rich text it MUST support, at a minimum, markdown syntax as described by [CommonMark 0.27](https://spec.commonmark.org/0.27/). Tooling MAY choose to ignore some CommonMark features to address security concerns.
 
-### <a name="relativeReferences"></a>Relative References in URLs
+### Relative References in URLs
 
 Unless specified otherwise, all properties that are URLs MAY be relative references as defined by [RFC3986](https://tools.ietf.org/html/rfc3986#section-4.2).
-Relative references are resolved using the URLs defined in the [`Server Object`](#serverObject) as a Base URI.
+Relative references are resolved using the URLs defined in the [`Server Object`](#server-object) as a Base URI.
 
-Relative references used in `$ref` are processed as per [JSON Reference](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03), using the URL of the current document as the base URI. See also the [Reference Object](#referenceObject).
+Relative references used in `$ref` are processed as per [JSON Reference](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03), using the URL of the current document as the base URI. See also the [Reference Object](#reference-object).
 
 ### Schema
 
 In the following description, if a field is not explicitly **REQUIRED** or described with a MUST or SHALL, it can be considered OPTIONAL.
 
-#### <a name="oasObject"></a>OpenAPI Object
+#### OpenAPI Object
 
-This is the root document object of the [OpenAPI document](#oasDocument).
+This is the root document object of the [OpenAPI document](#openapi-document).
 
 ##### Fixed Fields
 
 Field Name | Type | Description
 ---|:---:|---
 <a name="oasVersion"></a>openapi | `string` | **REQUIRED**. This string MUST be the [semantic version number](https://semver.org/spec/v2.0.0.html) of the [OpenAPI Specification version](#versions) that the OpenAPI document uses. The `openapi` field SHOULD be used by tooling specifications and clients to interpret the OpenAPI document. This is *not* related to the API [`info.version`](#infoVersion) string.
-<a name="oasInfo"></a>info | [Info Object](#infoObject) | **REQUIRED**. Provides metadata about the API. The metadata MAY be used by tooling as required.
-<a name="oasServers"></a>servers | [[Server Object](#serverObject)] | An array of Server Objects, which provide connectivity information to a target server. If the `servers` property is not provided, or is an empty array, the default value would be a [Server Object](#serverObject) with a [url](#serverUrl) value of `/`.
-<a name="oasPaths"></a>paths | [Paths Object](#pathsObject) | **REQUIRED**. The available paths and operations for the API.
-<a name="oasComponents"></a>components | [Components Object](#componentsObject) | An element to hold various schemas for the specification.
-<a name="oasSecurity"></a>security | [[Security Requirement Object](#securityRequirementObject)] | A declaration of which security mechanisms can be used across the API. The list of values includes alternative security requirement objects that can be used. Only one of the security requirement objects need to be satisfied to authorize a request. Individual operations can override this definition. To make security optional, an empty security requirement (`{}`) can be included in the array.
-<a name="oasTags"></a>tags | [[Tag Object](#tagObject)] | A list of tags used by the specification with additional metadata. The order of the tags can be used to reflect on their order by the parsing tools. Not all tags that are used by the [Operation Object](#operationObject) must be declared. The tags that are not declared MAY be organized randomly or based on the tools' logic. Each tag name in the list MUST be unique.
-<a name="oasExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation.
+<a name="oasInfo"></a>info | [Info Object](#info-object) | **REQUIRED**. Provides metadata about the API. The metadata MAY be used by tooling as required.
+<a name="oasServers"></a>servers | [[Server Object](#server-object)] | An array of Server Objects, which provide connectivity information to a target server. If the `servers` property is not provided, or is an empty array, the default value would be a [Server Object](#server-object) with a [url](#serverUrl) value of `/`.
+<a name="oasPaths"></a>paths | [Paths Object](#paths-object) | **REQUIRED**. The available paths and operations for the API.
+<a name="oasComponents"></a>components | [Components Object](#components-object) | An element to hold various schemas for the specification.
+<a name="oasSecurity"></a>security | [[Security Requirement Object](#security-requirement-object)] | A declaration of which security mechanisms can be used across the API. The list of values includes alternative security requirement objects that can be used. Only one of the security requirement objects need to be satisfied to authorize a request. Individual operations can override this definition. To make security optional, an empty security requirement (`{}`) can be included in the array.
+<a name="oasTags"></a>tags | [[Tag Object](#tag-object)] | A list of tags used by the specification with additional metadata. The order of the tags can be used to reflect on their order by the parsing tools. Not all tags that are used by the [Operation Object](#operation-object) must be declared. The tags that are not declared MAY be organized randomly or based on the tools' logic. Each tag name in the list MUST be unique.
+<a name="oasExternalDocs"></a>externalDocs | [External Documentation Object](#external-documentation-object) | Additional external documentation.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
-#### <a name="infoObject"></a>Info Object
+#### Info Object
 
 The object provides metadata about the API.
 The metadata MAY be used by the clients if needed, and MAY be presented in editing or documentation generation tools for convenience.
@@ -217,12 +217,12 @@ Field Name | Type | Description
 <a name="infoTitle"></a>title | `string` | **REQUIRED**. The title of the API.
 <a name="infoDescription"></a>description | `string` | A short description of the API. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
 <a name="infoTermsOfService"></a>termsOfService | `string` | A URL to the Terms of Service for the API. MUST be in the format of a URL.
-<a name="infoContact"></a>contact | [Contact Object](#contactObject) | The contact information for the exposed API.
-<a name="infoLicense"></a>license | [License Object](#licenseObject) | The license information for the exposed API.
+<a name="infoContact"></a>contact | [Contact Object](#contact-object) | The contact information for the exposed API.
+<a name="infoLicense"></a>license | [License Object](#license-object) | The license information for the exposed API.
 <a name="infoVersion"></a>version | `string` | **REQUIRED**. The version of the OpenAPI document (which is distinct from the [OpenAPI Specification version](#oasVersion) or the API implementation version).
 
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Info Object Example
 
@@ -258,7 +258,7 @@ license:
 version: 1.0.1
 ```
 
-#### <a name="contactObject"></a>Contact Object
+#### Contact Object
 
 Contact information for the exposed API.
 
@@ -270,7 +270,7 @@ Field Name | Type | Description
 <a name="contactUrl"></a>url | `string` | The URL pointing to the contact information. MUST be in the format of a URL.
 <a name="contactEmail"></a>email | `string` | The email address of the contact person/organization. MUST be in the format of an email address.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Contact Object Example
 
@@ -288,7 +288,7 @@ url: http://www.example.com/support
 email: support@example.com
 ```
 
-#### <a name="licenseObject"></a>License Object
+#### License Object
 
 License information for the exposed API.
 
@@ -299,7 +299,7 @@ Field Name | Type | Description
 <a name="licenseName"></a>name | `string` | **REQUIRED**. The license name used for the API.
 <a name="licenseUrl"></a>url | `string` | A URL to the license used for the API. MUST be in the format of a URL.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### License Object Example
 
@@ -315,7 +315,7 @@ name: Apache 2.0
 url: https://www.apache.org/licenses/LICENSE-2.0.html
 ```
 
-#### <a name="serverObject"></a>Server Object
+#### Server Object
 
 An object representing a Server.
 
@@ -325,9 +325,9 @@ Field Name | Type | Description
 ---|:---:|---
 <a name="serverUrl"></a>url | `string` | **REQUIRED**. A URL to the target host.  This URL supports Server Variables and MAY be relative, to indicate that the host location is relative to the location where the OpenAPI document is being served. Variable substitutions will be made when a variable is named in `{`brackets`}`.
 <a name="serverDescription"></a>description | `string` | An optional string describing the host designated by the URL. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="serverVariables"></a>variables | Map[`string`, [Server Variable Object](#serverVariableObject)] | A map between a variable name and its value.  The value is used for substitution in the server's URL template.
+<a name="serverVariables"></a>variables | Map[`string`, [Server Variable Object](#server-variable-object)] | A map between a variable name and its value.  The value is used for substitution in the server's URL template.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Server Object Example
 
@@ -425,7 +425,7 @@ servers:
 ```
 
 
-#### <a name="serverVariableObject"></a>Server Variable Object
+#### Server Variable Object
 
 An object representing a Server Variable for server URL template substitution.
 
@@ -434,12 +434,12 @@ An object representing a Server Variable for server URL template substitution.
 Field Name | Type | Description
 ---|:---:|---
 <a name="serverVariableEnum"></a>enum | [`string`] | An enumeration of string values to be used if the substitution options are from a limited set. The array SHOULD NOT be empty.
-<a name="serverVariableDefault"></a>default | `string` |  **REQUIRED**. The default value to use for substitution, which SHALL be sent if an alternate value is _not_ supplied. Note this behavior is different than the [Schema Object's](#schemaObject) treatment of default values, because in those cases parameter values are optional. If the [`enum`](#serverVariableEnum) is defined, the value SHOULD exist in the enum's values.
+<a name="serverVariableDefault"></a>default | `string` |  **REQUIRED**. The default value to use for substitution, which SHALL be sent if an alternate value is _not_ supplied. Note this behavior is different than the [Schema Object's](#schema-object) treatment of default values, because in those cases parameter values are optional. If the [`enum`](#serverVariableEnum) is defined, the value SHOULD exist in the enum's values.
 <a name="serverVariableDescription"></a>description | `string` | An optional description for the server variable. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
-#### <a name="componentsObject"></a>Components Object
+#### Components Object
 
 Holds a set of reusable objects for different aspects of the OAS.
 All objects defined within the components object will have no effect on the API unless they are explicitly referenced from properties outside the components object.
@@ -449,17 +449,17 @@ All objects defined within the components object will have no effect on the API 
 
 Field Name | Type | Description
 ---|:---|---
-<a name="componentsSchemas"></a> schemas | Map[`string`, [Schema Object](#schemaObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Schema Objects](#schemaObject).
-<a name="componentsResponses"></a> responses | Map[`string`, [Response Object](#responseObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Response Objects](#responseObject).
-<a name="componentsParameters"></a> parameters | Map[`string`, [Parameter Object](#parameterObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Parameter Objects](#parameterObject).
-<a name="componentsExamples"></a> examples | Map[`string`, [Example Object](#exampleObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Example Objects](#exampleObject).
-<a name="componentsRequestBodies"></a> requestBodies | Map[`string`, [Request Body Object](#requestBodyObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Request Body Objects](#requestBodyObject).
-<a name="componentsHeaders"></a> headers | Map[`string`, [Header Object](#headerObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Header Objects](#headerObject).
-<a name="componentsSecuritySchemes"></a> securitySchemes| Map[`string`, [Security Scheme Object](#securitySchemeObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Security Scheme Objects](#securitySchemeObject).
-<a name="componentsLinks"></a> links | Map[`string`, [Link Object](#linkObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Link Objects](#linkObject).
-<a name="componentsCallbacks"></a> callbacks | Map[`string`, [Callback Object](#callbackObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Callback Objects](#callbackObject).
+<a name="componentsSchemas"></a> schemas | Map[`string`, [Schema Object](#schema-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Schema Objects](#schema-object).
+<a name="componentsResponses"></a> responses | Map[`string`, [Response Object](#response-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Response Objects](#response-object).
+<a name="componentsParameters"></a> parameters | Map[`string`, [Parameter Object](#parameter-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Parameter Objects](#parameter-object).
+<a name="componentsExamples"></a> examples | Map[`string`, [Example Object](#example-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Example Objects](#example-object).
+<a name="componentsRequestBodies"></a> requestBodies | Map[`string`, [Request Body Object](#request-body-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Request Body Objects](#request-body-object).
+<a name="componentsHeaders"></a> headers | Map[`string`, [Header Object](#header-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Header Objects](#header-object).
+<a name="componentsSecuritySchemes"></a> securitySchemes| Map[`string`, [Security Scheme Object](#security-scheme-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Security Scheme Objects](#security-scheme-object).
+<a name="componentsLinks"></a> links | Map[`string`, [Link Object](#link-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Link Objects](#link-object).
+<a name="componentsCallbacks"></a> callbacks | Map[`string`, [Callback Object](#callback-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Callback Objects](#callback-object).
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 All the fixed fields declared above are objects that MUST use keys that match the regular expression: `^[a-zA-Z0-9\.\-_]+$`.
 
@@ -639,7 +639,7 @@ components:
       in: header
     petstore_auth:
       type: oauth2
-      flows: 
+      flows:
         implicit:
           authorizationUrl: http://example.org/api/oauth/dialog
           scopes:
@@ -648,18 +648,18 @@ components:
 ```
 
 
-#### <a name="pathsObject"></a>Paths Object
+#### Paths Object
 
 Holds the relative paths to the individual endpoints and their operations.
-The path is appended to the URL from the [`Server Object`](#serverObject) in order to construct the full URL.  The Paths MAY be empty, due to [ACL constraints](#securityFiltering).
+The path is appended to the URL from the [`Server Object`](#server-object) in order to construct the full URL.  The Paths MAY be empty, due to [ACL constraints](#security-filtering).
 
 ##### Patterned Fields
 
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="pathsPath"></a>/{path} | [Path Item Object](#pathItemObject) | A relative path to an individual endpoint. The field name MUST begin with a forward slash (`/`). The path is **appended** (no relative URL resolution) to the expanded URL from the [`Server Object`](#serverObject)'s `url` field in order to construct the full URL. [Path templating](#pathTemplating) is allowed. When matching URLs, concrete (non-templated) paths would be matched before their templated counterparts. Templated paths with the same hierarchy but different templated names MUST NOT exist as they are identical. In case of ambiguous matching, it's up to the tooling to decide which one to use.
+<a name="pathsPath"></a>/{path} | [Path Item Object](#path-item-object) | A relative path to an individual endpoint. The field name MUST begin with a forward slash (`/`). The path is **appended** (no relative URL resolution) to the expanded URL from the [`Server Object`](#server-object)'s `url` field in order to construct the full URL. [Path templating](#path-templating) is allowed. When matching URLs, concrete (non-templated) paths would be matched before their templated counterparts. Templated paths with the same hierarchy but different templated names MUST NOT exist as they are identical. In case of ambiguous matching, it's up to the tooling to decide which one to use.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Path Templating Matching
 
@@ -692,7 +692,7 @@ The following may lead to ambiguous resolution:
     "get": {
       "description": "Returns all pets from the system that the user has access to",
       "responses": {
-        "200": {          
+        "200": {         
           "description": "A list of pets.",
           "content": {
             "application/json": {
@@ -726,32 +726,32 @@ The following may lead to ambiguous resolution:
                 $ref: '#/components/schemas/pet'
 ```
 
-#### <a name="pathItemObject"></a>Path Item Object
+#### Path Item Object
 
 Describes the operations available on a single path.
-A Path Item MAY be empty, due to [ACL constraints](#securityFiltering).
+A Path Item MAY be empty, due to [ACL constraints](#security-filtering).
 The path itself is still exposed to the documentation viewer but they will not know which operations and parameters are available.
 
 ##### Fixed Fields
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="pathItemRef"></a>$ref | `string` | Allows for an external definition of this path item. The referenced structure MUST be in the format of a [Path Item Object](#pathItemObject).  In case a Path Item Object field appears both in the defined object and the referenced object, the behavior is undefined.
+<a name="pathItemRef"></a>$ref | `string` | Allows for an external definition of this path item. The referenced structure MUST be in the format of a [Path Item Object](#path-item-object).  In case a Path Item Object field appears both in the defined object and the referenced object, the behavior is undefined.
 <a name="pathItemSummary"></a>summary| `string` | An optional, string summary, intended to apply to all operations in this path.
 <a name="pathItemDescription"></a>description | `string` | An optional, string description, intended to apply to all operations in this path. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="pathItemGet"></a>get | [Operation Object](#operationObject) | A definition of a GET operation on this path.
-<a name="pathItemPut"></a>put | [Operation Object](#operationObject) | A definition of a PUT operation on this path.
-<a name="pathItemPost"></a>post | [Operation Object](#operationObject) | A definition of a POST operation on this path.
-<a name="pathItemDelete"></a>delete | [Operation Object](#operationObject) | A definition of a DELETE operation on this path.
-<a name="pathItemOptions"></a>options | [Operation Object](#operationObject) | A definition of a OPTIONS operation on this path.
-<a name="pathItemHead"></a>head | [Operation Object](#operationObject) | A definition of a HEAD operation on this path.
-<a name="pathItemPatch"></a>patch | [Operation Object](#operationObject) | A definition of a PATCH operation on this path.
-<a name="pathItemTrace"></a>trace | [Operation Object](#operationObject) | A definition of a TRACE operation on this path.
-<a name="pathItemServers"></a>servers | [[Server Object](#serverObject)] | An alternative `server` array to service all operations in this path.
-<a name="pathItemParameters"></a>parameters | [[Parameter Object](#parameterObject) \| [Reference Object](#referenceObject)] | A list of parameters that are applicable for all the operations described under this path. These parameters can be overridden at the operation level, but cannot be removed there. The list MUST NOT include duplicated parameters. A unique parameter is defined by a combination of a [name](#parameterName) and [location](#parameterIn). The list can use the [Reference Object](#referenceObject) to link to parameters that are defined at the [OpenAPI Object's components/parameters](#componentsParameters). 
+<a name="pathItemGet"></a>get | [Operation Object](#operation-object) | A definition of a GET operation on this path.
+<a name="pathItemPut"></a>put | [Operation Object](#operation-object) | A definition of a PUT operation on this path.
+<a name="pathItemPost"></a>post | [Operation Object](#operation-object) | A definition of a POST operation on this path.
+<a name="pathItemDelete"></a>delete | [Operation Object](#operation-object) | A definition of a DELETE operation on this path.
+<a name="pathItemOptions"></a>options | [Operation Object](#operation-object) | A definition of a OPTIONS operation on this path.
+<a name="pathItemHead"></a>head | [Operation Object](#operation-object) | A definition of a HEAD operation on this path.
+<a name="pathItemPatch"></a>patch | [Operation Object](#operation-object) | A definition of a PATCH operation on this path.
+<a name="pathItemTrace"></a>trace | [Operation Object](#operation-object) | A definition of a TRACE operation on this path.
+<a name="pathItemServers"></a>servers | [[Server Object](#server-object)] | An alternative `server` array to service all operations in this path.
+<a name="pathItemParameters"></a>parameters | [[Parameter Object](#parameter-object) \| [Reference Object](#reference-object)] | A list of parameters that are applicable for all the operations described under this path. These parameters can be overridden at the operation level, but cannot be removed there. The list MUST NOT include duplicated parameters. A unique parameter is defined by a combination of a [name](#parameterName) and [location](#parameterIn). The list can use the [Reference Object](#reference-object) to link to parameters that are defined at the [OpenAPI Object's components/parameters](#componentsParameters).
 
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Path Item Object Example
 
@@ -833,11 +833,11 @@ parameters:
   schema:
     type: array
     items:
-      type: string  
+      type: string 
   style: simple
 ```
 
-#### <a name="operationObject"></a>Operation Object
+#### Operation Object
 
 Describes a single API operation on a path.
 
@@ -848,17 +848,17 @@ Field Name | Type | Description
 <a name="operationTags"></a>tags | [`string`] | A list of tags for API documentation control. Tags can be used for logical grouping of operations by resources or any other qualifier.
 <a name="operationSummary"></a>summary | `string` | A short summary of what the operation does.
 <a name="operationDescription"></a>description | `string` | A verbose explanation of the operation behavior. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="operationExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation for this operation.
+<a name="operationExternalDocs"></a>externalDocs | [External Documentation Object](#external-documentation-object) | Additional external documentation for this operation.
 <a name="operationId"></a>operationId | `string` | Unique string used to identify the operation. The id MUST be unique among all operations described in the API. The operationId value is **case-sensitive**. Tools and libraries MAY use the operationId to uniquely identify an operation, therefore, it is RECOMMENDED to follow common programming naming conventions.
-<a name="operationParameters"></a>parameters | [[Parameter Object](#parameterObject) \| [Reference Object](#referenceObject)] | A list of parameters that are applicable for this operation. If a parameter is already defined at the [Path Item](#pathItemParameters), the new definition will override it but can never remove it. The list MUST NOT include duplicated parameters. A unique parameter is defined by a combination of a [name](#parameterName) and [location](#parameterIn). The list can use the [Reference Object](#referenceObject) to link to parameters that are defined at the [OpenAPI Object's components/parameters](#componentsParameters).
-<a name="operationRequestBody"></a>requestBody | [Request Body Object](#requestBodyObject) \| [Reference Object](#referenceObject) | The request body applicable for this operation.  The `requestBody` is only supported in HTTP methods where the HTTP 1.1 specification [RFC7231](https://tools.ietf.org/html/rfc7231#section-4.3.1) has explicitly defined semantics for request bodies.  In other cases where the HTTP spec is vague, `requestBody` SHALL be ignored by consumers.
-<a name="operationResponses"></a>responses | [Responses Object](#responsesObject) | **REQUIRED**. The list of possible responses as they are returned from executing this operation.
-<a name="operationCallbacks"></a>callbacks | Map[`string`, [Callback Object](#callbackObject) \| [Reference Object](#referenceObject)] | A map of possible out-of band callbacks related to the parent operation. The key is a unique identifier for the Callback Object. Each value in the map is a [Callback Object](#callbackObject) that describes a request that may be initiated by the API provider and the expected responses.
+<a name="operationParameters"></a>parameters | [[Parameter Object](#parameter-object) \| [Reference Object](#reference-object)] | A list of parameters that are applicable for this operation. If a parameter is already defined at the [Path Item](#pathItemParameters), the new definition will override it but can never remove it. The list MUST NOT include duplicated parameters. A unique parameter is defined by a combination of a [name](#parameterName) and [location](#parameterIn). The list can use the [Reference Object](#reference-object) to link to parameters that are defined at the [OpenAPI Object's components/parameters](#componentsParameters).
+<a name="operationRequestBody"></a>requestBody | [Request Body Object](#request-body-object) \| [Reference Object](#reference-object) | The request body applicable for this operation.  The `requestBody` is only supported in HTTP methods where the HTTP 1.1 specification [RFC7231](https://tools.ietf.org/html/rfc7231#section-4.3.1) has explicitly defined semantics for request bodies.  In other cases where the HTTP spec is vague, `requestBody` SHALL be ignored by consumers.
+<a name="operationResponses"></a>responses | [Responses Object](#responses-object) | **REQUIRED**. The list of possible responses as they are returned from executing this operation.
+<a name="operationCallbacks"></a>callbacks | Map[`string`, [Callback Object](#callback-object) \| [Reference Object](#reference-object)] | A map of possible out-of band callbacks related to the parent operation. The key is a unique identifier for the Callback Object. Each value in the map is a [Callback Object](#callback-object) that describes a request that may be initiated by the API provider and the expected responses.
 <a name="operationDeprecated"></a>deprecated | `boolean` | Declares this operation to be deprecated. Consumers SHOULD refrain from usage of the declared operation. Default value is `false`.
-<a name="operationSecurity"></a>security | [[Security Requirement Object](#securityRequirementObject)] | A declaration of which security mechanisms can be used for this operation. The list of values includes alternative security requirement objects that can be used. Only one of the security requirement objects need to be satisfied to authorize a request. To make security optional, an empty security requirement (`{}`) can be included in the array. This definition overrides any declared top-level [`security`](#oasSecurity). To remove a top-level security declaration, an empty array can be used.
-<a name="operationServers"></a>servers | [[Server Object](#serverObject)] | An alternative `server` array to service this operation. If an alternative `server` object is specified at the Path Item Object or Root level, it will be overridden by this value.
+<a name="operationSecurity"></a>security | [[Security Requirement Object](#security-requirement-object)] | A declaration of which security mechanisms can be used for this operation. The list of values includes alternative security requirement objects that can be used. Only one of the security requirement objects need to be satisfied to authorize a request. To make security optional, an empty security requirement (`{}`) can be included in the array. This definition overrides any declared top-level [`security`](#oasSecurity). To remove a top-level security declaration, an empty array can be used.
+<a name="operationServers"></a>servers | [[Server Object](#server-object)] | An alternative `server` array to service this operation. If an alternative `server` object is specified at the Path Item Object or Root level, it will be overridden by this value.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Operation Object Example
 
@@ -886,7 +886,7 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
         "schema": {
           "type": "object",
           "properties": {
-            "name": { 
+            "name": {
               "description": "Updated name of the pet",
               "type": "string"
             },
@@ -895,7 +895,7 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
               "type": "string"
             }
           },
-          "required": ["status"] 
+          "required": ["status"]
         }
       }
     }
@@ -944,7 +944,7 @@ requestBody:
     'application/x-www-form-urlencoded':
       schema:
        properties:
-          name: 
+          name:
             description: Updated name of the pet
             type: string
           status:
@@ -955,12 +955,12 @@ requestBody:
 responses:
   '200':
     description: Pet updated.
-    content: 
+    content:
       'application/json': {}
       'application/xml': {}
   '405':
     description: Method Not Allowed
-    content: 
+    content:
       'application/json': {}
       'application/xml': {}
 security:
@@ -970,7 +970,7 @@ security:
 ```
 
 
-#### <a name="externalDocumentationObject"></a>External Documentation Object
+#### External Documentation Object
 
 Allows referencing an external resource for extended documentation.
 
@@ -981,7 +981,7 @@ Field Name | Type | Description
 <a name="externalDocDescription"></a>description | `string` | A short description of the target documentation. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
 <a name="externalDocUrl"></a>url | `string` | **REQUIRED**. The URL for the target documentation. Value MUST be in the format of a URL.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### External Documentation Object Example
 
@@ -997,7 +997,7 @@ description: Find more info here
 url: https://example.com
 ```
 
-#### <a name="parameterObject"></a>Parameter Object
+#### Parameter Object
 
 Describes a single operation parameter.
 
@@ -1005,7 +1005,7 @@ A unique parameter is defined by a combination of a [name](#parameterName) and [
 
 ##### Parameter Locations
 There are four possible parameter locations specified by the `in` field:
-* path - Used together with [Path Templating](#pathTemplating), where the parameter value is actually part of the operation's URL. This does not include the host or base path of the API. For example, in `/items/{itemId}`, the path parameter is `itemId`.
+* path - Used together with [Path Templating](#path-templating), where the parameter value is actually part of the operation's URL. This does not include the host or base path of the API. For example, in `/items/{itemId}`, the path parameter is `itemId`.
 * query - Parameters that are appended to the URL. For example, in `/items?id=###`, the query parameter is `id`.
 * header - Custom headers that are expected as part of the request. Note that [RFC7230](https://tools.ietf.org/html/rfc7230#page-22) states header names are case insensitive.
 * cookie - Used to pass a specific cookie value to the API.
@@ -1014,7 +1014,7 @@ There are four possible parameter locations specified by the `in` field:
 ##### Fixed Fields
 Field Name | Type | Description
 ---|:---:|---
-<a name="parameterName"></a>name | `string` | **REQUIRED**. The name of the parameter. Parameter names are *case sensitive*. <ul><li>If [`in`](#parameterIn) is `"path"`, the `name` field MUST correspond to a template expression occurring within the [path](#pathsPath) field in the [Paths Object](#pathsObject). See [Path Templating](#pathTemplating) for further information.<li>If [`in`](#parameterIn) is `"header"` and the `name` field is `"Accept"`, `"Content-Type"` or `"Authorization"`, the parameter definition SHALL be ignored.<li>For all other cases, the `name` corresponds to the parameter name used by the [`in`](#parameterIn) property.</ul>
+<a name="parameterName"></a>name | `string` | **REQUIRED**. The name of the parameter. Parameter names are *case sensitive*. <ul><li>If [`in`](#parameterIn) is `"path"`, the `name` field MUST correspond to a template expression occurring within the [path](#pathsPath) field in the [Paths Object](#paths-object). See [Path Templating](#path-templating) for further information.<li>If [`in`](#parameterIn) is `"header"` and the `name` field is `"Accept"`, `"Content-Type"` or `"Authorization"`, the parameter definition SHALL be ignored.<li>For all other cases, the `name` corresponds to the parameter name used by the [`in`](#parameterIn) property.</ul>
 <a name="parameterIn"></a>in | `string` | **REQUIRED**. The location of the parameter. Possible values are `"query"`, `"header"`, `"path"` or `"cookie"`.
 <a name="parameterDescription"></a>description | `string` | A brief description of the parameter. This could contain examples of use. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
 <a name="parameterRequired"></a>required | `boolean` | Determines whether this parameter is mandatory. If the [parameter location](#parameterIn) is `"path"`, this property is **REQUIRED** and its value MUST be `true`. Otherwise, the property MAY be included and its default value is `false`.
@@ -1029,9 +1029,9 @@ Field Name | Type | Description
 <a name="parameterStyle"></a>style | `string` | Describes how the parameter value will be serialized depending on the type of the parameter value. Default values (based on value of `in`): for `query` - `form`; for `path` - `simple`; for `header` - `simple`; for `cookie` - `form`.
 <a name="parameterExplode"></a>explode | `boolean` | When this is true, parameter values of type `array` or `object` generate separate parameters for each value of the array or key-value pair of the map. For other types of parameters this property has no effect. When [`style`](#parameterStyle) is `form`, the default value is `true`. For all other styles, the default value is `false`.
 <a name="parameterAllowReserved"></a>allowReserved | `boolean` | Determines whether the parameter value SHOULD allow reserved characters, as defined by [RFC3986](https://tools.ietf.org/html/rfc3986#section-2.2) `:/?#[]@!$&'()*+,;=` to be included without percent-encoding. This property only applies to parameters with an `in` value of `query`. The default value is `false`.
-<a name="parameterSchema"></a>schema | [Schema Object](#schemaObject) \| [Reference Object](#referenceObject) | The schema defining the type used for the parameter.
+<a name="parameterSchema"></a>schema | [Schema Object](#schema-object) \| [Reference Object](#reference-object) | The schema defining the type used for the parameter.
 <a name="parameterExample"></a>example | Any | Example of the parameter's potential value. The example SHOULD match the specified schema and encoding properties if present. The `example` field is mutually exclusive of the `examples` field. Furthermore, if referencing a `schema` that contains an example, the `example` value SHALL _override_ the example provided by the schema. To represent examples of media types that cannot naturally be represented in JSON or YAML, a string value can contain the example with escaping where necessary.
-<a name="parameterExamples"></a>examples | Map[ `string`, [Example Object](#exampleObject) \| [Reference Object](#referenceObject)] | Examples of the parameter's potential value. Each example SHOULD contain a value in the correct format as specified in the parameter encoding. The `examples` field is mutually exclusive of the `example` field. Furthermore, if referencing a `schema` that contains an example, the `examples` value SHALL _override_ the example provided by the schema.
+<a name="parameterExamples"></a>examples | Map[ `string`, [Example Object](#example-object) \| [Reference Object](#reference-object)] | Examples of the parameter's potential value. Each example SHOULD contain a value in the correct format as specified in the parameter encoding. The `examples` field is mutually exclusive of the `example` field. Furthermore, if referencing a `schema` that contains an example, the `examples` value SHALL _override_ the example provided by the schema.
 
 For more complex scenarios, the [`content`](#parameterContent) property can define the media type and schema of the parameter.
 A parameter MUST contain either a `schema` property, or a `content` property, but not both.
@@ -1040,19 +1040,19 @@ When `example` or `examples` are provided in conjunction with the `schema` objec
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="parameterContent"></a>content | Map[`string`, [Media Type Object](#mediaTypeObject)] | A map containing the representations for the parameter. The key is the media type and the value describes it. The map MUST only contain one entry.
+<a name="parameterContent"></a>content | Map[`string`, [Media Type Object](#media-type-object)] | A map containing the representations for the parameter. The key is the media type and the value describes it. The map MUST only contain one entry.
 
 ##### Style Values
 
 In order to support common ways of serializing simple parameters, a set of `style` values are defined.
 
-`style` | [`type`](#dataTypes) |  `in` | Comments
+`style` | [`type`](#data-types) |  `in` | Comments
 ----------- | ------ | -------- | --------
-matrix |  `primitive`, `array`, `object` |  `path` | Path-style parameters defined by [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.7) 
+matrix |  `primitive`, `array`, `object` |  `path` | Path-style parameters defined by [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.7)
 label | `primitive`, `array`, `object` |  `path` | Label style parameters defined by [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.5)
 form |  `primitive`, `array`, `object` |  `query`, `cookie` | Form style parameters defined by [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.8). This option replaces `collectionFormat` with a `csv` (when `explode` is false) or `multi` (when `explode` is true) value from OpenAPI 2.0.
 simple | `array` | `path`, `header` | Simple style parameters defined by [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.2).  This option replaces `collectionFormat` with a `csv` value from OpenAPI 2.0.
-spaceDelimited | `array` | `query` | Space separated array values. This option replaces `collectionFormat` equal to `ssv` from OpenAPI 2.0. 
+spaceDelimited | `array` | `query` | Space separated array values. This option replaces `collectionFormat` equal to `ssv` from OpenAPI 2.0.
 pipeDelimited | `array` | `query` | Pipe separated array values. This option replaces `collectionFormat` equal to `pipes` from OpenAPI 2.0.
 deepObject | `object` | `query` | Provides a simple way of rendering nested objects using form parameters.
 
@@ -1082,7 +1082,7 @@ spaceDelimited | false | n/a | n/a | blue%20black%20brown | R%20100%20G%20200%20
 pipeDelimited | false | n/a | n/a | blue\|black\|brown | R\|100\|G\|200\|B\|150
 deepObject | true | n/a | n/a | n/a | color[R]=100&color[G]=200&color[B]=150
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Parameter Object Examples
 
@@ -1241,7 +1241,7 @@ content:
           type: number
 ```
 
-#### <a name="requestBodyObject"></a>Request Body Object
+#### Request Body Object
 
 Describes a single request body.
 
@@ -1249,11 +1249,11 @@ Describes a single request body.
 Field Name | Type | Description
 ---|:---:|---
 <a name="requestBodyDescription"></a>description | `string` | A brief description of the request body. This could contain examples of use.  [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="requestBodyContent"></a>content | Map[`string`, [Media Type Object](#mediaTypeObject)] | **REQUIRED**. The content of the request body. The key is a media type or [media type range](https://tools.ietf.org/html/rfc7231#appendix-D) and the value describes it.  For requests that match multiple keys, only the most specific key is applicable. e.g. text/plain overrides text/*
+<a name="requestBodyContent"></a>content | Map[`string`, [Media Type Object](#media-type-object)] | **REQUIRED**. The content of the request body. The key is a media type or [media type range](https://tools.ietf.org/html/rfc7231#appendix-D) and the value describes it.  For requests that match multiple keys, only the most specific key is applicable. e.g. text/plain overrides text/*
 <a name="requestBodyRequired"></a>required | `boolean` | Determines if the request body is required in the request. Defaults to `false`.
 
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Request Body Examples
 
@@ -1268,9 +1268,9 @@ A request body with a referenced model definition.
       },
       "examples": {
           "user" : {
-            "summary": "User Example", 
+            "summary": "User Example",
             "externalValue": "http://foo.bar/examples/user-example.json"
-          } 
+          }
         }
     },
     "application/xml": {
@@ -1288,9 +1288,9 @@ A request body with a referenced model definition.
       "examples": {
         "user" : {
             "summary": "User example in Plain text",
-            "externalValue": "http://foo.bar/examples/user-example.txt" 
+            "externalValue": "http://foo.bar/examples/user-example.txt"
         }
-      } 
+      }
     },
     "*/*": {
       "examples": {
@@ -1306,7 +1306,7 @@ A request body with a referenced model definition.
 
 ```yaml
 description: user to add to the system
-content: 
+content:
   'application/json':
     schema:
       $ref: '#/components/schemas/User'
@@ -1328,7 +1328,7 @@ content:
         externalValue: 'http://foo.bar/examples/user-example.txt'
   '*/*':
     examples:
-      user: 
+      user:
         summary: User example in other format
         externalValue: 'http://foo.bar/examples/user-example.whatever'
 ```
@@ -1362,18 +1362,18 @@ content:
 ```
 
 
-#### <a name="mediaTypeObject"></a>Media Type Object
+#### Media Type Object
 Each Media Type Object provides schema and examples for the media type identified by its key.
 
 ##### Fixed Fields
 Field Name | Type | Description
 ---|:---:|---
-<a name="mediaTypeSchema"></a>schema | [Schema Object](#schemaObject) \| [Reference Object](#referenceObject) | The schema defining the content of the request, response, or parameter.
+<a name="mediaTypeSchema"></a>schema | [Schema Object](#schema-object) \| [Reference Object](#reference-object) | The schema defining the content of the request, response, or parameter.
 <a name="mediaTypeExample"></a>example | Any | Example of the media type.  The example object SHOULD be in the correct format as specified by the media type.  The `example` field is mutually exclusive of the `examples` field.  Furthermore, if referencing a `schema` which contains an example, the `example` value SHALL _override_ the example provided by the schema.
-<a name="mediaTypeExamples"></a>examples | Map[ `string`, [Example Object](#exampleObject) \| [Reference Object](#referenceObject)] | Examples of the media type.  Each example object SHOULD  match the media type and specified schema if present.  The `examples` field is mutually exclusive of the `example` field.  Furthermore, if referencing a `schema` which contains an example, the `examples` value SHALL _override_ the example provided by the schema.
-<a name="mediaTypeEncoding"></a>encoding | Map[`string`, [Encoding Object](#encodingObject)] | A map between a property name and its encoding information. The key, being the property name, MUST exist in the schema as a property. The encoding object SHALL only apply to `requestBody` objects when the media type is `multipart` or `application/x-www-form-urlencoded`.
+<a name="mediaTypeExamples"></a>examples | Map[ `string`, [Example Object](#example-object) \| [Reference Object](#reference-object)] | Examples of the media type.  Each example object SHOULD  match the media type and specified schema if present.  The `examples` field is mutually exclusive of the `example` field.  Furthermore, if referencing a `schema` which contains an example, the `examples` value SHALL _override_ the example provided by the schema.
+<a name="mediaTypeEncoding"></a>encoding | Map[`string`, [Encoding Object](#encoding-object)] | A map between a property name and its encoding information. The key, being the property name, MUST exist in the schema as a property. The encoding object SHALL only apply to `requestBody` objects when the media type is `multipart` or `application/x-www-form-urlencoded`.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Media Type Examples
 
@@ -1386,7 +1386,7 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
     "examples": {
       "cat" : {
         "summary": "An example of a cat",
-        "value": 
+        "value":
           {
             "name": "Fluffy",
             "petType": "Cat",
@@ -1397,7 +1397,7 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
       },
       "dog": {
         "summary": "An example of a dog with a cat's name",
-        "value" :  { 
+        "value" :  {
           "name": "Puma",
           "petType": "Dog",
           "color": "Black",
@@ -1414,7 +1414,7 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
 ```
 
 ```yaml
-application/json: 
+application/json:
   schema:
     $ref: "#/components/schemas/Pet"
   examples:
@@ -1484,7 +1484,7 @@ requestBody:
     'image/png':
       schema:
         type: string
-        format: binary        
+        format: binary       
 ```
 
 To upload multiple files, a `multipart` media type MUST be used:
@@ -1527,7 +1527,7 @@ requestBody:
 
 In this example, the contents in the `requestBody` MUST be stringified per [RFC1866](https://tools.ietf.org/html/rfc1866/) when passed to the server.  In addition, the `address` field complex object will be stringified.
 
-When passing complex objects in the `application/x-www-form-urlencoded` content type, the default serialization strategy of such properties is described in the [`Encoding Object`](#encodingObject)'s [`style`](#encodingStyle) property as `form`.
+When passing complex objects in the `application/x-www-form-urlencoded` content type, the default serialization strategy of such properties is described in the [`Encoding Object`](#encoding-object)'s [`style`](#encodingStyle) property as `form`.
 
 ##### Special Considerations for `multipart` Content
 
@@ -1574,7 +1574,7 @@ requestBody:
 
 An `encoding` attribute is introduced to give you control over the serialization of parts of `multipart` request bodies.  This attribute is _only_ applicable to `multipart` and `application/x-www-form-urlencoded` request bodies.
 
-#### <a name="encodingObject"></a>Encoding Object
+#### Encoding Object
 
 A single encoding definition applied to a single schema property.
 
@@ -1582,12 +1582,12 @@ A single encoding definition applied to a single schema property.
 Field Name | Type | Description
 ---|:---:|---
 <a name="encodingContentType"></a>contentType | `string` | The Content-Type for encoding a specific property. Default value depends on the property type: for `string` with `format` being `binary` – `application/octet-stream`; for other primitive types – `text/plain`; for `object` - `application/json`; for `array` – the default is defined based on the inner type. The value can be a specific media type (e.g. `application/json`), a wildcard media type (e.g. `image/*`), or a comma-separated list of the two types.
-<a name="encodingHeaders"></a>headers | Map[`string`, [Header Object](#headerObject) \| [Reference Object](#referenceObject)] | A map allowing additional information to be provided as headers, for example `Content-Disposition`.  `Content-Type` is described separately and SHALL be ignored in this section. This property SHALL be ignored if the request body media type is not a `multipart`.
-<a name="encodingStyle"></a>style | `string` | Describes how a specific property value will be serialized depending on its type.  See [Parameter Object](#parameterObject) for details on the [`style`](#parameterStyle) property. The behavior follows the same values as `query` parameters, including default values. This property SHALL be ignored if the request body media type is not `application/x-www-form-urlencoded`.
+<a name="encodingHeaders"></a>headers | Map[`string`, [Header Object](#header-object) \| [Reference Object](#reference-object)] | A map allowing additional information to be provided as headers, for example `Content-Disposition`.  `Content-Type` is described separately and SHALL be ignored in this section. This property SHALL be ignored if the request body media type is not a `multipart`.
+<a name="encodingStyle"></a>style | `string` | Describes how a specific property value will be serialized depending on its type.  See [Parameter Object](#parameter-object) for details on the [`style`](#parameterStyle) property. The behavior follows the same values as `query` parameters, including default values. This property SHALL be ignored if the request body media type is not `application/x-www-form-urlencoded`.
 <a name="encodingExplode"></a>explode | `boolean` | When this is true, property values of type `array` or `object` generate separate parameters for each value of the array, or key-value-pair of the map.  For other types of properties this property has no effect. When [`style`](#encodingStyle) is `form`, the default value is `true`. For all other styles, the default value is `false`. This property SHALL be ignored if the request body media type is not `application/x-www-form-urlencoded`.
 <a name="encodingAllowReserved"></a>allowReserved | `boolean` | Determines whether the parameter value SHOULD allow reserved characters, as defined by [RFC3986](https://tools.ietf.org/html/rfc3986#section-2.2) `:/?#[]@!$&'()*+,;=` to be included without percent-encoding. The default value is `false`. This property SHALL be ignored if the request body media type is not `application/x-www-form-urlencoded`.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Encoding Object Example
 
@@ -1629,7 +1629,7 @@ requestBody:
                 type: integer
 ```
 
-#### <a name="responsesObject"></a>Responses Object
+#### Responses Object
 
 A container for the expected responses of an operation.
 The container maps a HTTP response code to the expected response.
@@ -1637,24 +1637,24 @@ The container maps a HTTP response code to the expected response.
 The documentation is not necessarily expected to cover all possible HTTP response codes because they may not be known in advance.
 However, documentation is expected to cover a successful operation response and any known errors.
 
-The `default` MAY be used as a default response object for all HTTP codes 
+The `default` MAY be used as a default response object for all HTTP codes
 that are not covered individually by the specification.
 
-The `Responses Object` MUST contain at least one response code, and it 
+The `Responses Object` MUST contain at least one response code, and it
 SHOULD be the response for a successful operation call.
 
 ##### Fixed Fields
 Field Name | Type | Description
 ---|:---:|---
-<a name="responsesDefault"></a>default | [Response Object](#responseObject) \| [Reference Object](#referenceObject) | The documentation of responses other than the ones declared for specific HTTP response codes. Use this field to cover undeclared responses. A [Reference Object](#referenceObject) can link to a response that the [OpenAPI Object's components/responses](#componentsResponses) section defines.
+<a name="responsesDefault"></a>default | [Response Object](#response-object) \| [Reference Object](#reference-object) | The documentation of responses other than the ones declared for specific HTTP response codes. Use this field to cover undeclared responses. A [Reference Object](#reference-object) can link to a response that the [OpenAPI Object's components/responses](#componentsResponses) section defines.
 
 ##### Patterned Fields
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="responsesCode"></a>[HTTP Status Code](#httpCodes) | [Response Object](#responseObject) \| [Reference Object](#referenceObject) | Any [HTTP status code](#httpCodes) can be used as the property name, but only one property per code, to describe the expected response for that HTTP status code.  A [Reference Object](#referenceObject) can link to a response that is defined in the [OpenAPI Object's components/responses](#componentsResponses) section. This field MUST be enclosed in quotation marks (for example, "200") for compatibility between JSON and YAML. To define a range of response codes, this field MAY contain the uppercase wildcard character `X`. For example, `2XX` represents all response codes between `[200-299]`. Only the following range definitions are allowed: `1XX`, `2XX`, `3XX`, `4XX`, and `5XX`. If a response is defined using an explicit code, the explicit code definition takes precedence over the range definition for that code.
+<a name="responsesCode"></a>[HTTP Status Code](#http-status-codes) | [Response Object](#response-object) \| [Reference Object](#reference-object) | Any [HTTP status code](#http-status-codes) can be used as the property name, but only one property per code, to describe the expected response for that HTTP status code.  A [Reference Object](#reference-object) can link to a response that is defined in the [OpenAPI Object's components/responses](#componentsResponses) section. This field MUST be enclosed in quotation marks (for example, "200") for compatibility between JSON and YAML. To define a range of response codes, this field MAY contain the uppercase wildcard character `X`. For example, `2XX` represents all response codes between `[200-299]`. Only the following range definitions are allowed: `1XX`, `2XX`, `3XX`, `4XX`, and `5XX`. If a response is defined using an explicit code, the explicit code definition takes precedence over the range definition for that code.
 
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Responses Object Example
 
@@ -1688,7 +1688,7 @@ A 200 response for a successful operation and a default response for others (imp
 ```yaml
 '200':
   description: a pet to be returned
-  content: 
+  content:
     application/json:
       schema:
         $ref: '#/components/schemas/Pet'
@@ -1700,19 +1700,19 @@ default:
         $ref: '#/components/schemas/ErrorModel'
 ```
 
-#### <a name="responseObject"></a>Response Object
-Describes a single response from an API Operation, including design-time, static 
+#### Response Object
+Describes a single response from an API Operation, including design-time, static
 `links` to operations based on the response.
 
 ##### Fixed Fields
 Field Name | Type | Description
 ---|:---:|---
 <a name="responseDescription"></a>description | `string` | **REQUIRED**. A short description of the response. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="responseHeaders"></a>headers | Map[`string`, [Header Object](#headerObject)  \| [Reference Object](#referenceObject)] |  Maps a header name to its definition. [RFC7230](https://tools.ietf.org/html/rfc7230#page-22) states header names are case insensitive. If a response header is defined with the name `"Content-Type"`, it SHALL be ignored.
-<a name="responseContent"></a>content | Map[`string`, [Media Type Object](#mediaTypeObject)] | A map containing descriptions of potential response payloads. The key is a media type or [media type range](https://tools.ietf.org/html/rfc7231#appendix-D) and the value describes it.  For responses that match multiple keys, only the most specific key is applicable. e.g. text/plain overrides text/*
-<a name="responseLinks"></a>links | Map[`string`, [Link Object](#linkObject) \| [Reference Object](#referenceObject)] | A map of operations links that can be followed from the response. The key of the map is a short name for the link, following the naming constraints of the names for [Component Objects](#componentsObject). 
+<a name="responseHeaders"></a>headers | Map[`string`, [Header Object](#header-object)  \| [Reference Object](#reference-object)] |  Maps a header name to its definition. [RFC7230](https://tools.ietf.org/html/rfc7230#page-22) states header names are case insensitive. If a response header is defined with the name `"Content-Type"`, it SHALL be ignored.
+<a name="responseContent"></a>content | Map[`string`, [Media Type Object](#media-type-object)] | A map containing descriptions of potential response payloads. The key is a media type or [media type range](https://tools.ietf.org/html/rfc7231#appendix-D) and the value describes it.  For responses that match multiple keys, only the most specific key is applicable. e.g. text/plain overrides text/*
+<a name="responseLinks"></a>links | Map[`string`, [Link Object](#link-object) \| [Reference Object](#reference-object)] | A map of operations links that can be followed from the response. The key of the map is a short name for the link, following the naming constraints of the names for [Component Objects](#components-object).
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Response Object Examples
 
@@ -1736,9 +1736,9 @@ Response of an array of a complex type:
 
 ```yaml
 description: A complex object array response
-content: 
+content:
   application/json:
-    schema: 
+    schema:
       type: array
       items:
         $ref: '#/components/schemas/VeryComplexType'
@@ -1838,25 +1838,25 @@ Response with no return value:
 description: object created
 ```
 
-#### <a name="callbackObject"></a>Callback Object
+#### Callback Object
 
 A map of possible out-of band callbacks related to the parent operation.
-Each value in the map is a [Path Item Object](#pathItemObject) that describes a set of requests that may be initiated by the API provider and the expected responses.
+Each value in the map is a [Path Item Object](#path-item-object) that describes a set of requests that may be initiated by the API provider and the expected responses.
 The key value used to identify the path item object is an expression, evaluated at runtime, that identifies a URL to use for the callback operation.
 
 ##### Patterned Fields
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="callbackExpression"></a>{expression} | [Path Item Object](#pathItemObject) | A Path Item Object used to define a callback request and expected responses.  A [complete example](../examples/v3.0/callback-example.yaml) is available.
+<a name="callbackExpression"></a>{expression} | [Path Item Object](#path-item-object) | A Path Item Object used to define a callback request and expected responses.  A [complete example](../examples/v3.0/callback-example.yaml) is available.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Key Expression
 
-The key that identifies the [Path Item Object](#pathItemObject) is a [runtime expression](#runtimeExpression) that can be evaluated in the context of a runtime HTTP request/response to identify the URL to be used for the callback request.
+The key that identifies the [Path Item Object](#path-item-object) is a [runtime expression](#runtime-expressions) that can be evaluated in the context of a runtime HTTP request/response to identify the URL to be used for the callback request.
 A simple example might be `$request.body#/url`.
-However, using a [runtime expression](#runtimeExpression) the complete HTTP message can be accessed.
-This includes accessing any part of a body that a JSON Pointer [RFC6901](https://tools.ietf.org/html/rfc6901) can reference. 
+However, using a [runtime expression](#runtime-expressions) the complete HTTP message can be accessed.
+This includes accessing any part of a body that a JSON Pointer [RFC6901](https://tools.ietf.org/html/rfc6901) can reference.
 
 For example, given the following HTTP request:
 
@@ -1872,7 +1872,7 @@ Content-Length: 187
     "http://clientdomain.com/fast",
     "http://clientdomain.com/medium",
     "http://clientdomain.com/slow"
-  ] 
+  ]
 }
 
 201 Created
@@ -1881,7 +1881,7 @@ Location: http://example.org/subscription/1
 
 The following examples show how the various expressions evaluate, assuming the callback operation has a path parameter named `eventType` and a query parameter named `queryUrl`.
 
-Expression | Value 
+Expression | Value
 ---|:---
 $url | http://example.org/subscribe/myevent?queryUrl=http://clientdomain.com/stillrunning
 $method | POST
@@ -1903,7 +1903,7 @@ myCallback:
     post:
       requestBody:
         description: Callback payload
-        content: 
+        content:
           'application/json':
             schema:
               $ref: '#/components/schemas/SomePayload'
@@ -1920,7 +1920,7 @@ transactionCallback:
     post:
       requestBody:
         description: Callback payload
-        content: 
+        content:
           'application/json':
             schema:
               $ref: '#/components/schemas/SomePayload'
@@ -1929,7 +1929,7 @@ transactionCallback:
           description: callback successfully processed
 ```
 
-#### <a name="exampleObject"></a>Example Object
+#### Example Object
 
 ##### Fixed Fields
 Field Name | Type | Description
@@ -1937,12 +1937,12 @@ Field Name | Type | Description
 <a name="exampleSummary"></a>summary | `string` | Short description for the example.
 <a name="exampleDescription"></a>description | `string` | Long description for the example. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
 <a name="exampleValue"></a>value | Any | Embedded literal example. The `value` field and `externalValue` field are mutually exclusive. To represent examples of media types that cannot naturally represented in JSON or YAML, use a string value to contain the example, escaping where necessary.
-<a name="exampleExternalValue"></a>externalValue | `string` | A URL that points to the literal example. This provides the capability to reference examples that cannot easily be included in JSON or YAML documents.  The `value` field and `externalValue` field are mutually exclusive. 
+<a name="exampleExternalValue"></a>externalValue | `string` | A URL that points to the literal example. This provides the capability to reference examples that cannot easily be included in JSON or YAML documents.  The `value` field and `externalValue` field are mutually exclusive.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
-In all cases, the example value is expected to be compatible with the type schema 
-of its associated value.  Tooling implementations MAY choose to 
+In all cases, the example value is expected to be compatible with the type schema
+of its associated value.  Tooling implementations MAY choose to
 validate compatibility automatically, and reject the example value(s) if incompatible.
 
 ##### Example Object Examples
@@ -1955,7 +1955,7 @@ requestBody:
     'application/json':
       schema:
         $ref: '#/components/schemas/Address'
-      examples: 
+      examples:
         foo:
           summary: A foo example
           value: {"foo": "bar"}
@@ -1963,13 +1963,13 @@ requestBody:
           summary: A bar example
           value: {"bar": "baz"}
     'application/xml':
-      examples: 
+      examples:
         xmlExample:
           summary: This is an example in XML
           externalValue: 'http://example.org/examples/address-example.xml'
     'text/plain':
       examples:
-        textExample: 
+        textExample:
           summary: This is a text example
           externalValue: 'http://foo.bar/examples/address-example.txt'
 ```
@@ -1984,7 +1984,7 @@ parameters:
       type: 'string'
       format: 'zip-code'
     examples:
-      zip-example: 
+      zip-example:
         $ref: '#/components/examples/zip-example'
 ```
 
@@ -1994,7 +1994,7 @@ In a response:
 responses:
   '200':
     description: your car appointment has been booked
-    content: 
+    content:
       application/json:
         schema:
           $ref: '#/components/schemas/SuccessResponse'
@@ -2004,31 +2004,31 @@ responses:
 ```
 
 
-#### <a name="linkObject"></a>Link Object
+#### Link Object
 
 The `Link object` represents a possible design-time link for a response.
 The presence of a link does not guarantee the caller's ability to successfully invoke it, rather it provides a known relationship and traversal mechanism between responses and other operations.
 
 Unlike _dynamic_ links (i.e. links provided **in** the response payload), the OAS linking mechanism does not require link information in the runtime response.
 
-For computing links, and providing instructions to execute them, a [runtime expression](#runtimeExpression) is used for accessing values in an operation and using them as parameters while invoking the linked operation.  
+For computing links, and providing instructions to execute them, a [runtime expression](#runtime-expressions) is used for accessing values in an operation and using them as parameters while invoking the linked operation. 
 
 ##### Fixed Fields
 
 Field Name  |  Type  | Description
 ---|:---:|---
-<a name="linkOperationRef"></a>operationRef | `string` | A relative or absolute URI reference to an OAS operation. This field is mutually exclusive of the `operationId` field, and MUST point to an [Operation Object](#operationObject). Relative `operationRef` values MAY be used to locate an existing [Operation Object](#operationObject) in the OpenAPI definition.
-<a name="linkOperationId"></a>operationId  | `string` | The name of an _existing_, resolvable OAS operation, as defined with a unique `operationId`.  This field is mutually exclusive of the `operationRef` field.  
-<a name="linkParameters"></a>parameters   | Map[`string`, Any \| [{expression}](#runtimeExpression)] | A map representing parameters to pass to an operation as specified with `operationId` or identified via `operationRef`. The key is the parameter name to be used, whereas the value can be a constant or an expression to be evaluated and passed to the linked operation.  The parameter name can be qualified using the [parameter location](#parameterIn) `[{in}.]{name}` for operations that use the same parameter name in different locations (e.g. path.id).
-<a name="linkRequestBody"></a>requestBody | Any \| [{expression}](#runtimeExpression) | A literal value or [{expression}](#runtimeExpression) to use as a request body when calling the target operation.
+<a name="linkOperationRef"></a>operationRef | `string` | A relative or absolute URI reference to an OAS operation. This field is mutually exclusive of the `operationId` field, and MUST point to an [Operation Object](#operation-object). Relative `operationRef` values MAY be used to locate an existing [Operation Object](#operation-object) in the OpenAPI definition.
+<a name="linkOperationId"></a>operationId  | `string` | The name of an _existing_, resolvable OAS operation, as defined with a unique `operationId`.  This field is mutually exclusive of the `operationRef` field. 
+<a name="linkParameters"></a>parameters   | Map[`string`, Any \| [{expression}](#runtime-expressions)] | A map representing parameters to pass to an operation as specified with `operationId` or identified via `operationRef`. The key is the parameter name to be used, whereas the value can be a constant or an expression to be evaluated and passed to the linked operation.  The parameter name can be qualified using the [parameter location](#parameterIn) `[{in}.]{name}` for operations that use the same parameter name in different locations (e.g. path.id).
+<a name="linkRequestBody"></a>requestBody | Any \| [{expression}](#runtime-expressions) | A literal value or [{expression}](#runtime-expressions) to use as a request body when calling the target operation.
 <a name="linkDescription"></a>description  | `string` | A description of the link. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="linkServer"></a>server       | [Server Object](#serverObject) | A server object to be used by the target operation.
+<a name="linkServer"></a>server       | [Server Object](#server-object) | A server object to be used by the target operation.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 A linked operation MUST be identified using either an `operationRef` or `operationId`.
 In the case of an `operationId`, it MUST be unique and resolved in the scope of the OAS document.
-Because of the potential for name clashes, the `operationRef` syntax is preferred 
+Because of the potential for name clashes, the `operationRef` syntax is preferred
 for specifications with external references.
 
 ##### Examples
@@ -2042,7 +2042,7 @@ paths:
     - name: id
       in: path
       required: true
-      description: the user identifier, as userId 
+      description: the user identifier, as userId
       schema:
         type: string
     get:
@@ -2070,7 +2070,7 @@ paths:
     - name: userid
       in: path
       required: true
-      description: the user identifier, as userId 
+      description: the user identifier, as userId
       schema:
         type: string
     # linked operation
@@ -2094,15 +2094,15 @@ links:
       userUuid: $response.body#/uuid
 ```
 
-Clients follow all links at their discretion. 
-Neither permissions, nor the capability to make a successful call to that link, is guaranteed 
+Clients follow all links at their discretion.
+Neither permissions, nor the capability to make a successful call to that link, is guaranteed
 solely by the existence of a relationship.
 
 
 ##### OperationRef Examples
 
-As references to `operationId` MAY NOT be possible (the `operationId` is an optional 
-field in an [Operation Object](#operationObject)), references MAY also be made through a relative `operationRef`:
+As references to `operationId` MAY NOT be possible (the `operationId` is an optional
+field in an [Operation Object](#operation-object)), references MAY also be made through a relative `operationRef`:
 
 ```yaml
 links:
@@ -2124,14 +2124,14 @@ links:
       username: $response.body#/username
 ```
 
-Note that in the use of `operationRef`, the _escaped forward-slash_ is necessary when 
+Note that in the use of `operationRef`, the _escaped forward-slash_ is necessary when
 using JSON references.
 
 
-##### <a name="runtimeExpression"></a>Runtime Expressions
+##### Runtime Expressions
 
 Runtime expressions allow defining values based on information that will only be available within the HTTP message in an actual API call.
-This mechanism is used by [Link Objects](#linkObject) and [Callback Objects](#callbackObject).
+This mechanism is used by [Link Objects](#link-object) and [Callback Objects](#callback-object).
 
 The runtime expression is defined by the following [ABNF](https://tools.ietf.org/html/rfc5234) syntax
 
@@ -2139,7 +2139,7 @@ The runtime expression is defined by the following [ABNF](https://tools.ietf.org
       expression = ( "$url" / "$method" / "$statusCode" / "$request." source / "$response." source )
       source = ( header-reference / query-reference / path-reference / body-reference )
       header-reference = "header." token
-      query-reference = "query." name  
+      query-reference = "query." name 
       path-reference = "path." name
       body-reference = "body" ["#" json-pointer ]
       json-pointer    = *( "/" reference-token )
@@ -2156,28 +2156,28 @@ The runtime expression is defined by the following [ABNF](https://tools.ietf.org
 
 Here, `json-pointer` is taken from [RFC 6901](https://tools.ietf.org/html/rfc6901), `char` from [RFC 7159](https://tools.ietf.org/html/rfc7159#section-7) and `token` from [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2.6).
 
-The `name` identifier is case-sensitive, whereas `token` is not. 
+The `name` identifier is case-sensitive, whereas `token` is not.
 
 The table below provides examples of runtime expressions and examples of their use in a value:
 
-##### <a name="runtimeExpressionExamples"></a>Examples
+##### Examples
 
 Source Location | example expression  | notes
 ---|:---|:---|
 HTTP Method            | `$method`         | The allowable values for the `$method` will be those for the HTTP operation.
-Requested media type | `$request.header.accept`        |  
+Requested media type | `$request.header.accept`        | 
 Request parameter      | `$request.path.id`        | Request parameters MUST be declared in the `parameters` section of the parent operation or they cannot be evaluated. This includes request headers.
 Request body property   | `$request.body#/user/uuid`   | In operations which accept payloads, references may be made to portions of the `requestBody` or the entire body.
-Request URL            | `$url`            |  
+Request URL            | `$url`            | 
 Response value         | `$response.body#/status`       |  In operations which return payloads, references may be made to portions of the response body or the entire body.
 Response header        | `$response.header.Server` |  Single header values only are available
 
 Runtime expressions preserve the type of the referenced value.
 Expressions can be embedded into string values by surrounding the expression with `{}` curly braces.
 
-#### <a name="headerObject"></a>Header Object
+#### Header Object
 
-The Header Object follows the structure of the [Parameter Object](#parameterObject) with the following changes:
+The Header Object follows the structure of the [Parameter Object](#parameter-object) with the following changes:
 
 1. `name` MUST NOT be specified, it is given in the corresponding `headers` map.
 1. `in` MUST NOT be specified, it is implicitly in `header`.
@@ -2202,9 +2202,9 @@ schema:
   type: integer
 ```
 
-#### <a name="tagObject"></a>Tag Object
+#### Tag Object
 
-Adds metadata to a single tag that is used by the [Operation Object](#operationObject).
+Adds metadata to a single tag that is used by the [Operation Object](#operation-object).
 It is not mandatory to have a Tag Object per tag defined in the Operation Object instances.
 
 ##### Fixed Fields
@@ -2212,9 +2212,9 @@ Field Name | Type | Description
 ---|:---:|---
 <a name="tagName"></a>name | `string` | **REQUIRED**. The name of the tag.
 <a name="tagDescription"></a>description | `string` | A short description for the tag. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="tagExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation for this tag.
+<a name="tagExternalDocs"></a>externalDocs | [External Documentation Object](#external-documentation-object) | Additional external documentation for this tag.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Tag Object Example
 
@@ -2231,11 +2231,11 @@ description: Pets operations
 ```
 
 
-#### <a name="referenceObject"></a>Reference Object
+#### Reference Object
 
 A simple object to allow referencing other components in the specification, internally and externally.
 
-The Reference Object is defined by [JSON Reference](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03) and follows the same structure, behavior and rules. 
+The Reference Object is defined by [JSON Reference](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03) and follows the same structure, behavior and rules.
 
 For this specification, reference resolution is accomplished as defined by the JSON Reference specification and not by the JSON Schema specification.
 
@@ -2280,7 +2280,7 @@ $ref: Pet.yaml
 $ref: definitions.yaml#/Pet
 ```
 
-#### <a name="schemaObject"></a>Schema Object
+#### Schema Object
 
 The Schema Object allows the definition of input and output data types.
 These types can be objects, but also primitives and arrays.
@@ -2289,7 +2289,7 @@ This object is an extended subset of the [JSON Schema Specification Wright Draft
 For more information about the properties, see [JSON Schema Core](https://tools.ietf.org/html/draft-wright-json-schema-00) and [JSON Schema Validation](https://tools.ietf.org/html/draft-wright-json-schema-validation-00).
 Unless stated otherwise, the property definitions follow the JSON Schema.
 
-##### Properties 
+##### Properties
 
 The following properties are taken directly from the JSON Schema definition and follow the same specifications:
 
@@ -2310,20 +2310,20 @@ The following properties are taken directly from the JSON Schema definition and 
 - required
 - enum
 
-The following properties are taken from the JSON Schema definition but their definitions were adjusted to the OpenAPI Specification. 
+The following properties are taken from the JSON Schema definition but their definitions were adjusted to the OpenAPI Specification.
 - type - Value MUST be a string. Multiple types via an array are not supported.
-- allOf - Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard JSON Schema.
-- oneOf - Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard JSON Schema.
-- anyOf - Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard JSON Schema.
-- not - Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard JSON Schema.
-- items - Value MUST be an object and not an array. Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard JSON Schema. `items` MUST be present if the `type` is `array`.
-- properties - Property definitions MUST be a [Schema Object](#schemaObject) and not a standard JSON Schema (inline or referenced).
-- additionalProperties - Value can be boolean or object. Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard JSON Schema. Consistent with JSON Schema, `additionalProperties` defaults to `true`.
+- allOf - Inline or referenced schema MUST be of a [Schema Object](#schema-object) and not a standard JSON Schema.
+- oneOf - Inline or referenced schema MUST be of a [Schema Object](#schema-object) and not a standard JSON Schema.
+- anyOf - Inline or referenced schema MUST be of a [Schema Object](#schema-object) and not a standard JSON Schema.
+- not - Inline or referenced schema MUST be of a [Schema Object](#schema-object) and not a standard JSON Schema.
+- items - Value MUST be an object and not an array. Inline or referenced schema MUST be of a [Schema Object](#schema-object) and not a standard JSON Schema. `items` MUST be present if the `type` is `array`.
+- properties - Property definitions MUST be a [Schema Object](#schema-object) and not a standard JSON Schema (inline or referenced).
+- additionalProperties - Value can be boolean or object. Inline or referenced schema MUST be of a [Schema Object](#schema-object) and not a standard JSON Schema. Consistent with JSON Schema, `additionalProperties` defaults to `true`.
 - description - [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
 - format - See [Data Type Formats](#dataTypeFormat) for further details. While relying on JSON Schema's defined formats, the OAS offers a few additional predefined formats.
 - default - The default value represents what would be assumed by the consumer of the input as the value of the schema if one is not provided. Unlike JSON Schema, the value MUST conform to the defined type for the Schema Object defined at the same level. For example, if `type` is `string`, then `default` can be `"foo"` but cannot be `1`.
 
-Alternatively, any time a Schema Object can be used, a [Reference Object](#referenceObject) can be used in its place. This allows referencing definitions instead of defining them inline.
+Alternatively, any time a Schema Object can be used, a [Reference Object](#reference-object) can be used in its place. This allows referencing definitions instead of defining them inline.
 
 Additional properties defined by the JSON Schema specification that are not mentioned here are strictly unsupported.
 
@@ -2333,20 +2333,20 @@ Other than the JSON Schema subset fields, the following fields MAY be used for f
 Field Name | Type | Description
 ---|:---:|---
 <a name="schemaNullable"></a>nullable | `boolean` | A `true` value adds `"null"` to the allowed type specified by the `type` keyword, only if `type` is explicitly defined within the same Schema Object. Other Schema Object constraints retain their defined behavior, and therefore may disallow the use of `null` as a value. A `false` value leaves the specified or default `type` unmodified. The default value is `false`.
-<a name="schemaDiscriminator"></a>discriminator | [Discriminator Object](#discriminatorObject) | Adds support for polymorphism. The discriminator is an object name that is used to differentiate between other schemas which may satisfy the payload description. See [Composition and Inheritance](#schemaComposition) for more details.
+<a name="schemaDiscriminator"></a>discriminator | [Discriminator Object](#discriminator-object) | Adds support for polymorphism. The discriminator is an object name that is used to differentiate between other schemas which may satisfy the payload description. See [Composition and Inheritance](#composition-and-inheritance-polymorphism) for more details.
 <a name="schemaReadOnly"></a>readOnly | `boolean` | Relevant only for Schema `"properties"` definitions. Declares the property as "read only". This means that it MAY be sent as part of a response but SHOULD NOT be sent as part of the request. If the property is marked as `readOnly` being `true` and is in the `required` list, the `required` will take effect on the response only. A property MUST NOT be marked as both `readOnly` and `writeOnly` being `true`. Default value is `false`.
 <a name="schemaWriteOnly"></a>writeOnly | `boolean` | Relevant only for Schema `"properties"` definitions. Declares the property as "write only". Therefore, it MAY be sent as part of a request but SHOULD NOT be sent as part of the response. If the property is marked as `writeOnly` being `true` and is in the `required` list, the `required` will take effect on the request only. A property MUST NOT be marked as both `readOnly` and `writeOnly` being `true`. Default value is `false`.
-<a name="schemaXml"></a>xml | [XML Object](#xmlObject) | This MAY be used only on properties schemas. It has no effect on root schemas. Adds additional metadata to describe the XML representation of this property.
-<a name="schemaExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation for this schema. 
+<a name="schemaXml"></a>xml | [XML Object](#xml-object) | This MAY be used only on properties schemas. It has no effect on root schemas. Adds additional metadata to describe the XML representation of this property.
+<a name="schemaExternalDocs"></a>externalDocs | [External Documentation Object](#external-documentation-object) | Additional external documentation for this schema.
 <a name="schemaExample"></a>example | Any | A free-form property to include an example of an instance for this schema. To represent examples that cannot be naturally represented in JSON or YAML, a string value can be used to contain the example with escaping where necessary.
 <a name="schemaDeprecated"></a> deprecated | `boolean` | Specifies that a schema is deprecated and SHOULD be transitioned out of usage. Default value is `false`.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
-###### <a name="schemaComposition"></a>Composition and Inheritance (Polymorphism)
+###### Composition and Inheritance (Polymorphism)
 
 The OpenAPI Specification allows combining and extending model definitions using the `allOf` property of JSON Schema, in effect offering model composition.
-`allOf` takes an array of object definitions that are validated *independently* but together compose a single object. 
+`allOf` takes an array of object definitions that are validated *independently* but together compose a single object.
 
 While composition offers model extensibility, it does not imply a hierarchy between the models.
 To support polymorphism, the OpenAPI Specification adds the `discriminator` field.
@@ -2360,7 +2360,7 @@ As such, inline schema definitions, which do not have a given id, *cannot* be us
 ###### XML Modeling
 
 The [xml](#schemaXml) property allows extra definitions when translating the JSON definition to XML.
-The [XML Object](#xmlObject) contains additional information about the available options.
+The [XML Object](#xml-object) contains additional information about the available options.
 
 ##### Schema Object Examples
 
@@ -2690,7 +2690,7 @@ components:
         - packSize
 ```
 
-#### <a name="discriminatorObject"></a>Discriminator Object
+#### Discriminator Object
 
 When request bodies or response payloads may be one of a number of different schemas, a `discriminator` object can be used to aid in serialization, deserialization, and validation.  The discriminator is a specific object in a schema which is used to inform the consumer of the specification of an alternative schema based on the value associated with it.
 
@@ -2823,7 +2823,7 @@ will indicate that the `Cat` schema be used.  Likewise this schema:
 will map to `Dog` because of the definition in the `mappings` element.
 
 
-#### <a name="xmlObject"></a>XML Object
+#### XML Object
 
 A metadata object that allows for more fine-tuned XML model definitions.
 
@@ -2839,11 +2839,11 @@ Field Name | Type | Description
 <a name="xmlAttribute"></a>attribute | `boolean` | Declares whether the property definition translates to an attribute instead of an element. Default value is `false`.
 <a name="xmlWrapped"></a>wrapped | `boolean` | MAY be used only for an array definition. Signifies whether the array is wrapped (for example, `<books><book/><book/></books>`) or unwrapped (`<book/><book/>`). Default value is `false`. The definition takes effect only when defined alongside `type` being `array` (outside the `items`).
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### XML Object Examples
 
-The examples of the XML object definitions are included inside a property definition of a [Schema Object](#schemaObject) with a sample of the XML representation of it.
+The examples of the XML object definitions are included inside a property definition of a [Schema Object](#schema-object) with a sample of the XML representation of it.
 
 ###### No XML Element
 
@@ -3176,7 +3176,7 @@ animals:
 </aliens>
 ```
 
-#### <a name="securitySchemeObject"></a>Security Scheme Object
+#### Security Scheme Object
 
 Defines a security scheme that can be used by the operations.
 Supported schemes are HTTP authentication, an API key (either as a header, a cookie parameter or as a query parameter), OAuth2's common flows (implicit, password, client credentials and authorization code) as defined in [RFC6749](https://tools.ietf.org/html/rfc6749), and [OpenID Connect Discovery](https://tools.ietf.org/html/draft-ietf-oauth-discovery-06).
@@ -3190,10 +3190,10 @@ Field Name | Type | Applies To | Description
 <a name="securitySchemeIn"></a>in | `string` | `apiKey` | **REQUIRED**. The location of the API key. Valid values are `"query"`, `"header"` or `"cookie"`.
 <a name="securitySchemeScheme"></a>scheme | `string` | `http` | **REQUIRED**. The name of the HTTP Authorization scheme to be used in the [Authorization header as defined in RFC7235](https://tools.ietf.org/html/rfc7235#section-5.1).  The values used SHOULD be registered in the [IANA Authentication Scheme registry](https://www.iana.org/assignments/http-authschemes/http-authschemes.xhtml).
 <a name="securitySchemeBearerFormat"></a>bearerFormat | `string` | `http` (`"bearer"`) | A hint to the client to identify how the bearer token is formatted.  Bearer tokens are usually generated by an authorization server, so this information is primarily for documentation purposes.
-<a name="securitySchemeFlows"></a>flows | [OAuth Flows Object](#oauthFlowsObject) | `oauth2` | **REQUIRED**. An object containing configuration information for the flow types supported.
+<a name="securitySchemeFlows"></a>flows | [OAuth Flows Object](#oauth-flows-object) | `oauth2` | **REQUIRED**. An object containing configuration information for the flow types supported.
 <a name="securitySchemeOpenIdConnectUrl"></a>openIdConnectUrl | `string` | `openIdConnect` | **REQUIRED**. OpenId Connect URL to discover OAuth2 configuration values. This MUST be in the form of a URL.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Security Scheme Object Example
 
@@ -3262,7 +3262,7 @@ bearerFormat: JWT
 
 ```yaml
 type: oauth2
-flows: 
+flows:
   implicit:
     authorizationUrl: https://example.com/api/oauth/dialog
     scopes:
@@ -3270,21 +3270,21 @@ flows:
       read:pets: read your pets
 ```
 
-#### <a name="oauthFlowsObject"></a>OAuth Flows Object
+#### OAuth Flows Object
 
 Allows configuration of the supported OAuth Flows.
 
 ##### Fixed Fields
 Field Name | Type | Description
 ---|:---:|---
-<a name="oauthFlowsImplicit"></a>implicit| [OAuth Flow Object](#oauthFlowObject) | Configuration for the OAuth Implicit flow 
-<a name="oauthFlowsPassword"></a>password| [OAuth Flow Object](#oauthFlowObject) | Configuration for the OAuth Resource Owner Password flow 
-<a name="oauthFlowsClientCredentials"></a>clientCredentials| [OAuth Flow Object](#oauthFlowObject) | Configuration for the OAuth Client Credentials flow.  Previously called `application` in OpenAPI 2.0.
-<a name="oauthFlowsAuthorizationCode"></a>authorizationCode| [OAuth Flow Object](#oauthFlowObject) | Configuration for the OAuth Authorization Code flow.  Previously called `accessCode` in OpenAPI 2.0.
+<a name="oauthFlowsImplicit"></a>implicit| [OAuth Flow Object](#oauth-flow-object) | Configuration for the OAuth Implicit flow
+<a name="oauthFlowsPassword"></a>password| [OAuth Flow Object](#oauth-flow-object) | Configuration for the OAuth Resource Owner Password flow
+<a name="oauthFlowsClientCredentials"></a>clientCredentials| [OAuth Flow Object](#oauth-flow-object) | Configuration for the OAuth Client Credentials flow.  Previously called `application` in OpenAPI 2.0.
+<a name="oauthFlowsAuthorizationCode"></a>authorizationCode| [OAuth Flow Object](#oauth-flow-object) | Configuration for the OAuth Authorization Code flow.  Previously called `accessCode` in OpenAPI 2.0.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
-#### <a name="oauthFlowObject"></a>OAuth Flow Object
+#### OAuth Flow Object
 
 Configuration details for a supported OAuth Flow
 
@@ -3296,7 +3296,7 @@ Field Name | Type | Applies To | Description
 <a name="oauthFlowRefreshUrl"></a>refreshUrl | `string` | `oauth2` | The URL to be used for obtaining refresh tokens. This MUST be in the form of a URL.
 <a name="oauthFlowScopes"></a>scopes | Map[`string`, `string`] | `oauth2` | **REQUIRED**. The available scopes for the OAuth2 security scheme. A map between the scope name and a short description for it. The map MAY be empty.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### OAuth Flow Object Examples
 
@@ -3325,7 +3325,7 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
 
 ```yaml
 type: oauth2
-flows: 
+flows:
   implicit:
     authorizationUrl: https://example.com/api/oauth/dialog
     scopes:
@@ -3336,24 +3336,24 @@ flows:
     tokenUrl: https://example.com/api/oauth/token
     scopes:
       write:pets: modify pets in your account
-      read:pets: read your pets 
+      read:pets: read your pets
 ```
 
-#### <a name="securityRequirementObject"></a>Security Requirement Object
+#### Security Requirement Object
 
 Lists the required security schemes to execute this operation.
-The name used for each property MUST correspond to a security scheme declared in the [Security Schemes](#componentsSecuritySchemes) under the [Components Object](#componentsObject).
+The name used for each property MUST correspond to a security scheme declared in the [Security Schemes](#componentsSecuritySchemes) under the [Components Object](#components-object).
 
 Security Requirement Objects that contain multiple schemes require that all schemes MUST be satisfied for a request to be authorized.
 This enables support for scenarios where multiple query parameters or HTTP headers are required to convey security information.
 
-When a list of Security Requirement Objects is defined on the [OpenAPI Object](#oasObject) or [Operation Object](#operationObject), only one of the Security Requirement Objects in the list needs to be satisfied to authorize the request.
+When a list of Security Requirement Objects is defined on the [OpenAPI Object](#openapi-object) or [Operation Object](#operation-object), only one of the Security Requirement Objects in the list needs to be satisfied to authorize the request.
 
 ##### Patterned Fields
 
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="securityRequirementsName"></a>{name} | [`string`] | Each name MUST correspond to a security scheme which is declared in the [Security Schemes](#componentsSecuritySchemes) under the [Components Object](#componentsObject). If the security scheme is of type `"oauth2"` or `"openIdConnect"`, then the value is a list of scope names required for the execution, and the list MAY be empty if authorization does not require a specified scope. For other security scheme types, the array MUST be empty.
+<a name="securityRequirementsName"></a>{name} | [`string`] | Each name MUST correspond to a security scheme which is declared in the [Security Schemes](#componentsSecuritySchemes) under the [Components Object](#components-object). If the security scheme is of type `"oauth2"` or `"openIdConnect"`, then the value is a list of scope names required for the execution, and the list MAY be empty if authorization does not require a specified scope. For other security scheme types, the array MUST be empty.
 
 ##### Security Requirement Object Examples
 
@@ -3412,7 +3412,7 @@ security:
     - read:pets
 ```
 
-### <a name="specificationExtensions"></a>Specification Extensions
+### Specification Extensions
 
 While the OpenAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.
 
@@ -3424,19 +3424,19 @@ Field Pattern | Type | Description
 
 The extensions may or may not be supported by the available tooling, but those may be extended as well to add requested support (if tools are internal or open-sourced).
 
-### <a name="securityFiltering"></a>Security Filtering
+### Security Filtering
 
-Some objects in the OpenAPI Specification MAY be declared and remain empty, or be completely removed, even though they are inherently the core of the API documentation. 
+Some objects in the OpenAPI Specification MAY be declared and remain empty, or be completely removed, even though they are inherently the core of the API documentation.
 
 The reasoning is to allow an additional layer of access control over the documentation.
 While not part of the specification itself, certain libraries MAY choose to allow access to parts of the documentation based on some form of authentication/authorization.
 
 Two examples of this:
 
-1. The [Paths Object](#pathsObject) MAY be empty. It may be counterintuitive, but this may tell the viewer that they got to the right place, but can't access any documentation. They'd still have access to the [Info Object](#infoObject) which may contain additional information regarding authentication.
-2. The [Path Item Object](#pathItemObject) MAY be empty. In this case, the viewer will be aware that the path exists, but will not be able to see any of its operations or parameters. This is different from hiding the path itself from the [Paths Object](#pathsObject), because the user will be aware of its existence. This allows the documentation provider to finely control what the viewer can see.
+1. The [Paths Object](#paths-object) MAY be empty. It may be counterintuitive, but this may tell the viewer that they got to the right place, but can't access any documentation. They'd still have access to the [Info Object](#info-object) which may contain additional information regarding authentication.
+2. The [Path Item Object](#path-item-object) MAY be empty. In this case, the viewer will be aware that the path exists, but will not be able to see any of its operations or parameters. This is different from hiding the path itself from the [Paths Object](#paths-object), because the user will be aware of its existence. This allows the documentation provider to finely control what the viewer can see.
 
-## <a name="revisionHistory"></a>Appendix A: Revision History
+## Appendix A: Revision History
 
 Version   | Date       | Notes
 ---       | ---        | ---

--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -16,69 +16,69 @@ An OpenAPI definition can then be used by documentation generation tools to disp
 <!-- TOC depthFrom:1 depthTo:3 withLinks:1 updateOnSave:1 orderedList:0 -->
 
 - [Definitions](#definitions)
-	- [OpenAPI Document](#oasDocument)
-	- [Path Templating](#pathTemplating)
-	- [Media Types](#mediaTypes)
-	- [HTTP Status Codes](#httpCodes)
+	- [OpenAPI Document](#openapi-document)
+	- [Path Templating](#path-templating)
+	- [Media Types](#media-types)
+	- [HTTP Status Codes](#http-status-codes)
 - [Specification](#specification)
 	- [Versions](#versions)
 	- [Format](#format)
-	- [Document Structure](#documentStructure)
-	- [Data Types](#dataTypes)
-	- [Rich Text Formatting](#richText)
-	- [Relative References In URIs](#relativeReferencesURI)
-	- [Relative References In URLs](#relativeReferencesURL)
+	- [Document Structure](#document-structure)
+	- [Data Types](#data-types)
+	- [Rich Text Formatting](#rich-text-formatting)
+	- [Relative References In URIs](#relative-references-in-uris)
+	- [Relative References In URLs](#relative-references-in-urls)
 	- [Schema](#schema)
-		- [OpenAPI Object](#oasObject)
-		- [Info Object](#infoObject)
-		- [Contact Object](#contactObject)
-		- [License Object](#licenseObject)
-		- [Server Object](#serverObject)
-		- [Server Variable Object](#serverVariableObject)
-		- [Components Object](#componentsObject)
-		- [Paths Object](#pathsObject)
-		- [Path Item Object](#pathItemObject)
-		- [Operation Object](#operationObject)
-		- [External Documentation Object](#externalDocumentationObject)
-		- [Parameter Object](#parameterObject)
-		- [Request Body Object](#requestBodyObject)
-		- [Media Type Object](#mediaTypeObject)
-		- [Encoding Object](#encodingObject)
-		- [Responses Object](#responsesObject)
-		- [Response Object](#responseObject)
-		- [Callback Object](#callbackObject)
-		- [Example Object](#exampleObject)
-		- [Link Object](#linkObject)
-		- [Header Object](#headerObject)
-		- [Tag Object](#tagObject)
-		- [Reference Object](#referenceObject)
-		- [Schema Object](#schemaObject)
-		- [Discriminator Object](#discriminatorObject)
-		- [XML Object](#xmlObject)
-		- [Security Scheme Object](#securitySchemeObject)
-		- [OAuth Flows Object](#oauthFlowsObject)
-		- [OAuth Flow Object](#oauthFlowObject)
-		- [Security Requirement Object](#securityRequirementObject)
-	- [Specification Extensions](#specificationExtensions)
-	- [Security Filtering](#securityFiltering)
-- [Appendix A: Revision History](#revisionHistory)
+		- [OpenAPI Object](#openapi-object)
+		- [Info Object](#info-object)
+		- [Contact Object](#contact-object)
+		- [License Object](#license-object)
+		- [Server Object](#server-object)
+		- [Server Variable Object](#server-variable-object)
+		- [Components Object](#components-object)
+		- [Paths Object](#paths-object)
+		- [Path Item Object](#path-item-object)
+		- [Operation Object](#operation-object)
+		- [External Documentation Object](#external-documentation-object)
+		- [Parameter Object](#parameter-object)
+		- [Request Body Object](#request-body-object)
+		- [Media Type Object](#media-type-object)
+		- [Encoding Object](#encoding-object)
+		- [Responses Object](#responses-object)
+		- [Response Object](#response-object)
+		- [Callback Object](#callback-object)
+		- [Example Object](#example-object)
+		- [Link Object](#link-object)
+		- [Header Object](#header-object)
+		- [Tag Object](#tag-object)
+		- [Reference Object](#reference-object)
+		- [Schema Object](#schema-object)
+		- [Discriminator Object](#discriminator-object)
+		- [XML Object](#xml-object)
+		- [Security Scheme Object](#security-scheme-object)
+		- [OAuth Flows Object](#oauth-flows-object)
+		- [OAuth Flow Object](#oauth-flow-object)
+		- [Security Requirement Object](#security-requirement-object)
+	- [Specification Extensions](#specification-extensions)
+	- [Security Filtering](#security-filtering)
+- [Appendix A: Revision History](#appendix-a-revision-history)
 	
 
 <!-- /TOC -->
 
 ## Definitions
 
-##### <a name="oasDocument"></a>OpenAPI Document
-A self-contained or composite resource which defines or describes an API or elements of an API. The OpenAPI document MUST contain at least one [paths](#pathsObject) field, a [components](#oasComponents) field or a [webhooks](#oasWebhooks) field. An OpenAPI document uses and conforms to the OpenAPI Specification.
+##### OpenAPI Document
+A self-contained or composite resource which defines or describes an API or elements of an API. The OpenAPI document MUST contain at least one [paths](#paths-object) field, a [components](#oasComponents) field or a [webhooks](#oasWebhooks) field. An OpenAPI document uses and conforms to the OpenAPI Specification.
 
-##### <a name="pathTemplating"></a>Path Templating
+##### Path Templating
 Path templating refers to the usage of template expressions, delimited by curly braces ({}), to mark a section of a URL path as replaceable using path parameters.
 
 Each template expression in the path MUST correspond to a path parameter that is included in the [Path Item](#path-item-object) itself and/or in each of the Path Item's [Operations](#operation-object). An exception is if the path item is empty, for example due to ACL constraints, matching path parameters are not required.
 
 The value for these path parameters MUST NOT contain any unescaped "generic syntax" characters described by [RFC3986](https://tools.ietf.org/html/rfc3986#section-3): forward slashes (`/`), question marks (`?`), or hashes (`#`).
 
-##### <a name="mediaTypes"></a>Media Types
+##### Media Types
 Media type definitions are spread across several resources.
 The media type definitions SHOULD be in compliance with [RFC6838](https://tools.ietf.org/html/rfc6838).
 
@@ -95,8 +95,8 @@ Some examples of possible media type definitions:
   application/vnd.github.v3.diff
   application/vnd.github.v3.patch
 ```
-##### <a name="httpCodes"></a>HTTP Status Codes
-The HTTP Status Codes are used to indicate the status of the executed operation. 
+##### HTTP Status Codes
+The HTTP Status Codes are used to indicate the status of the executed operation.
 The available status codes are defined by [RFC7231](https://tools.ietf.org/html/rfc7231#section-6) and registered status codes are listed in the [IANA Status Code Registry](https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml).
 
 ## Specification
@@ -125,7 +125,7 @@ This includes all fields that are used as keys in a map, except where explicitly
 
 The schema exposes two types of fields: Fixed fields, which have a declared name, and Patterned fields, which declare a regex pattern for the field name.
 
-Patterned fields MUST have unique names within the containing object. 
+Patterned fields MUST have unique names within the containing object.
 
 In order to preserve the ability to round-trip between YAML and JSON formats, YAML version [1.2](https://yaml.org/spec/1.2/spec.html) is RECOMMENDED along with some additional constraints:
 
@@ -134,24 +134,24 @@ In order to preserve the ability to round-trip between YAML and JSON formats, YA
 
 **Note:** While APIs may be defined by OpenAPI documents in either YAML or JSON format, the API request and response bodies and other content are not required to be JSON or YAML.
 
-### <a name="documentStructure"></a>Document Structure
+### Document Structure
 
-An OpenAPI document MAY be made up of a single document or be divided into multiple, connected parts at the discretion of the author. In the latter case, [`Reference Objects`](#referenceObject) and [`Schema Object`](#schemaObject) `$ref` keywords are used.
+An OpenAPI document MAY be made up of a single document or be divided into multiple, connected parts at the discretion of the author. In the latter case, [`Reference Objects`](#reference-object) and [`Schema Object`](#schema-object) `$ref` keywords are used.
 
 It is RECOMMENDED that the root OpenAPI document be named: `openapi.json` or `openapi.yaml`.
 
-### <a name="dataTypes"></a>Data Types
+### Data Types
 
 Data types in the OAS are based on the types supported by the [JSON Schema Specification Draft 2020-12](https://tools.ietf.org/html/draft-bhutton-json-schema-00#section-4.2.1).
-Note that `integer` as a type is also supported and is defined as a JSON number without a fraction or exponent part. 
-Models are defined using the [Schema Object](#schemaObject), which is a superset of JSON Schema Specification Draft 2020-12.
+Note that `integer` as a type is also supported and is defined as a JSON number without a fraction or exponent part.
+Models are defined using the [Schema Object](#schema-object), which is a superset of JSON Schema Specification Draft 2020-12.
 
 <a name="dataTypeFormat"></a>As defined by the [JSON Schema Validation vocabulary](https://tools.ietf.org/html/draft-bhutton-json-schema-validation-00#section-7.3), data types can have an optional modifier property: `format`.
 OAS defines additional formats to provide fine detail for primitive data types.
 
 The formats defined by the OAS are:
 
-[`type`](#dataTypes) | [`format`](#dataTypeFormat) | Comments
+[`type`](#data-types) | [`format`](#dataTypeFormat) | Comments
 ------ | -------- | --------
 `integer` | `int32` | signed 32 bits
 `integer` | `int64` | signed 64 bits (a.k.a long)
@@ -159,52 +159,52 @@ The formats defined by the OAS are:
 `number` | `double` | |
 `string` | `password` | A hint to UIs to obscure input.
 
-### <a name="richText"></a>Rich Text Formatting
+### Rich Text Formatting
 Throughout the specification `description` fields are noted as supporting CommonMark markdown formatting.
-Where OpenAPI tooling renders rich text it MUST support, at a minimum, markdown syntax as described by [CommonMark 0.27](https://spec.commonmark.org/0.27/). Tooling MAY choose to ignore some CommonMark features to address security concerns. 
+Where OpenAPI tooling renders rich text it MUST support, at a minimum, markdown syntax as described by [CommonMark 0.27](https://spec.commonmark.org/0.27/). Tooling MAY choose to ignore some CommonMark features to address security concerns.
 
-### <a name="relativeReferencesURI"></a>Relative References in URIs
+### Relative References in URIs
 
 Unless specified otherwise, all properties that are URIs MAY be relative references as defined by [RFC3986](https://tools.ietf.org/html/rfc3986#section-4.2).
 
-Relative references, including those in [`Reference Objects`](#referenceObject), [`PathItem Object`](#pathItemObject) `$ref` fields, [`Link Object`](#linkObject) `operationRef` fields and [`Example Object`](#exampleObject) `externalValue` fields, are resolved using the referring document as the Base URI according to [RFC3986](https://tools.ietf.org/html/rfc3986#section-5.2).
+Relative references, including those in [`Reference Objects`](#reference-object), [`PathItem Object`](#path-item-object) `$ref` fields, [`Link Object`](#link-object) `operationRef` fields and [`Example Object`](#example-object) `externalValue` fields, are resolved using the referring document as the Base URI according to [RFC3986](https://tools.ietf.org/html/rfc3986#section-5.2).
 
 If a URI contains a fragment identifier, then the fragment should be resolved per the fragment resolution mechanism of the referenced document.  If the representation of the referenced document is JSON or YAML, then the fragment identifier SHOULD be interpreted as a JSON-Pointer as per [RFC6901](https://tools.ietf.org/html/rfc6901).
 
-Relative references in [`Schema Objects`](#schemaObject), including any that appear as `$id` values, use the nearest parent `$id` as a Base URI, as described by [JSON Schema Specification Draft 2020-12](https://tools.ietf.org/html/draft-bhutton-json-schema-00#section-8.2).  If no parent schema contains an `$id`, then the Base URI MUST be determined according to [RFC3986](https://tools.ietf.org/html/rfc3986#section-5.1).
+Relative references in [`Schema Objects`](#schema-object), including any that appear as `$id` values, use the nearest parent `$id` as a Base URI, as described by [JSON Schema Specification Draft 2020-12](https://tools.ietf.org/html/draft-bhutton-json-schema-00#section-8.2).  If no parent schema contains an `$id`, then the Base URI MUST be determined according to [RFC3986](https://tools.ietf.org/html/rfc3986#section-5.1).
 
-### <a name="relativeReferencesURL"></a>Relative References in URLs
+### Relative References in URLs
 
 Unless specified otherwise, all properties that are URLs MAY be relative references as defined by [RFC3986](https://tools.ietf.org/html/rfc3986#section-4.2).
-Unless specified otherwise, relative references are resolved using the URLs defined in the [`Server Object`](#serverObject) as a Base URL. Note that these themselves MAY be relative to the referring document.
+Unless specified otherwise, relative references are resolved using the URLs defined in the [`Server Object`](#server-object) as a Base URL. Note that these themselves MAY be relative to the referring document.
 
 ### Schema
 
 In the following description, if a field is not explicitly **REQUIRED** or described with a MUST or SHALL, it can be considered OPTIONAL.
 
-#### <a name="oasObject"></a>OpenAPI Object
+#### OpenAPI Object
 
-This is the root object of the [OpenAPI document](#oasDocument).
+This is the root object of the [OpenAPI document](#openapi-document).
 
 ##### Fixed Fields
 
 Field Name | Type | Description
 ---|:---:|---
 <a name="oasVersion"></a>openapi | `string` | **REQUIRED**. This string MUST be the [version number](#versions) of the OpenAPI Specification that the OpenAPI document uses. The `openapi` field SHOULD be used by tooling to interpret the OpenAPI document. This is *not* related to the API [`info.version`](#infoVersion) string.
-<a name="oasInfo"></a>info | [Info Object](#infoObject) | **REQUIRED**. Provides metadata about the API. The metadata MAY be used by tooling as required.
-<a name="oasJsonSchemaDialect"></a> jsonSchemaDialect | `string` | The default value for the `$schema` keyword within [Schema Objects](#schemaObject) contained within this OAS document. This MUST be in the form of a URI.
-<a name="oasServers"></a>servers | [[Server Object](#serverObject)] | An array of Server Objects, which provide connectivity information to a target server. If the `servers` property is not provided, or is an empty array, the default value would be a [Server Object](#serverObject) with a [url](#serverUrl) value of `/`.
-<a name="oasPaths"></a>paths | [Paths Object](#pathsObject) | The available paths and operations for the API.
-<a name="oasWebhooks"></a>webhooks | Map[`string`, [Path Item Object](#pathItemObject) \| [Reference Object](#referenceObject)] ] | The incoming webhooks that MAY be received as part of this API and that the API consumer MAY choose to implement. Closely related to the `callbacks` feature, this section describes requests initiated other than by an API call, for example by an out of band registration. The key name is a unique string to refer to each webhook, while the (optionally referenced) Path Item Object describes a request that may be initiated by the API provider and the expected responses. An [example](../examples/v3.1/webhook-example.yaml) is available.
-<a name="oasComponents"></a>components | [Components Object](#componentsObject) | An element to hold various schemas for the document.
-<a name="oasSecurity"></a>security | [[Security Requirement Object](#securityRequirementObject)] | A declaration of which security mechanisms can be used across the API. The list of values includes alternative security requirement objects that can be used. Only one of the security requirement objects need to be satisfied to authorize a request. Individual operations can override this definition. To make security optional, an empty security requirement (`{}`) can be included in the array.
-<a name="oasTags"></a>tags | [[Tag Object](#tagObject)] | A list of tags used by the document with additional metadata. The order of the tags can be used to reflect on their order by the parsing tools. Not all tags that are used by the [Operation Object](#operationObject) must be declared. The tags that are not declared MAY be organized randomly or based on the tools' logic. Each tag name in the list MUST be unique.
-<a name="oasExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation.
+<a name="oasInfo"></a>info | [Info Object](#info-object) | **REQUIRED**. Provides metadata about the API. The metadata MAY be used by tooling as required.
+<a name="oasJsonSchemaDialect"></a> jsonSchemaDialect | `string` | The default value for the `$schema` keyword within [Schema Objects](#schema-object) contained within this OAS document. This MUST be in the form of a URI.
+<a name="oasServers"></a>servers | [[Server Object](#server-object)] | An array of Server Objects, which provide connectivity information to a target server. If the `servers` property is not provided, or is an empty array, the default value would be a [Server Object](#server-object) with a [url](#serverUrl) value of `/`.
+<a name="oasPaths"></a>paths | [Paths Object](#paths-object) | The available paths and operations for the API.
+<a name="oasWebhooks"></a>webhooks | Map[`string`, [Path Item Object](#path-item-object) \| [Reference Object](#reference-object)] ] | The incoming webhooks that MAY be received as part of this API and that the API consumer MAY choose to implement. Closely related to the `callbacks` feature, this section describes requests initiated other than by an API call, for example by an out of band registration. The key name is a unique string to refer to each webhook, while the (optionally referenced) Path Item Object describes a request that may be initiated by the API provider and the expected responses. An [example](../examples/v3.1/webhook-example.yaml) is available.
+<a name="oasComponents"></a>components | [Components Object](#components-object) | An element to hold various schemas for the document.
+<a name="oasSecurity"></a>security | [[Security Requirement Object](#security-requirement-object)] | A declaration of which security mechanisms can be used across the API. The list of values includes alternative security requirement objects that can be used. Only one of the security requirement objects need to be satisfied to authorize a request. Individual operations can override this definition. To make security optional, an empty security requirement (`{}`) can be included in the array.
+<a name="oasTags"></a>tags | [[Tag Object](#tag-object)] | A list of tags used by the document with additional metadata. The order of the tags can be used to reflect on their order by the parsing tools. Not all tags that are used by the [Operation Object](#operation-object) must be declared. The tags that are not declared MAY be organized randomly or based on the tools' logic. Each tag name in the list MUST be unique.
+<a name="oasExternalDocs"></a>externalDocs | [External Documentation Object](#external-documentation-object) | Additional external documentation.
 
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
-#### <a name="infoObject"></a>Info Object
+#### Info Object
 
 The object provides metadata about the API.
 The metadata MAY be used by the clients if needed, and MAY be presented in editing or documentation generation tools for convenience.
@@ -217,12 +217,12 @@ Field Name | Type | Description
 <a name="infoSummary"></a>summary | `string` | A short summary of the API.
 <a name="infoDescription"></a>description | `string` | A description of the API. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
 <a name="infoTermsOfService"></a>termsOfService | `string` | A URL to the Terms of Service for the API. This MUST be in the form of a URL.
-<a name="infoContact"></a>contact | [Contact Object](#contactObject) | The contact information for the exposed API.
-<a name="infoLicense"></a>license | [License Object](#licenseObject) | The license information for the exposed API.
+<a name="infoContact"></a>contact | [Contact Object](#contact-object) | The contact information for the exposed API.
+<a name="infoLicense"></a>license | [License Object](#license-object) | The license information for the exposed API.
 <a name="infoVersion"></a>version | `string` | **REQUIRED**. The version of the OpenAPI document (which is distinct from the [OpenAPI Specification version](#oasVersion) or the API implementation version).
 
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Info Object Example
 
@@ -260,7 +260,7 @@ license:
 version: 1.0.1
 ```
 
-#### <a name="contactObject"></a>Contact Object
+#### Contact Object
 
 Contact information for the exposed API.
 
@@ -272,7 +272,7 @@ Field Name | Type | Description
 <a name="contactUrl"></a>url | `string` | The URL pointing to the contact information. This MUST be in the form of a URL.
 <a name="contactEmail"></a>email | `string` | The email address of the contact person/organization. This MUST be in the form of an email address.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Contact Object Example
 
@@ -290,7 +290,7 @@ url: https://www.example.com/support
 email: support@example.com
 ```
 
-#### <a name="licenseObject"></a>License Object
+#### License Object
 
 License information for the exposed API.
 
@@ -302,7 +302,7 @@ Field Name | Type | Description
 <a name="licenseIdentifier"></a>identifier | `string` | An [SPDX](https://spdx.org/spdx-specification-21-web-version#h.jxpfx0ykyb60) license expression for the API. The `identifier` field is mutually exclusive of the `url` field.
 <a name="licenseUrl"></a>url | `string` | A URL to the license used for the API. This MUST be in the form of a URL. The `url` field is mutually exclusive of the `identifier` field.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### License Object Example
 
@@ -318,7 +318,7 @@ name: Apache 2.0
 identifier: Apache-2.0
 ```
 
-#### <a name="serverObject"></a>Server Object
+#### Server Object
 
 An object representing a Server.
 
@@ -328,9 +328,9 @@ Field Name | Type | Description
 ---|:---:|---
 <a name="serverUrl"></a>url | `string` | **REQUIRED**. A URL to the target host.  This URL supports Server Variables and MAY be relative, to indicate that the host location is relative to the location where the OpenAPI document is being served. Variable substitutions will be made when a variable is named in `{`brackets`}`.
 <a name="serverDescription"></a>description | `string` | An optional string describing the host designated by the URL. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="serverVariables"></a>variables | Map[`string`, [Server Variable Object](#serverVariableObject)] | A map between a variable name and its value.  The value is used for substitution in the server's URL template.
+<a name="serverVariables"></a>variables | Map[`string`, [Server Variable Object](#server-variable-object)] | A map between a variable name and its value.  The value is used for substitution in the server's URL template.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Server Object Example
 
@@ -428,7 +428,7 @@ servers:
 ```
 
 
-#### <a name="serverVariableObject"></a>Server Variable Object
+#### Server Variable Object
 
 An object representing a Server Variable for server URL template substitution.
 
@@ -437,12 +437,12 @@ An object representing a Server Variable for server URL template substitution.
 Field Name | Type | Description
 ---|:---:|---
 <a name="serverVariableEnum"></a>enum | [`string`] | An enumeration of string values to be used if the substitution options are from a limited set. The array MUST NOT be empty.
-<a name="serverVariableDefault"></a>default | `string` |  **REQUIRED**. The default value to use for substitution, which SHALL be sent if an alternate value is _not_ supplied. Note this behavior is different than the [Schema Object's](#schemaObject) treatment of default values, because in those cases parameter values are optional. If the [`enum`](#serverVariableEnum) is defined, the value MUST exist in the enum's values.
+<a name="serverVariableDefault"></a>default | `string` |  **REQUIRED**. The default value to use for substitution, which SHALL be sent if an alternate value is _not_ supplied. Note this behavior is different than the [Schema Object's](#schema-object) treatment of default values, because in those cases parameter values are optional. If the [`enum`](#serverVariableEnum) is defined, the value MUST exist in the enum's values.
 <a name="serverVariableDescription"></a>description | `string` | An optional description for the server variable. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
-#### <a name="componentsObject"></a>Components Object
+#### Components Object
 
 Holds a set of reusable objects for different aspects of the OAS.
 All objects defined within the components object will have no effect on the API unless they are explicitly referenced from properties outside the components object.
@@ -452,19 +452,19 @@ All objects defined within the components object will have no effect on the API 
 
 Field Name | Type | Description
 ---|:---|---
-<a name="componentsSchemas"></a> schemas | Map[`string`, [Schema Object](#schemaObject)] | An object to hold reusable [Schema Objects](#schemaObject).
-<a name="componentsResponses"></a> responses | Map[`string`, [Response Object](#responseObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Response Objects](#responseObject).
-<a name="componentsParameters"></a> parameters | Map[`string`, [Parameter Object](#parameterObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Parameter Objects](#parameterObject).
-<a name="componentsExamples"></a> examples | Map[`string`, [Example Object](#exampleObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Example Objects](#exampleObject).
-<a name="componentsRequestBodies"></a> requestBodies | Map[`string`, [Request Body Object](#requestBodyObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Request Body Objects](#requestBodyObject).
-<a name="componentsHeaders"></a> headers | Map[`string`, [Header Object](#headerObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Header Objects](#headerObject).
-<a name="componentsSecuritySchemes"></a> securitySchemes| Map[`string`, [Security Scheme Object](#securitySchemeObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Security Scheme Objects](#securitySchemeObject).
-<a name="componentsLinks"></a> links | Map[`string`, [Link Object](#linkObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Link Objects](#linkObject).
-<a name="componentsCallbacks"></a> callbacks | Map[`string`, [Callback Object](#callbackObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Callback Objects](#callbackObject).
-<a name="componentsPathItems"></a> pathItems | Map[`string`, [Path Item Object](#pathItemObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Path Item Object](#pathItemObject).
+<a name="componentsSchemas"></a> schemas | Map[`string`, [Schema Object](#schema-object)] | An object to hold reusable [Schema Objects](#schema-object).
+<a name="componentsResponses"></a> responses | Map[`string`, [Response Object](#response-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Response Objects](#response-object).
+<a name="componentsParameters"></a> parameters | Map[`string`, [Parameter Object](#parameter-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Parameter Objects](#parameter-object).
+<a name="componentsExamples"></a> examples | Map[`string`, [Example Object](#example-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Example Objects](#example-object).
+<a name="componentsRequestBodies"></a> requestBodies | Map[`string`, [Request Body Object](#request-body-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Request Body Objects](#request-body-object).
+<a name="componentsHeaders"></a> headers | Map[`string`, [Header Object](#header-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Header Objects](#header-object).
+<a name="componentsSecuritySchemes"></a> securitySchemes| Map[`string`, [Security Scheme Object](#security-scheme-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Security Scheme Objects](#security-scheme-object).
+<a name="componentsLinks"></a> links | Map[`string`, [Link Object](#link-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Link Objects](#link-object).
+<a name="componentsCallbacks"></a> callbacks | Map[`string`, [Callback Object](#callback-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Callback Objects](#callback-object).
+<a name="componentsPathItems"></a> pathItems | Map[`string`, [Path Item Object](#path-item-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Path Item Object](#path-item-object).
 
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 All the fixed fields declared above are objects that MUST use keys that match the regular expression: `^[a-zA-Z0-9\.\-_]+$`.
 
@@ -644,7 +644,7 @@ components:
       in: header
     petstore_auth:
       type: oauth2
-      flows: 
+      flows:
         implicit:
           authorizationUrl: https://example.org/api/oauth/dialog
           scopes:
@@ -652,18 +652,18 @@ components:
             read:pets: read your pets
 ```
 
-#### <a name="pathsObject"></a>Paths Object
+#### Paths Object
 
 Holds the relative paths to the individual endpoints and their operations.
-The path is appended to the URL from the [`Server Object`](#serverObject) in order to construct the full URL.  The Paths MAY be empty, due to [Access Control List (ACL) constraints](#securityFiltering).
+The path is appended to the URL from the [`Server Object`](#server-object) in order to construct the full URL.  The Paths MAY be empty, due to [Access Control List (ACL) constraints](#security-filtering).
 
 ##### Patterned Fields
 
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="pathsPath"></a>/{path} | [Path Item Object](#pathItemObject) | A relative path to an individual endpoint. The field name MUST begin with a forward slash (`/`). The path is **appended** (no relative URL resolution) to the expanded URL from the [`Server Object`](#serverObject)'s `url` field in order to construct the full URL. [Path templating](#pathTemplating) is allowed. When matching URLs, concrete (non-templated) paths would be matched before their templated counterparts. Templated paths with the same hierarchy but different templated names MUST NOT exist as they are identical. In case of ambiguous matching, it's up to the tooling to decide which one to use.
+<a name="pathsPath"></a>/{path} | [Path Item Object](#path-item-object) | A relative path to an individual endpoint. The field name MUST begin with a forward slash (`/`). The path is **appended** (no relative URL resolution) to the expanded URL from the [`Server Object`](#server-object)'s `url` field in order to construct the full URL. [Path templating](#path-templating) is allowed. When matching URLs, concrete (non-templated) paths would be matched before their templated counterparts. Templated paths with the same hierarchy but different templated names MUST NOT exist as they are identical. In case of ambiguous matching, it's up to the tooling to decide which one to use.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Path Templating Matching
 
@@ -696,7 +696,7 @@ The following may lead to ambiguous resolution:
     "get": {
       "description": "Returns all pets from the system that the user has access to",
       "responses": {
-        "200": {          
+        "200": {         
           "description": "A list of pets.",
           "content": {
             "application/json": {
@@ -730,32 +730,32 @@ The following may lead to ambiguous resolution:
                 $ref: '#/components/schemas/pet'
 ```
 
-#### <a name="pathItemObject"></a>Path Item Object
+#### Path Item Object
 
 Describes the operations available on a single path.
-A Path Item MAY be empty, due to [ACL constraints](#securityFiltering).
+A Path Item MAY be empty, due to [ACL constraints](#security-filtering).
 The path itself is still exposed to the documentation viewer but they will not know which operations and parameters are available.
 
 ##### Fixed Fields
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="pathItemRef"></a>$ref | `string` | Allows for a referenced definition of this path item. The referenced structure MUST be in the form of a [Path Item Object](#pathItemObject).  In case a Path Item Object field appears both in the defined object and the referenced object, the behavior is undefined. See the rules for resolving [Relative References](#relativeReferencesURI).
+<a name="pathItemRef"></a>$ref | `string` | Allows for a referenced definition of this path item. The referenced structure MUST be in the form of a [Path Item Object](#path-item-object).  In case a Path Item Object field appears both in the defined object and the referenced object, the behavior is undefined. See the rules for resolving [Relative References](#relative-references-in-uris).
 <a name="pathItemSummary"></a>summary| `string` | An optional, string summary, intended to apply to all operations in this path.
 <a name="pathItemDescription"></a>description | `string` | An optional, string description, intended to apply to all operations in this path. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="pathItemGet"></a>get | [Operation Object](#operationObject) | A definition of a GET operation on this path.
-<a name="pathItemPut"></a>put | [Operation Object](#operationObject) | A definition of a PUT operation on this path.
-<a name="pathItemPost"></a>post | [Operation Object](#operationObject) | A definition of a POST operation on this path.
-<a name="pathItemDelete"></a>delete | [Operation Object](#operationObject) | A definition of a DELETE operation on this path.
-<a name="pathItemOptions"></a>options | [Operation Object](#operationObject) | A definition of a OPTIONS operation on this path.
-<a name="pathItemHead"></a>head | [Operation Object](#operationObject) | A definition of a HEAD operation on this path.
-<a name="pathItemPatch"></a>patch | [Operation Object](#operationObject) | A definition of a PATCH operation on this path.
-<a name="pathItemTrace"></a>trace | [Operation Object](#operationObject) | A definition of a TRACE operation on this path.
-<a name="pathItemServers"></a>servers | [[Server Object](#serverObject)] | An alternative `server` array to service all operations in this path.
-<a name="pathItemParameters"></a>parameters | [[Parameter Object](#parameterObject) \| [Reference Object](#referenceObject)] | A list of parameters that are applicable for all the operations described under this path. These parameters can be overridden at the operation level, but cannot be removed there. The list MUST NOT include duplicated parameters. A unique parameter is defined by a combination of a [name](#parameterName) and [location](#parameterIn). The list can use the [Reference Object](#referenceObject) to link to parameters that are defined at the [OpenAPI Object's components/parameters](#componentsParameters). 
+<a name="pathItemGet"></a>get | [Operation Object](#operation-object) | A definition of a GET operation on this path.
+<a name="pathItemPut"></a>put | [Operation Object](#operation-object) | A definition of a PUT operation on this path.
+<a name="pathItemPost"></a>post | [Operation Object](#operation-object) | A definition of a POST operation on this path.
+<a name="pathItemDelete"></a>delete | [Operation Object](#operation-object) | A definition of a DELETE operation on this path.
+<a name="pathItemOptions"></a>options | [Operation Object](#operation-object) | A definition of a OPTIONS operation on this path.
+<a name="pathItemHead"></a>head | [Operation Object](#operation-object) | A definition of a HEAD operation on this path.
+<a name="pathItemPatch"></a>patch | [Operation Object](#operation-object) | A definition of a PATCH operation on this path.
+<a name="pathItemTrace"></a>trace | [Operation Object](#operation-object) | A definition of a TRACE operation on this path.
+<a name="pathItemServers"></a>servers | [[Server Object](#server-object)] | An alternative `server` array to service all operations in this path.
+<a name="pathItemParameters"></a>parameters | [[Parameter Object](#parameter-object) \| [Reference Object](#reference-object)] | A list of parameters that are applicable for all the operations described under this path. These parameters can be overridden at the operation level, but cannot be removed there. The list MUST NOT include duplicated parameters. A unique parameter is defined by a combination of a [name](#parameterName) and [location](#parameterIn). The list can use the [Reference Object](#reference-object) to link to parameters that are defined at the [OpenAPI Object's components/parameters](#componentsParameters).
 
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Path Item Object Example
 
@@ -837,11 +837,11 @@ parameters:
   schema:
     type: array
     items:
-      type: string  
+      type: string 
   style: simple
 ```
 
-#### <a name="operationObject"></a>Operation Object
+#### Operation Object
 
 Describes a single API operation on a path.
 
@@ -852,17 +852,17 @@ Field Name | Type | Description
 <a name="operationTags"></a>tags | [`string`] | A list of tags for API documentation control. Tags can be used for logical grouping of operations by resources or any other qualifier.
 <a name="operationSummary"></a>summary | `string` | A short summary of what the operation does.
 <a name="operationDescription"></a>description | `string` | A verbose explanation of the operation behavior. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="operationExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation for this operation.
+<a name="operationExternalDocs"></a>externalDocs | [External Documentation Object](#external-documentation-object) | Additional external documentation for this operation.
 <a name="operationId"></a>operationId | `string` | Unique string used to identify the operation. The id MUST be unique among all operations described in the API. The operationId value is **case-sensitive**. Tools and libraries MAY use the operationId to uniquely identify an operation, therefore, it is RECOMMENDED to follow common programming naming conventions.
-<a name="operationParameters"></a>parameters | [[Parameter Object](#parameterObject) \| [Reference Object](#referenceObject)] | A list of parameters that are applicable for this operation. If a parameter is already defined at the [Path Item](#pathItemParameters), the new definition will override it but can never remove it. The list MUST NOT include duplicated parameters. A unique parameter is defined by a combination of a [name](#parameterName) and [location](#parameterIn). The list can use the [Reference Object](#referenceObject) to link to parameters that are defined at the [OpenAPI Object's components/parameters](#componentsParameters).
-<a name="operationRequestBody"></a>requestBody | [Request Body Object](#requestBodyObject) \| [Reference Object](#referenceObject) | The request body applicable for this operation.  The `requestBody` is fully supported in HTTP methods where the HTTP 1.1 specification [RFC7231](https://tools.ietf.org/html/rfc7231#section-4.3.1) has explicitly defined semantics for request bodies.  In other cases where the HTTP spec is vague (such as [GET](https://tools.ietf.org/html/rfc7231#section-4.3.1), [HEAD](https://tools.ietf.org/html/rfc7231#section-4.3.2) and [DELETE](https://tools.ietf.org/html/rfc7231#section-4.3.5)), `requestBody` is permitted but does not have well-defined semantics and SHOULD be avoided if possible.
-<a name="operationResponses"></a>responses | [Responses Object](#responsesObject) | The list of possible responses as they are returned from executing this operation.
-<a name="operationCallbacks"></a>callbacks | Map[`string`, [Callback Object](#callbackObject) \| [Reference Object](#referenceObject)] | A map of possible out-of band callbacks related to the parent operation. The key is a unique identifier for the Callback Object. Each value in the map is a [Callback Object](#callbackObject) that describes a request that may be initiated by the API provider and the expected responses.
+<a name="operationParameters"></a>parameters | [[Parameter Object](#parameter-object) \| [Reference Object](#reference-object)] | A list of parameters that are applicable for this operation. If a parameter is already defined at the [Path Item](#pathItemParameters), the new definition will override it but can never remove it. The list MUST NOT include duplicated parameters. A unique parameter is defined by a combination of a [name](#parameterName) and [location](#parameterIn). The list can use the [Reference Object](#reference-object) to link to parameters that are defined at the [OpenAPI Object's components/parameters](#componentsParameters).
+<a name="operationRequestBody"></a>requestBody | [Request Body Object](#request-body-object) \| [Reference Object](#reference-object) | The request body applicable for this operation.  The `requestBody` is fully supported in HTTP methods where the HTTP 1.1 specification [RFC7231](https://tools.ietf.org/html/rfc7231#section-4.3.1) has explicitly defined semantics for request bodies.  In other cases where the HTTP spec is vague (such as [GET](https://tools.ietf.org/html/rfc7231#section-4.3.1), [HEAD](https://tools.ietf.org/html/rfc7231#section-4.3.2) and [DELETE](https://tools.ietf.org/html/rfc7231#section-4.3.5)), `requestBody` is permitted but does not have well-defined semantics and SHOULD be avoided if possible.
+<a name="operationResponses"></a>responses | [Responses Object](#responses-object) | The list of possible responses as they are returned from executing this operation.
+<a name="operationCallbacks"></a>callbacks | Map[`string`, [Callback Object](#callback-object) \| [Reference Object](#reference-object)] | A map of possible out-of band callbacks related to the parent operation. The key is a unique identifier for the Callback Object. Each value in the map is a [Callback Object](#callback-object) that describes a request that may be initiated by the API provider and the expected responses.
 <a name="operationDeprecated"></a>deprecated | `boolean` | Declares this operation to be deprecated. Consumers SHOULD refrain from usage of the declared operation. Default value is `false`.
-<a name="operationSecurity"></a>security | [[Security Requirement Object](#securityRequirementObject)] | A declaration of which security mechanisms can be used for this operation. The list of values includes alternative security requirement objects that can be used. Only one of the security requirement objects need to be satisfied to authorize a request. To make security optional, an empty security requirement (`{}`) can be included in the array. This definition overrides any declared top-level [`security`](#oasSecurity). To remove a top-level security declaration, an empty array can be used.
-<a name="operationServers"></a>servers | [[Server Object](#serverObject)] | An alternative `server` array to service this operation. If an alternative `server` object is specified at the Path Item Object or Root level, it will be overridden by this value.
+<a name="operationSecurity"></a>security | [[Security Requirement Object](#security-requirement-object)] | A declaration of which security mechanisms can be used for this operation. The list of values includes alternative security requirement objects that can be used. Only one of the security requirement objects need to be satisfied to authorize a request. To make security optional, an empty security requirement (`{}`) can be included in the array. This definition overrides any declared top-level [`security`](#oasSecurity). To remove a top-level security declaration, an empty array can be used.
+<a name="operationServers"></a>servers | [[Server Object](#server-object)] | An alternative `server` array to service this operation. If an alternative `server` object is specified at the Path Item Object or Root level, it will be overridden by this value.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Operation Object Example
 
@@ -890,7 +890,7 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
         "schema": {
           "type": "object",
           "properties": {
-            "name": { 
+            "name": {
               "description": "Updated name of the pet",
               "type": "string"
             },
@@ -899,7 +899,7 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
               "type": "string"
             }
           },
-          "required": ["status"] 
+          "required": ["status"]
         }
       }
     }
@@ -949,7 +949,7 @@ requestBody:
       schema:
        type: object
        properties:
-          name: 
+          name:
             description: Updated name of the pet
             type: string
           status:
@@ -960,12 +960,12 @@ requestBody:
 responses:
   '200':
     description: Pet updated.
-    content: 
+    content:
       'application/json': {}
       'application/xml': {}
   '405':
     description: Method Not Allowed
-    content: 
+    content:
       'application/json': {}
       'application/xml': {}
 security:
@@ -975,7 +975,7 @@ security:
 ```
 
 
-#### <a name="externalDocumentationObject"></a>External Documentation Object
+#### External Documentation Object
 
 Allows referencing an external resource for extended documentation.
 
@@ -986,7 +986,7 @@ Field Name | Type | Description
 <a name="externalDocDescription"></a>description | `string` | A description of the target documentation. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
 <a name="externalDocUrl"></a>url | `string` | **REQUIRED**. The URL for the target documentation. This MUST be in the form of a URL.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### External Documentation Object Example
 
@@ -1002,7 +1002,7 @@ description: Find more info here
 url: https://example.com
 ```
 
-#### <a name="parameterObject"></a>Parameter Object
+#### Parameter Object
 
 Describes a single operation parameter.
 
@@ -1010,7 +1010,7 @@ A unique parameter is defined by a combination of a [name](#parameterName) and [
 
 ##### Parameter Locations
 There are four possible parameter locations specified by the `in` field:
-* path - Used together with [Path Templating](#pathTemplating), where the parameter value is actually part of the operation's URL. This does not include the host or base path of the API. For example, in `/items/{itemId}`, the path parameter is `itemId`.
+* path - Used together with [Path Templating](#path-templating), where the parameter value is actually part of the operation's URL. This does not include the host or base path of the API. For example, in `/items/{itemId}`, the path parameter is `itemId`.
 * query - Parameters that are appended to the URL. For example, in `/items?id=###`, the query parameter is `id`.
 * header - Custom headers that are expected as part of the request. Note that [RFC7230](https://tools.ietf.org/html/rfc7230#page-22) states header names are case insensitive.
 * cookie - Used to pass a specific cookie value to the API.
@@ -1019,7 +1019,7 @@ There are four possible parameter locations specified by the `in` field:
 ##### Fixed Fields
 Field Name | Type | Description
 ---|:---:|---
-<a name="parameterName"></a>name | `string` | **REQUIRED**. The name of the parameter. Parameter names are *case sensitive*. <ul><li>If [`in`](#parameterIn) is `"path"`, the `name` field MUST correspond to a template expression occurring within the [path](#pathsPath) field in the [Paths Object](#pathsObject). See [Path Templating](#pathTemplating) for further information.<li>If [`in`](#parameterIn) is `"header"` and the `name` field is `"Accept"`, `"Content-Type"` or `"Authorization"`, the parameter definition SHALL be ignored.<li>For all other cases, the `name` corresponds to the parameter name used by the [`in`](#parameterIn) property.</ul>
+<a name="parameterName"></a>name | `string` | **REQUIRED**. The name of the parameter. Parameter names are *case sensitive*. <ul><li>If [`in`](#parameterIn) is `"path"`, the `name` field MUST correspond to a template expression occurring within the [path](#pathsPath) field in the [Paths Object](#paths-object). See [Path Templating](#path-templating) for further information.<li>If [`in`](#parameterIn) is `"header"` and the `name` field is `"Accept"`, `"Content-Type"` or `"Authorization"`, the parameter definition SHALL be ignored.<li>For all other cases, the `name` corresponds to the parameter name used by the [`in`](#parameterIn) property.</ul>
 <a name="parameterIn"></a>in | `string` | **REQUIRED**. The location of the parameter. Possible values are `"query"`, `"header"`, `"path"` or `"cookie"`.
 <a name="parameterDescription"></a>description | `string` | A brief description of the parameter. This could contain examples of use. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
 <a name="parameterRequired"></a>required | `boolean` | Determines whether this parameter is mandatory. If the [parameter location](#parameterIn) is `"path"`, this property is **REQUIRED** and its value MUST be `true`. Otherwise, the property MAY be included and its default value is `false`.
@@ -1034,9 +1034,9 @@ Field Name | Type | Description
 <a name="parameterStyle"></a>style | `string` | Describes how the parameter value will be serialized depending on the type of the parameter value. Default values (based on value of `in`): for `query` - `form`; for `path` - `simple`; for `header` - `simple`; for `cookie` - `form`.
 <a name="parameterExplode"></a>explode | `boolean` | When this is true, parameter values of type `array` or `object` generate separate parameters for each value of the array or key-value pair of the map. For other types of parameters this property has no effect. When [`style`](#parameterStyle) is `form`, the default value is `true`. For all other styles, the default value is `false`.
 <a name="parameterAllowReserved"></a>allowReserved | `boolean` | Determines whether the parameter value SHOULD allow reserved characters, as defined by [RFC3986](https://tools.ietf.org/html/rfc3986#section-2.2) `:/?#[]@!$&'()*+,;=` to be included without percent-encoding. This property only applies to parameters with an `in` value of `query`. The default value is `false`.
-<a name="parameterSchema"></a>schema | [Schema Object](#schemaObject) | The schema defining the type used for the parameter.
+<a name="parameterSchema"></a>schema | [Schema Object](#schema-object) | The schema defining the type used for the parameter.
 <a name="parameterExample"></a>example | Any | Example of the parameter's potential value. The example SHOULD match the specified schema and encoding properties if present. The `example` field is mutually exclusive of the `examples` field. Furthermore, if referencing a `schema` that contains an example, the `example` value SHALL _override_ the example provided by the schema. To represent examples of media types that cannot naturally be represented in JSON or YAML, a string value can contain the example with escaping where necessary.
-<a name="parameterExamples"></a>examples | Map[ `string`, [Example Object](#exampleObject) \| [Reference Object](#referenceObject)] | Examples of the parameter's potential value. Each example SHOULD contain a value in the correct format as specified in the parameter encoding. The `examples` field is mutually exclusive of the `example` field. Furthermore, if referencing a `schema` that contains an example, the `examples` value SHALL _override_ the example provided by the schema.
+<a name="parameterExamples"></a>examples | Map[ `string`, [Example Object](#example-object) \| [Reference Object](#reference-object)] | Examples of the parameter's potential value. Each example SHOULD contain a value in the correct format as specified in the parameter encoding. The `examples` field is mutually exclusive of the `example` field. Furthermore, if referencing a `schema` that contains an example, the `examples` value SHALL _override_ the example provided by the schema.
 
 For more complex scenarios, the [`content`](#parameterContent) property can define the media type and schema of the parameter.
 A parameter MUST contain either a `schema` property, or a `content` property, but not both.
@@ -1045,19 +1045,19 @@ When `example` or `examples` are provided in conjunction with the `schema` objec
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="parameterContent"></a>content | Map[`string`, [Media Type Object](#mediaTypeObject)] | A map containing the representations for the parameter. The key is the media type and the value describes it. The map MUST only contain one entry.
+<a name="parameterContent"></a>content | Map[`string`, [Media Type Object](#media-type-object)] | A map containing the representations for the parameter. The key is the media type and the value describes it. The map MUST only contain one entry.
 
-##### <a name="styleValues"></a>Style Values
+##### Style Values
 
 In order to support common ways of serializing simple parameters, a set of `style` values are defined.
 
-`style` | [`type`](#dataTypes) |  `in` | Comments
+`style` | [`type`](#data-types) |  `in` | Comments
 ----------- | ------ | -------- | --------
-matrix |  `primitive`, `array`, `object` |  `path` | Path-style parameters defined by [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.7) 
+matrix |  `primitive`, `array`, `object` |  `path` | Path-style parameters defined by [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.7)
 label | `primitive`, `array`, `object` |  `path` | Label style parameters defined by [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.5)
 form |  `primitive`, `array`, `object` |  `query`, `cookie` | Form style parameters defined by [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.8). This option replaces `collectionFormat` with a `csv` (when `explode` is false) or `multi` (when `explode` is true) value from OpenAPI 2.0.
 simple | `array` | `path`, `header` | Simple style parameters defined by [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.2).  This option replaces `collectionFormat` with a `csv` value from OpenAPI 2.0.
-spaceDelimited | `array`, `object` | `query` | Space separated array or object values. This option replaces `collectionFormat` equal to `ssv` from OpenAPI 2.0. 
+spaceDelimited | `array`, `object` | `query` | Space separated array or object values. This option replaces `collectionFormat` equal to `ssv` from OpenAPI 2.0.
 pipeDelimited | `array`, `object` | `query` | Pipe separated array or object values. This option replaces `collectionFormat` equal to `pipes` from OpenAPI 2.0.
 deepObject | `object` | `query` | Provides a simple way of rendering nested objects using form parameters.
 
@@ -1073,7 +1073,7 @@ Assume a parameter named `color` has one of the following values:
 ```
 The following table shows examples of rendering differences for each value.
 
-[`style`](#styleValues) | `explode` | `empty` | `string` | `array` | `object`
+[`style`](#style-values) | `explode` | `empty` | `string` | `array` | `object`
 ----------- | ------ | -------- | -------- | -------- | -------
 matrix | false | ;color | ;color=blue | ;color=blue,black,brown | ;color=R,100,G,200,B,150
 matrix | true | ;color | ;color=blue | ;color=blue;color=black;color=brown | ;R=100;G=200;B=150
@@ -1087,7 +1087,7 @@ spaceDelimited | false | n/a | n/a | blue%20black%20brown | R%20100%20G%20200%20
 pipeDelimited | false | n/a | n/a | blue\|black\|brown | R\|100\|G\|200\|B\|150
 deepObject | true | n/a | n/a | n/a | color[R]=100&color[G]=200&color[B]=150
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Parameter Object Examples
 
@@ -1246,7 +1246,7 @@ content:
           type: number
 ```
 
-#### <a name="requestBodyObject"></a>Request Body Object
+#### Request Body Object
 
 Describes a single request body.
 
@@ -1254,11 +1254,11 @@ Describes a single request body.
 Field Name | Type | Description
 ---|:---:|---
 <a name="requestBodyDescription"></a>description | `string` | A brief description of the request body. This could contain examples of use.  [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="requestBodyContent"></a>content | Map[`string`, [Media Type Object](#mediaTypeObject)] | **REQUIRED**. The content of the request body. The key is a media type or [media type range](https://tools.ietf.org/html/rfc7231#appendix-D) and the value describes it.  For requests that match multiple keys, only the most specific key is applicable. e.g. text/plain overrides text/*
+<a name="requestBodyContent"></a>content | Map[`string`, [Media Type Object](#media-type-object)] | **REQUIRED**. The content of the request body. The key is a media type or [media type range](https://tools.ietf.org/html/rfc7231#appendix-D) and the value describes it.  For requests that match multiple keys, only the most specific key is applicable. e.g. text/plain overrides text/*
 <a name="requestBodyRequired"></a>required | `boolean` | Determines if the request body is required in the request. Defaults to `false`.
 
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Request Body Examples
 
@@ -1273,9 +1273,9 @@ A request body with a referenced model definition.
       },
       "examples": {
           "user" : {
-            "summary": "User Example", 
+            "summary": "User Example",
             "externalValue": "https://foo.bar/examples/user-example.json"
-          } 
+          }
         }
     },
     "application/xml": {
@@ -1293,9 +1293,9 @@ A request body with a referenced model definition.
       "examples": {
         "user" : {
             "summary": "User example in Plain text",
-            "externalValue": "https://foo.bar/examples/user-example.txt" 
+            "externalValue": "https://foo.bar/examples/user-example.txt"
         }
-      } 
+      }
     },
     "*/*": {
       "examples": {
@@ -1311,7 +1311,7 @@ A request body with a referenced model definition.
 
 ```yaml
 description: user to add to the system
-content: 
+content:
   'application/json':
     schema:
       $ref: '#/components/schemas/User'
@@ -1333,7 +1333,7 @@ content:
         externalValue: 'https://foo.bar/examples/user-example.txt'
   '*/*':
     examples:
-      user: 
+      user:
         summary: User example in other format
         externalValue: 'https://foo.bar/examples/user-example.whatever'
 ```
@@ -1368,18 +1368,18 @@ content:
 ```
 
 
-#### <a name="mediaTypeObject"></a>Media Type Object
+#### Media Type Object
 Each Media Type Object provides schema and examples for the media type identified by its key.
 
 ##### Fixed Fields
 Field Name | Type | Description
 ---|:---:|---
-<a name="mediaTypeSchema"></a>schema | [Schema Object](#schemaObject) | The schema defining the content of the request, response, or parameter.
+<a name="mediaTypeSchema"></a>schema | [Schema Object](#schema-object) | The schema defining the content of the request, response, or parameter.
 <a name="mediaTypeExample"></a>example | Any | Example of the media type.  The example object SHOULD be in the correct format as specified by the media type.  The `example` field is mutually exclusive of the `examples` field.  Furthermore, if referencing a `schema` which contains an example, the `example` value SHALL _override_ the example provided by the schema.
-<a name="mediaTypeExamples"></a>examples | Map[ `string`, [Example Object](#exampleObject) \| [Reference Object](#referenceObject)] | Examples of the media type.  Each example object SHOULD  match the media type and specified schema if present.  The `examples` field is mutually exclusive of the `example` field.  Furthermore, if referencing a `schema` which contains an example, the `examples` value SHALL _override_ the example provided by the schema.
-<a name="mediaTypeEncoding"></a>encoding | Map[`string`, [Encoding Object](#encodingObject)] | A map between a property name and its encoding information. The key, being the property name, MUST exist in the schema as a property. The encoding object SHALL only apply to `requestBody` objects when the media type is `multipart` or `application/x-www-form-urlencoded`.
+<a name="mediaTypeExamples"></a>examples | Map[ `string`, [Example Object](#example-object) \| [Reference Object](#reference-object)] | Examples of the media type.  Each example object SHOULD  match the media type and specified schema if present.  The `examples` field is mutually exclusive of the `example` field.  Furthermore, if referencing a `schema` which contains an example, the `examples` value SHALL _override_ the example provided by the schema.
+<a name="mediaTypeEncoding"></a>encoding | Map[`string`, [Encoding Object](#encoding-object)] | A map between a property name and its encoding information. The key, being the property name, MUST exist in the schema as a property. The encoding object SHALL only apply to `requestBody` objects when the media type is `multipart` or `application/x-www-form-urlencoded`.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Media Type Examples
 
@@ -1392,7 +1392,7 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
     "examples": {
       "cat" : {
         "summary": "An example of a cat",
-        "value": 
+        "value":
           {
             "name": "Fluffy",
             "petType": "Cat",
@@ -1403,7 +1403,7 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
       },
       "dog": {
         "summary": "An example of a dog with a cat's name",
-        "value" :  { 
+        "value" :  {
           "name": "Puma",
           "petType": "Dog",
           "color": "Black",
@@ -1420,7 +1420,7 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
 ```
 
 ```yaml
-application/json: 
+application/json:
   schema:
     $ref: "#/components/schemas/Pet"
   examples:
@@ -1450,7 +1450,7 @@ In contrast with the 2.0 specification, `file` input/output content in OpenAPI i
 
 In contrast with the 3.0 specification, the `format` keyword has no effect on the content-encoding of the schema. JSON Schema offers a `contentEncoding` keyword, which may be used to specify the `Content-Encoding` for the schema. The `contentEncoding` keyword supports all encodings defined in [RFC4648](https://tools.ietf.org/html/rfc4648), including "base64" and "base64url", as well as "quoted-printable" from [RFC2045](https://tools.ietf.org/html/rfc2045#section-6.7). The encoding specified by the `contentEncoding` keyword is independent of an encoding specified by the `Content-Type` header in the request or response or metadata of a multipart body -- when both are present, the encoding specified in the `contentEncoding` is applied first and then the encoding specified in the `Content-Type` header.
 
-JSON Schema also offers a `contentMediaType` keyword.  However, when the media type is already specified by the Media Type Object's key, or by the `contentType` field of an [Encoding Object](#encodingObject), the `contentMediaType` keyword SHALL be ignored if present.
+JSON Schema also offers a `contentMediaType` keyword.  However, when the media type is already specified by the Media Type Object's key, or by the `contentType` field of an [Encoding Object](#encoding-object), the `contentMediaType` keyword SHALL be ignored if present.
 
 Examples:
 
@@ -1541,13 +1541,13 @@ requestBody:
 
 In this example, the contents in the `requestBody` MUST be stringified per [RFC1866](https://tools.ietf.org/html/rfc1866/) when passed to the server.  In addition, the `address` field complex object will be stringified.
 
-When passing complex objects in the `application/x-www-form-urlencoded` content type, the default serialization strategy of such properties is described in the [`Encoding Object`](#encodingObject)'s [`style`](#encodingStyle) property as `form`.
+When passing complex objects in the `application/x-www-form-urlencoded` content type, the default serialization strategy of such properties is described in the [`Encoding Object`](#encoding-object)'s [`style`](#encodingStyle) property as `form`.
 
 ##### Special Considerations for `multipart` Content
 
 It is common to use `multipart/form-data` as a `Content-Type` when transferring request bodies to operations.  In contrast to 2.0, a `schema` is REQUIRED to define the input parameters to the operation when using `multipart` content.  This supports complex structures as well as supporting mechanisms for multiple file uploads.
 
-In a `multipart/form-data` request body, each schema property, or each element of a schema array property, takes a section in the payload with an internal header as defined by [RFC7578](https://tools.ietf.org/html/rfc7578). The serialization strategy for each property of a `multipart/form-data` request body can be specified in an associated [`Encoding Object`](#encodingObject).
+In a `multipart/form-data` request body, each schema property, or each element of a schema array property, takes a section in the payload with an internal header as defined by [RFC7578](https://tools.ietf.org/html/rfc7578). The serialization strategy for each property of a `multipart/form-data` request body can be specified in an associated [`Encoding Object`](#encoding-object).
 
 When passing in `multipart` types, boundaries MAY be used to separate sections of the content being transferred – thus, the following default `Content-Type`s are defined for `multipart`:
 
@@ -1593,20 +1593,20 @@ requestBody:
 
 An `encoding` attribute is introduced to give you control over the serialization of parts of `multipart` request bodies.  This attribute is _only_ applicable to `multipart` and `application/x-www-form-urlencoded` request bodies.
 
-#### <a name="encodingObject"></a>Encoding Object
+#### Encoding Object
 
 A single encoding definition applied to a single schema property.
 
 ##### Fixed Fields
 Field Name | Type | Description
 ---|:---:|---
-<a name="encodingContentType"></a>contentType | `string` | The Content-Type for encoding a specific property. Default value depends on the property type: for `object` - `application/json`;  for `array` – the default is defined based on the inner type; for all other cases the default is `application/octet-stream`. The value can be a specific media type (e.g. `application/json`), a wildcard media type (e.g. `image/*`), or a comma-separated list of the two types. 
-<a name="encodingHeaders"></a>headers | Map[`string`, [Header Object](#headerObject) \| [Reference Object](#referenceObject)] | A map allowing additional information to be provided as headers, for example `Content-Disposition`.  `Content-Type` is described separately and SHALL be ignored in this section. This property SHALL be ignored if the request body media type is not a `multipart`.
-<a name="encodingStyle"></a>style | `string` | Describes how a specific property value will be serialized depending on its type.  See [Parameter Object](#parameterObject) for details on the [`style`](#parameterStyle) property. The behavior follows the same values as `query` parameters, including default values. This property SHALL be ignored if the request body media type is not `application/x-www-form-urlencoded` or `multipart/form-data`. If a value is explicitly defined, then the value of [`contentType`](#encodingContentType) (implicit or explicit) SHALL be ignored.
+<a name="encodingContentType"></a>contentType | `string` | The Content-Type for encoding a specific property. Default value depends on the property type: for `object` - `application/json`;  for `array` – the default is defined based on the inner type; for all other cases the default is `application/octet-stream`. The value can be a specific media type (e.g. `application/json`), a wildcard media type (e.g. `image/*`), or a comma-separated list of the two types.
+<a name="encodingHeaders"></a>headers | Map[`string`, [Header Object](#header-object) \| [Reference Object](#reference-object)] | A map allowing additional information to be provided as headers, for example `Content-Disposition`.  `Content-Type` is described separately and SHALL be ignored in this section. This property SHALL be ignored if the request body media type is not a `multipart`.
+<a name="encodingStyle"></a>style | `string` | Describes how a specific property value will be serialized depending on its type.  See [Parameter Object](#parameter-object) for details on the [`style`](#parameterStyle) property. The behavior follows the same values as `query` parameters, including default values. This property SHALL be ignored if the request body media type is not `application/x-www-form-urlencoded` or `multipart/form-data`. If a value is explicitly defined, then the value of [`contentType`](#encodingContentType) (implicit or explicit) SHALL be ignored.
 <a name="encodingExplode"></a>explode | `boolean` | When this is true, property values of type `array` or `object` generate separate parameters for each value of the array, or key-value-pair of the map.  For other types of properties this property has no effect. When [`style`](#encodingStyle) is `form`, the default value is `true`. For all other styles, the default value is `false`. This property SHALL be ignored if the request body media type is not `application/x-www-form-urlencoded` or `multipart/form-data`. If a value is explicitly defined, then the value of [`contentType`](#encodingContentType) (implicit or explicit) SHALL be ignored.
 <a name="encodingAllowReserved"></a>allowReserved | `boolean` | Determines whether the parameter value SHOULD allow reserved characters, as defined by [RFC3986](https://tools.ietf.org/html/rfc3986#section-2.2) `:/?#[]@!$&'()*+,;=` to be included without percent-encoding. The default value is `false`. This property SHALL be ignored if the request body media type is not `application/x-www-form-urlencoded` or `multipart/form-data`. If a value is explicitly defined, then the value of [`contentType`](#encodingContentType) (implicit or explicit) SHALL be ignored.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Encoding Object Example
 
@@ -1645,7 +1645,7 @@ requestBody:
                 type: integer
 ```
 
-#### <a name="responsesObject"></a>Responses Object
+#### Responses Object
 
 A container for the expected responses of an operation.
 The container maps a HTTP response code to the expected response.
@@ -1653,7 +1653,7 @@ The container maps a HTTP response code to the expected response.
 The documentation is not necessarily expected to cover all possible HTTP response codes because they may not be known in advance.
 However, documentation is expected to cover a successful operation response and any known errors.
 
-The `default` MAY be used as a default response object for all HTTP codes 
+The `default` MAY be used as a default response object for all HTTP codes
 that are not covered individually by the `Responses Object`.
 
 The `Responses Object` MUST contain at least one response code, and if only one
@@ -1663,15 +1663,15 @@ call.
 ##### Fixed Fields
 Field Name | Type | Description
 ---|:---:|---
-<a name="responsesDefault"></a>default | [Response Object](#responseObject) \| [Reference Object](#referenceObject) | The documentation of responses other than the ones declared for specific HTTP response codes. Use this field to cover undeclared responses.
+<a name="responsesDefault"></a>default | [Response Object](#response-object) \| [Reference Object](#reference-object) | The documentation of responses other than the ones declared for specific HTTP response codes. Use this field to cover undeclared responses.
 
 ##### Patterned Fields
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="responsesCode"></a>[HTTP Status Code](#httpCodes) | [Response Object](#responseObject) \| [Reference Object](#referenceObject) | Any [HTTP status code](#httpCodes) can be used as the property name, but only one property per code, to describe the expected response for that HTTP status code. This field MUST be enclosed in quotation marks (for example, "200") for compatibility between JSON and YAML. To define a range of response codes, this field MAY contain the uppercase wildcard character `X`. For example, `2XX` represents all response codes between `[200-299]`. Only the following range definitions are allowed: `1XX`, `2XX`, `3XX`, `4XX`, and `5XX`. If a response is defined using an explicit code, the explicit code definition takes precedence over the range definition for that code.
+<a name="responsesCode"></a>[HTTP Status Code](#http-status-codes) | [Response Object](#response-object) \| [Reference Object](#reference-object) | Any [HTTP status code](#http-status-codes) can be used as the property name, but only one property per code, to describe the expected response for that HTTP status code. This field MUST be enclosed in quotation marks (for example, "200") for compatibility between JSON and YAML. To define a range of response codes, this field MAY contain the uppercase wildcard character `X`. For example, `2XX` represents all response codes between `[200-299]`. Only the following range definitions are allowed: `1XX`, `2XX`, `3XX`, `4XX`, and `5XX`. If a response is defined using an explicit code, the explicit code definition takes precedence over the range definition for that code.
 
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Responses Object Example
 
@@ -1705,7 +1705,7 @@ A 200 response for a successful operation and a default response for others (imp
 ```yaml
 '200':
   description: a pet to be returned
-  content: 
+  content:
     application/json:
       schema:
         $ref: '#/components/schemas/Pet'
@@ -1717,19 +1717,19 @@ default:
         $ref: '#/components/schemas/ErrorModel'
 ```
 
-#### <a name="responseObject"></a>Response Object
-Describes a single response from an API Operation, including design-time, static 
+#### Response Object
+Describes a single response from an API Operation, including design-time, static
 `links` to operations based on the response.
 
 ##### Fixed Fields
 Field Name | Type | Description
 ---|:---:|---
 <a name="responseDescription"></a>description | `string` | **REQUIRED**. A description of the response. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="responseHeaders"></a>headers | Map[`string`, [Header Object](#headerObject)  \| [Reference Object](#referenceObject)] |  Maps a header name to its definition. [RFC7230](https://tools.ietf.org/html/rfc7230#page-22) states header names are case insensitive. If a response header is defined with the name `"Content-Type"`, it SHALL be ignored.
-<a name="responseContent"></a>content | Map[`string`, [Media Type Object](#mediaTypeObject)] | A map containing descriptions of potential response payloads. The key is a media type or [media type range](https://tools.ietf.org/html/rfc7231#appendix-D) and the value describes it.  For responses that match multiple keys, only the most specific key is applicable. e.g. text/plain overrides text/*
-<a name="responseLinks"></a>links | Map[`string`, [Link Object](#linkObject) \| [Reference Object](#referenceObject)] | A map of operations links that can be followed from the response. The key of the map is a short name for the link, following the naming constraints of the names for [Component Objects](#componentsObject). 
+<a name="responseHeaders"></a>headers | Map[`string`, [Header Object](#header-object)  \| [Reference Object](#reference-object)] |  Maps a header name to its definition. [RFC7230](https://tools.ietf.org/html/rfc7230#page-22) states header names are case insensitive. If a response header is defined with the name `"Content-Type"`, it SHALL be ignored.
+<a name="responseContent"></a>content | Map[`string`, [Media Type Object](#media-type-object)] | A map containing descriptions of potential response payloads. The key is a media type or [media type range](https://tools.ietf.org/html/rfc7231#appendix-D) and the value describes it.  For responses that match multiple keys, only the most specific key is applicable. e.g. text/plain overrides text/*
+<a name="responseLinks"></a>links | Map[`string`, [Link Object](#link-object) \| [Reference Object](#reference-object)] | A map of operations links that can be followed from the response. The key of the map is a short name for the link, following the naming constraints of the names for [Component Objects](#components-object).
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Response Object Examples
 
@@ -1753,9 +1753,9 @@ Response of an array of a complex type:
 
 ```yaml
 description: A complex object array response
-content: 
+content:
   application/json:
-    schema: 
+    schema:
       type: array
       items:
         $ref: '#/components/schemas/VeryComplexType'
@@ -1855,10 +1855,10 @@ Response with no return value:
 description: object created
 ```
 
-#### <a name="callbackObject"></a>Callback Object
+#### Callback Object
 
 A map of possible out-of band callbacks related to the parent operation.
-Each value in the map is a [Path Item Object](#pathItemObject) that describes a set of requests that may be initiated by the API provider and the expected responses.
+Each value in the map is a [Path Item Object](#path-item-object) that describes a set of requests that may be initiated by the API provider and the expected responses.
 The key value used to identify the path item object is an expression, evaluated at runtime, that identifies a URL to use for the callback operation.
 
 To describe incoming requests from the API provider independent from another API call, use the [`webhooks`](#oasWebhooks) field.
@@ -1866,16 +1866,16 @@ To describe incoming requests from the API provider independent from another API
 ##### Patterned Fields
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="callbackExpression"></a>{expression} | [Path Item Object](#pathItemObject) \| [Reference Object](#referenceObject) | A Path Item Object, or a reference to one, used to define a callback request and expected responses.  A [complete example](../examples/v3.0/callback-example.yaml) is available.
+<a name="callbackExpression"></a>{expression} | [Path Item Object](#path-item-object) \| [Reference Object](#reference-object) | A Path Item Object, or a reference to one, used to define a callback request and expected responses.  A [complete example](../examples/v3.0/callback-example.yaml) is available.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Key Expression
 
-The key that identifies the [Path Item Object](#pathItemObject) is a [runtime expression](#runtimeExpression) that can be evaluated in the context of a runtime HTTP request/response to identify the URL to be used for the callback request.
+The key that identifies the [Path Item Object](#path-item-object) is a [runtime expression](#runtime-expressions) that can be evaluated in the context of a runtime HTTP request/response to identify the URL to be used for the callback request.
 A simple example might be `$request.body#/url`.
-However, using a [runtime expression](#runtimeExpression) the complete HTTP message can be accessed.
-This includes accessing any part of a body that a JSON Pointer [RFC6901](https://tools.ietf.org/html/rfc6901) can reference. 
+However, using a [runtime expression](#runtime-expressions) the complete HTTP message can be accessed.
+This includes accessing any part of a body that a JSON Pointer [RFC6901](https://tools.ietf.org/html/rfc6901) can reference.
 
 For example, given the following HTTP request:
 
@@ -1891,7 +1891,7 @@ Content-Length: 187
     "https://clientdomain.com/fast",
     "https://clientdomain.com/medium",
     "https://clientdomain.com/slow"
-  ] 
+  ]
 }
 
 201 Created
@@ -1900,7 +1900,7 @@ Location: https://example.org/subscription/1
 
 The following examples show how the various expressions evaluate, assuming the callback operation has a path parameter named `eventType` and a query parameter named `queryUrl`.
 
-Expression | Value 
+Expression | Value
 ---|:---
 $url | https://example.org/subscribe/myevent?queryUrl=https://clientdomain.com/stillrunning
 $method | POST
@@ -1948,7 +1948,7 @@ transactionCallback:
           description: callback successfully processed
 ```
 
-#### <a name="exampleObject"></a>Example Object
+#### Example Object
 
 ##### Fixed Fields
 Field Name | Type | Description
@@ -1956,12 +1956,12 @@ Field Name | Type | Description
 <a name="exampleSummary"></a>summary | `string` | Short description for the example.
 <a name="exampleDescription"></a>description | `string` | Long description for the example. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
 <a name="exampleValue"></a>value | Any | Embedded literal example. The `value` field and `externalValue` field are mutually exclusive. To represent examples of media types that cannot naturally represented in JSON or YAML, use a string value to contain the example, escaping where necessary.
-<a name="exampleExternalValue"></a>externalValue | `string` | A URI that points to the literal example. This provides the capability to reference examples that cannot easily be included in JSON or YAML documents.  The `value` field and `externalValue` field are mutually exclusive. See the rules for resolving [Relative References](#relativeReferencesURI).
+<a name="exampleExternalValue"></a>externalValue | `string` | A URI that points to the literal example. This provides the capability to reference examples that cannot easily be included in JSON or YAML documents.  The `value` field and `externalValue` field are mutually exclusive. See the rules for resolving [Relative References](#relative-references-in-uris).
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
-In all cases, the example value is expected to be compatible with the type schema 
-of its associated value.  Tooling implementations MAY choose to 
+In all cases, the example value is expected to be compatible with the type schema
+of its associated value.  Tooling implementations MAY choose to
 validate compatibility automatically, and reject the example value(s) if incompatible.
 
 ##### Example Object Examples
@@ -1974,7 +1974,7 @@ requestBody:
     'application/json':
       schema:
         $ref: '#/components/schemas/Address'
-      examples: 
+      examples:
         foo:
           summary: A foo example
           value: {"foo": "bar"}
@@ -1982,13 +1982,13 @@ requestBody:
           summary: A bar example
           value: {"bar": "baz"}
     'application/xml':
-      examples: 
+      examples:
         xmlExample:
           summary: This is an example in XML
           externalValue: 'https://example.org/examples/address-example.xml'
     'text/plain':
       examples:
-        textExample: 
+        textExample:
           summary: This is a text example
           externalValue: 'https://foo.bar/examples/address-example.txt'
 ```
@@ -2003,7 +2003,7 @@ parameters:
       type: 'string'
       format: 'zip-code'
     examples:
-      zip-example: 
+      zip-example:
         $ref: '#/components/examples/zip-example'
 ```
 
@@ -2013,7 +2013,7 @@ In a response:
 responses:
   '200':
     description: your car appointment has been booked
-    content: 
+    content:
       application/json:
         schema:
           $ref: '#/components/schemas/SuccessResponse'
@@ -2023,31 +2023,31 @@ responses:
 ```
 
 
-#### <a name="linkObject"></a>Link Object
+#### Link Object
 
 The `Link object` represents a possible design-time link for a response.
 The presence of a link does not guarantee the caller's ability to successfully invoke it, rather it provides a known relationship and traversal mechanism between responses and other operations.
 
 Unlike _dynamic_ links (i.e. links provided **in** the response payload), the OAS linking mechanism does not require link information in the runtime response.
 
-For computing links, and providing instructions to execute them, a [runtime expression](#runtimeExpression) is used for accessing values in an operation and using them as parameters while invoking the linked operation.  
+For computing links, and providing instructions to execute them, a [runtime expression](#runtime-expressions) is used for accessing values in an operation and using them as parameters while invoking the linked operation. 
 
 ##### Fixed Fields
 
 Field Name  |  Type  | Description
 ---|:---:|---
-<a name="linkOperationRef"></a>operationRef | `string` | A relative or absolute URI reference to an OAS operation. This field is mutually exclusive of the `operationId` field, and MUST point to an [Operation Object](#operationObject). Relative `operationRef` values MAY be used to locate an existing [Operation Object](#operationObject) in the OpenAPI definition. See the rules for resolving [Relative References](#relativeReferencesURI).
-<a name="linkOperationId"></a>operationId  | `string` | The name of an _existing_, resolvable OAS operation, as defined with a unique `operationId`.  This field is mutually exclusive of the `operationRef` field.  
-<a name="linkParameters"></a>parameters   | Map[`string`, Any \| [{expression}](#runtimeExpression)] | A map representing parameters to pass to an operation as specified with `operationId` or identified via `operationRef`. The key is the parameter name to be used, whereas the value can be a constant or an expression to be evaluated and passed to the linked operation.  The parameter name can be qualified using the [parameter location](#parameterIn) `[{in}.]{name}` for operations that use the same parameter name in different locations (e.g. path.id).
-<a name="linkRequestBody"></a>requestBody | Any \| [{expression}](#runtimeExpression) | A literal value or [{expression}](#runtimeExpression) to use as a request body when calling the target operation.
+<a name="linkOperationRef"></a>operationRef | `string` | A relative or absolute URI reference to an OAS operation. This field is mutually exclusive of the `operationId` field, and MUST point to an [Operation Object](#operation-object). Relative `operationRef` values MAY be used to locate an existing [Operation Object](#operation-object) in the OpenAPI definition. See the rules for resolving [Relative References](#relative-references-in-uris).
+<a name="linkOperationId"></a>operationId  | `string` | The name of an _existing_, resolvable OAS operation, as defined with a unique `operationId`.  This field is mutually exclusive of the `operationRef` field. 
+<a name="linkParameters"></a>parameters   | Map[`string`, Any \| [{expression}](#runtime-expressions)] | A map representing parameters to pass to an operation as specified with `operationId` or identified via `operationRef`. The key is the parameter name to be used, whereas the value can be a constant or an expression to be evaluated and passed to the linked operation.  The parameter name can be qualified using the [parameter location](#parameterIn) `[{in}.]{name}` for operations that use the same parameter name in different locations (e.g. path.id).
+<a name="linkRequestBody"></a>requestBody | Any \| [{expression}](#runtime-expressions) | A literal value or [{expression}](#runtime-expressions) to use as a request body when calling the target operation.
 <a name="linkDescription"></a>description  | `string` | A description of the link. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="linkServer"></a>server       | [Server Object](#serverObject) | A server object to be used by the target operation.
+<a name="linkServer"></a>server       | [Server Object](#server-object) | A server object to be used by the target operation.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 A linked operation MUST be identified using either an `operationRef` or `operationId`.
 In the case of an `operationId`, it MUST be unique and resolved in the scope of the OAS document.
-Because of the potential for name clashes, the `operationRef` syntax is preferred 
+Because of the potential for name clashes, the `operationRef` syntax is preferred
 for OpenAPI documents with external references.
 
 ##### Examples
@@ -2061,7 +2061,7 @@ paths:
     - name: id
       in: path
       required: true
-      description: the user identifier, as userId 
+      description: the user identifier, as userId
       schema:
         type: string
     get:
@@ -2089,7 +2089,7 @@ paths:
     - name: userid
       in: path
       required: true
-      description: the user identifier, as userId 
+      description: the user identifier, as userId
       schema:
         type: string
     # linked operation
@@ -2113,15 +2113,15 @@ links:
       userUuid: $response.body#/uuid
 ```
 
-Clients follow all links at their discretion. 
-Neither permissions, nor the capability to make a successful call to that link, is guaranteed 
+Clients follow all links at their discretion.
+Neither permissions, nor the capability to make a successful call to that link, is guaranteed
 solely by the existence of a relationship.
 
 
 ##### OperationRef Examples
 
-As references to `operationId` MAY NOT be possible (the `operationId` is an optional 
-field in an [Operation Object](#operationObject)), references MAY also be made through a relative `operationRef`:
+As references to `operationId` MAY NOT be possible (the `operationId` is an optional
+field in an [Operation Object](#operation-object)), references MAY also be made through a relative `operationRef`:
 
 ```yaml
 links:
@@ -2143,14 +2143,14 @@ links:
       username: $response.body#/username
 ```
 
-Note that in the use of `operationRef`, the _escaped forward-slash_ is necessary when 
+Note that in the use of `operationRef`, the _escaped forward-slash_ is necessary when
 using JSON references.
 
 
-##### <a name="runtimeExpression"></a>Runtime Expressions
+##### Runtime Expressions
 
 Runtime expressions allow defining values based on information that will only be available within the HTTP message in an actual API call.
-This mechanism is used by [Link Objects](#linkObject) and [Callback Objects](#callbackObject).
+This mechanism is used by [Link Objects](#link-object) and [Callback Objects](#callback-object).
 
 The runtime expression is defined by the following [ABNF](https://tools.ietf.org/html/rfc5234) syntax
 
@@ -2158,7 +2158,7 @@ The runtime expression is defined by the following [ABNF](https://tools.ietf.org
       expression = ( "$url" / "$method" / "$statusCode" / "$request." source / "$response." source )
       source = ( header-reference / query-reference / path-reference / body-reference )
       header-reference = "header." token
-      query-reference = "query." name  
+      query-reference = "query." name 
       path-reference = "path." name
       body-reference = "body" ["#" json-pointer ]
       json-pointer    = *( "/" reference-token )
@@ -2175,28 +2175,28 @@ The runtime expression is defined by the following [ABNF](https://tools.ietf.org
 
 Here, `json-pointer` is taken from [RFC6901](https://tools.ietf.org/html/rfc6901), `char` from [RFC7159](https://tools.ietf.org/html/rfc7159#section-7) and `token` from [RFC7230](https://tools.ietf.org/html/rfc7230#section-3.2.6).
 
-The `name` identifier is case-sensitive, whereas `token` is not. 
+The `name` identifier is case-sensitive, whereas `token` is not.
 
 The table below provides examples of runtime expressions and examples of their use in a value:
 
-##### <a name="runtimeExpressionExamples"></a>Examples
+##### Examples
 
 Source Location | example expression  | notes
 ---|:---|:---|
 HTTP Method            | `$method`         | The allowable values for the `$method` will be those for the HTTP operation.
-Requested media type | `$request.header.accept`        |  
+Requested media type | `$request.header.accept`        | 
 Request parameter      | `$request.path.id`        | Request parameters MUST be declared in the `parameters` section of the parent operation or they cannot be evaluated. This includes request headers.
 Request body property   | `$request.body#/user/uuid`   | In operations which accept payloads, references may be made to portions of the `requestBody` or the entire body.
-Request URL            | `$url`            |  
+Request URL            | `$url`            | 
 Response value         | `$response.body#/status`       |  In operations which return payloads, references may be made to portions of the response body or the entire body.
 Response header        | `$response.header.Server` |  Single header values only are available
 
 Runtime expressions preserve the type of the referenced value.
 Expressions can be embedded into string values by surrounding the expression with `{}` curly braces.
 
-#### <a name="headerObject"></a>Header Object
+#### Header Object
 
-The Header Object follows the structure of the [Parameter Object](#parameterObject) with the following changes:
+The Header Object follows the structure of the [Parameter Object](#parameter-object) with the following changes:
 
 1. `name` MUST NOT be specified, it is given in the corresponding `headers` map.
 1. `in` MUST NOT be specified, it is implicitly in `header`.
@@ -2221,9 +2221,9 @@ schema:
   type: integer
 ```
 
-#### <a name="tagObject"></a>Tag Object
+#### Tag Object
 
-Adds metadata to a single tag that is used by the [Operation Object](#operationObject).
+Adds metadata to a single tag that is used by the [Operation Object](#operation-object).
 It is not mandatory to have a Tag Object per tag defined in the Operation Object instances.
 
 ##### Fixed Fields
@@ -2231,9 +2231,9 @@ Field Name | Type | Description
 ---|:---:|---
 <a name="tagName"></a>name | `string` | **REQUIRED**. The name of the tag.
 <a name="tagDescription"></a>description | `string` | A description for the tag. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="tagExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation for this tag.
+<a name="tagExternalDocs"></a>externalDocs | [External Documentation Object](#external-documentation-object) | Additional external documentation for this tag.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Tag Object Example
 
@@ -2250,13 +2250,13 @@ description: Pets operations
 ```
 
 
-#### <a name="referenceObject"></a>Reference Object
+#### Reference Object
 
 A simple object to allow referencing other components in the OpenAPI document, internally and externally.
 
 The `$ref` string value contains a URI [RFC3986](https://tools.ietf.org/html/rfc3986), which identifies the location of the value being referenced.
 
-See the rules for resolving [Relative References](#relativeReferencesURI).
+See the rules for resolving [Relative References](#relative-references-in-uris).
 
 ##### Fixed Fields
 Field Name | Type | Description
@@ -2267,7 +2267,7 @@ Field Name | Type | Description
 
 This object cannot be extended with additional properties and any properties added SHALL be ignored.
 
-Note that this restriction on additional properties is a difference between Reference Objects and [`Schema Objects`](#schemaObject) that contain a `$ref` keyword.
+Note that this restriction on additional properties is a difference between Reference Objects and [`Schema Objects`](#schema-object) that contain a `$ref` keyword.
 
 ##### Reference Object Example
 
@@ -2303,7 +2303,7 @@ $ref: Pet.yaml
 $ref: definitions.yaml#/Pet
 ```
 
-#### <a name="schemaObject"></a>Schema Object
+#### Schema Object
 
 The Schema Object allows the definition of input and output data types.
 These types can be objects, but also primitives and arrays. This object is a superset of the [JSON Schema Specification Draft 2020-12](https://tools.ietf.org/html/draft-bhutton-json-schema-00).
@@ -2315,7 +2315,7 @@ Where JSON Schema indicates that behavior is defined by the application (e.g. fo
 
 ##### Properties
 
-The OpenAPI Schema Object [dialect](https://tools.ietf.org/html/draft-bhutton-json-schema-00#section-4.3.3) is defined as requiring the [OAS base vocabulary](#baseVocabulary), in addition to the vocabularies as specified in the JSON Schema draft 2020-12 [general purpose meta-schema](https://tools.ietf.org/html/draft-bhutton-json-schema-00#section-8).
+The OpenAPI Schema Object [dialect](https://tools.ietf.org/html/draft-bhutton-json-schema-00#section-4.3.3) is defined as requiring the [OAS base vocabulary](#fixed-fields-20), in addition to the vocabularies as specified in the JSON Schema draft 2020-12 [general purpose meta-schema](https://tools.ietf.org/html/draft-bhutton-json-schema-00#section-8).
 
 The OpenAPI Schema Object dialect for this version of the specification is identified by the URI `https://spec.openapis.org/oas/3.1/dialect/base` (the <a name="dialectSchemaId"></a>"OAS dialect schema id").
 
@@ -2328,18 +2328,18 @@ In addition to the JSON Schema properties comprising the OAS dialect, the Schema
 
 The OpenAPI Specification's base vocabulary is comprised of the following keywords:
 
-##### <a name="baseVocabulary"></a>Fixed Fields
+##### Fixed Fields
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="schemaDiscriminator"></a>discriminator | [Discriminator Object](#discriminatorObject) | Adds support for polymorphism. The discriminator is an object name that is used to differentiate between other schemas which may satisfy the payload description. See [Composition and Inheritance](#schemaComposition) for more details.
-<a name="schemaXml"></a>xml | [XML Object](#xmlObject) | This MAY be used only on properties schemas. It has no effect on root schemas. Adds additional metadata to describe the XML representation of this property.
-<a name="schemaExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation for this schema.
+<a name="schemaDiscriminator"></a>discriminator | [Discriminator Object](#discriminator-object) | Adds support for polymorphism. The discriminator is an object name that is used to differentiate between other schemas which may satisfy the payload description. See [Composition and Inheritance](#composition-and-inheritance-polymorphism) for more details.
+<a name="schemaXml"></a>xml | [XML Object](#xml-object) | This MAY be used only on properties schemas. It has no effect on root schemas. Adds additional metadata to describe the XML representation of this property.
+<a name="schemaExternalDocs"></a>externalDocs | [External Documentation Object](#external-documentation-object) | Additional external documentation for this schema.
 <a name="schemaExample"></a>example | Any | A free-form property to include an example of an instance for this schema. To represent examples that cannot be naturally represented in JSON or YAML, a string value can be used to contain the example with escaping where necessary.<br><br>**Deprecated:** The `example` property has been deprecated in favor of the JSON Schema `examples` keyword. Use of `example` is discouraged, and later versions of this specification may remove it.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions), though as noted, additional properties MAY omit the `x-` prefix within this object.
+This object MAY be extended with [Specification Extensions](#specification-extensions), though as noted, additional properties MAY omit the `x-` prefix within this object.
 
-###### <a name="schemaComposition"></a>Composition and Inheritance (Polymorphism)
+###### Composition and Inheritance (Polymorphism)
 
 The OpenAPI Specification allows combining and extending model definitions using the `allOf` property of JSON Schema, in effect offering model composition.
 `allOf` takes an array of object definitions that are validated *independently* but together compose a single object.
@@ -2356,7 +2356,7 @@ As such, inline schema definitions, which do not have a given id, *cannot* be us
 ###### XML Modeling
 
 The [xml](#schemaXml) property allows extra definitions when translating the JSON definition to XML.
-The [XML Object](#xmlObject) contains additional information about the available options.
+The [XML Object](#xml-object) contains additional information about the available options.
 
 ###### Specifying Schema Dialects
 
@@ -2364,7 +2364,7 @@ It is important for tooling to be able to determine which dialect or meta-schema
 
 The `$schema` keyword MAY be present in any root Schema Object, and if present MUST be used to determine which dialect should be used when processing the schema. This allows use of Schema Objects which comply with other drafts of JSON Schema than the default Draft 2020-12 support. Tooling MUST support the <a href="#dialectSchemaId">OAS dialect schema id</a>, and MAY support additional values of `$schema`.
 
-To allow use of a different default `$schema` value for all Schema Objects contained within an OAS document, a `jsonSchemaDialect` value may be set within the <a href="#oasObject">OpenAPI Object</a>. If this default is not set, then the OAS dialect schema id MUST be used for these Schema Objects. The value of `$schema` within a Schema Object always overrides any default.
+To allow use of a different default `$schema` value for all Schema Objects contained within an OAS document, a `jsonSchemaDialect` value may be set within the <a href="#openapi-object">OpenAPI Object</a>. If this default is not set, then the OAS dialect schema id MUST be used for these Schema Objects. The value of `$schema` within a Schema Object always overrides any default.
 
 When a Schema Object is referenced from an external resource which is not an OAS document (e.g. a bare JSON Schema resource), then the value of the `$schema` keyword for schemas within that resource MUST follow [JSON Schema rules](https://tools.ietf.org/html/draft-bhutton-json-schema-00#section-8.1.1).
 
@@ -2696,7 +2696,7 @@ components:
         - packSize
 ```
 
-#### <a name="discriminatorObject"></a>Discriminator Object
+#### Discriminator Object
 
 When request bodies or response payloads may be one of a number of different schemas, a `discriminator` object can be used to aid in serialization, deserialization, and validation.  The discriminator is a specific object in a schema which is used to inform the consumer of the document of an alternative schema based on the value associated with it.
 
@@ -2708,7 +2708,7 @@ Field Name | Type | Description
 <a name="propertyName"></a>propertyName | `string` | **REQUIRED**. The name of the property in the payload that will hold the discriminator value.
 <a name="discriminatorMapping"></a> mapping | Map[`string`, `string`] | An object to hold mappings between payload values and schema names or references.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 The discriminator object is legal only when using one of the composite keywords `oneOf`, `anyOf`, `allOf`.
 
@@ -2831,7 +2831,7 @@ will indicate that the `Cat` schema be used.  Likewise this schema:
 will map to `Dog` because of the definition in the `mapping` element.
 
 
-#### <a name="xmlObject"></a>XML Object
+#### XML Object
 
 A metadata object that allows for more fine-tuned XML model definitions.
 
@@ -2847,11 +2847,11 @@ Field Name | Type | Description
 <a name="xmlAttribute"></a>attribute | `boolean` | Declares whether the property definition translates to an attribute instead of an element. Default value is `false`.
 <a name="xmlWrapped"></a>wrapped | `boolean` | MAY be used only for an array definition. Signifies whether the array is wrapped (for example, `<books><book/><book/></books>`) or unwrapped (`<book/><book/>`). Default value is `false`. The definition takes effect only when defined alongside `type` being `array` (outside the `items`).
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### XML Object Examples
 
-The examples of the XML object definitions are included inside a property definition of a [Schema Object](#schemaObject) with a sample of the XML representation of it.
+The examples of the XML object definitions are included inside a property definition of a [Schema Object](#schema-object) with a sample of the XML representation of it.
 
 ###### No XML Element
 
@@ -3184,7 +3184,7 @@ animals:
 </aliens>
 ```
 
-#### <a name="securitySchemeObject"></a>Security Scheme Object
+#### Security Scheme Object
 
 Defines a security scheme that can be used by the operations.
 
@@ -3200,10 +3200,10 @@ Field Name | Type | Applies To | Description
 <a name="securitySchemeIn"></a>in | `string` | `apiKey` | **REQUIRED**. The location of the API key. Valid values are `"query"`, `"header"` or `"cookie"`.
 <a name="securitySchemeScheme"></a>scheme | `string` | `http` | **REQUIRED**. The name of the HTTP Authorization scheme to be used in the [Authorization header as defined in RFC7235](https://tools.ietf.org/html/rfc7235#section-5.1).  The values used SHOULD be registered in the [IANA Authentication Scheme registry](https://www.iana.org/assignments/http-authschemes/http-authschemes.xhtml).
 <a name="securitySchemeBearerFormat"></a>bearerFormat | `string` | `http` (`"bearer"`) | A hint to the client to identify how the bearer token is formatted.  Bearer tokens are usually generated by an authorization server, so this information is primarily for documentation purposes.
-<a name="securitySchemeFlows"></a>flows | [OAuth Flows Object](#oauthFlowsObject) | `oauth2` | **REQUIRED**. An object containing configuration information for the flow types supported.
+<a name="securitySchemeFlows"></a>flows | [OAuth Flows Object](#oauth-flows-object) | `oauth2` | **REQUIRED**. An object containing configuration information for the flow types supported.
 <a name="securitySchemeOpenIdConnectUrl"></a>openIdConnectUrl | `string` | `openIdConnect` | **REQUIRED**. OpenId Connect URL to discover OAuth2 configuration values. This MUST be in the form of a URL. The OpenID Connect standard requires the use of TLS.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Security Scheme Object Example
 
@@ -3272,7 +3272,7 @@ bearerFormat: JWT
 
 ```yaml
 type: oauth2
-flows: 
+flows:
   implicit:
     authorizationUrl: https://example.com/api/oauth/dialog
     scopes:
@@ -3280,21 +3280,21 @@ flows:
       read:pets: read your pets
 ```
 
-#### <a name="oauthFlowsObject"></a>OAuth Flows Object
+#### OAuth Flows Object
 
 Allows configuration of the supported OAuth Flows.
 
 ##### Fixed Fields
 Field Name | Type | Description
 ---|:---:|---
-<a name="oauthFlowsImplicit"></a>implicit| [OAuth Flow Object](#oauthFlowObject) | Configuration for the OAuth Implicit flow 
-<a name="oauthFlowsPassword"></a>password| [OAuth Flow Object](#oauthFlowObject) | Configuration for the OAuth Resource Owner Password flow 
-<a name="oauthFlowsClientCredentials"></a>clientCredentials| [OAuth Flow Object](#oauthFlowObject) | Configuration for the OAuth Client Credentials flow.  Previously called `application` in OpenAPI 2.0.
-<a name="oauthFlowsAuthorizationCode"></a>authorizationCode| [OAuth Flow Object](#oauthFlowObject) | Configuration for the OAuth Authorization Code flow.  Previously called `accessCode` in OpenAPI 2.0.
+<a name="oauthFlowsImplicit"></a>implicit| [OAuth Flow Object](#oauth-flow-object) | Configuration for the OAuth Implicit flow
+<a name="oauthFlowsPassword"></a>password| [OAuth Flow Object](#oauth-flow-object) | Configuration for the OAuth Resource Owner Password flow
+<a name="oauthFlowsClientCredentials"></a>clientCredentials| [OAuth Flow Object](#oauth-flow-object) | Configuration for the OAuth Client Credentials flow.  Previously called `application` in OpenAPI 2.0.
+<a name="oauthFlowsAuthorizationCode"></a>authorizationCode| [OAuth Flow Object](#oauth-flow-object) | Configuration for the OAuth Authorization Code flow.  Previously called `accessCode` in OpenAPI 2.0.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
-#### <a name="oauthFlowObject"></a>OAuth Flow Object
+#### OAuth Flow Object
 
 Configuration details for a supported OAuth Flow
 
@@ -3306,7 +3306,7 @@ Field Name | Type | Applies To | Description
 <a name="oauthFlowRefreshUrl"></a>refreshUrl | `string` | `oauth2` | The URL to be used for obtaining refresh tokens. This MUST be in the form of a URL. The OAuth2 standard requires the use of TLS.
 <a name="oauthFlowScopes"></a>scopes | Map[`string`, `string`] | `oauth2` | **REQUIRED**. The available scopes for the OAuth2 security scheme. A map between the scope name and a short description for it. The map MAY be empty.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### OAuth Flow Object Examples
 
@@ -3335,7 +3335,7 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
 
 ```yaml
 type: oauth2
-flows: 
+flows:
   implicit:
     authorizationUrl: https://example.com/api/oauth/dialog
     scopes:
@@ -3346,24 +3346,24 @@ flows:
     tokenUrl: https://example.com/api/oauth/token
     scopes:
       write:pets: modify pets in your account
-      read:pets: read your pets 
+      read:pets: read your pets
 ```
 
-#### <a name="securityRequirementObject"></a>Security Requirement Object
+#### Security Requirement Object
 
 Lists the required security schemes to execute this operation.
-The name used for each property MUST correspond to a security scheme declared in the [Security Schemes](#componentsSecuritySchemes) under the [Components Object](#componentsObject).
+The name used for each property MUST correspond to a security scheme declared in the [Security Schemes](#componentsSecuritySchemes) under the [Components Object](#components-object).
 
 Security Requirement Objects that contain multiple schemes require that all schemes MUST be satisfied for a request to be authorized.
 This enables support for scenarios where multiple query parameters or HTTP headers are required to convey security information.
 
-When a list of Security Requirement Objects is defined on the [OpenAPI Object](#oasObject) or [Operation Object](#operationObject), only one of the Security Requirement Objects in the list needs to be satisfied to authorize the request.
+When a list of Security Requirement Objects is defined on the [OpenAPI Object](#openapi-object) or [Operation Object](#operation-object), only one of the Security Requirement Objects in the list needs to be satisfied to authorize the request.
 
 ##### Patterned Fields
 
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="securityRequirementsName"></a>{name} | [`string`] | Each name MUST correspond to a security scheme which is declared in the [Security Schemes](#componentsSecuritySchemes) under the [Components Object](#componentsObject). If the security scheme is of type `"oauth2"` or `"openIdConnect"`, then the value is a list of scope names required for the execution, and the list MAY be empty if authorization does not require a specified scope. For other security scheme types, the array MAY contain a list of role names which are required for the execution, but are not otherwise defined or exchanged in-band.
+<a name="securityRequirementsName"></a>{name} | [`string`] | Each name MUST correspond to a security scheme which is declared in the [Security Schemes](#componentsSecuritySchemes) under the [Components Object](#components-object). If the security scheme is of type `"oauth2"` or `"openIdConnect"`, then the value is a list of scope names required for the execution, and the list MAY be empty if authorization does not require a specified scope. For other security scheme types, the array MAY contain a list of role names which are required for the execution, but are not otherwise defined or exchanged in-band.
 
 ##### Security Requirement Object Examples
 
@@ -3422,7 +3422,7 @@ security:
     - read:pets
 ```
 
-### <a name="specificationExtensions"></a>Specification Extensions
+### Specification Extensions
 
 While the OpenAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.
 
@@ -3434,24 +3434,24 @@ Field Pattern | Type | Description
 
 The extensions may or may not be supported by the available tooling, but those may be extended as well to add requested support (if tools are internal or open-sourced).
 
-### <a name="securityFiltering"></a>Security Filtering
+### Security Filtering
 
-Some objects in the OpenAPI Specification MAY be declared and remain empty, or be completely removed, even though they are inherently the core of the API documentation. 
+Some objects in the OpenAPI Specification MAY be declared and remain empty, or be completely removed, even though they are inherently the core of the API documentation.
 
 The reasoning is to allow an additional layer of access control over the documentation.
 While not part of the specification itself, certain libraries MAY choose to allow access to parts of the documentation based on some form of authentication/authorization.
 
 Two examples of this:
 
-1. The [Paths Object](#pathsObject) MAY be present but empty. It may be counterintuitive, but this may tell the viewer that they got to the right place, but can't access any documentation. They would still have access to at least the [Info Object](#infoObject) which may contain additional information regarding authentication.
-2. The [Path Item Object](#pathItemObject) MAY be empty. In this case, the viewer will be aware that the path exists, but will not be able to see any of its operations or parameters. This is different from hiding the path itself from the [Paths Object](#pathsObject), because the user will be aware of its existence. This allows the documentation provider to finely control what the viewer can see.
+1. The [Paths Object](#paths-object) MAY be present but empty. It may be counterintuitive, but this may tell the viewer that they got to the right place, but can't access any documentation. They would still have access to at least the [Info Object](#info-object) which may contain additional information regarding authentication.
+2. The [Path Item Object](#path-item-object) MAY be empty. In this case, the viewer will be aware that the path exists, but will not be able to see any of its operations or parameters. This is different from hiding the path itself from the [Paths Object](#paths-object), because the user will be aware of its existence. This allows the documentation provider to finely control what the viewer can see.
 
 
-## <a name="revisionHistory"></a>Appendix A: Revision History
+## Appendix A: Revision History
 
 Version   | Date       | Notes
 ---       | ---        | ---
-3.1.0     | 2021-02-15 | Release of the OpenAPI Specification 3.1.0 
+3.1.0     | 2021-02-15 | Release of the OpenAPI Specification 3.1.0
 3.1.0-rc1 | 2020-10-08 | rc1 of the 3.1 specification
 3.1.0-rc0 | 2020-06-18 | rc0 of the 3.1 specification
 3.0.3     | 2020-02-20 | Patch release of the OpenAPI Specification 3.0.3


### PR DESCRIPTION
Closes #3207 #3160 #3136 #3128 #3029 #3197 #3132

This PR mechanically corrects for the change made by GitHub to its markdown renderer which no longer honours the mixed markdown/html form:

`### <a name="myAnchor"></a> My Anchor`

(the use of `name` or `id` makes no difference), and only links to the **implicit** anchor `#my-anchor` now work.

This PR affects the `main` branch, so published versions of the OAS only. If merged, follow-up PRs will be raised for in-flight `-dev` branch versions.

An example of the result of this PR can be previewed [here](https://github.com/MikeRalphson/OpenAPI-Specification/blob/anchor-fixes/versions/3.1.0.md).