### PR TITLE
Added a CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# Global Repo Owners
+* @oai/openapi-maintainers @oai/tsc
+
+# Specification Versions
+/versions/ @oai/tsc
+
+# Protect specific top level files
+/MAINTAINERS.md @oai/tsc
+/TOB.md @oai/tsc
+/GOVERNANCE.md @oai/tsc
+/LICENSE @oai/tsc


### PR DESCRIPTION
This file will allow us to enable a broader group than just the TSC to approve PRs on this repo.  TSC review will still be required for the actual specifications and some of the core governance files.

Members of the @OAI/openapi-maintainers team will have write access to the repo, except for the files called out in this CODEOWNERS file that require @OAI/tsc approval.