### PR TITLE
Encapsulate page layout for namespaces

### DIFF
--- a/_includes/namespace-entry.md
+++ b/_includes/namespace-entry.md
@@ -1,0 +1,11 @@
+# <a href="..">{{ page.collection }}</a>
+
+## {{ page.slug }} - {{ page.description }}
+
+{{ include.summary }}
+
+{% if page.issue %}
+### GitHub Issue
+
+* [#{{ page.issue }}](https://github.com/OAI/OpenAPI-Specification/issues/{{ page.issue }})
+{% endif %}

--- a/registries/_namespace/ms.md
+++ b/registries/_namespace/ms.md
@@ -5,15 +5,8 @@ description: Extensions created and used by Microsoft
 layout: default
 ---
 
-# <a href="..">{{ page.collection }}</a>
-
-## {{ page.slug }} - {{ page.description }}
-
-
+{% capture summary %}
 The `x-{{page.slug}}-` prefix is reserved for extensions created by Microsoft. These extensions are available for use by anyone.
+{% endcapture %}
 
-{% if page.issue %}
-### GitHub Issue
-
-* [#{{ page.issue }}](https://github.com/OAI/OpenAPI-Specification/issues/{{ page.issue }})
-{% endif %}
+{% include namespace-entry.md summary=summary %}

--- a/registries/_namespace/oas-draft.md
+++ b/registries/_namespace/oas-draft.md
@@ -5,15 +5,8 @@ description: Extensions created by OAI to indicate proposed changes to the OAS s
 layout: default
 ---
 
-# <a href="..">{{ page.collection }}</a>
-
-## {{ page.slug }} - {{ page.description }}
-
-
+{% capture summary %}
 The `x-{{page.slug}}-` prefix is reserved for extensions created as part of the [draft features(https://github.com/OAI/OpenAPI-Specification/blob/main/DEVELOPMENT.md#draft-features)] process. These extensions are available for use by anyone.
+{% endcapture %}
 
-{% if page.issue %}
-### GitHub Issue
-
-* [#{{ page.issue }}](https://github.com/OAI/OpenAPI-Specification/issues/{{ page.issue }})
-{% endif %}
+{% include namespace-entry.md summary=summary %}

--- a/registries/_namespace/oas-draft.md
+++ b/registries/_namespace/oas-draft.md
@@ -6,7 +6,7 @@ layout: default
 ---
 
 {% capture summary %}
-The `x-{{page.slug}}-` prefix is reserved for extensions created as part of the [draft features(https://github.com/OAI/OpenAPI-Specification/blob/main/DEVELOPMENT.md#draft-features)] process. These extensions are available for use by anyone.
+The `x-{{page.slug}}-` prefix is reserved for extensions created as part of the [draft features](https://github.com/OAI/OpenAPI-Specification/blob/main/DEVELOPMENT.md#draft-features) process. These extensions are available for use by anyone.
 {% endcapture %}
 
 {% include namespace-entry.md summary=summary %}

--- a/registries/_namespace/sap.md
+++ b/registries/_namespace/sap.md
@@ -5,17 +5,10 @@ description: Extensions created and used by SAP
 layout: default
 ---
 
-# <a href="..">{{ page.collection }}</a>
-
-## {{ page.slug }} - {{ page.description }}
-
-
+{% capture summary %}
 The `x-{{page.slug}}-` prefix is reserved for extensions created by SAP. These extensions are available for use by anyone.
 
 The official list of supported SAP extensions can be found in [SAP/openapi-specification](https://github.com/SAP/openapi-specification) repository.
+{% endcapture %}
 
-{% if page.issue %}
-### GitHub Issue
-
-* [#{{ page.issue }}](https://github.com/OAI/OpenAPI-Specification/issues/{{ page.issue }})
-{% endif %}
+{% include namespace-entry.md summary=summary %}


### PR DESCRIPTION
Partially addresses: https://github.com/OAI/OpenAPI-Specification/issues/1823

This commit fixes a broken link: https://github.com/OAI/OpenAPI-Specification/commit/26fa6beb0536156f131cbbdc95ab57e0bdc59a5d

A rendered result can be seen here: https://bellangelo.github.io/OpenAPI-Specification/registry/namespace/index.html