### PR TITLE
Allow URI-references for Security Requirements (3.2.0)

### DIFF
--- a/versions/3.2.0.md
+++ b/versions/3.2.0.md
@@ -3558,7 +3558,9 @@ flows:
 #### <a name="securityRequirementObject"></a>Security Requirement Object
 
 Lists the required security schemes to execute this operation.
-The name used for each property MUST correspond to a security scheme declared in the [Security Schemes](#componentsSecuritySchemes) under the [Components Object](#componentsObject).
+The name used for each property MUST either correspond to a security scheme declared in the [Security Schemes](#componentsSecuritySchemes) under the [Components Object](#componentsObject), or be the URI of a Security Scheme Object.
+Property names that match the syntax of a component name under the Components Object MUST be treated as a component name.
+To reference a Security Scheme with a single-segment relative URI reference (e.g. `foo`), use the `.` path segment (e.g. `./foo`).
 
 Security Requirement Objects that contain multiple schemes require that all schemes MUST be satisfied for a request to be authorized.
 This enables support for scenarios where multiple query parameters or HTTP headers are required to convey security information.
@@ -3569,7 +3571,7 @@ When a list of Security Requirement Objects is defined on the [OpenAPI Object](#
 
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="securityRequirementsName"></a>{name} | [`string`] | Each name MUST correspond to a security scheme which is declared in the [Security Schemes](#componentsSecuritySchemes) under the [Components Object](#componentsObject). If the security scheme is of type `"oauth2"` or `"openIdConnect"`, then the value is a list of scope names required for the execution, and the list MAY be empty if authorization does not require a specified scope. For other security scheme types, the array MAY contain a list of role names which are required for the execution, but are not otherwise defined or exchanged in-band.
+<a name="securityRequirementsName"></a>{name} | [`string`] | Each name MUST correspond to a security scheme name or be a URI, as described above. If the security scheme is of type `"oauth2"` or `"openIdConnect"`, then the value is a list of scope names required for the execution, and the list MAY be empty if authorization does not require a specified scope. For other security scheme types, the array MAY contain a list of role names which are required for the execution, but are not otherwise defined or exchanged in-band.
 
 ##### Security Requirement Object Examples
 


### PR DESCRIPTION
_**NOTE:** This is a draft because I was going to make it a proposal, but its **much** shorter to just show the PR than explain it some other way.  See PR #3823 for more context._

Fixes:
* #3776 
* #1972

This allows Security Requirement Objects to reference Security Scheme Objects by URI instead of implicit component name. Without this ability, it is difficult to share Security Schemes in a way that is consistent with re-usable component documents.

This approach provides parity with how the Discriminator Object's `mapping` field works.

<!--
Thank you for contributing to the OpenAPI Specification!

Please make certain you are submitting your PR on the correct
branch and file:

* 3.0.x spec: v3.0.4-dev branch, versions/3.0.4.md
* 3.1.x spec: v3.1.1-dev branch, versions/3.1.1.md
* 3.2.0 spec: v3.2.0-dev branch, versions/3.2.0.md
* 3.0 schema: main branch, schemas/v3.0/...
* 3.1 schema: main branch, schemas/v3.1/...
* registry templates: gh-pages branch, registry/...
* registry contents: gh-pages branch, registries/...

Note that we do not accept changes to published specifications.
-->
