### PR TITLE
Clarify spaceDelimited with spaces in values (3.1.1 port of #3723)

### DIFF
--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -1072,6 +1072,7 @@ spaceDelimited | `array`, `object` | `query` | Space separated array values or o
 pipeDelimited | `array`, `object` | `query` | Pipe separated array values or object properties and values. This option replaces `collectionFormat` equal to `pipes` from OpenAPI 2.0.
 deepObject | `object` | `query` | Allows objects with scalar properties to be represented using form parameters. The representation of array or object properties is not defined.
 
+The behavior of applying a style that uses a delimiter to data containing that delimiter is not defined, and is therefore NOT RECOMMENDED.  To ensure interoperability, any such delimiter characters need to be escaped prior to serializing with the style, and unescaped after parsing.  In the case of `spaceDelimited`, care must be taken to avoid confusing interactions with URL parameter encoding of spaces.
 
 ##### Style Examples
 


### PR DESCRIPTION
* Ports #3723 from 3.04 to 3.1.1
* Fixes #3550 

The OAS does not define how to avoid collisions between parameter values and style delimiters.  Mostly, this is straightforward, but the need to URL encode space characters introduces extra confusion.  Make it clear that managing this occurs outside of the use of style, and is the responsibility of users.
