### PR TITLE
PR guidance on branches and files

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+<!--
+Thank you for contributing to the OpenAPI Specification!
+
+Please make certain you are submitting your PR on the correct
+branch and file:
+
+* 3.0.x spec: v3.0.4-dev branch, versions/3.0.4.md
+* 3.1.x spec: v3.1.1-dev branch, versions/3.1.1.md
+* 3.2.0 spec: v3.2.0-dev branch, versions/3.2.0.md
+* 3.0 schema: main branch, schemas/v3.0/...
+* 3.1 schema: main branch, schemas/v3.1/...
+* registry templates: gh-pages branch, registry/...
+* registry contents: gh-pages branch, registries/...
+
+Note that we do not accept changes to pulblished specifications.
+-->


### PR DESCRIPTION
This adds a default PR template with a comment explaining what branches and files can be used for which purposes.