### PR TITLE
Update actions used in respec workflow

### DIFF
--- a/.github/workflows/respec.yaml
+++ b/.github/workflows/respec.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2 # checkout main branch
+    - uses: actions/checkout@v4 # checkout main branch
       with:
         fetch-depth: 0
 
@@ -32,7 +32,7 @@ jobs:
     - name: Install dependencies
       run: npm ci
 
-    - uses: actions/checkout@v2 # checkout gh-pages branch
+    - uses: actions/checkout@v4 # checkout gh-pages branch
       with:
         ref: gh-pages
         path: deploy
@@ -41,7 +41,7 @@ jobs:
       run: scripts/md2html/build.sh
 
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v5
+      uses: peter-evans/create-pull-request@v6
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         branch: update-respec-version


### PR DESCRIPTION
Update the github workflow that runs respec. By updating the actions, hopefully eliminate the error and warnings that we're currently seeing from this action. Fixes #3629 