### PR TITLE
[new] scripts/update-schema-latest

### DIFF
--- a/scripts/update-schema-latest
+++ b/scripts/update-schema-latest
@@ -145,13 +145,13 @@ class Options < OptionParser
 
   def check_pattern(value, option, pattern)
     if value !~ pattern then
-      error_exit "ERROR: The given string '#{value}' does not match the expected #{option} pattern."
+      abort "ERROR: The given string '#{value}' does not match the expected #{option} pattern."
     end
   end
 
   def error_if_missing(value, option)
     if value.nil?
-      error_exit "ERROR: '#{option}' is missing."
+      abort "ERROR: '#{option}' is missing."
     end
   end
 
@@ -172,15 +172,6 @@ end
 
 
 #------------------------------------------------------------
-# error_exit
-#------------------------------------------------------------
-def error_exit(message)
-  $stderr.puts message
-  exit false
-end
-
-
-#------------------------------------------------------------
 # execute_command
 #------------------------------------------------------------
 def execute_command(options, command)
@@ -191,7 +182,7 @@ def execute_command(options, command)
   system command unless options.dry_run
 
   if !options.dry_run && $?.exitstatus != 0
-    error_exit "ERROR: The command failed."
+    abort "ERROR: The command failed."
   end
 end
 

--- a/scripts/update-schema-latest
+++ b/scripts/update-schema-latest
@@ -1,0 +1,261 @@
+#!/usr/bin/env ruby
+#
+# OVERVIEW
+# --------
+#
+#   This script does the following.
+#
+#     1. Switch to the 'gh-pages' branch.
+#
+#     2. Copy "schemas/v{major}.{minor}/schema.json" in the 'main' branch to
+#        "oas/{major}.{minor}/schema/{YYYY-MM-DD}" in the 'gh-pages' branch.
+#        The value of {YYYY-MM-DD} is extracted from the '$id' property in
+#        the schema.json file.
+#
+#     3. Create a symbolic link "latest" under "oas/{major}.{minor}/schema"
+#        that points to the "{YYYY-MM-DD}" file.
+#
+#     4. Copy "schemas/v{major}.{minor}/schema-base.json" in the 'main' branch to
+#        "oas/{major}.{minor}/schema-base/{YYYY-MM-DD}" in the 'gh-pages' branch.
+#        The value of {YYYY-MM-DD} is extracted from the '$id' property in
+#        the schema-base.json file.
+#
+#     5. Create a symbolic link "latest" under "oas/{major}.{minor}/schema-base"
+#        that points to the "{YYYY-MM-DD}" file.
+#
+# USAGE
+# -----
+#
+#   update-schema-latest
+#     --version VERSION   # -v VERSION (required)
+#     --dry-run           # -n
+#     --quiet             # -q
+#     --help              # -h
+#
+# EXAMPLE
+# -------
+#
+#   ./scripts/update-schema-latest -v 3.1
+#
+#   If the above command line is executed, the following external commands
+#   are invoked by the script. This example assumes that the value of the
+#   '$id' property in the schema files ends with '2022-10-07'.
+#
+#     git checkout gh-pages
+#
+#     git show main:schemas/v3.1/schema.json > oas/3.1/schema/2022-10-07
+#
+#     (cd oas/3.1/schema && ln -sf 2022-10-07 latest)
+#
+#     git show main:schemas/v3.1/schema-base.json > oas/3.1/schema-base/2022-10-07
+#
+#     (cd oas/3.1/schema-base && ln -sf 2022-10-07 latest)
+#
+# NOTE
+# ----
+#
+#   This script requires the following external commands.
+#
+#     - git
+#     - jq
+#
+
+
+require 'bundler/inline'
+
+gemfile do
+  source 'https://rubygems.org'
+  gem 'optparse'
+end
+
+
+#------------------------------------------------------------
+# main
+#------------------------------------------------------------
+def main(args)
+  # Process the command line options.
+  options = Options.process(args)
+
+  # 1. Check out the 'gh-pages' branch.
+  checkout_gh_pages(options)
+
+  # 2. Copy main:schemas/v{major}.{minor}/schema.json to
+  #    oas/{major}.{minor}/schema/YYYY-MM-DD.
+  #
+  # 3. Update oas/{major}.{minor}/schema/latest (symlink) to
+  #    make it point to YYYY-MM-DD.
+  update_schema(options)
+
+  # 4. Copy main:schemas/v{major}.{minor}/schema-base.json to
+  #    oas/{major}.{minor}/schema-base/YYYY-MM-DD.
+  #
+  # 5. Update oas/{major}.{minor}/schema-base/latest (symlink) to
+  #    make it point to YYYY-MM-DD.
+  update_schema_base(options)
+end
+
+
+#------------------------------------------------------------
+# Ver
+#------------------------------------------------------------
+class Ver
+  attr_reader :major, :minor
+
+  def initialize(version)
+    m = /^(\d+)\.(\d+)$/.match(version)
+
+    @major = m[1]
+    @minor = m[2]
+  end
+end
+
+
+#------------------------------------------------------------
+# Options
+#------------------------------------------------------------
+class Options < OptionParser
+  DESC_VERSION = "specifies the target version in the 'major.minor' format. For example, '3.1'. This option is mandatory."
+  DESC_DRY_RUN = "turns on the dry-run mode that shows external commands to execute but does not actually execute them."
+  DESC_QUIET   = "turns on the quiet mode."
+
+  attr_reader :version, :dry_run, :quiet
+
+  def initialize
+    super
+
+    @version = nil
+    @dry_run = false
+    @quiet   = false
+
+    self.on('-v VERSION', '--version VERSION', DESC_VERSION) do |value|
+      check_pattern(value, 'version', /^\d+\.\d+$/)
+      @version = Ver.new(value)
+    end
+
+    self.on('-n', '--dry-run', DESC_DRY_RUN) do
+      @dry_run = true
+    end
+
+    self.on('-q', '--quiet', DESC_QUIET) do
+      @quiet = true
+    end
+  end
+
+  private
+
+  def check_pattern(value, option, pattern)
+    if value !~ pattern then
+      error_exit "ERROR: The given string '#{value}' does not match the expected #{option} pattern."
+    end
+  end
+
+  def error_if_missing(value, option)
+    if value.nil?
+      error_exit "ERROR: '#{option}' is missing."
+    end
+  end
+
+  public
+
+  def validate
+    error_if_missing(@version, '--version VERSION')
+  end
+
+  def self.process(args)
+    options = Options.new
+    options.parse(args)
+    options.validate()
+
+    return options
+  end
+end
+
+
+#------------------------------------------------------------
+# error_exit
+#------------------------------------------------------------
+def error_exit(message)
+  $stderr.puts message
+  exit false
+end
+
+
+#------------------------------------------------------------
+# execute_command
+#------------------------------------------------------------
+def execute_command(options, command)
+  # Print the command unless the quiet mode is on.
+  puts command unless options.quiet
+
+  # Execute the command unless the dry-run mode is on.
+  system command unless options.dry_run
+
+  if !options.dry_run && $?.exitstatus != 0
+    error_exit "ERROR: The command failed."
+  end
+end
+
+
+#------------------------------------------------------------
+# checkout_gh_pages
+#------------------------------------------------------------
+def checkout_gh_pages(options)
+  # The command to checkout the 'gh-pages' branch.
+  command = "git checkout gh-pages"
+
+  # Execute the command.
+  execute_command(options, command)
+end
+
+
+#------------------------------------------------------------
+# update_schema
+#------------------------------------------------------------
+def update_schema(options)
+  update(options, "schema")
+end
+
+
+#------------------------------------------------------------
+# update_schema_base
+#------------------------------------------------------------
+def update_schema_base(options)
+  update(options, "schema-base")
+end
+
+
+#------------------------------------------------------------
+# update
+#------------------------------------------------------------
+def update(options, file_base)
+  # Version
+  ver = options.version
+
+  # The source file in the 'main' branch.
+  src_file = "schemas/v#{ver.major}.#{ver.minor}/#{file_base}.json"
+
+  # Extract the 'YYYY-MM-DD' part of the "$id" property.
+  date = `git show main:#{src_file} | jq -rj '."$id"|split("/")|last'`
+
+  # The destination directory in the 'gh-pages' branch.
+  dst_dir = "oas/#{ver.major}.#{ver.minor}/#{file_base}"
+
+  # The destination file in the 'gh-pages' branch.
+  dst_file = "#{dst_dir}/#{date}"
+
+  # The command to copy the source file to the destination file.
+  copy_command = "git show main:#{src_file} > #{dst_file}"
+
+  # The command to update the 'latest' file.
+  link_command = "(cd #{dst_dir} && ln -sf #{date} latest)"
+
+  # Execute the commands.
+  execute_command(options, copy_command)
+  execute_command(options, link_command)
+end
+
+
+#------------------------------------------------------------
+# Entry Point
+#------------------------------------------------------------
+main(ARGV)


### PR DESCRIPTION
This script does the following.

  1. Switch to the 'gh-pages' branch.

  2. Copy "schemas/v{major}.{minor}/schema.json" in the 'main' branch to "oas/{major}.{minor}/schema/{YYYY-MM-DD}" in the 'gh-pages' branch. The value of {YYYY-MM-DD} is extracted from the '$id' property in the schema.json file.

  3. Create a symbolic link "latest" under "oas/{major}.{minor}/schema" that points to the "{YYYY-MM-DD}" file.

  4. Copy "schemas/v{major}.{minor}/schema-base.json" in the 'main' branch to "oas/{major}.{minor}/schema-base/{YYYY-MM-DD}" in the 'gh-pages' branch. The value of {YYYY-MM-DD} is extracted from the '$id' property in the schema-base.json file.

  5. Create a symbolic link "latest" under "oas/{major}.{minor}/schema-base" that points to the "{YYYY-MM-DD}" file.

<!--
Thank you for contributing to the OpenAPI Specification!

Please make certain you are submitting your PR on the correct
branch and file:

* 3.0.x spec: v3.0.4-dev branch, versions/3.0.4.md
* 3.1.x spec: v3.1.1-dev branch, versions/3.1.1.md
* 3.2.0 spec: v3.2.0-dev branch, versions/3.2.0.md
* 3.0 schema: main branch, schemas/v3.0/...
* 3.1 schema: main branch, schemas/v3.1/...
* registry templates: gh-pages branch, registry/...
* registry contents: gh-pages branch, registries/...

Note that we do not accept changes to published specifications.
-->
