### PR TITLE
Clarify how to model streaming binary data (3.1.1 port of #3729)

### DIFF
--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -196,6 +196,9 @@ The `contentMediaType` keyword is redundant if the media type is already set:
 
 If the Schema Object will be processed by a non-OAS-aware JSON Schema implementation, it may be useful to include `contentMediaType` even if it is redundant.  However, if `contentMediaType` contradicts a relevant Media Type Object or Encoding Object, then `contentMediaType` SHALL be ignored.
 
+The `maxLength` keyword MAY be used to set an expected upper bound on the length of a streaming payload.  The keyword can be applied to either string data, including encoded binary data, or to unencoded binary data.  For unencoded binary, the length is the number of octets.
+
+##### Migrating binary descriptions from OAS 3.0
 The following table shows how to migrate from OAS 3.0 binary data descriptions, continuing to use `image/png` as the example binary media type:
 
 OAS < 3.1 | OAS 3.1 | Comments


### PR DESCRIPTION
* Ports #3729, plus an additional subsection heading as the section was getting complex
* Fixes #1576 

Also make the translation from 3.0 binary modeling a subsection, as otherwise the line about streaming either feels randomly inserted into the middle of the section, or feels disconnected when placed after the conversion table.

<!--
Thank you for contributing to the OpenAPI Specification!

Please make certain you are submitting your PR on the correct
branch and file:

* 3.0.x spec: v3.0.4-dev branch, versions/3.0.4.md
* 3.1.x spec: v3.1.1-dev branch, versions/3.1.1.md
* 3.2.0 spec: v3.2.0-dev branch, versions/3.2.0.md
* 3.0 schema: main branch, schemas/v3.0/...
* 3.1 schema: main branch, schemas/v3.1/...
* registry templates: gh-pages branch, registry/...
* registry contents: gh-pages branch, registries/...

Note that we do not accept changes to published specifications.
-->
