### PR TITLE
Apply improved wording around status codes from 3.1.1

### DIFF
--- a/versions/3.0.4.md
+++ b/versions/3.0.4.md
@@ -94,7 +94,7 @@ Some examples of possible media type definitions:
 ```
 ##### <a name="httpCodes"></a>HTTP Status Codes
 The HTTP Status Codes are used to indicate the status of the executed operation. 
-The available status codes are defined by [RFC7231](https://tools.ietf.org/html/rfc7231#section-6) and registered status codes are listed in the [IANA Status Code Registry](https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml).
+Status codes SHOULD be selected from the available status codes registered in the [IANA Status Code Registry](https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml).
 
 ## Specification
 


### PR DESCRIPTION
We added better wording around HTTP status codes that are supported to the 3.1.1 draft, but we should include this in 3.0.4 too ( original PR #2630 with thanks to @ioggstream).