### PR TITLE
Provide a more direct set of issue routing links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,9 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
+
+# The local issue filing links are included in "contact_links" because
+# GitHub's regular issue template mechanism forces the local issue
+# links to be first in the list, when we want them to be last so 
+# visitors can be routed to other repos when appropriate.
 contact_links:
   - name: Have a question about using OpenAPI?
     url: https://communityinviter.com/apps/open-api/openapi
@@ -7,8 +12,17 @@ contact_links:
     url: https://tools.openapis.org/
     about: Please ask your tooling vendor!
   - name: Want to add to our list of OpenAPI Tools?
-    url: https://github.com/OAI/Tooling/issues/new/choose
-    about: Open an issue on our tooling site!
-  - name: Want to suggest more documentation and examples?
+    url: https://tools.openapis.org/
+    about: Please take a look at our tooling site's instructions!
+  - name: Want to suggest more how-to documentation and examples?
     url: https://github.com/OAI/learn.openapis.org/issues/new
-    about: Open an issue on our learning site!
+    about: Please open an issue on our learning site!
+  - name: Want to add to the registries at spec.openapis.org/registry ?
+    url: https://github.com/OAI/OpenAPI-Specification/issues/new
+    about: Please open an issue in this repository!
+  - name: Want to report an error in the specification?
+    url: https://github.com/OAI/OpenAPI-Specification/issues/new
+    about: Please open an issue in this repository!
+  - name: Want to request a new feature in the specification?
+    url: https://github.com/OAI/OpenAPI-Specification/discussions/new?category=enhancements
+    about: Please start a discussion in this repository!

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,17 +1,14 @@
 blank_issues_enabled: true
 contact_links:
-  - name: OpenAPI Specification
-    url: https://spec.openapis.org/oas/latest.html
-    about: View the latest version of the specification
-  - name: Getting started documentation
-    url: https://learn.openapis.org
-    about: Learn about the OpenAPI Specification
-  - name: OpenAPI Tooling
-    url: https://tools.openapis.org
-    about: Open-source and commercial tools for OpenAPI
-  - name: OpenAPI Initiative Registry
-    url: https://spec.openapis.org/registry/index.html
-    about: Registry of formats, extension namespaces etc.
-  - name: OpenAPI Initiative Slack
+  - name: Have a question about using OpenAPI?
     url: https://communityinviter.com/apps/open-api/openapi
-    about: Join our online community.
+    about: Ask us on our Slack!
+  - name: Have a question bout OpenAPI Tooling?
+    url: https://tools.openapis.org/
+    about: Please ask your tooling vendor!
+  - name: Want to add to our list of OpenAPI Tools?
+    url: https://github.com/OAI/Tooling/issues/new/choose
+    about: Open an issue on our tooling site!
+  - name: Want to suggest more documentation and examples?
+    url: https://github.com/OAI/learn.openapis.org/issues/new
+    about: Open an issue on our learning site!

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,7 +3,7 @@ contact_links:
   - name: Have a question about using OpenAPI?
     url: https://communityinviter.com/apps/open-api/openapi
     about: Ask us on our Slack!
-  - name: Have a question bout OpenAPI Tooling?
+  - name: Have a question about OpenAPI Tooling?
     url: https://tools.openapis.org/
     about: Please ask your tooling vendor!
   - name: Want to add to our list of OpenAPI Tools?


### PR DESCRIPTION
Fixes #3517 

We want to send people asking questions (as opposed to reporting issues) or asking about tools or additional documentation to the right places.  The previous links mostly sent people to other docs rather than to places where they could get questions answered or report other kinds of issues.

<!--
Thank you for contributing to the OpenAPI Specification!

Please make certain you are submitting your PR on the correct
branch and file:

* 3.0.x spec: v3.0.4-dev branch, versions/3.0.4.md
* 3.1.x spec: v3.1.1-dev branch, versions/3.1.1.md
* 3.2.0 spec: v3.2.0-dev branch, versions/3.2.0.md
* 3.0 schema: main branch, schemas/v3.0/...
* 3.1 schema: main branch, schemas/v3.1/...
* registry templates: gh-pages branch, registry/...
* registry contents: gh-pages branch, registries/...

Note that we do not accept changes to published specifications.
-->
