### PR TITLE
Move Mutual TLS example from 3.1.0 to 3.1.1 to prepare for patch release

### DIFF
--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -3250,6 +3250,20 @@ scheme: bearer
 bearerFormat: JWT
 ```
 
+###### MutualTLS Sample
+
+```json
+{
+  "type": "mutualTLS",
+  "description": "Cert must be signed by example.com CA"
+}
+```
+
+```yaml
+type: mutualTLS
+description: Cert must be signed by example.com CA
+```
+
 ###### Implicit OAuth2 Sample
 
 ```json


### PR DESCRIPTION
Since the 3.1.0 release, an example was added to illustrate Mutual TLS (PR #2625). This pull request moves it to 3.1.1.md as part of #3626 in preparation for a 3.1.1 patch release.