### PR TITLE
fix style=form examples (3.0.4)

### DIFF
--- a/versions/3.0.4.md
+++ b/versions/3.0.4.md
@@ -1080,8 +1080,8 @@ form | false | color= | color=blue | color=blue,black,brown | color=R,100,G,200,
 form | true | color= | color=blue | color=blue&color=black&color=brown | R=100&G=200&B=150
 simple | false | n/a | blue | blue,black,brown | R,100,G,200,B,150
 simple | true | n/a | blue | blue,black,brown | R=100,G=200,B=150
-spaceDelimited | false | n/a | n/a | blue%20black%20brown | R%20100%20G%20200%20B%20150
-pipeDelimited | false | n/a | n/a | blue\|black\|brown | R\|100\|G\|200\|B\|150
+spaceDelimited | false | n/a | n/a | color=blue%20black%20brown | color=R%20100%20G%20200%20B%20150
+pipeDelimited | false | n/a | n/a | color=blue\|black\|brown | color=R\|100\|G\|200\|B\|150
 deepObject | true | n/a | n/a | n/a | color[R]=100&color[G]=200&color[B]=150
 
 This object MAY be extended with [Specification Extensions](#specificationExtensions).


### PR DESCRIPTION
These should have the parameter name in the resulting string (see issue #3737).
