### PR TITLE
Moving @mikeralphson to Emeritus

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,10 +2,10 @@
 * Darrel Miller [@darrelmiller](https://github.com/darrelmiller)
 * Jeremy Whitlock [@whitlockjc](https://github.com/whitlockjc)
 * Marsh Gardiner [@earth2marsh](https://github.com/earth2marsh)
-* Mike Ralphson [@MikeRalphson](https://github.com/MikeRalphson)
 * Ron Ratovsky [@webron](https://github.com/webron)
 
 ## Emeritus
+* Mike Ralphson [@MikeRalphson](https://github.com/MikeRalphson)
 * Uri Sarid [@usarid](https://github.com/usarid)
 * Jason Harmon [@jharmn](https://github.com/jharmn)
 * Tony Tam [@fehguy](https://github.com/fehguy)


### PR DESCRIPTION
Thank you, @MikeRalphson , for all your contributions through the years, and we hope to see more of you in the future whenever you're able. 🙏