### PR TITLE
Update SIGs list, improve formatting and links

### DIFF
--- a/SPECIAL_INTEREST_GROUPS.md
+++ b/SPECIAL_INTEREST_GROUPS.md
@@ -1,43 +1,78 @@
-## Codegen
-> code-gen vocabulary special interest (working) group
+# OpenAPI Special Interest Groups (SIGs)
 
-* Slack channel: #sig-codegen
+OpenAPI Special Interest Groups, or "SIGs", are the OpenAPI Initiative's way of focusing work in particular areas.  SIGs may start with just a Slack channel to guage interest.  SIGs with enough traction to produce work may have their own GitHub repositories and regular Zoom calls, and ultimately produce work that becomes part of, or a companion to, the OpenAPI Specification.
+
+## Codegen
+
+Code Generation JSON Schema vocabulary special interest (working) group
+
+* [Slack](https://communityinviter.com/apps/open-api/openapi) channel: #sig-codegen
+
+## Finance
+
+Focusing on finance topics such as Open Banking / Open Finance
+
+* [Slack](https://communityinviter.com/apps/open-api/openapi) channel: #sig-finance
 
 ## Formats
-> Focusing on the Formats Registry efforts
 
-* Slack channel: #sig-formats
+Focusing on the [Formats Registry](https://spec.openapis.org/registry/format/) efforts.
+
+* [Slack](https://communityinviter.com/apps/open-api/openapi) channel: #sig-formats
+* Work Items: [Open Issues](https://github.com/OAI/OpenAPI-Specification/issues?q=is%3Aissue+is%3Aopen+label%3Aformat-registry), [Open PRs](https://github.com/OAI/OpenAPI-Specification/pulls?q=is%3Apr+is%3Aopen+label%3Aformat-registry)
+
+## Inudstry Standards
+
+Focusing on how industry standards groups make use of OpenAPI specifications.
+
+* [Slack](https://communityinviter.com/apps/open-api/openapi) channel: #sig-industry-standards
 
 ## Lifecycle
-> A place to discuss how to represent how APIs change in time in the context of OpenAPI
 
-* Slack channel: #sig-lifecycle
+A place to discuss how to represent how APIs change in time in the context of OpenAPI.
+
+* [Slack](https://communityinviter.com/apps/open-api/openapi) channel: #sig-lifecycle
+
+## Moonwalk
+
+Working group for the next major (post-3.x) version of the OpenAPI Specification
+
+* GitHub: [OAI/sig-moonwalk](https://github.com/OAI/sig-moonwalk)
+* Zoom Meetings: Tuesdays at 9AM US-Pacific
 
 ## Overlays
-> The Overlay specification defines a way of creating documents that contain information to be merged with an OpenAPI description at some later point in time, for the purpose of updating the OpenAPI description with additional information.
 
-* Github: https://github.com/OAI/Overlay-Specification
-* Slack channel: #sig-overlays
+The Overlay specification defines a way of creating documents that contain information to be merged with an OpenAPI description at some later point in time, for the purpose of updating the OpenAPI description with additional information.
+
+* GitHub: [OAI/Overlay-Specification](https://github.com/OAI/Overlay-Specification)
+* [Slack](https://communityinviter.com/apps/open-api/openapi) channel: #sig-overlays
 
 ## Security
-> Workgroup to shape security components of the OpenAPI Spec
-* Slack channel: #sig-security
+
+Workgroup to shape security components of the OpenAPI Specification.
+
+* [Slack](https://communityinviter.com/apps/open-api/openapi) channel: #sig-security
 
 ## SLA (Service Level Agreement)
-> Service level agreements and APIs.
 
-* Github: https://github.com/isa-group/SLA4OAI-TC
-* Slack channel: #sig-sla
+Service level agreements and APIs.
+
+* GitHub: [isa-group/SLA4OAI-TC](https://github.com/isa-group/SLA4OAI-TC)
+* [Slack](https://communityinviter.com/apps/open-api/openapi) channel: #sig-sla
 
 ## Travel
-> An OpenAPI Initiative workgroup to address industry specific connective/API concerns of the travel industry
 
-* Slack channel: #sig-travel
+An OpenAPI Initiative workgroup to address industry specific connective/API concerns of the travel industry.
+
+* [Slack](https://communityinviter.com/apps/open-api/openapi) channel: #sig-travel
 
 ## Workflows
-> This is a channel dedicated to discussing workflows, automations, and scenarios.
 
-> The OpenAPI Specification provides a way to document individual API calls and how to use them, but it doesn't give insight into the common ways to sequence those operations. While all APIs can benefit from formally describing these workflows, this is particularly important when considering more complex or more secure APIs. 
-> The OpenAPI Workflows Special Interest Group was created to address this common problem. The goal is to construct a formal way to describe these sequences and support documentation of flows, such as a multi-part OAuth flow with JSON signing and refresh token behavior. 
+The OpenAPI Specification provides a way to document individual API calls and how to use them, but it doesn't give insight into the common ways to sequence those operations. While all APIs can benefit from formally describing these workflows, this is particularly important when considering more complex or more secure APIs. 
 
-* Slack channel: #sig-workflows
+The OpenAPI Workflows Special Interest Group was created to address this common problem. The goal is to construct a formal way to describe these sequences and support documentation of flows, such as a multi-part OAuth flow with JSON signing and refresh token behavior. 
+
+* GitHub: [OAI/sig-workflows](https://github.com/OAI/sig-workflows)
+* [Slack](https://communityinviter.com/apps/open-api/openapi) channel: #sig-workflows
+* Zoom Meetings: Wednesdays at 9AM US-Pacific
+


### PR DESCRIPTION
This updates the list with newer SIGs, which I also checked against the list of "sig-" channels on Slack.  It also adds some links to things that are mentioned, and makes what I consider to be formatting improvements.

I added a title and a bit of text at the top, but if someone wants to more properly define SIGs or whatever processes we have around them, I'd be happy to replace the text (or someone else can do it as a follow-on PR).
