### PR TITLE
Correctly handle appendicies in md2html

### DIFF
--- a/scripts/md2html/md2html.js
+++ b/scripts/md2html/md2html.js
@@ -293,18 +293,22 @@ for (let l in lines) {
         //if (delta<0) delta = -1;
         if (Math.abs(delta)>1) console.warn(delta,line);
         let prefix = '';
+        let newSection = '<section>';
+        if (line.includes('Appendix')) {
+            newSection = '<section class="appendix">';
+        }
 
         // heading level delta is either 0 or is +1/-1, or we're in respec mode
         /* respec insists on <section>...</section> breaks around headings */
 
         if (delta === 0) {
-            prefix = '</section><section>';
+            prefix = '</section>'+newSection;
         }
         else if (delta > 0) {
-            prefix = '<section>'.repeat(delta);
+            prefix = newSection.repeat(delta);
         }
         else {
-            prefix = '</section>'+('</section>').repeat(Math.abs(delta))+'<section>';
+            prefix = '</section>'+('</section>').repeat(Math.abs(delta))+newSection;
         }
         prevHeading = heading;
         line = prefix+md.render(line);


### PR DESCRIPTION
We have an Appendix A that was getting treated as a numbered section, with a second Appendix A generated for references.

This now correctly detects sections with "Appendix" in the name, and assigns letters appropriately.  The generated references section is now Appendix B (and will always be the last appendix).

<!--
Thank you for contributing to the OpenAPI Specification!

Please make certain you are submitting your PR on the correct
branch and file:

* 3.0.x spec: v3.0.4-dev branch, versions/3.0.4.md
* 3.1.x spec: v3.1.1-dev branch, versions/3.1.1.md
* 3.2.0 spec: v3.2.0-dev branch, versions/3.2.0.md
* 3.0 schema: main branch, schemas/v3.0/...
* 3.1 schema: main branch, schemas/v3.1/...
* registry templates: gh-pages branch, registry/...
* registry contents: gh-pages branch, registries/...

Note that we do not accept changes to published specifications.
-->
