### PR TITLE
Non-string discriminator values (3.2.0 port of #3728)

### DIFF
--- a/versions/3.2.0.md
+++ b/versions/3.2.0.md
@@ -2707,7 +2707,7 @@ Field Name | Type | Description
 
 This object MAY be extended with [Specification Extensions](#specificationExtensions).
 
-The discriminator object is legal only when using one of the composite keywords `oneOf`, `anyOf`, `allOf`.
+The discriminator object is legal only when using one of the composite keywords `oneOf`, `anyOf`, `allOf`.  Note that because the discrinating property's value is used as a component name and/or as the key in the `mapping` object, the behavior of any value that is not a string is undefined.
 
 In OAS 3.0, a response payload MAY be described to be exactly one of any number of types:
 

--- a/versions/3.2.0.md
+++ b/versions/3.2.0.md
@@ -2707,7 +2707,7 @@ Field Name | Type | Description
 
 This object MAY be extended with [Specification Extensions](#specificationExtensions).
 
-The discriminator object is legal only when using one of the composite keywords `oneOf`, `anyOf`, `allOf`.  Note that because the discrinating property's value is used as a component name and/or as the key in the `mapping` object, the behavior of any value that is not a string is undefined.
+The discriminator object is legal only when using one of the composite keywords `oneOf`, `anyOf`, `allOf`.  Note that because the discriminating property's value is used as a component name and/or as the key in the `mapping` object, the behavior of any value that is not a string is undefined.
 
 In OAS 3.0, a response payload MAY be described to be exactly one of any number of types:
 


### PR DESCRIPTION
The "undefined" wording was chosen to allow implementations that make a good-faith effort to accommodate non-string values to remain compliant.  However, new implementations are not expected to implement any sort of type coersion, and this guides API designers away from that expectation.
