### PR TITLE
Align the markdown workflow's JavaScript environment with the others

### DIFF
--- a/.github/workflows/validate-markdown.yaml
+++ b/.github/workflows/validate-markdown.yaml
@@ -23,10 +23,10 @@ jobs:
         fetch-depth: 0
     - name: use the javascript environment from main
       run: |
-        git checkout remotes/origin/main -- package.json
+        git checkout remotes/origin/main -- package.json package-lock.json
     - uses: actions/setup-node@v4 # setup Node.js
       with:
-        node-version: '14.x'
+        node-version: '20.x'
     - name: Validate markdown
-      run: npx mdv versions/3.*.md
+      run: npx --yes mdv versions/3.*.md
 


### PR DESCRIPTION
Checkout package-lock.json from main and use node v20. Add --yes (automatically install all needed dependencies) to npx because it seems to need it when run locally, although it's probably redundant in the CI environment.  But it's safe to include.

<!--
Thank you for contributing to the OpenAPI Specification!

Please make certain you are submitting your PR on the correct
branch and file:

* 3.0.x spec: v3.0.4-dev branch, versions/3.0.4.md
* 3.1.x spec: v3.1.1-dev branch, versions/3.1.1.md
* 3.2.0 spec: v3.2.0-dev branch, versions/3.2.0.md
* 3.0 schema: main branch, schemas/v3.0/...
* 3.1 schema: main branch, schemas/v3.1/...
* registry templates: gh-pages branch, registry/...
* registry contents: gh-pages branch, registries/...

Note that we do not accept changes to published specifications.
-->
