### PR TITLE
OAuth2 implicit grant is not secure

### DIFF
--- a/versions/1.2.md
+++ b/versions/1.2.md
@@ -172,6 +172,10 @@ Field Name | Type | Description
 <a name="rlInfo"/>info | [Info Object](#513-info-object) | Provides metadata about the API. The metadata can be used by the clients if needed, and can be presented in the Swagger-UI for convenience.
 <a name="rlAuthorizations"/>authorizations | [Authorizations Object](#514-authorizations-object) | Provides information about the authorization schemes allowed on this API.
 
+```
+Security note: OAuth2 implicit grant is considered to be not secure and should not be used by clients.
+```
+
 #### 5.1.1 Object Example
 
 ```js
@@ -342,6 +346,10 @@ The object provides information about a specific authorization scheme. Currently
 
 Within OAuth2, the Authorization Code Grant and Implicit Grant are supported.
 
+```
+Security note: OAuth2 implicit grant is considered to be not secure and should not be used by clients.
+```
+
 In the table below, the `Validity` column imposes additional limitations to the requirement of the [`type`](#authorizationType) in order to be able to use that field.
 
 Field Name | Type | Validity | Description
@@ -407,6 +415,10 @@ Field Name | Type | Description
 #### 5.1.7 Grant Types Object
 Provides details regarding the OAuth2 grant types that are supported by the API. Currently, the Authorization Code and Implicit grants are supported.
 
+```
+Security note: OAuth2 implicit grant is considered to be not secure and should not be used by clients.
+```
+
 At least one of the grant types MUST be included (otherwise there's no need for the OAuth2 declaration).
 
 Field Name | Type | Description
@@ -438,6 +450,11 @@ Field Name | Type | Description
 ```
 
 #### 5.1.8 Implicit Object
+
+```
+Security note: OAuth2 implicit grant is considered to be not secure and should not be used by clients.
+```
+
 Provides details regarding the OAuth2's Implicit Grant flow type.
 
 Field Name | Type | Description
@@ -479,6 +496,11 @@ Field Name | Type | Description
 ```
 
 #### 5.1.10 Login Endpoint Object
+
+```
+Security note: OAuth2 implicit grant is considered to be not secure and should not be used by clients.
+```
+
 Provides details regarding the Implicit Grant's *authorization endpoint*.
 
 Field Name | Type | Description

--- a/versions/2.0.md
+++ b/versions/2.0.md
@@ -2097,6 +2097,10 @@ Field Pattern | Type | Description
 
 ##### Security Definitions Object Example
 
+```
+Security note: OAuth2 implicit grant is considered to be not secure and should not be used by clients.
+```
+
 ```js
 {
   "api_key": {
@@ -2133,6 +2137,10 @@ petstore_auth:
 #### Security Scheme Object
 
 Allows the definition of a security scheme that can be used by the operations. Supported schemes are basic authentication, an API key (either as a header or as a query parameter) and OAuth2's common flows (implicit, password, application and access code).
+
+```
+Security note: OAuth2 implicit grant is considered to be not secure and should not be used by clients.
+```
 
 ##### Fixed Fields
 Field Name | Type | Validity | Description
@@ -2183,6 +2191,10 @@ in: header
 ```
 
 ###### Implicit OAuth2 Sample
+
+```
+Security note: OAuth2 implicit grant is considered to be not secure and should not be used by clients.
+```
 
 ```js
 {

--- a/versions/3.0.0.md
+++ b/versions/3.0.0.md
@@ -559,6 +559,10 @@ my.org.User
 }
 ```
 
+```
+Security note: OAuth2 implicit grant is considered to be not secure and should not be used by clients.
+```
+
 ```yaml
 components:
   schemas:
@@ -3196,6 +3200,10 @@ animals:
 Defines a security scheme that can be used by the operations.
 Supported schemes are HTTP authentication, an API key (either as a header or as a query parameter), OAuth2's common flows (implicit, password, application and access code) as defined in [RFC6749](https://tools.ietf.org/html/rfc6749), and [OpenID Connect Discovery](https://tools.ietf.org/html/draft-ietf-oauth-discovery-06).
 
+```
+Security note: OAuth2 implicit grant is considered to be not secure and should not be used by clients.
+```
+
 ##### Fixed Fields
 Field Name | Type | Applies To | Description
 ---|:---:|---|---
@@ -3259,6 +3267,10 @@ bearerFormat: JWT
 ```
 
 ###### Implicit OAuth2 Sample
+
+```
+Security note: OAuth2 implicit grant is considered to be not secure and should not be used by clients.
+```
 
 ```json
 {

--- a/versions/3.0.1.md
+++ b/versions/3.0.1.md
@@ -469,6 +469,10 @@ my.org.User
 
 ##### Components Object Example
 
+```
+Security note: OAuth2 implicit grant is considered to be not secure and should not be used by clients.
+```
+
 ```json
 "components": {
   "schemas": {
@@ -3134,6 +3138,10 @@ animals:
 Defines a security scheme that can be used by the operations.
 Supported schemes are HTTP authentication, an API key (either as a header or as a query parameter), OAuth2's common flows (implicit, password, application and access code) as defined in [RFC6749](https://tools.ietf.org/html/rfc6749), and [OpenID Connect Discovery](https://tools.ietf.org/html/draft-ietf-oauth-discovery-06).
 
+```
+Security note: OAuth2 implicit grant is considered to be not secure and should not be used by clients.
+```
+
 ##### Fixed Fields
 Field Name | Type | Applies To | Description
 ---|:---:|---|---
@@ -3197,6 +3205,10 @@ bearerFormat: JWT
 ```
 
 ###### Implicit OAuth2 Sample
+
+```
+Security note: OAuth2 implicit grant is considered to be not secure and should not be used by clients.
+```
 
 ```json
 {

--- a/versions/3.0.2.md
+++ b/versions/3.0.2.md
@@ -3165,6 +3165,10 @@ animals:
 Defines a security scheme that can be used by the operations.
 Supported schemes are HTTP authentication, an API key (either as a header, a cookie parameter or as a query parameter), OAuth2's common flows (implicit, password, application and access code) as defined in [RFC6749](https://tools.ietf.org/html/rfc6749), and [OpenID Connect Discovery](https://tools.ietf.org/html/draft-ietf-oauth-discovery-06).
 
+```
+Security note: OAuth2 implicit grant is considered to be not secure and should not be used by clients.
+```
+
 ##### Fixed Fields
 Field Name | Type | Applies To | Description
 ---|:---:|---|---
@@ -3228,6 +3232,10 @@ bearerFormat: JWT
 ```
 
 ###### Implicit OAuth2 Sample
+
+```
+Security note: OAuth2 implicit grant is considered to be not secure and should not be used by clients.
+```
 
 ```json
 {

--- a/versions/3.0.3.md
+++ b/versions/3.0.3.md
@@ -3245,6 +3245,10 @@ bearerFormat: JWT
 
 ###### Implicit OAuth2 Sample
 
+```
+Security note: OAuth2 implicit grant is considered to be not secure and should not be used by clients.
+```
+
 ```json
 {
   "type": "oauth2",

--- a/versions/3.1.0.md
+++ b/versions/3.1.0.md
@@ -3255,6 +3255,10 @@ bearerFormat: JWT
 
 ###### Implicit OAuth2 Sample
 
+```
+Security note: OAuth2 implicit grant is considered to be not secure and should not be used by clients.
+```
+
 ```json
 {
   "type": "oauth2",
@@ -3283,6 +3287,10 @@ flows:
 #### OAuth Flows Object
 
 Allows configuration of the supported OAuth Flows.
+
+```
+Security note: OAuth2 implicit grant is considered to be not secure and should not be used by clients.
+```
 
 ##### Fixed Fields
 Field Name | Type | Description


### PR DESCRIPTION
This is a PR for all versions of OAI.

The IETF OAuth2 working group considers the OAuth2 implicit grant NOT to be secure.
Time has changed. Implicit grant was secure enough, but in 2024 it isn't .
Please see https://datatracker.ietf.org/doc/html/draft-ietf-oauth-security-topics.html

```
Technology has changed. For example, the way browsers treat fragments when redirecting requests has changed, and with it, the implicit grant's underlying security model.
```

https://datatracker.ietf.org/doc/html/draft-ietf-oauth-security-topics.html#section-2.1.2
```
In order to avoid these issues, clients SHOULD NOT use the implicit grant (response type "token") or other response types issuing access tokens in the authorization response, unless access token injection in the authorization response is prevented and the aforementioned token leakage vectors are mitigated.Clients SHOULD instead use the response type "code" (aka authorization code grant type)
```

This PR adds a security note whenever OAI markdown mentions implicit grant in definitions and examples


BTW: I wished that OAI would rely more on OpenId Connect because OIDC is the authentication framework on top of OAuth2. Whenever an API use requires user consent OIDC authorization code flow should be used.