### PR TITLE
Sync validate-markdown workflow with main (3.2.0)

### DIFF
--- a/.github/workflows/validate-markdown.yaml
+++ b/.github/workflows/validate-markdown.yaml
@@ -18,10 +18,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2 # checkout repo content
-    - uses: actions/setup-node@v1 # setup Node.js
+    - uses: actions/checkout@v4 # checkout repo content
       with:
-        node-version: '12.x'
+        fetch-depth: 0
+    - name: use the javascript environment from main
+      run: |
+        git checkout remotes/origin/main -- package.json
+    - uses: actions/setup-node@v4 # setup Node.js
+      with:
+        node-version: '14.x'
     - name: Validate markdown
       run: npx mdv versions/3.*.md
 

--- a/.github/workflows/validate-markdown.yaml
+++ b/.github/workflows/validate-markdown.yaml
@@ -23,10 +23,10 @@ jobs:
         fetch-depth: 0
     - name: use the javascript environment from main
       run: |
-        git checkout remotes/origin/main -- package.json
+        git checkout remotes/origin/main -- package.json package-lock.json
     - uses: actions/setup-node@v4 # setup Node.js
       with:
-        node-version: '14.x'
+        node-version: '20.x'
     - name: Validate markdown
-      run: npx mdv versions/3.*.md
+      run: npx --yes mdv versions/3.*.md
 


### PR DESCRIPTION
It turns out we do need to have the workflow files match on the branch.  However, we change these much less often, so let's just keep them up to date.  This just copies the current file over rather than trying to do any fancy merging as I don't have time to figure out how to disentangle some of the commits.