### PR TITLE
Correctly escape example operationRef URLs

### DIFF
--- a/versions/3.0.4.md
+++ b/versions/3.0.4.md
@@ -2124,7 +2124,7 @@ field in an [Operation Object](#operationObject)), references MAY also be made t
 links:
   UserRepositories:
     # returns array of '#/components/schemas/repository'
-    operationRef: '#/paths/~12.0~1repositories~1{username}/get'
+    operationRef: '#/paths/~12.0~1repositories~1%7Busername%7D/get'
     parameters:
       username: $response.body#/username
 ```
@@ -2135,13 +2135,14 @@ or an absolute `operationRef`:
 links:
   UserRepositories:
     # returns array of '#/components/schemas/repository'
-    operationRef: https://na2.gigantic-server.com/#/paths/~12.0~1repositories~1{username}/get
+    operationRef: https://na2.gigantic-server.com/#/paths/~12.0~1repositories~1%7Busername%7D/get
     parameters:
       username: $response.body#/username
 ```
 
 Note that in the use of `operationRef`, the _escaped forward-slash_ is necessary when 
-using JSON references.
+using JSON Pointers, and it is necessary to URL-encode `{` and `}` as `%7B` and `%7D`, respectively when
+using JSON Pointers as URI fragments.
 
 
 ##### <a name="runtimeExpression"></a>Runtime Expressions


### PR DESCRIPTION
* Fixes #1677 

It's ugly, but that's URL-encoding for you.  If accepted, I will port this to 3.1.1 and 3.2.0.