### PR TITLE
Encapsulate page layout for extensions

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,8 +20,7 @@ collections:
   extension:
     slug: extension
     name: Specification Extension Registry
-    output: false
-    hidden: true
+    output: true
     permalink: /registry/:collection/:title
   draft-feature:
     slug: draft-feature

--- a/_includes/extension-entry.md
+++ b/_includes/extension-entry.md
@@ -1,0 +1,16 @@
+# <a href="..">{{ page.collection }}</a>
+
+## {{ page.slug }} - {{ page.description }}
+
+{{ include.summary }}
+
+### Schema
+
+```yaml
+{{page.schema}}
+```
+
+### Example
+
+{{ include.example }}
+

--- a/registries/_extension/x-twitter.md
+++ b/registries/_extension/x-twitter.md
@@ -12,7 +12,7 @@ layout: default
 The `x-twitter` extension is used to hold a reference to the API provider's Twitter account. It can appear as a property in the following objects: `{{page.objects|jsonify}}`.
 {% endcapture %}
 
-{%capture example $}
+{% capture example %}
 ```yaml
 openapi: 3.0.0
 info:

--- a/registries/_extension/x-twitter.md
+++ b/registries/_extension/x-twitter.md
@@ -8,20 +8,11 @@ objects: [ "contactObject" ]
 layout: default
 ---
 
-# <a href="..">{{ page.collection }}</a>
-
-## {{ page.slug }} - {{ page.description }}
-
+{% capture summary %}
 The `x-twitter` extension is used to hold a reference to the API provider's Twitter account. It can appear as a property in the following objects: `{{page.objects|jsonify}}`.
+{% endcapture %}
 
-### Schema
-
-```yaml
-{{page.schema}}
-```
-
-### Example
-
+{%capture example $}
 ```yaml
 openapi: 3.0.0
 info:
@@ -34,4 +25,6 @@ info:
 Used by: (informational)
 
 * APIs.guru
+{% endcapture %}
 
+{% include extension-entry.md summary=summary example=example %}  


### PR DESCRIPTION
Partially addresses: https://github.com/OAI/OpenAPI-Specification/issues/1823

This [commit](https://github.com/OAI/OpenAPI-Specification/commit/ccbf6a835d78d1bd44b9c21f5820f61437c30849) re-enables the page building of the extension which was disabled in https://github.com/OAI/OpenAPI-Specification/pull/3212.

I have no idea why it was disabled but in production it produces a 404 link. You can check it here https://spec.openapis.org/registry/extension/index.html by clicking on the `x-twitter` link.

A rendered result can be seen here: https://bellangelo.github.io/OpenAPI-Specification/registry/extension/x-twitter.html