### PR TITLE
Fix JSON media type example (3.2.0)

### DIFF
--- a/versions/3.2.0.md
+++ b/versions/3.2.0.md
@@ -1389,29 +1389,28 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
          "$ref": "#/components/schemas/Pet"
     },
     "examples": {
-      "cat" : {
+      "cat": {
         "summary": "An example of a cat",
-        "value": 
-          {
-            "name": "Fluffy",
-            "petType": "Cat",
-            "color": "White",
-            "gender": "male",
-            "breed": "Persian"
-          }
+        "value": {
+          "name": "Fluffy",
+          "petType": "Cat",
+          "color": "White",
+          "gender": "male",
+          "breed": "Persian"
+        }
       },
       "dog": {
         "summary": "An example of a dog with a cat's name",
-        "value" :  { 
+        "value": {
           "name": "Puma",
           "petType": "Dog",
           "color": "Black",
           "gender": "Female",
           "breed": "Mixed"
-        },
-      "frog": {
-          "$ref": "#/components/examples/frog-example"
         }
+      },
+      "frog": {
+        "$ref": "#/components/examples/frog-example"
       }
     }
   }


### PR DESCRIPTION
Co-Author: Florian Loitsch <florian@loitsch.com>

Fix contributed by Florian Loitsch, ported to 3.2.0.md file.

<!--
Thank you for contributing to the OpenAPI Specification!

Please make certain you are submitting your PR on the correct
branch and file:

* 3.0.x spec: v3.0.4-dev branch, versions/3.0.4.md
* 3.1.x spec: v3.1.1-dev branch, versions/3.1.1.md
* 3.2.0 spec: v3.2.0-dev branch, versions/3.2.0.md
* 3.0 schema: main branch, schemas/v3.0/...
* 3.1 schema: main branch, schemas/v3.1/...
* registry templates: gh-pages branch, registry/...
* registry contents: gh-pages branch, registries/...

Note that we do not accept changes to published specifications.
-->
