### PR TITLE
doc: Improve syntax highlighting by using ```json instead of ```js

### DIFF
--- a/versions/1.2.md
+++ b/versions/1.2.md
@@ -136,7 +136,7 @@ If the [`type`](#dataTypeType) field is included it MUST NOT have the value `arr
 ##### 4.3.4.1 Object Examples
 
 For a primitive type:
-```js
+```json
 {
   "type": "string"
 }
@@ -144,7 +144,7 @@ For a primitive type:
 
 For a complex type (model):
 
-```js
+```json
 {
   "$ref": "Pet"
 }
@@ -174,7 +174,7 @@ Field Name | Type | Description
 
 #### 5.1.1 Object Example
 
-```js
+```json
 {
   "apiVersion": "1.0.0",
   "swaggerVersion": "1.2",
@@ -247,7 +247,7 @@ Field Name | Type | Description
 
 ##### 5.1.2.1 Object Example:
 
-```js
+```json
 {
     "path": "/pets",
     "description": "Operations about pets."
@@ -268,7 +268,7 @@ Field Name | Type | Description
 
 ##### 5.1.3.1 Object Example:
 
-```js
+```json
 {
   "title": "Swagger Sample App",
   "description": "This is a sample server Petstore server.",
@@ -300,7 +300,7 @@ Field Name | Type | Description
 <a name="authorizationsAuthorizationName"/>{Authorization Name} | [Authorization Object](#515-authorization-object) | A new authorization definition. The name given to the {Authorization Name} is a friendly name that should be used when referring to the authorization scheme. In many cases, the {Authorization Name} used is the same as its type, but it can be anything.
 
 ##### 5.1.4.1 Object Example:
-```js
+```json
 {
   "oauth2": {
     "type": "oauth2",
@@ -397,7 +397,7 @@ Field Name | Type | Description
 <a name="scope"/>description | `string` | *Recommended.* A short description of the scope.
 
 ##### 5.1.6.1 Object Example:
-```js
+```json
 {
   "scope": "email",
   "description": "Access to your email address"
@@ -415,7 +415,7 @@ Field Name | Type | Description
 <a name="grantTypesAuthorizationCode"/>authorization_code | [Authorization Code Object](#519-authorization-code-object) | The Authorization Code Grant flow definition.
 
 ##### 5.1.7.1 Object Example:
-```js
+```json
 {
   "implicit": {
     "loginEndpoint": {
@@ -446,7 +446,7 @@ Field Name | Type | Description
 <a name="implicitTokenName"/>tokenName | `string` | An optional alternative name to standard "access_token" OAuth2 parameter.
 
 ##### 5.1.8.1 Object Example:
-```js
+```json
 {
   "loginEndpoint": {
     "url": "http://petstore.swagger.wordnik.com/oauth/dialog"
@@ -464,7 +464,7 @@ Field Name | Type | Description
 <a name="acTokenEndpoint"/>tokenEndpoint | [Token Endpoint Object](#5112-token-endpoint-object) | **Required.** The token endpoint definition.
 
 ##### 5.1.9.1 Object Example:
-```js
+```json
 {
   "tokenRequestEndpoint": {
     "url": "http://petstore.swagger.wordnik.com/oauth/requestToken",
@@ -486,7 +486,7 @@ Field Name | Type | Description
 <a name="leUrl"/>url | `string` | **Required.** The URL of the authorization endpoint for the implicit grant flow. The value SHOULD be in a URL format.
 
 ##### 5.1.10.1 Object Example:
-```js
+```json
 {
   "url": "http://petstore.swagger.wordnik.com/oauth/dialog"
 }
@@ -502,7 +502,7 @@ Field Name | Type | Description
 <a name="treCliendSecretName"/>clientSecretName | `string` | An optional alternative name to the standard "client_secret" OAuth2 parameter.
 
 ##### 5.1.11.1 Object Example:
-```js
+```json
 {
   "url": "http://petstore.swagger.wordnik.com/oauth/requestToken",
   "clientIdName": "client_id",
@@ -519,7 +519,7 @@ Field Name | Type | Description
 <a name="treTokenName"/>tokenName | `string` | An optional alternative name to standard "access_token" OAuth2 parameter.
 
 ##### 5.1.12.1 Object Example:
-```js
+```json
 {
   "url": "http://petstore.swagger.wordnik.com/oauth/token",
   "tokenName": "access_code"
@@ -543,7 +543,7 @@ Field Name | Type | Description
 <a name="adAuthorizations"/>authorizations | [Authorizations Object](#5210-authorizations-object) | A list of authorizations schemes *required* for the operations listed in this API declaration. Individual operations may override this setting. If there are multiple authorization schemes described here, it means they're **all** applied.
 
 #### 5.2.1 Object Example
-```js
+```json
 {
   "apiVersion": "1.0.0",
   "swaggerVersion": "1.2",
@@ -702,7 +702,7 @@ Field Name | Type | Description
 
 ##### 5.2.2.1 Object Example:
 
-```js
+```json
       {
       "path": "/pet",
       "operations": [
@@ -799,7 +799,7 @@ Field Name | Type | Description
 
 ##### 5.2.3.1 Object Example
 
-````js
+````json
         {
           "method": "GET",
           "summary": "Find pet by ID",
@@ -869,7 +869,7 @@ Field Name | Type | Description
 
 ##### 5.2.4.2 Object Example
 
-```js
+```json
 {
   "name": "body",
   "description": "Pet object that needs to be updated in the store",
@@ -891,7 +891,7 @@ Field Name | Type | Description |
 
 ##### 5.2.5.1 Object Example
 
-```js
+```json
   {
     "code": 404,
     "message": "no project found",
@@ -919,7 +919,7 @@ Field Name | Type | Description
 
 ##### 5.2.6.1 Object Example
 
-```js
+```json
 {
     "Category": {
       "id": "Category",
@@ -953,7 +953,7 @@ Field Name | Type | Description
 
 ##### 5.2.7.1 Object Example
 
-```js
+```json
 {
   "id": "Order",
   "properties": {
@@ -1040,7 +1040,7 @@ Field Name | Type | Description
 <a name="propertiesPropertyName"/>{Property Name} | [Property Object](#529-property-object) | A new model property definition. Note the actual name of the field is the name you're giving your property. For example, "id", "name", "age".
 
 ##### 5.2.8.1 Object Example
-```js
+```json
       {
         "id": {
           "type": "integer",
@@ -1116,7 +1116,7 @@ Field Name | Type | Description
 <a name="adAuthorizationsAuthorizationName"/>{Authorization Name} | * | The authorization scheme to be used. The name given to the {Authorization Name} MUST be a friendly name that was given to an authorization scheme in the Resource Listing's [authorizations](#rlAuthorizations). If the friendly name describes an OAuth2 security scheme, the value should be of type \[[Scope Object](#5211-scope-object)\] (but may be an empty array to denote 'no scopes'). For all other authorization scheme types, the value MUST be an empty array.
 
 ##### 5.2.10 Object Example:
-```js
+```json
 {
   "oauth2": [
     {
@@ -1140,7 +1140,7 @@ Field Name | Type | Description
 <a name="scope"/>description | `string` | *Recommended.* A short description of the scope.
 
 ##### 5.2.11.1 Object Example:
-```js
+```json
 {
   "scope": "email",
   "description": "Access to your email address"

--- a/versions/2.0.md
+++ b/versions/2.0.md
@@ -151,7 +151,7 @@ Field Pattern | Type | Description
 
 ##### Info Object Example:
 
-```js
+```json
 {
   "title": "Swagger Sample App",
   "description": "This is a sample server Petstore server.",
@@ -203,7 +203,7 @@ Field Pattern | Type | Description
 
 ##### Contact Object Example:
 
-```js
+```json
 {
   "name": "API Support",
   "url": "http://www.swagger.io/support",
@@ -236,7 +236,7 @@ Field Pattern | Type | Description
 
 ##### License Object Example:
 
-```js
+```json
 {
   "name": "Apache 2.0",
   "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
@@ -262,7 +262,7 @@ Field Pattern | Type | Description
 
 ##### Paths Object Example
 
-```js
+```json
 {
   "/pets": {
     "get": {
@@ -328,7 +328,7 @@ Field Pattern | Type | Description
 
 ##### Path Item Object Example
 
-```js
+```json
 {
   "get": {
     "description": "Returns pets based on ID",
@@ -431,7 +431,7 @@ Field Pattern | Type | Description
 
 ##### Operation Object Example
 
-```js
+```json
 {
   "tags": [
     "pet"
@@ -546,7 +546,7 @@ Field Pattern | Type | Description
 
 ##### External Documentation Object Example
 
-```js
+```json
 {
   "description": "Find more info here",
   "url": "https://swagger.io"
@@ -622,7 +622,7 @@ Field Pattern | Type | Description
 ###### Body Parameters
 
 A body parameter with a referenced schema definition (normally for a model definition):
-```js
+```json
 {
   "name": "user",
   "in": "body",
@@ -644,7 +644,7 @@ schema:
 ```
 
 A body parameter that is an array of string values:
-```js
+```json
 {
   "name": "user",
   "in": "body",
@@ -674,7 +674,7 @@ schema:
 
 A header parameter with an array of 64 bit integer numbers:
 
-```js
+```json
 {
   "name": "token",
   "in": "header",
@@ -702,7 +702,7 @@ collectionFormat: csv
 ```
 
 A path parameter of a string value:
-```js
+```json
 {
   "name": "username",
   "in": "path",
@@ -721,7 +721,7 @@ type: string
 ```
 
 An optional query parameter of a string value, allowing multiple values by repeating the query parameter:
-```js
+```json
 {
   "name": "id",
   "in": "query",
@@ -747,7 +747,7 @@ collectionFormat: multi
 ```
 
 A form data with file type for a file upload:
-```js
+```json
 {
   "name": "avatar",
   "in": "formData",
@@ -800,7 +800,7 @@ Field Pattern | Type | Description
 
 Items must be of type  string and have the minimum length of  2 characters:
 
-```js
+```json
 {
     "type": "string",
     "minLength": 2
@@ -814,7 +814,7 @@ minLength: 2
 
 An array of arrays, the internal array being of type integer, numbers must be between 0 and 63 (inclusive):
 
-```js
+```json
 {
     "type": "array",
     "items": {
@@ -857,7 +857,7 @@ Field Pattern | Type | Description
 
 A 200 response for successful operation and a default response for others (implying an error):
 
-```js
+```json
 {
   "200": {
     "description": "a pet to be returned",
@@ -906,7 +906,7 @@ Field Pattern | Type | Description
 
 Response of an array of a complex type:
 
-```js
+```json
 {
   "description": "A complex object array response",
   "schema": {
@@ -928,7 +928,7 @@ schema:
 
 Response with a string type:
 
-```js
+```json
 {
   "description": "A simple string response",
   "schema": {
@@ -945,7 +945,7 @@ schema:
 
 Response with headers:
 
-```js
+```json
 {
   "description": "A simple string response",
   "schema": {
@@ -986,7 +986,7 @@ headers:
 
 Response with no return value:
 
-```js
+```json
 {
   "description": "object created"
 }
@@ -1008,7 +1008,7 @@ Field Pattern | Type | Description
 
 Rate-limit headers:
 
-```js
+```json
 {
     "X-Rate-Limit-Limit": {
         "description": "The number of allowed requests in the current period",
@@ -1050,7 +1050,7 @@ Field Pattern | Type | Description
 
 Example response for application/json mimetype of a Pet data type:
 
-```js
+```json
 {
   "application/json": {
     "name": "Puma",
@@ -1104,7 +1104,7 @@ Field Pattern | Type | Description
 
 A simple header with of an integer type:
 
-```js
+```json
 {
   "description": "The number of allowed requests in the current period",
   "type": "integer"
@@ -1134,7 +1134,7 @@ Field Pattern | Type | Description
 
 ##### Tag Object Example
 
-```js
+```json
 {
 	"name": "pet",
 	"description": "Pets operations"
@@ -1159,7 +1159,7 @@ Field Name | Type | Description
 
 ##### Reference Object Example
 
-```js
+```json
 {
 	"$ref": "#/definitions/Pet"
 }
@@ -1170,7 +1170,7 @@ $ref: '#/definitions/Pet'
 ```
 
 ##### Relative Schema File Example
-```js
+```json
 {
   "$ref": "Pet.json"
 }
@@ -1181,7 +1181,7 @@ $ref: 'Pet.yaml'
 ```
 
 ##### Relative Files With Embedded Schema Example
-```js
+```json
 {
   "$ref": "definitions.json#/Pet"
 }
@@ -1259,7 +1259,7 @@ The [xml](#schemaXml) property allows extra definitions when translating the JSO
 
 Unlike previous versions of Swagger, Schema definitions can be used to describe primitive and arrays as well.
 
-```js
+```json
 {
     "type": "string",
     "format": "email"
@@ -1273,7 +1273,7 @@ format: email
 
 ###### Simple Model
 
-```js
+```json
 {
   "type": "object",
   "required": [
@@ -1314,7 +1314,7 @@ properties:
 
 For a simple string to string mapping:
 
-```js
+```json
 {
   "type": "object",
   "additionalProperties": {
@@ -1331,7 +1331,7 @@ additionalProperties:
 
 For a string to model mapping:
 
-```js
+```json
 {
   "type": "object",
   "additionalProperties": {
@@ -1348,7 +1348,7 @@ additionalProperties:
 
 ###### Model with Example
 
-```js
+```json
 {
   "type": "object",
   "properties": {
@@ -1387,7 +1387,7 @@ example:
 
 ###### Models with Composition
 
-```js
+```json
 {
   "definitions": {
     "ErrorModel": {
@@ -1456,7 +1456,7 @@ definitions:
 
 ###### Models with Polymorphism Support
 
-```js
+```json
 {
   "definitions": {
     "Pet": {
@@ -1604,7 +1604,7 @@ The examples of the XML object definitions are included inside a property defini
 
 Basic string property:
 
-```js
+```json
 {
     "animals": {
         "type": "string"
@@ -1623,7 +1623,7 @@ animals:
 
 Basic string array property ([`wrapped`](#xmlWrapped) is `false` by default):
 
-```js
+```json
 {
     "animals": {
         "type": "array",
@@ -1649,7 +1649,7 @@ animals:
 
 ###### XML Name Replacement
 
-```js
+```json
 {
   "animals": {
     "type": "string",
@@ -1676,7 +1676,7 @@ animals:
 
 In this example, a full model definition is shown.
 
-```js
+```json
 {
   "Person": {
     "type": "object",
@@ -1726,7 +1726,7 @@ Person:
 
 Changing the element names:
 
-```js
+```json
 {
   "animals": {
     "type": "array",
@@ -1756,7 +1756,7 @@ animals:
 
 The external `name` property has no effect on the XML:
 
-```js
+```json
 {
   "animals": {
     "type": "array",
@@ -1791,7 +1791,7 @@ animals:
 
 Even when the array is wrapped, if no name is explicitly defined, the same name will be used both internally and externally:
 
-```js
+```json
 {
   "animals": {
     "type": "array",
@@ -1823,7 +1823,7 @@ animals:
 
 To overcome the above example, the following definition can be used:
 
-```js
+```json
 {
   "animals": {
     "type": "array",
@@ -1860,7 +1860,7 @@ animals:
 
 Affecting both internal and external names:
 
-```js
+```json
 {
   "animals": {
     "type": "array",
@@ -1899,7 +1899,7 @@ animals:
 
 If we change the external element but not the internal ones:
 
-```js
+```json
 {
   "animals": {
     "type": "array",
@@ -1943,7 +1943,7 @@ Field Pattern | Type | Description
 
 ##### Definitions Object Example
 
-```js
+```json
 {
   "Category": {
     "type": "object",
@@ -2005,7 +2005,7 @@ Field Pattern | Type | Description
 
 ##### Parameters Definition Object Example
 
-```js
+```json
 {
   "skipParam": {
     "name": "skip",
@@ -2058,7 +2058,7 @@ Field Pattern | Type | Description
 
 ##### Responses Definitions Object Example
 
-```js
+```json
 {
   "NotFound": {
     "description": "Entity not found."
@@ -2097,7 +2097,7 @@ Field Pattern | Type | Description
 
 ##### Security Definitions Object Example
 
-```js
+```json
 {
   "api_key": {
     "type": "apiKey",
@@ -2156,7 +2156,7 @@ Field Name | Type | Description
 
 ###### Basic Authentication Sample
 
-```js
+```json
 {
   "type": "basic"
 }
@@ -2168,7 +2168,7 @@ type: basic
 
 ###### API Key Sample
 
-```js
+```json
 {
   "type": "apiKey",
   "name": "api_key",
@@ -2184,7 +2184,7 @@ in: header
 
 ###### Implicit OAuth2 Sample
 
-```js
+```json
 {
   "type": "oauth2",
   "authorizationUrl": "http://swagger.io/api/oauth/dialog",
@@ -2223,7 +2223,7 @@ Field Pattern | Type | Description
 
 ##### Scopes Object Example
 
-```js
+```json
 {
   "write:pets": "modify pets in your account",
   "read:pets": "read your pets"
@@ -2251,7 +2251,7 @@ Field Pattern | Type | Description
 
 ###### Non-OAuth2 Security Requirement
 
-```js
+```json
 {
   "api_key": []
 }
@@ -2263,7 +2263,7 @@ api_key: []
 
 ###### OAuth2 Security Requirement
 
-```js
+```json
 {
   "petstore_auth": [
     "write:pets",

--- a/versions/3.0.1.md
+++ b/versions/3.0.1.md
@@ -1351,7 +1351,7 @@ This object MAY be extended with [Specification Extensions](#specification-exten
 
 ##### Media Type Examples
 
-```js
+```json
 {
   "application/json": {
     "schema": {


### PR DESCRIPTION
![js-vs-json](https://github.com/OAI/OpenAPI-Specification/assets/207248/3de1c76e-957c-42a2-a86d-453d0274885e)
