### PR TITLE
Capture allows the usage of curly braces

### DIFF
--- a/registries/_alternative-schema/jsonSchema.md
+++ b/registries/_alternative-schema/jsonSchema.md
@@ -5,4 +5,8 @@ description: JSON Schema
 layout: default
 ---
 
-{% include alternative-schema-entry.md summary="The `{{ page.slug }}` `alternativeSchema` `type` refers to [JSON Schema](http://json-schema.org/) in any version." %}
+{% capture summary %}
+The `{{ page.slug }}` `alternativeSchema` `type` refers to [JSON Schema](http://json-schema.org/) in any version.
+{% endcapture %}
+
+{% include alternative-schema-entry.md summary=summary %}

--- a/registries/_alternative-schema/xmlSchema.md
+++ b/registries/_alternative-schema/xmlSchema.md
@@ -5,4 +5,8 @@ description: xml Schema
 layout: default
 ---
 
-{% include alternative-schema-entry.md summary="The `{{ page.slug }}` `alternativeSchema` `type` refers to [xml Schema](https://www.w3.org/XML/Schema) in any version." %}
+{% capture summary %}
+The `{{ page.slug }}` `alternativeSchema` `type` refers to [xml Schema](https://www.w3.org/XML/Schema) in any version.
+{% endcapture %}
+
+{% include alternative-schema-entry.md summary=summary %}


### PR DESCRIPTION
In this [PR](https://github.com/OAI/OpenAPI-Specification/pull/3825) we tried to bypass the issue that Jekyll does not support variables in the front-matter. What we did instead was to break the syntax, once more: https://github.com/OAI/OpenAPI-Specification/actions/runs/9163554322/job/25192911220.

The documentation even proposes the syntax but i missed it originally ( face-palm ): https://jekyllrb.com/docs/includes/#passing-parameter-variables-to-includes

You can check the rendered results here: https://bellangelo.github.io/OpenAPI-Specification/registry/alternative-schema/xmlSchema.html