### PR TITLE
Fix "it" -> "its" typo

### DIFF
--- a/versions/3.0.4.md
+++ b/versions/3.0.4.md
@@ -1062,7 +1062,7 @@ Field Name | Type | Description
 
 ###### Fixed Fields and considerations for use with `content`
 
-For more complex scenarios, the [`content`](#parameterContent) property can define the media type and schema of the parameter, as well as give examples of it use.
+For more complex scenarios, the [`content`](#parameterContent) property can define the media type and schema of the parameter, as well as give examples of its use.
 
 Field Name | Type | Description
 ---|:---:|---


### PR DESCRIPTION
This was missed in the 3.0.4 PR for this change, but caught in the 3.1.1 and 3.2.0 versions.