### PR TITLE
Correctly escape example operationRef URLs (3.1.1 port of #3731)

### DIFF
--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -2136,7 +2136,7 @@ field in an [Operation Object](#operationObject)), references MAY also be made t
 links:
   UserRepositories:
     # returns array of '#/components/schemas/repository'
-    operationRef: '#/paths/~12.0~1repositories~1{username}/get'
+    operationRef: '#/paths/~12.0~1repositories~1%7Busername%7D/get'
     parameters:
       username: $response.body#/username
 ```
@@ -2147,13 +2147,13 @@ or an absolute `operationRef`:
 links:
   UserRepositories:
     # returns array of '#/components/schemas/repository'
-    operationRef: https://na2.gigantic-server.com/#/paths/~12.0~1repositories~1{username}/get
+    operationRef: https://na2.gigantic-server.com/#/paths/~12.0~1repositories~1%7Busername%7D/get
     parameters:
       username: $response.body#/username
 ```
 
 Note that in the use of `operationRef`, the _escaped forward-slash_ is necessary when 
-using JSON references.
+using JSON Pointer, and it is necessary to URL-encode `{` and `}` as `%7B` and `%7D`, respectively when using JSON Pointer as URI fragments.
 
 
 ##### <a name="runtimeExpression"></a>Runtime Expressions


### PR DESCRIPTION
* Fixes issue #1677 
* Fixes issue #2738 