### PR TITLE
Clarify entry/complete document terminology (3.0.4)

### DIFF
--- a/versions/3.0.4.md
+++ b/versions/3.0.4.md
@@ -146,7 +146,10 @@ In order to preserve the ability to round-trip between YAML and JSON formats, YA
 
 ### <a name="documentStructure"></a>OpenAPI Description Structure
 
-An OpenAPI Description (OAD) MAY be made up of a single document or be divided into multiple, connected parts at the discretion of the author. In the latter case, [Reference Object](#referenceObject) and [Path Item Object](#pathItemObject) `$ref` keywords, as well as the [Link Object](#linkObject) `operationRef` keyword, are used.  In a multi-document description, the document containing the [OpenAPI Object](#oasObject) is known as the **entry OpenAPI document.**
+An OpenAPI Description (OAD) MAY be made up of a single document or be divided into multiple, connected parts at the discretion of the author. In the latter case, [Reference Object](#referenceObject) and [Path Item Object](#pathItemObject) `$ref` keywords, as well as the [Link Object](#linkObject) `operationRef` keyword, are used.
+
+Any document consisting entirely of an OpenAPI Object is known as a **complete OpenAPI document**.
+In a multi-document description, the document containing the [OpenAPI Object](#oasObject) where parsing begins for a specific API's description is known as that API's **entry OpenAPI document**, or simply **entry document**.
 
 It is RECOMMENDED that the entry OpenAPI document be named: `openapi.json` or `openapi.yaml`.
 


### PR DESCRIPTION
@ralfhandl caught that our phrasing here seemed to imply only one document with an OpenAPI Object, which was emphatically not the intention.

Clarifies that there can be multiple complete OpenAPI documents, only one of which is an entry OpenAPI document.  The term "complete OpenAPI document" is useful in other guidance (to be tidied up in a later PR as it is currently only mentioned in 3.1.1).

Also added "entry document" as shorthand for "entry OpenAPI document" because I know I've used it that way and it reads better in some contexts.

<!--
Thank you for contributing to the OpenAPI Specification!

Please make certain you are submitting your PR on the correct
branch and file:

* 3.0.x spec: v3.0.4-dev branch, versions/3.0.4.md
* 3.1.x spec: v3.1.1-dev branch, versions/3.1.1.md
* 3.2.0 spec: v3.2.0-dev branch, versions/3.2.0.md
* 3.0 schema: main branch, schemas/v3.0/...
* 3.1 schema: main branch, schemas/v3.1/...
* registry templates: gh-pages branch, registry/...
* registry contents: gh-pages branch, registries/...

Note that we do not accept changes to published specifications.
-->
