### PR TITLE
$ref objects are legal in all path-item objects

### DIFF
--- a/schemas/v3.1/schema.json
+++ b/schemas/v3.1/schema.json
@@ -278,7 +278,7 @@
       "type": "object",
       "patternProperties": {
         "^/": {
-          "$ref": "#/$defs/path-item"
+          "$ref": "#/$defs/path-item-or-reference"
         }
       },
       "$ref": "#/$defs/specification-extensions",

--- a/schemas/v3.1/schema.yaml
+++ b/schemas/v3.1/schema.yaml
@@ -192,7 +192,7 @@ $defs:
     type: object
     patternProperties:
       '^/':
-        $ref: '#/$defs/path-item'
+        $ref: '#/$defs/path-item-or-reference'
     $ref: '#/$defs/specification-extensions'
     unevaluatedProperties: false
 


### PR DESCRIPTION
See #2657 - this was added to the specification but not the schema.
