### PR TITLE
Explain that dynamic refs can implement generics

### DIFF
--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -2790,7 +2790,9 @@ components:
     objWithTypedArray:
       $id: obj_with_typed_array
       type: object
-      required: [dataType, data]
+      required: 
+      - dataType 
+      - data
       properties:
         dataType:
           enum: [string, number]

--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -2346,6 +2346,13 @@ While composition offers model extensibility, it does not imply a hierarchy betw
 To support polymorphism, the OpenAPI Specification adds the `discriminator` keyword.
 When used, the `discriminator` indicates the name of the property that hints which schema definition is expected to validate the structure of the model.
 
+###### Generic (Template) Data Structures
+
+Implementations MAY support defining generic or template data structures using JSON Schema's dynamic referencing feature:
+
+* `$dynamicAnchor` identifies set of possible schemas (including a default placeholder schema) to which a `$dynamicRef` can resolve
+* `$dynamicRef` resolves to the first matching encountered on its path from the schema entry point to the reference, as described in the JSON Schema specification
+
 ###### XML Modeling
 
 The [xml](#schemaXml) property allows extra definitions when translating the JSON definition to XML.
@@ -2687,6 +2694,111 @@ components:
             minimum: 0
         required:
         - packSize
+```
+
+###### Generic Data Structure Model
+
+```JSON
+{
+  "components": {
+    "schemas": {
+      "genericArrayComponent": {
+        "$id": "fully_generic_array",
+        "type": "array",
+        "items": {
+          "$dynamicRef": "#generic-array"
+        },
+        "$defs": {
+          "allowAll": {
+            "$dynamicAnchor": "generic-array"
+          }
+        }
+      },
+      "numberArray": {
+        "$id": "array_of_numbers",
+        "$ref": "fully_generic_array",
+        "$defs": {
+          "numbersOnly": {
+            "$dynamicAnchor": "generic-array",
+            "type": "number"
+          }
+        }
+      },
+      "stringArray": {
+        "$id": "array_of_strings",
+        "$ref": "fully_generic_array",
+        "$defs": {
+          "stringsOnly": {
+            "$dynamicAnchor": "generic-array",
+            "type": "string"
+          }
+        }
+      },
+      "objWithTypedArray": {
+        "$id": "obj_with_typed_array",
+        "type": "object",
+        "required": ["dataType", "data"],
+        "properties": {
+          "dataType": {
+            "enum": ["string", "number"]
+          }
+        },
+        "oneOf": [{
+          "properties": {
+            "dataType": {"const": "string"},
+            "data": {"$ref": "array_of_strings"}
+          }
+        }, {
+          "properties": {
+            "dataType": {"const": "number"},
+            "data": {"$ref": "array_of_numbers"}
+          }
+        }]
+      }
+    }
+  }
+}
+```
+
+```YAML
+components:
+  schemas:
+    genericArray:
+      $id: fully_generic_array
+      type: array
+      items:
+        $dynamicRef: #generic-array
+      $defs:
+        allowAll:
+          $dynamicAnchor: generic-array
+    numberArray:
+      $id: array_of_numbers
+      $ref: fully_generic_array
+      $defs:
+        numbersOnly:
+          $dynamicAnchor: generic-array
+          type: number
+    stringArray:
+      $id: array_of_strings
+      $ref: fully_generic_array
+      $defs:
+        stringsOnly:
+          $dynamicAnchor: generic-array
+          type: string
+    objWithTypedArray:
+      $id: obj_with_typed_array
+      type: object
+      required: [dataType, data]
+      properties:
+        dataType:
+          enum: [string, number]
+      oneOf:
+      - properties:
+          dataType: {const: string}
+          data: {$ref: array_of_strings}
+      - properties:
+          dataType: {const: number}
+          data: {$ref: array_of_numbers}
 ```
 
 #### <a name="discriminatorObject"></a>Discriminator Object

--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -2353,6 +2353,8 @@ Implementations MAY support defining generic or template data structures using J
 * `$dynamicAnchor` identifies a set of possible schemas (including a default placeholder schema) to which a `$dynamicRef` can resolve
 * `$dynamicRef` resolves to the first matching `$dynamicAnchor` encountered on its path from the schema entry point to the reference, as described in the JSON Schema specification
 
+An example is included in the "Schema Object Examples" section below, and further information can be found on the Learn OpenAPI site's ["Dynamic References"](https://learn.openapis.org/referencing/dynamic.html) page.
+
 ###### XML Modeling
 
 The [xml](#schemaXml) property allows extra definitions when translating the JSON definition to XML.

--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -2350,7 +2350,7 @@ When used, the `discriminator` indicates the name of the property that hints whi
 
 Implementations MAY support defining generic or template data structures using JSON Schema's dynamic referencing feature:
 
-* `$dynamicAnchor` identifies set of possible schemas (including a default placeholder schema) to which a `$dynamicRef` can resolve
+* `$dynamicAnchor` identifies a set of possible schemas (including a default placeholder schema) to which a `$dynamicRef` can resolve
 * `$dynamicRef` resolves to the first matching encountered on its path from the schema entry point to the reference, as described in the JSON Schema specification
 
 ###### XML Modeling

--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -2795,7 +2795,9 @@ components:
       - data
       properties:
         dataType:
-          enum: [string, number]
+          enum:
+          - string
+          - number
       oneOf:
       - properties:
           dataType: {const: string}

--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -2800,11 +2800,15 @@ components:
           - number
       oneOf:
       - properties:
-          dataType: {const: string}
-          data: {$ref: array_of_strings}
+          dataType:
+            const: string
+          data:
+            $ref: array_of_strings
       - properties:
-          dataType: {const: number}
-          data: {$ref: array_of_numbers}
+          dataType:
+            const: number
+          data:
+            $ref: array_of_numbers
 ```
 
 #### <a name="discriminatorObject"></a>Discriminator Object

--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -2765,7 +2765,7 @@ components:
 ```YAML
 components:
   schemas:
-    genericArray:
+    genericArrayComponent:
       $id: fully_generic_array
       type: array
       items:

--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -2351,7 +2351,7 @@ When used, the `discriminator` indicates the name of the property that hints whi
 Implementations MAY support defining generic or template data structures using JSON Schema's dynamic referencing feature:
 
 * `$dynamicAnchor` identifies a set of possible schemas (including a default placeholder schema) to which a `$dynamicRef` can resolve
-* `$dynamicRef` resolves to the first matching encountered on its path from the schema entry point to the reference, as described in the JSON Schema specification
+* `$dynamicRef` resolves to the first matching `$dynamicAnchor` encountered on its path from the schema entry point to the reference, as described in the JSON Schema specification
 
 ###### XML Modeling
 
@@ -2767,7 +2767,7 @@ components:
       $id: fully_generic_array
       type: array
       items:
-        $dynamicRef: #generic-array
+        $dynamicRef: "#generic-array"
       $defs:
         allowAll:
           $dynamicAnchor: generic-array


### PR DESCRIPTION
Fixes #3601.

Includes an example.  This intentionally does not explain how dynamic referencing works, as there are better resources available in both the spec and (more readably) the official JSON Schema blog.
