### PR TITLE
Use pinned version of MAINTAINERS.md per spec version

### DIFF
--- a/scripts/md2html/build.sh
+++ b/scripts/md2html/build.sh
@@ -10,7 +10,8 @@ mkdir -p deploy/js
 
 cd scripts/md2html
 mkdir -p history
-git show c740e950d:MAINTAINERS.md > history/MAINTAINERS_v2.0.md
+git show c740e95:MAINTAINERS.md > history/MAINTAINERS_v2.0.md
+git show e9fe5bc:MAINTAINERS.md > history/MAINTAINERS_v3.x.md
 cp -p js/* ../../deploy/js 2> /dev/null
 cp -p markdown/* ../../deploy/ 2> /dev/null
 
@@ -20,7 +21,7 @@ latest=`git describe --abbrev=0 --tags`
 latestCopied=none
 for filename in ../../versions/[3456789].*.md ; do
   version=$(basename "$filename" .md)
-  node md2html.js --respec --maintainers ../../MAINTAINERS.md ${filename} > ../../deploy/oas/v$version.html
+  node md2html.js --respec --maintainers ./history/MAINTAINERS_v3.x.md ${filename} > ../../deploy/oas/v$version.html
   if [ $version = $latest ]; then
     if [[ ${version} != *"rc"* ]];then
       # version is not a Release Candidate

--- a/scripts/md2html/build.sh
+++ b/scripts/md2html/build.sh
@@ -11,7 +11,7 @@ mkdir -p deploy/js
 cd scripts/md2html
 mkdir -p history
 git show c740e95:MAINTAINERS.md > history/MAINTAINERS_v2.0.md
-git show e9fe5bc:MAINTAINERS.md > history/MAINTAINERS_v3.0.0.md
+git show c740e95:MAINTAINERS.md > history/MAINTAINERS_v3.0.0.md
 cp history/MAINTAINERS_v3.0.0.md history/MAINTAINERS_v3.0.1.md
 git show 3140640:MAINTAINERS.md > history/MAINTAINERS_v3.0.2.md
 cp history/MAINTAINERS_v3.0.2.md history/MAINTAINERS_v3.0.3.md

--- a/scripts/md2html/build.sh
+++ b/scripts/md2html/build.sh
@@ -11,17 +11,22 @@ mkdir -p deploy/js
 cd scripts/md2html
 mkdir -p history
 git show c740e95:MAINTAINERS.md > history/MAINTAINERS_v2.0.md
-git show e9fe5bc:MAINTAINERS.md > history/MAINTAINERS_v3.x.md
+git show e9fe5bc:MAINTAINERS.md > history/MAINTAINERS_v3.0.0.md
+cp history/MAINTAINERS_v3.0.0.md history/MAINTAINERS_v3.0.1.md
+git show 3140640:MAINTAINERS.md > history/MAINTAINERS_v3.0.2.md
+cp history/MAINTAINERS_v3.0.2.md history/MAINTAINERS_v3.0.3.md
+cp history/MAINTAINERS_v3.0.2.md history/MAINTAINERS_v3.0.3.md
+cp history/MAINTAINERS_v3.0.2.md history/MAINTAINERS_v3.1.0.md
+# add lines for 3.0.4, 3.1.1, ...
+
 cp -p js/* ../../deploy/js 2> /dev/null
 cp -p markdown/* ../../deploy/ 2> /dev/null
 
-node md2html.js --respec --maintainers ./history/MAINTAINERS_v2.0.md ../../versions/2.0.md > ../../deploy/oas/v2.0.html
-
 latest=`git describe --abbrev=0 --tags`
 latestCopied=none
-for filename in ../../versions/[3456789].*.md ; do
+for filename in ../../versions/[23456789].*.md ; do
   version=$(basename "$filename" .md)
-  node md2html.js --respec --maintainers ./history/MAINTAINERS_v3.x.md ${filename} > ../../deploy/oas/v$version.html
+  node md2html.js --respec --maintainers ./history/MAINTAINERS_v$version.md ${filename} > ../../deploy/oas/v$version.html
   if [ $version = $latest ]; then
     if [[ ${version} != *"rc"* ]];then
       # version is not a Release Candidate

--- a/scripts/md2html/build.sh
+++ b/scripts/md2html/build.sh
@@ -17,10 +17,9 @@ cat > history/MAINTAINERS_v2.0.md <<EOF
 * Ron Ratovsky [@webron](https://github.com/webron)
 * Tony Tam [@fehguy](https://github.com/fehguy)
 EOF
-git show c740e95:MAINTAINERS.md > history/MAINTAINERS_v3.0.0.md
-cp history/MAINTAINERS_v3.0.0.md history/MAINTAINERS_v3.0.1.md
+cp history/MAINTAINERS_v2.0.md history/MAINTAINERS_v3.0.0.md
+git show c740e95:MAINTAINERS.md > history/MAINTAINERS_v3.0.1.md
 git show 3140640:MAINTAINERS.md > history/MAINTAINERS_v3.0.2.md
-cp history/MAINTAINERS_v3.0.2.md history/MAINTAINERS_v3.0.3.md
 cp history/MAINTAINERS_v3.0.2.md history/MAINTAINERS_v3.0.3.md
 cp history/MAINTAINERS_v3.0.2.md history/MAINTAINERS_v3.1.0.md
 # add lines for 3.0.4, 3.1.1, ...

--- a/scripts/md2html/build.sh
+++ b/scripts/md2html/build.sh
@@ -17,7 +17,6 @@ cat > history/MAINTAINERS_v2.0.md <<EOF
 * Ron Ratovsky [@webron](https://github.com/webron)
 * Tony Tam [@fehguy](https://github.com/fehguy)
 EOF
-
 git show c740e95:MAINTAINERS.md > history/MAINTAINERS_v3.0.0.md
 cp history/MAINTAINERS_v3.0.0.md history/MAINTAINERS_v3.0.1.md
 git show 3140640:MAINTAINERS.md > history/MAINTAINERS_v3.0.2.md

--- a/scripts/md2html/build.sh
+++ b/scripts/md2html/build.sh
@@ -10,7 +10,14 @@ mkdir -p deploy/js
 
 cd scripts/md2html
 mkdir -p history
-git show c740e95:MAINTAINERS.md > history/MAINTAINERS_v2.0.md
+cat > history/MAINTAINERS_v2.0.md <<EOF
+## Active
+* Jeremy Whitlock [@whitlockjc](https://github.com/whitlockjc)
+* Marsh Gardiner [@earth2marsh](https://github.com/earth2marsh)
+* Ron Ratovsky [@webron](https://github.com/webron)
+* Tony Tam [@fehguy](https://github.com/fehguy)
+EOF
+
 git show c740e95:MAINTAINERS.md > history/MAINTAINERS_v3.0.0.md
 cp history/MAINTAINERS_v3.0.0.md history/MAINTAINERS_v3.0.1.md
 git show 3140640:MAINTAINERS.md > history/MAINTAINERS_v3.0.2.md

--- a/scripts/md2html/md2html.js
+++ b/scripts/md2html/md2html.js
@@ -118,7 +118,8 @@ function doMaintainers() {
         let t = $(this).text().split('@')[0];
         maintainers.push({name:t});
     });
-    u = $('ul').eq(1);
+    if ($("ul").length < 2) return;
+    u = $("ul").last();
     $(u).children('li').each(function(e){
         let t = $(this).text().split('@')[0];
         emeritus.push({name:t});


### PR DESCRIPTION
Fixes #3693

Quick fix for respec build script:
- use pinned version of `MAINTAINERS.md` for all 3.x specs

TODO:
- [x] use nearest version of `MAINTAINERS.md` for each 3.x spec
- [x] create static content for missing version of `MAINTAINERS.md` for 2.0 spec