### PR TITLE
Limit interoperable parsing expectations (avoid type conflicts)

### DIFF
--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -148,7 +148,7 @@ When parsing an OAD, JSON or YAML objects are parsed into specific Objects (such
 * As the Object type implied by its parent Object within the document
 * As a reference target, with the Object type matching the reference source's context
 
-If the same JSON/YAML object is parsed multiple times contexts requiring it to be parsed as _different_ Object types, the resulting behavior is _implementation defined_, and MAY be treated as an error if detected.  An example would be referencing an empty Schema Object under `#/components/schemas` where a Path Item Object is expected, as an empty object is valid for both types.  For maximum interoperability, it is RECOMMENDED that OpenAPI Description authors avoid such scenarios.
+If the same JSON/YAML object is parsed multiple times and the respective contexts require it to be parsed as _different_ Object types, the resulting behavior is _implementation defined_, and MAY be treated as an error if detected.  An example would be referencing an empty Schema Object under `#/components/schemas` where a Path Item Object is expected, as an empty object is valid for both types.  For maximum interoperability, it is RECOMMENDED that OpenAPI Description authors avoid such scenarios.
 
 ### <a name="dataTypes"></a>Data Types
 

--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -148,7 +148,7 @@ When parsing an OAD, JSON or YAML objects are parsed into specific Objects (such
 * As the Object type implied by its parent Object within the document
 * As a reference target, with the Object type matching the reference source's context
 
-If the same JSON/YAML object is parsed multiple times contexts requiring it to be parsed as _different_ Object types, the resulting behavior is _implementation defined_, and MAY be treated as an error if detected.  For maximum interoperability, it is RECOMMENDED that OpenAPI Description authors avoid such scenarios.
+If the same JSON/YAML object is parsed multiple times contexts requiring it to be parsed as _different_ Object types, the resulting behavior is _implementation defined_, and MAY be treated as an error if detected.  An example would be referencing an empty Schema Object under `#/components/schemas` where a Path Item Object is expected, as an empty object is valid for both types.  For maximum interoperability, it is RECOMMENDED that OpenAPI Description authors avoid such scenarios.
 
 ### <a name="dataTypes"></a>Data Types
 

--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -140,7 +140,7 @@ An OpenAPI Description (OAD) MAY be made up of a single document or be divided i
 
 It is RECOMMENDED that the entry OpenAPI document be named: `openapi.json` or `openapi.yaml`.
 
-### <a name="structuralInteroperability"></a>Structural Interoperability
+#### <a name="structuralInteroperability"></a>Structural Interoperability
 
 When parsing an OAD, JSON or YAML objects are parsed into specific Objects (such as [Operation Objects](#operationObject), [Response Objects](#responseObject), [Reference Objects](#referenceObject), etc.) based on the parsing context.  Depending on how references are arranged, a given JSON or YAML object can be parsed in multiple different contexts:
 

--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -136,9 +136,19 @@ In order to preserve the ability to round-trip between YAML and JSON formats, YA
 
 ### <a name="documentStructure"></a>OpenAPI Description Structure
 
-An OpenAPI Description MAY be made up of a single document or be divided into multiple, connected parts at the discretion of the author. In the latter case, [`Reference Objects`](#referenceObject) and [`Schema Object`](#schemaObject) `$ref` keywords are used.  In a multi-document description, the document containing the [OpenAPI Object](#oasObject) is known as the **entry OpenAPI document.**
+An OpenAPI Description (OAD) MAY be made up of a single document or be divided into multiple, connected parts at the discretion of the author. In the latter case, [Reference Object](#referenceObject), [Path Item Object](#pathItemObject) and [Schema Object](#schemaObject) `$ref` keywords, as well as the [Link Object](#linkObject) `operationRef` keyword, are used.  In a multi-document description, the document containing the [OpenAPI Object](#oasObject) is known as the **entry OpenAPI document.**
 
 It is RECOMMENDED that the entry OpenAPI document be named: `openapi.json` or `openapi.yaml`.
+
+### <a name="structuralInteroperability"></a>Structural Interoperability
+
+When parsing an OAD, JSON or YAML objects are parsed into specific Objects (such as [Operation Objects](#operationObject), [Response Objects](#responseObject), [Reference Objects](#referenceObject), etc.) based on the parsing context.  Depending on how references are arranged, a given JSON or YAML object can be parsed in multiple different contexts:
+
+* As a full OpenAPI Description document (an [OpenAPI Object](#oasObject) taking up an entire document)
+* As the Object type implied by its parent Object within the document
+* As a reference target, with the Object type matching the reference source's context
+
+If the same JSON/YAML object is parsed multiple times contexts requiring it to be parsed as _different_ Object types, the resulting behavior is _implementation defined_, and MAY be treated as an error if detected.  For maximum interoperability, it is RECOMMENDED that OpenAPI Description authors avoid such scenarios.
 
 ### <a name="dataTypes"></a>Data Types
 


### PR DESCRIPTION
This is the first of several changes to un-block the OASComply project.

As discovered through the OASComply project, certain referencing scenarios are ambiguous, with different authorities holding contradictory interpretations regarding whether and how they are to be supported.  As a result, it is impossible to define compliance, as all of the interpretations can be argued to be "correct" in some sense.

This change excludes some particularly challenging scenarios from compliance testing by making their behavior explicitly implementation-defined.  This has several benefits:

* _No current implementation is rendered non-compliant_
* _No currently usable OAD is rendered invalid_
* New implementers need not put effort into handling these scenarios
* User expectations are set to _not_ expect consistent behavior for these scenarios
* Linters can write a rule to match these expectations
* Everyone is guided towards straightforward best practices

_Note that the scenarios being deemed "implementation-defined" here are rarely if ever done on purpose._

If you are unclear as to why there is ambiguity in these parsing rules, please read at least the [summary report](https://github.com/OAI/oascomply/blob/main/reports/processing-model-summary.md) on this topic, before objecting.  While the scenarios excluded here were arguably well-specified in 2.0, the relevant language was removed in 3.0, with the requirements becoming even more ambiguous in 3.1.

If accepted, I will forward-port this to 3.2.0.  I believe this can also be backported to 3.0.4, but the requirements are slightly different there so I wanted to start with the easiest case, which is 3.1.1.