### PR TITLE
operationRef is a URI-reference

### DIFF
--- a/schemas/v3.0/schema.yaml
+++ b/schemas/v3.0/schema.yaml
@@ -980,6 +980,7 @@ definitions:
         type: string
       operationRef:
         type: string
+        format: uri-reference
       parameters:
         type: object
         additionalProperties: {}

--- a/schemas/v3.1/schema.yaml
+++ b/schemas/v3.1/schema.yaml
@@ -622,6 +622,7 @@ $defs:
     properties:
       operationRef:
         type: string
+        format: uri-reference
       operationId:
         type: string
       parameters:


### PR DESCRIPTION
Restore these "format" values to the schemas, which were removed when they were removed from the Server Object's "url" field, which is a template and not a URI-reference.

* Partially reverts #3455 (but leaves the Server Object changes in place)
* Companion to #3731, #3747, and #3748