### PR TITLE
Non-string discriminator values have undefined behavior (3.0.4)

### DIFF
--- a/versions/3.0.4.md
+++ b/versions/3.0.4.md
@@ -2718,7 +2718,7 @@ Field Name | Type | Description
 <a name="propertyName"></a>propertyName | `string` | **REQUIRED**. The name of the property in the payload that will hold the discriminator value.
 <a name="discriminatorMapping"></a> mapping | Map[`string`, `string`] | An object to hold mappings between payload values and schema names or references.
 
-The discriminator object is legal only when using one of the composite keywords `oneOf`, `anyOf`, `allOf`.  Note that because the discrinating property's value is used as a component name and/or as the key in the `mapping` object, the behavior of any value that is not a string is undefined.
+The discriminator object is legal only when using one of the composite keywords `oneOf`, `anyOf`, `allOf`.  Note that because the discriminating property's value is used as a component name and/or as the key in the `mapping` object, the behavior of any value that is not a string is undefined.
 
 In OAS 3.0, a response payload MAY be described to be exactly one of any number of types:
 

--- a/versions/3.0.4.md
+++ b/versions/3.0.4.md
@@ -2718,7 +2718,7 @@ Field Name | Type | Description
 <a name="propertyName"></a>propertyName | `string` | **REQUIRED**. The name of the property in the payload that will hold the discriminator value.
 <a name="discriminatorMapping"></a> mapping | Map[`string`, `string`] | An object to hold mappings between payload values and schema names or references.
 
-The discriminator object is legal only when using one of the composite keywords `oneOf`, `anyOf`, `allOf`.
+The discriminator object is legal only when using one of the composite keywords `oneOf`, `anyOf`, `allOf`.  Note that because the discrinating property's value is used as a component name and/or as the key in the `mapping` object, the behavior of any value that is not a string is undefined.
 
 In OAS 3.0, a response payload MAY be described to be exactly one of any number of types:
 


### PR DESCRIPTION
* Fixes #3475 

The "undefined" wording was chosen to allow implementations that make a good-faith effort to accommodate non-string values to remain compliant.  However, new implementations are not expected to implement any sort of type coersion, and this guides API designers away from that expectation.

If accepted, I will port this to 3.1.1.  For 3.2.0 we might either want to strengthen this to outright forbid non-strings or define a mapping for at least certain non-strings (e.g. booleans).
