### PR TITLE
Format Registry documentation is not accurate / well published

### DIFF
--- a/api/format.json
+++ b/api/format.json
@@ -10,7 +10,7 @@ parent: API
   "description": "{{ page.description }}",
   "url": "{{ site.baseurl }}{{ page.url }}",
   "owner": "{{ page.owner }}",
-  "base_type": "{{ page.base_type" }}"
+  "base_type": ["{{ page.base_type | join: '", "' }}"],
 }{% unless forloop.last %},{% endunless %}
 {% endfor %}
 }

--- a/registries/_format/sf-integer.md
+++ b/registries/_format/sf-integer.md
@@ -4,7 +4,7 @@ issue:
 description: structured fields integer as defined in [RFC8941]
 source: https://www.rfc-editor.org/rfc/rfc8941#name-integers
 source_label: RFC 8941
-base_type: integer, number
+base_type: [integer, number]
 layout: default
 ---
 

--- a/registry/format.md
+++ b/registry/format.md
@@ -24,6 +24,6 @@ Please raise a [Pull-Request](https://github.com/OAI/OpenAPI-Specification/pulls
 
 |Value|Description|Type|Source|Deprecated|
 |---|---|----|---|---|----|
-{% for value in site.format %}| <a href="./{{ value.slug }}.html">{{ value.slug }}</a> | {{ value.description }} | {{ value.base_type }} | {% if value.source %}<a href="{{ value.source }}">{% if value.source_label %}{{value.source_label}}{% else %}Open{% endif %}</a>{% endif %} | {% if value.deprecated_note %}Yes{% else %}No{% endif %} |
+{% for value in site.format %}| <a href="./{{ value.slug }}.html">{{ value.slug }}</a> | {{ value.description }} | {{ value.base_type | join: ', ' }} | {% if value.source %}<a href="{{ value.source }}">{% if value.source_label %}{{value.source_label}}{% else %}Open{% endif %}</a>{% endif %} | {% if value.deprecated_note %}Yes{% else %}No{% endif %} |
 {% endfor %}
 


### PR DESCRIPTION
Closes https://github.com/OAI/OpenAPI-Specification/issues/3703

i have changed the format of the `base_type` in the produced JSON to array for all the formats since I think we should be consistent with the property types between the formats.