### PR TITLE
fix types to use an array rather than a string when multiple types are valid

### DIFF
--- a/registries/_format/decimal.md
+++ b/registries/_format/decimal.md
@@ -2,7 +2,7 @@
 owner: baywet
 issue: 889
 description: A fixed point decimal number of unspecified precision and range
-base_type: string, number
+base_type: [string, number]
 layout: default
 remarks: This format is used in a variety of conflicting ways and is not interoperable.
 ---

--- a/registries/_format/decimal128.md
+++ b/registries/_format/decimal128.md
@@ -2,7 +2,7 @@
 owner:
 issue:
 description: A decimal floating-point number with 34 significant decimal digits
-base_type: string, number
+base_type: [string, number]
 layout: default
 ---
 

--- a/registries/_format/int64.md
+++ b/registries/_format/int64.md
@@ -2,7 +2,7 @@
 owner: DarrelMiller
 issue: 
 description: signed 64-bit integer
-base_type: number, string
+base_type: [number, string]
 layout: default
 source: https://spec.openapis.org/oas/latest.html#data-types
 source_label: OAS


### PR DESCRIPTION
Programmatic users of api/format.json will expect to see an array here, not a string containing an invalid type.