### PR TITLE
Clarify spaceDelimited with spaces in values (3.2.0 port of #3723)

### DIFF
--- a/versions/3.2.0.md
+++ b/versions/3.2.0.md
@@ -1060,6 +1060,7 @@ spaceDelimited | `array`, `object` | `query` | Space separated array values or o
 pipeDelimited | `array`, `object` | `query` | Pipe separated array values or object properties and values. This option replaces `collectionFormat` equal to `pipes` from OpenAPI 2.0.
 deepObject | `object` | `query` | Provides a simple way of rendering nested objects using form parameters.
 
+The behavior of applying a style that uses a delimiter to data containing that delimiter is not defined, and is therefore NOT RECOMMENDED.  To ensure interoperability, any such delimiter characters need to be escaped prior to serializing with the style, and unescaped after parsing.  In the case of `spaceDelimited`, care must be taken to avoid confusing interactions with URL parameter encoding of spaces.
 
 ##### Style Examples
 


### PR DESCRIPTION
* Ports #3723 from 3.04 to 3.2.0
* Fixes #3550 

The OAS does not define how to avoid collisions between parameter values and style delimiters.  Mostly, this is straightforward, but the need to URL encode space characters introduces extra confusion.  Make it clear that managing this occurs outside of the use of style, and is the responsibility of users.

<!--
Thank you for contributing to the OpenAPI Specification!

Please make certain you are submitting your PR on the correct
branch and file:

* 3.0.x spec: v3.0.4-dev branch, versions/3.0.4.md
* 3.1.x spec: v3.1.1-dev branch, versions/3.1.1.md
* 3.2.0 spec: v3.2.0-dev branch, versions/3.2.0.md
* 3.0 schema: main branch, schemas/v3.0/...
* 3.1 schema: main branch, schemas/v3.1/...
* registry templates: gh-pages branch, registry/...
* registry contents: gh-pages branch, registries/...

Note that we do not accept changes to published specifications.
-->
