### PR TITLE
Clarify `spaceDelimited` with spaces (3.0.4)

### DIFF
--- a/versions/3.0.4.md
+++ b/versions/3.0.4.md
@@ -1058,6 +1058,7 @@ spaceDelimited | `array`, `object` | `query` | Space separated array values or o
 pipeDelimited | `array`, `object` | `query` | Pipe separated array values or object properties and values. This option replaces `collectionFormat` equal to `pipes` from OpenAPI 2.0.
 deepObject | `object` | `query` | Provides a simple way of rendering nested objects using form parameters.
 
+The behavior of applying a style that uses a delimiter to data containing that delimiter is not defined, and is therefore NOT RECOMMENDED.  To ensure interoperability, any such delimiter characters need to be escaped prior to serializing with the style, and unescaped after parsing.  In the case of `spaceDelimited`, care must be taken to avoid confusing interactions with URL parameter encoding of spaces.
 
 ##### Style Examples
 


### PR DESCRIPTION
Fixes #3550.  I will port this to 3.1.1 and 3.2.0 if it is accepted.

The OAS does not define how to avoid collisions between parameter values and style delimiters.  Mostly, this is straightforward, but the need to URL encode space characters introduces extra confusion.  Make it clear that managing this occurs outside of the use of style, and is the responsibility of users.
