### PR TITLE
Backport a clarification about deepObject to 3.0.4

### DIFF
--- a/versions/3.0.4.md
+++ b/versions/3.0.4.md
@@ -1058,7 +1058,7 @@ simple | `primitive`, `array`, `object` | `path`, `header` | Simple style parame
 form | `primitive`, `array`, `object` | `query`, `cookie` | Form style parameters defined by [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.8). This option replaces `collectionFormat` with a `csv` (when `explode` is false) or `multi` (when `explode` is true) value from OpenAPI 2.0.
 spaceDelimited | `array`, `object` | `query` | Space separated array values or object properties and values. This option replaces `collectionFormat` equal to `ssv` from OpenAPI 2.0.
 pipeDelimited | `array`, `object` | `query` | Pipe separated array values or object properties and values. This option replaces `collectionFormat` equal to `pipes` from OpenAPI 2.0.
-deepObject | `object` | `query` | Provides a simple way of rendering nested objects using form parameters.
+deepObject | `object` | `query` | Allows objects with scalar properties to be represented using form parameters. The representation of array or object properties is not defined.
 
 The behavior of applying a style that uses a delimiter to data containing that delimiter is not defined, and is therefore NOT RECOMMENDED.  To ensure interoperability, any such delimiter characters need to be escaped prior to serializing with the style, and unescaped after parsing.  In the case of `spaceDelimited`, care must be taken to avoid confusing interactions with URL parameter encoding of spaces.
 


### PR DESCRIPTION
Port #2846 from 3.1.1. to 3.0.4 as a good expansion of what `deepObject` is (and is not). With thanks to @hkosova for the original patch.