### PR TITLE
Update weekly meeting agenda to direct topic suggestions and add housekeeping time

### DIFF
--- a/.github/templates/agenda.md
+++ b/.github/templates/agenda.md
@@ -2,21 +2,19 @@
 
 Zoom Meeting link: [https://zoom.us/j/975841675](https://zoom.us/j/975841675?pwd=SUh4MjRLaEFKNlI3RElpWTdhRDVVUT09). Dial-in passcode: 763054 - [Code-of-Conduct](https://github.com/OAI/OpenAPI-Specification/blob/main/CODE_OF_CONDUCT.md#code-of-conduct)
 
-In order to give some more visibility into the topics we cover in the TDC meetings here is the planned agenda for the next meeting.  Hopefully this will allow people to plan to attend meetings for topics that they have an interest in.  And for folks who cannot attend they can comment on this issue prior to the meeting.  Feel free to suggest other potential agenda topics.
+In order to give visibility into the topics we cover in the TDC meetings, here is the planned agenda for the next meeting.  Sharing agenda items allows people to plan to attend meetings for topics that they have an interest in.  Everyone can comment on this issue prior to the meeting, to suggest topics or add comments on planned topics, whether attending or not.  Feel free to suggest other potential agenda topics.
 
 **Please submit comments below for topics or proposals that you wish to present in the TDC meeting**
 
 ![F10B5460-B4B3-4463-9CDE-C7F782202EA9](https://user-images.githubusercontent.com/21603/121568843-0b260900-ca18-11eb-9362-69fda4162be8.jpeg)
 
-The agenda backlog is currently maintained in issue #2482
-
 | Topic | Owner | Decision/NextStep |
 |-------|---------|---------|  
 | | | |
-Reports from Special Interest Groups | TDC | |
-AOB (see below) | TDC | |
+Housekeeping issues (10 mins) | TDC | |
+Reports from Special Interest Groups (10 mins) | SIG members | |
+AOB (add comments below to suggest topics) | TDC | |
 [Approved spec PRs](https://github.com/OAI/OpenAPI-Specification/pulls?q=is%3Apr+is%3Aopen+review%3Aapproved) | TDC | |
-New issues / PRs labelled [review](https://github.com/OAI/OpenAPI-Specification/labels/review) | @OAI/triage | |
 [New issues](https://github.com/search?q=repo%3Aoai%2Fopenapi-specification+is%3Aissue+comments%3A0+no%3Alabel+is%3Aopen) without response yet | @OAI/triage  | |
 
 

--- a/.github/templates/agenda.md
+++ b/.github/templates/agenda.md
@@ -1,21 +1,22 @@
-**NOTE: This meeting is on Thursday at 9am - 10am PT**
+**NOTE: weekly meetings happen on Thursdays at 9am - 10am Pacific.**
 
-Zoom Meeting link: [https://zoom.us/j/975841675](https://zoom.us/j/975841675?pwd=SUh4MjRLaEFKNlI3RElpWTdhRDVVUT09). Dial-in passcode: 763054 - [Code-of-Conduct](https://github.com/OAI/OpenAPI-Specification/blob/main/CODE_OF_CONDUCT.md#code-of-conduct)
+This agenda gives visibility into discussion topics for the weekly Technical Developer Community (TDC) meetings. Sharing agenda items in advance allows people to plan to attend meetings where they have an interest in specific topics. 
 
-In order to give visibility into the topics we cover in the TDC meetings, here is the planned agenda for the next meeting.  Sharing agenda items allows people to plan to attend meetings for topics that they have an interest in.  Everyone can comment on this issue prior to the meeting, to suggest topics or add comments on planned topics, whether attending or not.  Feel free to suggest other potential agenda topics.
+Whether attending or not, **anyone can comment on this issue prior to the meeting to suggest topics or to add comments on planned topics or proposals**.
 
-**Please submit comments below for topics or proposals that you wish to present in the TDC meeting**
+Zoom: [https://zoom.us/j/975841675](https://zoom.us/j/975841675?pwd=SUh4MjRLaEFKNlI3RElpWTdhRDVVUT09), dial-in passcode: 763054
+
+Participants must abide by our [Code-of-Conduct](https://github.com/OAI/OpenAPI-Specification/blob/main/CODE_OF_CONDUCT.md#code-of-conduct).
 
 ![F10B5460-B4B3-4463-9CDE-C7F782202EA9](https://user-images.githubusercontent.com/21603/121568843-0b260900-ca18-11eb-9362-69fda4162be8.jpeg)
 
 | Topic | Owner | Decision/NextStep |
 |-------|---------|---------|  
 | | | |
-Housekeeping issues (10 mins) | TDC | |
-Reports from Special Interest Groups (10 mins) | SIG members | |
-AOB (add comments below to suggest topics) | TDC | |
+Intros and governance meta-topics (5 mins) | TDC | |
+Reports from Special Interest Groups (5 mins) | SIG members | |
+Any other business (add comments below to suggest topics) | TDC | |
 [Approved spec PRs](https://github.com/OAI/OpenAPI-Specification/pulls?q=is%3Apr+is%3Aopen+review%3Aapproved) | TDC | |
-[New issues](https://github.com/search?q=repo%3Aoai%2Fopenapi-specification+is%3Aissue+comments%3A0+no%3Alabel+is%3Aopen) without response yet | @OAI/triage  | |
+[New issues needing attention](https://github.com/search?q=repo%3Aoai%2Fopenapi-specification+is%3Aissue+comments%3A0+no%3Alabel+is%3Aopen) | @OAI/triage  | |
 
-
-/cc @OAI/tsc Please suggest items for inclusion
+/cc [@OAI/tsc](https://github.com/orgs/OAI/teams/tsc) please suggest items for inclusion.


### PR DESCRIPTION
After the discussion this week (#3500 ), I updated the weekly meeting agenda template to include the following changes:
 - remove the link to the old meeting agenda backlog, we don't check it so people should use the weekly issues
 - remove the list of items to review, we don't tag that way now (and we can change it again if we decide to)
 - add a timeslot at the start of each meeting to discuss housekeeping issues
 - minor copy edits