### PR TITLE
Clarify resolving implicit connections (3.1.1)

### DIFF
--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -182,11 +182,54 @@ It is the responsibility of an embedding format to define how to parse embedded 
 
 When parsing an OAD, JSON or YAML objects are parsed into specific Objects (such as [Operation Objects](#operationObject), [Response Objects](#responseObject), [Reference Objects](#referenceObject), etc.) based on the parsing context.  Depending on how references are arranged, a given JSON or YAML object can be parsed in multiple different contexts:
 
-* As a full OpenAPI Description document (an [OpenAPI Object](#oasObject) taking up an entire document)
+* As a complete OpenAPI Description document
 * As the Object type implied by its parent Object within the document
 * As a reference target, with the Object type matching the reference source's context
 
 If the same JSON/YAML object is parsed multiple times and the respective contexts require it to be parsed as _different_ Object types, the resulting behavior is _implementation defined_, and MAY be treated as an error if detected.  An example would be referencing an empty Schema Object under `#/components/schemas` where a Path Item Object is expected, as an empty object is valid for both types.  For maximum interoperability, it is RECOMMENDED that OpenAPI Description authors avoid such scenarios.
+
+#### <a name="resolvingIndirectLinkages"></a>Resolving Indirect Connections
+
+Several features of this specification require resolving a non-URI-based connection to some other part of the OpenAPI Description (OAD).  Most connections to Objects directly under the [OpenAPI Object](#oasObject)'s `components` or `servers` fields, while the Link Object's `operationId` connects to the identically-named field in a Path Item Object.
+
+These connections are easily resolved in single-document OADs, but the resolution process in multi-document OADs has never been spelled out, and is therefore _implementation-defined_, within the constraints described in this section.  In some cases, an unambiguous alternative is available, and OAD authors are RECOMMENDED to always use the alternative:
+
+Source Object | Source | Target Object | Target | Alternative
+------------- | ------ | ------------- | ------ | -----------
+[Security Requirement Object](#securityRequirementObject) | `{name}` | [Components Object](#componentsObject) | [Security Scheme Object](#securitySchemeObject) component name | _n/a_
+[Discriminator Object](#discriminatorObject) | `mapping` _(implicit or by name)_ | Components Object | [Schema Object](#schemaObject) component name | `mapping` _(explicit URI for all instance values)_
+[Link Object](#linkObject) | `operationId` | [Path Item Object](#pathItemObject) | `operationId` | `operationRef`
+[Paths Object](#pathsObject) | _prefix to_ `/{path}` | [Server Object](#serverObject) _at top level_ | `url` | _n/a_
+
+Note that since this version of the OAS requires parsing all documents completely, there is no need to search for Schema Objects using `allOf` to participate in a [Discriminator Object](#discriminatorObject)'s hierarchy.
+When using `mapping` to provide explicit Schema Object URIs, some relative URI-references consisting of a single path segment are also valid component names.
+In such cases OAD authors SHOULD use the `.` path segment (e.g. "`./foo`" instead of "`foo`") to ensure that the `mapping` values are processed as URIs rather than names.
+
+Note also that Server Objects local to Path Item Objects or Operation Objects are always unambiguous.
+
+For resolving indirect connections from a referenced (non-entry) document, it is RECOMMENDED that tools support one or both of the following approaches, and it is likewise RECOMMENDED that OAD authors organize their documents to work well with them.
+
+##### OADs Using Only Complete Documents
+
+The approach in this section is RECOMMENDED for OADs that are composed entirely of complete OpenAPI documents, optionally including standalone JSON Schema documents as long as any Discriminator Objects within them only use explicit `mapping` URIs for all possible values.
+This OAD design is RECOMMENDED when sharing components among multiple OADs.
+
+In this approach, each document is self-contained when resolving components (to that document's `#/components/{type}/{name}`) and global servers (likewise to `#/servers`).  When resolving `operationId`, all Path Item Objects from all parsed documents are considered.
+
+When sharing components among multiple OADs, it is RECOMMENDED to place all shared components, including Path Item Objects, in documents that do _not_ contain `paths`, `webhooks`, or `servers`.
+Other Path Item Objects can still be connected via `operationRef`.
+
+One drawback of this approach is that Security Schemes have to be defined in each document where they are used, as there is no URI-based alternative for resolving them.
+For forward-compatibility with the OAS version 3.2, implementations MAY provide an _opt-in_ configuration setting to support treating [Security Requirement Object](#securityRequirementObject) property names that do not match the syntax for a component name under the Components Object as URIs for the required [Security Scheme Object](#securitySchemeObject).
+
+##### OADs With Only One OpenAPI Object
+
+The approach in this section is RECOMMENDED for OADs where the entry OpenAPI document is the only document containing an OpenAPI Object.
+This approach is most suitable for splitting an otherwise self-contained single-document OAD into multiple documents for author convenience, in which case it is RECOMMENDED to arrange the documents in a directory structure mirroring the structure of a single-document OAD.
+
+In this approach, all component names and global servers are resolved through the entry document, and all `operationId`s are resolved through Path Item Objects reachable through the `paths` or `webhooks` fields.
+
+Since this version of the OAS specification requires complete parsing of all documents, Schema Objects that use `allOf` to participate in another Schema Object's use of `discriminator` SHOULD be recognized and considered to be part of the OAD, even if they are not otherwise directly referenced.
 
 ### <a name="dataTypes"></a>Data Types
 


### PR DESCRIPTION
Fixes:
* #2520 
* #3591 
* #3776 (sort-of, see the last "Reviewer Question" below)
* and various questions no one thought to ask in issues 🙃 

This clarifies how to handle resolving implicit (non-URI-based) connections in multi-document OpenAPI Descriptions.  While the behavior is implementation-defined overall, two approaches are RECOMMENDED for tool developers and OAD authors: one that is best suited for sharing components among OADs, and one that is compatible with pre-3.1 parsing approaches and is convenient for breaking a monolithic document up purely for author convenience.

Note that the term "complete OpenAPI document" has been defined in another change (PR #3820) pending approval on the 3.0.4 branch.

### Reviewer Questions

_This will be taken out of draft when I am confident that we have the right approach.  Also, this will get backported to 3.0.4, but without the full-document part; the backport will be easy once we've agreed on the 3.1 approach._

* For the resolve-within-complete documents approach, I decided that it was most consistent to treat all `operationId`s from all Path Item Objects in any of the documents to be available; we could instead still require that only those reachable via the entry document's `paths` or `webhooks` are considered (in any event, this PR recommends using `operationRef` instead as it has more predictable behavior)
* For the one-OpenAPI-Object-only approach, I went with Path Item Objects reachable through `paths` or `webhooks`, but we could make whole-document as well since all documents are fully parsed
* For the `allOf` usage of the Discriminator Object in both approachs, this makes any Schema Object able to participate in such an arrangement since they are all detectable by the full-document parsing requirement, just like `$id`, `$anchor`, etc. are detectable; it seems worth calling this out as it might be surprising
* The "for forward compatibility with 3.2" bit for the Security Requirement Object is my attempt at a Python-esque "from future import..." for a simple enhancement (see PR #3821) that is easily implemented to make shared component documents much more consistent in 3.1.  ***I am happy to split this into its own PR if it is at all controversial.*** Or even just take it out.  But it felt like such a vexing restriction, and it's easy to address without requiring full 3.2 support (whatever that ends up being).  The reason I added the opt-in part is that someone might rely on getting an error for something that is not a valid component name (and also you have to opt into Python's "from future" imports as well)
