### PR TITLE
Clarify interoperable parsing expectations (3.0.4 port of #3732)

### DIFF
--- a/versions/3.0.4.md
+++ b/versions/3.0.4.md
@@ -146,7 +146,7 @@ In order to preserve the ability to round-trip between YAML and JSON formats, YA
 
 ### <a name="documentStructure"></a>OpenAPI Description Structure
 
-An OpenAPI Description (OAD) MAY be made up of a single document or be divided into multiple, connected parts at the discretion of the author. In the latter case, [Reference Object](#referenceObject), [Path Item Object](#pathItemObject) and [Schema Object](#schemaObject) `$ref` keywords, as well as the [Link Object](#linkObject) `operationRef` keyword, are used.  In a multi-document description, the document containing the [OpenAPI Object](#oasObject) is known as the **entry OpenAPI document.**
+An OpenAPI Description (OAD) MAY be made up of a single document or be divided into multiple, connected parts at the discretion of the author. In the latter case, [Reference Object](#referenceObject) and [Path Item Object](#pathItemObject) `$ref` keywords, as well as the [Link Object](#linkObject) `operationRef` keyword, are used.  In a multi-document description, the document containing the [OpenAPI Object](#oasObject) is known as the **entry OpenAPI document.**
 
 It is RECOMMENDED that the entry OpenAPI document be named: `openapi.json` or `openapi.yaml`.
 

--- a/versions/3.0.4.md
+++ b/versions/3.0.4.md
@@ -146,9 +146,19 @@ In order to preserve the ability to round-trip between YAML and JSON formats, YA
 
 ### <a name="documentStructure"></a>OpenAPI Description Structure
 
-An OpenAPI Description MAY be made up of a single document or be divided into multiple, connected parts at the discretion of the author. In the latter case, `$ref` fields MUST be used in the specification to reference those parts as follows from the [JSON Schema](https://json-schema.org) definitions.  In a multi-document description, the document containing the [OpenAPI Object](#oasObject) is known as the **entry OpenAPI document.**
+An OpenAPI Description (OAD) MAY be made up of a single document or be divided into multiple, connected parts at the discretion of the author. In the latter case, [Reference Object](#referenceObject), [Path Item Object](#pathItemObject) and [Schema Object](#schemaObject) `$ref` keywords, as well as the [Link Object](#linkObject) `operationRef` keyword, are used.  In a multi-document description, the document containing the [OpenAPI Object](#oasObject) is known as the **entry OpenAPI document.**
 
 It is RECOMMENDED that the entry OpenAPI document be named: `openapi.json` or `openapi.yaml`.
+
+#### <a name="structuralInteroperability"></a>Structural Interoperability
+
+When parsing an OAD, JSON or YAML objects are parsed into specific Objects (such as [Operation Objects](#operationObject), [Response Objects](#responseObject), [Reference Objects](#referenceObject), etc.) based on the parsing context.  Depending on how references are arranged, a given JSON or YAML object can be parsed in multiple different contexts:
+
+* As a full OpenAPI Description document (an [OpenAPI Object](#oasObject) taking up an entire document)
+* As the Object type implied by its parent Object within the document
+* As a reference target, with the Object type matching the reference source's context
+
+If the same JSON/YAML object is parsed multiple times and the respective contexts require it to be parsed as _different_ Object types, the resulting behavior is _implementation defined_, and MAY be treated as an error if detected.  An example would be referencing an empty Schema Object under `#/components/schemas` where a Path Item Object is expected, as an empty object is valid for both types.  For maximum interoperability, it is RECOMMENDED that OpenAPI Description authors avoid such scenarios.
 
 ### <a name="dataTypes"></a>Data Types
 


### PR DESCRIPTION
_[**EDIT:** After much discussion, based on today's TDC call this PR is now a direct port of #3732, as the intended model had shifted from 2.0's "copy the JSON/YAML and then apply OAS Semantics" to "the reference target has OAS Semantics, but the implications of this were not entirely worked out."]_

This is sort-of a port of #3732, but modified because the scenario involved was mostly assumed to be valid based on the more direct text of OAS 2.0.  So instead of making the scenario implementation-defined, I opted to acknowledge that it's the common assumption _(there is probably better wording for this, please feel free to suggest - I fear that my current wording is too skeptical or judgemental)_, but also that the text does not cleary require it in 3.0.  And then recommend against doing it because it is not required to be supported in 3.1.  See the commit message below for more details of how this is different from the 3.1.1 PR.

----

As discovered through the OASComply project, certain referencing scenarios are ambiguous, with different authorities holding contradictory interpretations regarding whether and how they are to be supported.

This particular scenario, where the same JSON/YAML object is parsed in different semantic contexts, is well-defined if the requirements of 2.0 are assumed to apply despite no longer appearing in the text.  However, the scenario is *not* well-defined in 3.1, so we should advise against it.

While the 3.1 version of this change made the scenario explicitly implementation-defined, it seems better to acknowledge the assumption here while still noting that it is not clearly required.

This also removes the confusing reference to JSON Schema for "$ref" as the Reference Object *explicitly* states that it is governed by JSON Reference and *not* JSON Schema.  It also enumerates more of the referencing keywords like we do in 3.1.

<!--
Thank you for contributing to the OpenAPI Specification!

Please make certain you are submitting your PR on the correct
branch and file:

* 3.0.x spec: v3.0.4-dev branch, versions/3.0.4.md
* 3.1.x spec: v3.1.1-dev branch, versions/3.1.1.md
* 3.2.0 spec: v3.2.0-dev branch, versions/3.2.0.md
* 3.0 schema: main branch, schemas/v3.0/...
* 3.1 schema: main branch, schemas/v3.1/...
* registry templates: gh-pages branch, registry/...
* registry contents: gh-pages branch, registries/...

Note that we do not accept changes to published specifications.
-->
