### PR TITLE
Drop `uri-reference` format for template URLs

### DIFF
--- a/schemas/v3.0/schema.yaml
+++ b/schemas/v3.0/schema.yaml
@@ -975,7 +975,6 @@ definitions:
         type: string
       operationRef:
         type: string
-        format: uri-reference
       parameters:
         type: object
         additionalProperties: {}

--- a/schemas/v3.1/schema.yaml
+++ b/schemas/v3.1/schema.yaml
@@ -119,7 +119,6 @@ $defs:
     properties:
       url:
         type: string
-        format: uri-reference
       description:
         type: string
       variables:
@@ -632,7 +631,6 @@ $defs:
     properties:
       operationRef:
         type: string
-        format: uri-reference
       operationId:
         type: string
       parameters:


### PR DESCRIPTION
`Server.url` and `Link.operationRef` both allow variable substitution with {brackets}, which means they're not always valid URI references.

For example, the [current specification][0] shows
`https://{username}.gigantic-server.com:{port}/{basePath}` as a Server Object `url`, but it's not a valid URI reference because the host includes curly brackets.

[`operationRef`][1] similarly includes
`https://na2.gigantic-server.com/#/paths/~12.0~1repositories~1{username}/get` as an example that isn't valid using the `uri-reference` format.

I looked into the other uses of `uri-reference` and they seemed ok.

I'm not sure how to update the actual JSON schemas but [readme](https://github.com/OAI/OpenAPI-Specification/blob/main/schemas/v3.1/README.md#contributing) says to just update the yaml files, so let me know if there's anything else to do.

Related:
- https://github.com/OAI/OpenAPI-Specification/pull/2586
- https://github.com/OAI/OpenAPI-Specification/pull/3235
- https://github.com/OAI/OpenAPI-Specification/issues/3256
- https://github.com/davishmcclurg/json_schemer/issues/158

[0]: https://spec.openapis.org/oas/v3.1.0#server-object-example
[1]: https://spec.openapis.org/oas/v3.1.0#operationref-examples