### PR TITLE
Clarify allowEmptyValue further

### DIFF
--- a/versions/3.0.4.md
+++ b/versions/3.0.4.md
@@ -1044,7 +1044,7 @@ Field Name | Type | Description
 <a name="parameterDescription"></a>description | `string` | A brief description of the parameter. This could contain examples of use. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
 <a name="parameterRequired"></a>required | `boolean` | Determines whether this parameter is mandatory. If the [parameter location](#parameterIn) is `"path"`, this property is **REQUIRED** and its value MUST be `true`. Otherwise, the property MAY be included and its default value is `false`.
 <a name="parameterDeprecated"></a> deprecated | `boolean` | Specifies that a parameter is deprecated and SHOULD be transitioned out of usage. Default value is `false`.
-<a name="parameterAllowEmptyValue"></a> allowEmptyValue | `boolean` | Sets the ability to pass empty-valued parameters. This is valid only for `query` parameters and allows sending a parameter with an empty value. Default value is `false`. If [`style`](#parameterStyle) is used, and if behavior is `n/a` (cannot be serialized), the value of `allowEmptyValue` SHALL be ignored. Use of this property is NOT RECOMMENDED, as it is likely to be removed in a later revision.
+<a name="parameterAllowEmptyValue"></a> allowEmptyValue | `boolean` | If `true`, allows passing empty-valued parameters regardless of `schema` or `content`. This is valid only for `query` parameters. Default value is `false`. If [`style`](#parameterStyle) is used, and if behavior is `n/a` (cannot be serialized), the value of `allowEmptyValue` SHALL be ignored. Use of this property is NOT RECOMMENDED, as it is likely to be removed in a later revision; instead, ensure that the parameter's schema accepts any desired empty value(s).
 
 ###### Fixed Fields for use with `schema`
 


### PR DESCRIPTION
_[**EDIT:** See #3803 for an alternative based on discussion below.]_

* Fixes #3792 

Make it clear that the default value does not do anything, and the non-default value (true) changes the normal expected behavior of the "schema" or "content" fields.  This also explains why the keyword is safe to deprecate, as "schema" and "content" can be used to allow empty values in a more typical way.

<!--
Thank you for contributing to the OpenAPI Specification!

Please make certain you are submitting your PR on the correct
branch and file:

* 3.0.x spec: v3.0.4-dev branch, versions/3.0.4.md
* 3.1.x spec: v3.1.1-dev branch, versions/3.1.1.md
* 3.2.0 spec: v3.2.0-dev branch, versions/3.2.0.md
* 3.0 schema: main branch, schemas/v3.0/...
* 3.1 schema: main branch, schemas/v3.1/...
* registry templates: gh-pages branch, registry/...
* registry contents: gh-pages branch, registries/...

Note that we do not accept changes to published specifications.
-->
