### PR TITLE
Clarify constraints on Param Obj fields (3.2.0 port of #3760)

### DIFF
--- a/versions/3.2.0.md
+++ b/versions/3.2.0.md
@@ -1086,7 +1086,7 @@ Field Name | Type | Description
 
 ###### Fixed Fields and considerations for use with `content`
 
-For more complex scenarios, the [`content`](#parameterContent) property can define the media type and schema of the parameter, as well as give examples of it use.
+For more complex scenarios, the [`content`](#parameterContent) property can define the media type and schema of the parameter, as well as give examples of its use.
 
 Field Name | Type | Description
 ---|:---:|---

--- a/versions/3.2.0.md
+++ b/versions/3.2.0.md
@@ -1053,6 +1053,14 @@ There are four possible parameter locations specified by the `in` field:
 
 
 ##### Fixed Fields
+
+The rules for serialization of the parameter are specified in one of two ways.
+Parameter Objects MUST include either a `content` field or a `schema` field, but not both.
+
+###### Common Fixed Fields
+
+These fields MAY be used with either `content` or `schema`.
+
 Field Name | Type | Description
 ---|:---:|---
 <a name="parameterName"></a>name | `string` | **REQUIRED**. The name of the parameter. Parameter names are *case sensitive*. <ul><li>If [`in`](#parameterIn) is `"path"`, the `name` field MUST correspond to a template expression occurring within the [path](#pathsPath) field in the [Paths Object](#pathsObject). See [Path Templating](#pathTemplating) for further information.<li>If [`in`](#parameterIn) is `"header"` and the `name` field is `"Accept"`, `"Content-Type"` or `"Authorization"`, the parameter definition SHALL be ignored.<li>For all other cases, the `name` corresponds to the parameter name used by the [`in`](#parameterIn) property.</ul>
@@ -1062,8 +1070,10 @@ Field Name | Type | Description
 <a name="parameterDeprecated"></a> deprecated | `boolean` | Specifies that a parameter is deprecated and SHOULD be transitioned out of usage. Default value is `false`.
 <a name="parameterAllowEmptyValue"></a> allowEmptyValue | `boolean` | Sets the ability to pass empty-valued parameters. This is valid only for `query` parameters and allows sending a parameter with an empty value. Default value is `false`. If [`style`](#parameterStyle) is used, and if behavior is `n/a` (cannot be serialized), the value of `allowEmptyValue` SHALL be ignored. Use of this property is NOT RECOMMENDED, as it is likely to be removed in a later revision.
 
-The rules for serialization of the parameter are specified in one of two ways.
+###### Fixed Fields for use with `schema`
+
 For simpler scenarios, a [`schema`](#parameterSchema) and [`style`](#parameterStyle) can describe the structure and syntax of the parameter.
+When `example` or `examples` are provided in conjunction with the `schema` object, the example MUST follow the prescribed serialization strategy for the parameter.
 
 Field Name | Type | Description
 ---|:---:|---
@@ -1074,10 +1084,9 @@ Field Name | Type | Description
 <a name="parameterExample"></a>example | Any | Example of the parameter's potential value. The example SHOULD match the specified schema and encoding properties if present. The `example` field is mutually exclusive of the `examples` field. Furthermore, if referencing a `schema` that contains an example, the `example` value SHALL _override_ the example provided by the schema. To represent examples of media types that cannot naturally be represented in JSON or YAML, a string value can contain the example with escaping where necessary.
 <a name="parameterExamples"></a>examples | Map[ `string`, [Example Object](#exampleObject) \| [Reference Object](#referenceObject)] | Examples of the parameter's potential value. Each example SHOULD contain a value in the correct format as specified in the parameter encoding. The `examples` field is mutually exclusive of the `example` field. Furthermore, if referencing a `schema` that contains an example, the `examples` value SHALL _override_ the example provided by the schema.
 
-For more complex scenarios, the [`content`](#parameterContent) property can define the media type and schema of the parameter.
-A parameter MUST contain either a `schema` property, or a `content` property, but not both.
-When `example` or `examples` are provided in conjunction with the `schema` object, the example MUST follow the prescribed serialization strategy for the parameter.
+###### Fixed Fields and considerations for use with `content`
 
+For more complex scenarios, the [`content`](#parameterContent) property can define the media type and schema of the parameter, as well as give examples of it use.
 
 Field Name | Type | Description
 ---|:---:|---


### PR DESCRIPTION
* Ports #3760 
* Fixes #1542 

This makes the relational requirements of `content` vs `schema` and associated fields more clear.  The mutual exclusivity requirement is moved up to the top of the Fixed Fields section, and each table table is given a subsection clarifying its meaning.  This makes it easier to follow the multi-table format, which is unusual within the OAS.

The commentary on `example` and `examples` is moved to the section on `schema` and related parameters as it appears to only apply in that case.
