### PR TITLE
Reinstate validation of JSON Schemas (and examples) in build process

### DIFF
--- a/tests/v3.0/examples.test.js
+++ b/tests/v3.0/examples.test.js
@@ -1,0 +1,27 @@
+import { readdirSync, readFileSync } from "node:fs";
+import YAML from "yaml";
+import { validate, setMetaSchemaOutputFormat } from "@hyperjump/json-schema/openapi-3-0";
+import { BASIC } from "@hyperjump/json-schema/experimental";
+import { describe, test, expect } from "vitest";
+
+const parseYamlFromFile = (filePath) => {
+    const schemaYaml = readFileSync(filePath, "utf8");
+    return YAML.parse(schemaYaml, { prettyErrors: true });
+};
+
+setMetaSchemaOutputFormat(BASIC);
+
+const validateOpenApi = await validate("./schemas/v3.0/schema.json");
+const folder = './examples/v3.0/';
+
+describe("v3.0 - Validate examples", async () => {
+    readdirSync(folder, { withFileTypes: true })
+        .filter((entry) => entry.isFile() && /\.yaml$/.test(entry.name))
+        .forEach((entry) => {
+            test(entry.name, () => {
+                const instance = parseYamlFromFile(folder + entry.name);
+                const output = validateOpenApi(instance, BASIC);
+                expect(output.valid).to.equal(true);
+            });
+        });
+});

--- a/tests/v3.1/examples.test.js
+++ b/tests/v3.1/examples.test.js
@@ -1,0 +1,27 @@
+import { readdirSync, readFileSync } from "node:fs";
+import YAML from "yaml";
+import { validate, setMetaSchemaOutputFormat } from "@hyperjump/json-schema/openapi-3-1";
+import { BASIC } from "@hyperjump/json-schema/experimental";
+import { describe, test, expect } from "vitest";
+
+const parseYamlFromFile = (filePath) => {
+    const schemaYaml = readFileSync(filePath, "utf8");
+    return YAML.parse(schemaYaml, { prettyErrors: true });
+};
+
+setMetaSchemaOutputFormat(BASIC);
+
+const validateOpenApi = await validate("./schemas/v3.1/schema.json");
+const folder = './examples/v3.1/';
+
+describe("v3.1 - Validate examples", async () => {
+    readdirSync(folder, { withFileTypes: true })
+        .filter((entry) => entry.isFile() && /\.yaml$/.test(entry.name))
+        .forEach((entry) => {
+            test(entry.name, () => {
+                const instance = parseYamlFromFile(folder + entry.name);
+                const output = validateOpenApi(instance, BASIC);
+                expect(output.valid).to.equal(true);
+            });
+        });
+});

--- a/tests/v3.1/schema.test.mjs
+++ b/tests/v3.1/schema.test.mjs
@@ -4,14 +4,12 @@ import { validate, setMetaSchemaOutputFormat } from "@hyperjump/json-schema/open
 import { BASIC } from "@hyperjump/json-schema/experimental";
 import { describe, test, expect } from "vitest";
 
-
 const parseYamlFromFile = (filePath) => {
   const schemaYaml = readFileSync(filePath, "utf8");
   return YAML.parse(schemaYaml, { prettyErrors: true });
 };
 
 setMetaSchemaOutputFormat(BASIC);
-// setShouldValidateSchema(false);
 
 const validateOpenApi = await validate("./schemas/v3.1/schema.json");
 


### PR DESCRIPTION
Closes https://github.com/OAI/OpenAPI-Specification/issues/1739

> [Script to validate JSON Schema instances against JSON Schema metaschema has been written and tested. Will be included in PR for HTML spec / registry go live.](https://github.com/OAI/OpenAPI-Specification/issues/1739#issuecomment-440813393)

From my understanding, this is covered now by the validation library itself `@hyperjump/json-schema`.

> [Also script to validate examples against OAS schema instances, ditto.](https://github.com/OAI/OpenAPI-Specification/issues/1739#issuecomment-440845307)

This is now covered by https://github.com/OAI/OpenAPI-Specification/commit/983e12e534695f55af58f0038d99eb6b7c08a05c and https://github.com/OAI/OpenAPI-Specification/commit/e60a11359f881117021794bf285ed9c317b25d45

Last but not least, I have made some small clean-ups in the existing tests here https://github.com/OAI/OpenAPI-Specification/commit/1e36a8bbd8e3ed96567d015cc485e89b793dd7ce