### PR TITLE
Jekyll does not load variables in front-matter

### DIFF
--- a/_includes/alternative-schema-entry.md
+++ b/_includes/alternative-schema-entry.md
@@ -2,7 +2,7 @@
 
 ## {{ page.slug }} - {{ page.description }}
 
-{{ page.summary }}
+{{ include.summary }}
 
 {% if page.issue %}
 ### GitHub Issue

--- a/registries/_alternative-schema/jsonSchema.md
+++ b/registries/_alternative-schema/jsonSchema.md
@@ -2,8 +2,7 @@
 owner: darrelmiller
 issue: 1532
 description: JSON Schema
-summary: The `{{ page.slug }}` `alternativeSchema` `type` refers to [JSON Schema](http://json-schema.org/) in any version.
 layout: default
 ---
 
-{% include alternative-schema-entry.md %}
+{% include alternative-schema-entry.md summary="The `{{ page.slug }}` `alternativeSchema` `type` refers to [JSON Schema](http://json-schema.org/) in any version." %}

--- a/registries/_alternative-schema/xmlSchema.md
+++ b/registries/_alternative-schema/xmlSchema.md
@@ -2,8 +2,7 @@
 owner: darrelmiller
 issue: 1532
 description: xml Schema
-summary: The `{{ page.slug }}` `alternativeSchema` `type` refers to [xml Schema](https://www.w3.org/XML/Schema) in any version.
 layout: default
 ---
 
-{% include alternative-schema-entry.md %}
+{% include alternative-schema-entry.md summary="The `{{ page.slug }}` `alternativeSchema` `type` refers to [xml Schema](https://www.w3.org/XML/Schema) in any version." %}


### PR DESCRIPTION
Jekyll does not support variables in the front-matter. After the merge of this [PR](https://github.com/OAI/OpenAPI-Specification/pull/3799) this is how it is shown:
![image](https://github.com/OAI/OpenAPI-Specification/assets/9512427/ea10a667-8c6f-491e-ba61-9f5a9555de35)

Based on this https://stackoverflow.com/questions/10218779/custom-variables-in-jekyll-front-matter we can pass variables to the included file.
Documentation: https://jekyllrb.com/docs/includes/

