### PR TITLE
switch the order of these styles in the tables (3.0.4)

### DIFF
--- a/versions/3.0.4.md
+++ b/versions/3.0.4.md
@@ -1048,12 +1048,12 @@ Field Name | Type | Description
 
 In order to support common ways of serializing simple parameters, a set of `style` values are defined.
 
-`style` | [`type`](#dataTypes) |  `in` | Comments
+`style` | [`type`](#dataTypes) | `in` | Comments
 ----------- | ------ | -------- | --------
-matrix |  `primitive`, `array`, `object` |  `path` | Path-style parameters defined by [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.7) 
-label | `primitive`, `array`, `object` |  `path` | Label style parameters defined by [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.5)
-form |  `primitive`, `array`, `object` |  `query`, `cookie` | Form style parameters defined by [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.8). This option replaces `collectionFormat` with a `csv` (when `explode` is false) or `multi` (when `explode` is true) value from OpenAPI 2.0.
-simple | `primitive`, `array`, `object` | `path`, `header` | Simple style parameters defined by [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.2).  This option replaces `collectionFormat` with a `csv` value from OpenAPI 2.0.
+matrix | `primitive`, `array`, `object` | `path` | Path-style parameters defined by [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.7)
+label | `primitive`, `array`, `object` | `path` | Label style parameters defined by [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.5)
+simple | `primitive`, `array`, `object` | `path`, `header` | Simple style parameters defined by [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.2). This option replaces `collectionFormat` with a `csv` value from OpenAPI 2.0.
+form | `primitive`, `array`, `object` | `query`, `cookie` | Form style parameters defined by [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.8). This option replaces `collectionFormat` with a `csv` (when `explode` is false) or `multi` (when `explode` is true) value from OpenAPI 2.0.
 spaceDelimited | `array`, `object` | `query` | Space separated array values or object properties and values. This option replaces `collectionFormat` equal to `ssv` from OpenAPI 2.0.
 pipeDelimited | `array`, `object` | `query` | Pipe separated array values or object properties and values. This option replaces `collectionFormat` equal to `pipes` from OpenAPI 2.0.
 deepObject | `object` | `query` | Provides a simple way of rendering nested objects using form parameters.
@@ -1074,12 +1074,12 @@ The following table shows examples of rendering differences for each value.
 ----------- | ------ | -------- | -------- | -------- | -------
 matrix | false | ;color | ;color=blue | ;color=blue,black,brown | ;color=R,100,G,200,B,150
 matrix | true | ;color | ;color=blue | ;color=blue;color=black;color=brown | ;R=100;G=200;B=150
-label | false | .  | .blue |  .blue,black,brown | .R,100,G,200,B,150
-label | true | . | .blue |  .blue.black.brown | .R=100.G=200.B=150
-form | false | color= | color=blue | color=blue,black,brown | color=R,100,G,200,B,150
-form | true | color= | color=blue | color=blue&color=black&color=brown | R=100&G=200&B=150
+label | false | . | .blue | .blue,black,brown | .R,100,G,200,B,150
+label | true | . | .blue | .blue.black.brown | .R=100.G=200.B=150
 simple | false | n/a | blue | blue,black,brown | R,100,G,200,B,150
 simple | true | n/a | blue | blue,black,brown | R=100,G=200,B=150
+form | false | color= | color=blue | color=blue,black,brown | color=R,100,G,200,B,150
+form | true | color= | color=blue | color=blue&color=black&color=brown | R=100&G=200&B=150
 spaceDelimited | false | n/a | n/a | blue%20black%20brown | R%20100%20G%20200%20B%20150
 pipeDelimited | false | n/a | n/a | blue\|black\|brown | R\|100\|G\|200\|B\|150
 deepObject | true | n/a | n/a | n/a | color[R]=100&color[G]=200&color[B]=150


### PR DESCRIPTION
This is a more natural grouping of similar types, making the data much easier to read.

(This is the same as #3398, #3399)
