### PR TITLE
Always checkout JavaScript environment from main

### DIFF
--- a/.github/workflows/schema-tests.yaml
+++ b/.github/workflows/schema-tests.yaml
@@ -20,12 +20,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1 # checkout repo content
+    - uses: actions/checkout@v4 # checkout repo content
+      with:
+        fetch-depth: 0
     - uses: actions/setup-node@v4 # setup Node.js
       with:
         node-version: '20.x'
-    - name: Install dependencies
-      run: npm i
+    - name: Install dependencies from main
+      run: |
+        git checkout remotes/origin/main -- package.json
+        npm i
     - name: Run tests
       run: npm run test
 

--- a/.github/workflows/validate-markdown.yaml
+++ b/.github/workflows/validate-markdown.yaml
@@ -18,7 +18,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2 # checkout repo content
+    - uses: actions/checkout@v4 # checkout repo content
+      with:
+        fetch-depth: 0
+    - name: use the javascript environment from main
+      run: |
+        git checkout remotes/origin/main -- package.json
     - uses: actions/setup-node@v4 # setup Node.js
       with:
         node-version: '14.x'


### PR DESCRIPTION
Fixes #3542 

Workflows run from the workflow file on main, even when they run on branches.  But just running "npm i" or a command like "npx" that also installs packages uses the package.json file from the branch.

Rather than attempt to keep the branch package files up-to-date (which would _quadruple_ the number of update PRs, adding three branch update PRs for every dependabot PR), let's just checkout the package.json from main whenver we run.  The other workflows only run on main - these two are the ones that run on branches.

<!--
Thank you for contributing to the OpenAPI Specification!

Please make certain you are submitting your PR on the correct
branch and file:

* 3.0.x spec: v3.0.4-dev branch, versions/3.0.4.md
* 3.1.x spec: v3.1.1-dev branch, versions/3.1.1.md
* 3.2.0 spec: v3.2.0-dev branch, versions/3.2.0.md
* 3.0 schema: main branch, schemas/v3.0/...
* 3.1 schema: main branch, schemas/v3.1/...
* registry templates: gh-pages branch, registry/...
* registry contents: gh-pages branch, registries/...

Note that we do not accept changes to published specifications.
-->
