### PR TITLE
Fixed link to SPDX identifiers

### DIFF
--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -299,7 +299,7 @@ License information for the exposed API.
 Field Name | Type | Description
 ---|:---:|---
 <a name="licenseName"></a>name | `string` | **REQUIRED**. The license name used for the API.
-<a name="licenseIdentifier"></a>identifier | `string` | An [SPDX](https://spdx.github.io/spdx-spec/v2.3/SPDX-license-list/#a1-licenses-with-short-identifiers) license expression for the API. The `identifier` field is mutually exclusive of the `url` field.
+<a name="licenseIdentifier"></a>identifier | `string` | An [SPDX](https://spdx.org/licenses/) license expression for the API. The `identifier` field is mutually exclusive of the `url` field.
 <a name="licenseUrl"></a>url | `string` | A URL to the license used for the API. This MUST be in the form of a URL. The `url` field is mutually exclusive of the `identifier` field.
 
 This object MAY be extended with [Specification Extensions](#specificationExtensions).

--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -299,7 +299,7 @@ License information for the exposed API.
 Field Name | Type | Description
 ---|:---:|---
 <a name="licenseName"></a>name | `string` | **REQUIRED**. The license name used for the API.
-<a name="licenseIdentifier"></a>identifier | `string` | An [SPDX](https://spdx.org/spdx-specification-21-web-version#h.jxpfx0ykyb60) license expression for the API. The `identifier` field is mutually exclusive of the `url` field.
+<a name="licenseIdentifier"></a>identifier | `string` | An [SPDX](https://spdx.github.io/spdx-spec/v2.3/SPDX-license-list/#a1-licenses-with-short-identifiers) license expression for the API. The `identifier` field is mutually exclusive of the `url` field.
 <a name="licenseUrl"></a>url | `string` | A URL to the license used for the API. This MUST be in the form of a URL. The `url` field is mutually exclusive of the `identifier` field.
 
 This object MAY be extended with [Specification Extensions](#specificationExtensions).


### PR DESCRIPTION
The currently URL in 3.1.0 is broken, and this looks like the closest guess at what it should link to now.