### PR TITLE
Add open projects to the weekly TDC agenda

### DIFF
--- a/.github/templates/agenda.md
+++ b/.github/templates/agenda.md
@@ -29,7 +29,8 @@ Meetings take place over Zoom: [https://zoom.us/j/975841675](https://zoom.us/j/9
 Intros and governance meta-topics (5 mins) | TDC | |
 Reports from Special Interest Groups (5 mins) | SIG members | |
 Any other business (add comments below to suggest topics) | TDC | |
-[Approved spec PRs](https://github.com/OAI/OpenAPI-Specification/pulls?q=is%3Apr+is%3Aopen+review%3Aapproved) | TDC | |
+[Approved spec PRs](https://github.com/OAI/OpenAPI-Specification/pulls?q=is%3Apr+is%3Aopen+review%3Aapproved) | @OAI/tsc | |
+[Active Projects](https://github.com/OAI/OpenAPI-Specification/projects?query=is%3Aopen) | @OAI/openapi-maintainers | |
 [New issues needing attention](https://github.com/search?q=repo%3Aoai%2Fopenapi-specification+is%3Aissue+comments%3A0+no%3Alabel+is%3Aopen) | @OAI/triage  | |
 
 /cc [@OAI/tsc](https://github.com/orgs/OAI/teams/tsc) please suggest items for inclusion.


### PR DESCRIPTION
We've started actually reaching the end of the meeting-specific agenda, which is great.  We have tended to look at the open projects, but that has required someone suggesting that action.

This adds a link to the open projects after the spec PRs and before the new issues (which looks for unlabled issues).

<!--
Thank you for contributing to the OpenAPI Specification!

Please make certain you are submitting your PR on the correct
branch and file:

* 3.0.x spec: v3.0.4-dev branch, versions/3.0.4.md
* 3.1.x spec: v3.1.1-dev branch, versions/3.1.1.md
* 3.2.0 spec: v3.2.0-dev branch, versions/3.2.0.md
* 3.0 schema: main branch, schemas/v3.0/...
* 3.1 schema: main branch, schemas/v3.1/...
* registry templates: gh-pages branch, registry/...
* registry contents: gh-pages branch, registries/...

Note that we do not accept changes to published specifications.
-->
