### PR TITLE
Add appendix "Informative references" to published spec documents

### DIFF
--- a/scripts/md2html/md2html.js
+++ b/scripts/md2html/md2html.js
@@ -47,7 +47,6 @@ const md = require('markdown-it')({
     }
 });
 
-function preface(title,options) {
 const localBiblio = {};
 const baseURL = 'https://github.com/OAI/OpenAPI-Specification/';
 
@@ -81,6 +80,7 @@ md.renderer.rules.link_open = function(tokens, idx, options, env, self) {
     return self.renderToken(tokens, idx, options);
 };
 
+function preface(title, options, localBublio) {
     const respec = {
         specStatus: "base",
         editors: maintainers,
@@ -97,7 +97,8 @@ md.renderer.rules.link_open = function(tokens, idx, options, env, self) {
         noTOC: false,
         lint: false,
         additionalCopyrightHolders: "the Linux Foundation",
-        includePermalinks: true
+        includePermalinks: true,
+        localBiblio
     };
 
     let preface = `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>${md.utils.escapeHtml(title)}</title>`;
@@ -345,7 +346,7 @@ for (let l in lines) {
     lines[l] = (linkTarget ? linkTarget : '') + line;
 }
 
-s = preface(`OpenAPI Specification v${argv.subtitle} | Introduction, Definitions, & More`,argv)+'\n\n'+lines.join('\n');
+s = preface(`OpenAPI Specification v${argv.subtitle} | Introduction, Definitions, & More`, argv, localBiblio)+'\n\n'+lines.join('\n');
 let out = md.render(s);
 out = out.replace(/\[([RGB])\]/g,function(match,group1){
     console.warn('Fixing',match,group1);

--- a/scripts/md2html/md2html.js
+++ b/scripts/md2html/md2html.js
@@ -49,6 +49,7 @@ const md = require('markdown-it')({
 
 const localBiblio = {};
 const baseURL = 'https://github.com/OAI/OpenAPI-Specification/';
+const formativeRFC = 'https://tools.ietf.org';
 
 md.renderer.rules.link_open = function(tokens, idx, options, env, self) {
     if (
@@ -62,7 +63,7 @@ md.renderer.rules.link_open = function(tokens, idx, options, env, self) {
         if (
             url.startsWith('http')
             && !url.startsWith(baseURL)
-            && !url.startsWith('https://tools.ietf.org')
+            && !url.startsWith(formativeRFC)
         ) {
             localBiblio[text] = {
                 title: text,

--- a/scripts/md2html/md2html.js
+++ b/scripts/md2html/md2html.js
@@ -49,7 +49,6 @@ const md = require('markdown-it')({
 
 const localBiblio = {};
 const baseURL = 'https://github.com/OAI/OpenAPI-Specification/';
-const formativeRFC = 'https://tools.ietf.org';
 
 md.renderer.rules.link_open = function(tokens, idx, options, env, self) {
     if (
@@ -58,14 +57,16 @@ md.renderer.rules.link_open = function(tokens, idx, options, env, self) {
         && tokens[idx + 2] && tokens[idx + 2].type === 'link_close'
     ) {
         const text = tokens[idx + 1].content;
+        // Reference must not contain any whitespace.
+        const reference = text.replace(/\s+/g, '-');
         const url = tokens[idx].attrs[tokens[idx].attrIndex('href')][1];
 
         if (
             url.startsWith('http')
             && !url.startsWith(baseURL)
-            && !url.startsWith(formativeRFC)
+            && !text.includes('RFC')
         ) {
-            localBiblio[text] = {
+            localBiblio[reference] = {
                 title: text,
                 href: url
             };
@@ -74,7 +75,7 @@ md.renderer.rules.link_open = function(tokens, idx, options, env, self) {
             tokens[idx + 1].content = '';
             tokens[idx + 2].hidden = true;
 
-            return '[[' + text + ']]';
+            return '[[' + reference + ']]';
         }
     }
 

--- a/scripts/md2html/md2html.js
+++ b/scripts/md2html/md2html.js
@@ -48,6 +48,39 @@ const md = require('markdown-it')({
 });
 
 function preface(title,options) {
+const localBiblio = {};
+const baseURL = 'https://github.com/OAI/OpenAPI-Specification/';
+
+md.renderer.rules.link_open = function(tokens, idx, options, env, self) {
+    if (
+        idx > 0
+        && tokens[idx + 1] && tokens[idx + 1].type === 'text'
+        && tokens[idx + 2] && tokens[idx + 2].type === 'link_close'
+    ) {
+        const text = tokens[idx + 1].content;
+        const url = tokens[idx].attrs[tokens[idx].attrIndex('href')][1];
+
+        if (
+            url.startsWith('http')
+            && !url.startsWith(baseURL)
+            && !url.startsWith('https://tools.ietf.org')
+        ) {
+            localBiblio[text] = {
+                title: text,
+                href: url
+            };
+
+            // Do not show url text and closing html tag.
+            tokens[idx + 1].content = '';
+            tokens[idx + 2].hidden = true;
+
+            return '[[' + text + ']]';
+        }
+    }
+
+    return self.renderToken(tokens, idx, options);
+};
+
     const respec = {
         specStatus: "base",
         editors: maintainers,
@@ -55,9 +88,9 @@ function preface(title,options) {
         publishDate: options.publishDate,
         subtitle: 'Version '+options.subtitle,
         processVersion: 2017,
-        edDraftURI: "https://github.com/OAI/OpenAPI-Specification/",
+        edDraftURI: baseURL,
         github: {
-            repoURL: "https://github.com/OAI/OpenAPI-Specification/",
+            repoURL: baseURL,
             branch: "master"
         },
         shortName: "OAS",


### PR DESCRIPTION
Closes https://github.com/OAI/OpenAPI-Specification/issues/3740

This PR parses every link that is not local and is not an formative RFC using the format that the Respec expects. See https://respec.org/docs/#:~:text=ReSpec%20uses%20the%20context%20of,reference%20is%20treated%20as%20normative.

It achieves it by using the [localBiblio](https://respec.org/docs/#localBiblio) feature of the Respec. Although, its usage is discouraged I couldn't find any other native way of adding a Informative list. Also, it is only discouraged to force you to apply your references to their free database.

You can check its result here: https://codebeautify.org/htmlviewer/y247136c8

## A few notes
1. `path.id` is appearing as a link is fixed in another [PR](https://github.com/OAI/OpenAPI-Specification/pull/3708)
2. The first entry in the list ( `1.2` ) is basically the referenced version in the YAML spec. We could change the url's text to contain more data so it would be more user friendly. For example, `YAML-Version-12`.
3. You might have noticed that all references have their spaces replaced with dashes. This is because the Respec does not allow spaces in the references.
4. After this PR is merged we might need to change how we handle the formative links since we will have 2 places where we handle links. 