### PR TITLE
Designate our markdown files as our source code

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.md linguist-detectable


### PR DESCRIPTION
This parallels a [change submitted by @i-ky on our learn repo](https://github.com/OAI/learn.openapis.org/pull/92), as a way to attract the right participation.  Our repo currently looks more like a JavaScript package, which may partially explain several recent issues opened with the expectation that this is a published JavaScript project. Our JavaScript is really just our test environment for our Markdown.

<!--
Thank you for contributing to the OpenAPI Specification!

Please make certain you are submitting your PR on the correct
branch and file:

* 3.0.x spec: v3.0.4-dev branch, versions/3.0.4.md
* 3.1.x spec: v3.1.1-dev branch, versions/3.1.1.md
* 3.2.0 spec: v3.2.0-dev branch, versions/3.2.0.md
* 3.0 schema: main branch, schemas/v3.0/...
* 3.1 schema: main branch, schemas/v3.1/...
* registry templates: gh-pages branch, registry/...
* registry contents: gh-pages branch, registries/...

Note that we do not accept changes to published specifications.
-->
