### PR TITLE
Clarify how Schema Objects require full-document parsing (3.1.1)

### DIFF
--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -154,7 +154,7 @@ Implementations MAY support complete-document parsing in any of the following wa
 * Detecting a document containing a referenceable Object at its root based on the expected type of the reference
 * Allowing users to configure the type of documents that might be loaded due to a reference to a non-root Object
 
-Embedding fragments of OpenAPI content in other formats can produce unexpected interactions among the enclosing format, the OAS, and JSON Schema.  While implementations MAY choose to support such arrangements, the resulting behavior is _implementation defined_.  This includes parsing fragments of OpenAPI out of a complete OpenAPI document while treating the rest of the document as arbitrary JSON or YAML.
+Embedding fragments of OpenAPI content in other formats can produce unexpected interactions among the enclosing format, the OAS, and JSON Schema.  While implementations MAY choose to support such arrangements, the resulting behavior is _implementation defined_.  This includes parsing fragments of OpenAPI out of a complete OpenAPI document while treating the rest of the document as arbitrary JSON or YAML.  Since parsing isolated fragments in this way will fail to notice keywords that might impact meaning or behavior, including in ways that contradict this specification's requirements, it is RECOMMENDED that OpenAPI Description authors avoid depending on such behavior.
 
 #### <a name="structuralInteroperability"></a>Structural Interoperability
 

--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -154,7 +154,16 @@ Implementations MAY support complete-document parsing in any of the following wa
 * Detecting a document containing a referenceable Object at its root based on the expected type of the reference
 * Allowing users to configure the type of documents that might be loaded due to a reference to a non-root Object
 
-Embedding fragments of OpenAPI content in other formats can produce unexpected interactions among the enclosing format, the OAS, and JSON Schema.  While implementations MAY choose to support such arrangements, the resulting behavior is _implementation defined_.  This includes parsing fragments of OpenAPI out of a complete OpenAPI document while treating the rest of the document as arbitrary JSON or YAML.  Since parsing isolated fragments in this way will fail to notice keywords that might impact meaning or behavior, including in ways that contradict this specification's requirements, it is RECOMMENDED that OpenAPI Description authors avoid depending on such behavior.
+Implementations that parse referenced fragments of OpenAPI content without regard for the content of the rest of the containing document will miss keywords that change the meaning and behavior of the reference target.
+In particular, failing to take into account keywords that change the base URI introduces security risks by causing references to resolve to unintended URIs, with unpredictable results.
+While some implementations support this sort of parsing due to the requirements of past versions of this specification, in version 3.1, the result of parsing fragments in isolation is _undefined_ and likely to contradict the requirements of this specification.
+
+While it is possible to structure certain OpenAPI Descriptions to ensure that they will behave correctly when references are parsed as isolated fragments, depending on this is NOT RECOMMENDED.
+This specification does not explicitly enumerate the conditions under which such behavior is safe, and provides no guarantee for continued safety in any future versions of the OAS.
+
+A special case of parsing fragments of OAS content would be if such fragments are embedded in another format, referred to as an _embedding format_ with respect to the OAS.
+Note that the OAS itself is an embedding format with respect to JSON Schema, which is embedded as Schema Objects.
+It is the responsibility of an embedding format to define how to parse embedded content, and OAS implementations that do not document support for an embedding format cannot be expected to parse embedded OAS content correctly.
 
 #### <a name="structuralInteroperability"></a>Structural Interoperability
 

--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -140,6 +140,22 @@ An OpenAPI Description (OAD) MAY be made up of a single document or be divided i
 
 It is RECOMMENDED that the entry OpenAPI document be named: `openapi.json` or `openapi.yaml`.
 
+#### <a name="parsingDocuments"></a>Parsing Documents
+
+In order to properly handle [Schema Objects](#schemaObject), OAS 3.1 inherits the parsing requirements of [JSON Schema draft 2020-12 §9](https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-00#section-9), with appropriate modifications regarding base URIs as specified in [Relative References In URIs](#relativeReferencesURI).
+
+This includes a requirement to parse complete documents before deeming a Schema object reference to be unresolvable, in order to detect keywords that might provide the reference target or impact the determination of the appropriate base URI.
+
+Implementations MAY support complete-document parsing in any of the following ways:
+
+* Detecting OpenAPI or JSON Schema documents using media types
+* Detecting OpenAPI documents through the root `openapi` property
+* Detecting JSON Schema documents through detecting keywords or otherwise successfully parsing the document in accordance with the JSON Schema specification
+* Detecting a document containing a referenceable Object at its root based on the expected type of the reference
+* Allowing users to configure the type of documents that might be loaded due to a reference to a non-root Object
+
+Embedding fragments of OpenAPI content in other formats can produce unexpected interactions among the enclosing format, the OAS, and JSON Schema.  While implementations MAY choose to support such arrangements, the resulting behavior is _implementation defined_.  This includes parsing fragments of OpenAPI out of a complete OpenAPI document while treating the rest of the document as arbitrary JSON or YAML.
+
 #### <a name="structuralInteroperability"></a>Structural Interoperability
 
 When parsing an OAD, JSON or YAML objects are parsed into specific Objects (such as [Operation Objects](#operationObject), [Response Objects](#responseObject), [Reference Objects](#referenceObject), etc.) based on the parsing context.  Depending on how references are arranged, a given JSON or YAML object can be parsed in multiple different contexts:


### PR DESCRIPTION
This is the next step in un-blocking OASComply.  Unlike the previous OASComply-related PR, this PR ***does not*** apply to v3.0.4.  What, if any, wording about document parsing needs to go in 3.0.4 is something we can sort out later.

The implied requirement might be surprising to some, but is an unambiguous result of normatively citing JSON Schema 2020-12.  Resolution of references to `$id` values that do not match the document's location (e.g. are resolved as URIs rather than URLs, including by noticing them in already-parsed content) was affirmed multiple times by TSC decisions during the work on OAS 3.1:

* https://github.com/OAI/OpenAPI-Specification/pull/1977#issuecomment-571665656
* https://github.com/OAI/OpenAPI-Specification/issues/2092#issuecomment-585881781
* https://github.com/OAI/OpenAPI-Specification/issues/2159#issuecomment-601283402

Unfortunately, it seems like we never did get around to adding explicit wording highlighting this.  Which does not change the fact that a.) it was decided and re-affirmed, and b.) normatively citing JSON Schema 2020-12 mandates this behavior as the only possible way to satisfy its requirements.

There might be further changes related to this in the "Resolving Relative References in URIs", but I'll deal with that when I fix #3545, which covers both that section and "Resolving Relative References in URLs".

I also expect we'll want to add further guidance for both implementors and description authors on the Learn site.  I tried to keep the text here as minimal as possible while heading off the misunderstandings we've seen as folks implement 3.1.

------
_Commit message:_

JSON Schema draft 2020-12 includes numerous keywords that require parsing the entire document prior to deeming a reference unresolvable. This makes that more clear and outlines several approaches.

The practice of embedding OpenAPI fragments in other formats is deemed to have implementation-defined (non-interoperable) behavior, as the potential complications that might arise are not predictable.
