### PR TITLE
build: update mdv dev. dep.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@hyperjump/json-schema": "^0.17.0",
     "chai": "^4.3.1",
-    "mdv": "^1.0.7",
+    "mdv": "^1.3.4",
     "mocha": "^8.3.0",
     "yaml": "^1.8.3"
   },


### PR DESCRIPTION
This PR updates the npm dev. dependency for `mdv` (the markdown link validator) to `v1.3.4` which includes the new format of GitHub gfm auto-links for headers. Refs #3408