### PR TITLE
Encapsulate page layout for formats - Part 4

### DIFF
--- a/registries/_format/sf-boolean.md
+++ b/registries/_format/sf-boolean.md
@@ -8,12 +8,7 @@ base_type: string
 layout: default
 ---
 
-# <a href="..">{{ page.collection }}</a>
-
-## {{ page.slug }} - {{ page.description }}
-
-Base type: `{{ page.base_type }}`.
-
+{% capture summary %}
 The `{{page.slug}}` format represents a structured fields boolean as defined in [RFC8941].
 
 ```abnf
@@ -24,17 +19,8 @@ boolean    = "0" / "1"
 A Boolean is indicated with a leading "?" character followed by a "1" for a true value or "0" for false.
 
 This format is appropriate for a header value that must conform to the {{page.slug}} structured field definition.
+{% endcapture %}
 
-{% if page.issue %}
-### GitHub Issue
-
-* [#{{ page.issue }}](https://github.com/OAI/OpenAPI-Specification/issues/{{ page.issue }})
-{% endif %}
-
-{% if page.remarks %}
-### Remarks
-
-{{ page.remarks }}
-{% endif %}
+{% include format-entry.md summary=summary %}
 
 [RFC8941]: https://www.rfc-editor.org/rfc/rfc8941#name-booleans

--- a/registries/_format/sf-decimal.md
+++ b/registries/_format/sf-decimal.md
@@ -8,12 +8,7 @@ base_type: number
 layout: default
 ---
 
-# <a href="..">{{ page.collection }}</a>
-
-## {{ page.slug }} - {{ page.description }}
-
-Base type: `{{ page.base_type }}`.
-
+{% capture summary %}
 The `{{page.slug}}` format represents a structured fields decimal as defined in [RFC8941].
 
 ```abnf
@@ -24,17 +19,8 @@ Decimals are numbers with an integer and a fractional component.
 The integer component has at most 12 digits; the fractional component has at most three digits.
 
 This format is appropriate for a header value that must conform to the {{page.slug}} structured field definition.
+{% endcapture %}
 
-{% if page.issue %}
-### GitHub Issue
-
-* [#{{ page.issue }}](https://github.com/OAI/OpenAPI-Specification/issues/{{ page.issue }})
-{% endif %}
-
-{% if page.remarks %}
-### Remarks
-
-{{ page.remarks }}
-{% endif %}
+{% include format-entry.md summary=summary %}
 
 [RFC8941]: https://www.rfc-editor.org/rfc/rfc8941#name-decimals

--- a/registries/_format/sf-integer.md
+++ b/registries/_format/sf-integer.md
@@ -8,12 +8,7 @@ base_type: [integer, number]
 layout: default
 ---
 
-# <a href="..">{{ page.collection }}</a>
-
-## {{ page.slug }} - {{ page.description }}
-
-Base type: `{{ page.base_type }}`.
-
+{% capture summary %}
 The `{{page.slug}}` format represents a structured fields integer as defined in [RFC8941].
 
 ```abnf
@@ -24,18 +19,9 @@ Integers have a range of -999,999,999,999,999 to 999,999,999,999,999 inclusive (
 for IEEE 754 compatibility [IEEE754].
 
 This format is appropriate for a header value that must conform to the {{page.slug}} structured field definition.
+{% endcapture %}
 
-{% if page.issue %}
-### GitHub Issue
-
-* [#{{ page.issue }}](https://github.com/OAI/OpenAPI-Specification/issues/{{ page.issue }})
-{% endif %}
-
-{% if page.remarks %}
-### Remarks
-
-{{ page.remarks }}
-{% endif %}
+{% include format-entry.md summary=summary %}
 
 [RFC8941]: https://www.rfc-editor.org/rfc/rfc8941#name-integers
 [IEEE754]: https://ieeexplore.ieee.org/document/8766229

--- a/registries/_format/sf-string.md
+++ b/registries/_format/sf-string.md
@@ -8,12 +8,7 @@ base_type: string
 layout: default
 ---
 
-# <a href="..">{{ page.collection }}</a>
-
-## {{ page.slug }} - {{ page.description }}
-
-Base type: `{{ page.base_type }}`.
-
+{% capture summary %}
 The `{{page.slug}}` format represents a structured fields string as defined in [RFC8941].
 
 ```abnf
@@ -29,17 +24,8 @@ Note that this excludes tabs, newlines, carriage returns, etc.
 Strings are delimited with double quotes, using a backslash ("\") to escape double quotes and backslashes.
 
 This format is appropriate for a header value that must conform to the {{page.slug}} structured field definition.
+{% endcapture %}
 
-{% if page.issue %}
-### GitHub Issue
-
-* [#{{ page.issue }}](https://github.com/OAI/OpenAPI-Specification/issues/{{ page.issue }})
-{% endif %}
-
-{% if page.remarks %}
-### Remarks
-
-{{ page.remarks }}
-{% endif %}
+{% include format-entry.md summary=summary %}
 
 [RFC8941]: https://www.rfc-editor.org/rfc/rfc8941#name-strings

--- a/registries/_format/sf-token.md
+++ b/registries/_format/sf-token.md
@@ -8,12 +8,7 @@ base_type: string
 layout: default
 ---
 
-# <a href="..">{{ page.collection }}</a>
-
-## {{ page.slug }} - {{ page.description }}
-
-Base type: `{{ page.base_type }}`.
-
+{% capture summary %}
 The `{{page.slug}}` format represents a structured fields token as defined in [RFC8941].
 
 ```abnf
@@ -23,17 +18,8 @@ sf-token = ( ALPHA / "*" ) *( tchar / ":" / "/" )
 Tokens are short textual words; their abstract model is identical to their expression in the HTTP field value serialization.
 
 This format is appropriate for a header value that must conform to the {{page.slug}} structured field definition.
+{% endcapture %}
 
-{% if page.issue %}
-### GitHub Issue
-
-* [#{{ page.issue }}](https://github.com/OAI/OpenAPI-Specification/issues/{{ page.issue }})
-{% endif %}
-
-{% if page.remarks %}
-### Remarks
-
-{{ page.remarks }}
-{% endif %}
+{% include format-entry.md summary=summary %}
 
 [RFC8941]: https://www.rfc-editor.org/rfc/rfc8941#name-tokens

--- a/registries/_format/time.md
+++ b/registries/_format/time.md
@@ -8,22 +8,8 @@ source_label: JSON Schema
 source: https://json-schema.org/draft/2020-12/json-schema-validation.html#name-dates-times-and-duration
 ---
 
-# <a href="..">{{ page.collection }}</a>
-
-## {{ page.slug }} - {{ page.description }}
-
-Base type: `{{ page.base_type }}`.
-
+{% capture summary %}
 The `{{page.slug}}` format represents a time as defined by full-time - [RFC3339](https://www.rfc-editor.org/rfc/rfc3339.html#section-5.6).
+{% endcapture %}
 
-{% if page.issue %}
-### GitHub Issue
-
-* [#{{ page.issue }}](https://github.com/OAI/OpenAPI-Specification/issues/{{ page.issue }})
-{% endif %}
-
-{% if page.remarks %}
-### Remarks
-
-{{ page.remarks }}
-{% endif %}
+{% include format-entry.md summary=summary %}

--- a/registries/_format/uint8.md
+++ b/registries/_format/uint8.md
@@ -8,22 +8,8 @@ source: https://spec.openapis.org/oas/latest.html#data-types
 source_label: OAS
 ---
 
-# <a href="..">{{ page.collection }}</a>
-
-## {{ page.slug }} - {{ page.description }}
-
-Base type: `{{ page.base_type }}`.
-
+{% capture summary %}
 The `{{page.slug}}` format represents an unsigned 8-bit integer, with the range 0 to 255.
+{% endcapture %}
 
-{% if page.issue %}
-### GitHub Issue
-
-* [#{{ page.issue }}](https://github.com/OAI/OpenAPI-Specification/issues/{{ page.issue }})
-{% endif %}
-
-{% if page.remarks %}
-### Remarks
-
-{{ page.remarks }}
-{% endif %}
+{% include format-entry.md summary=summary %}

--- a/registries/_format/uri-reference.md
+++ b/registries/_format/uri-reference.md
@@ -8,22 +8,8 @@ source_label: JSON Schema
 source: https://json-schema.org/draft/2020-12/json-schema-validation.html#name-resource-identifiers
 ---
 
-# <a href="..">{{ page.collection }}</a>
-
-## {{ page.slug }} - {{ page.description }}
-
-Base type: `{{ page.base_type }}`.
-
+{% capture summary %}
 The `{{page.slug}}` format is a URI reference as defined in RFC3986.
+{% endcapture %}
 
-{% if page.issue %}
-### GitHub Issue
-
-* [#{{ page.issue }}](https://github.com/OAI/OpenAPI-Specification/issues/{{ page.issue }})
-{% endif %}
-
-{% if page.remarks %}
-### Remarks
-
-{{ page.remarks }}
-{% endif %}
+{% include format-entry.md summary=summary %}

--- a/registries/_format/uri-template.md
+++ b/registries/_format/uri-template.md
@@ -8,22 +8,8 @@ source_label: JSON Schema
 source: https://json-schema.org/draft/2020-12/json-schema-validation.html#name-uri-template
 ---
 
-# <a href="..">{{ page.collection }}</a>
-
-## {{ page.slug }} - {{ page.description }}
-
-Base type: `{{ page.base_type }}`.
-
+{% capture summary %}
 The `{{page.slug}}` format is a URI Template as defined in [RFC6570](https://www.rfc-editor.org/rfc/rfc6570).
+{% endcapture %}
 
-{% if page.issue %}
-### GitHub Issue
-
-* [#{{ page.issue }}](https://github.com/OAI/OpenAPI-Specification/issues/{{ page.issue }})
-{% endif %}
-
-{% if page.remarks %}
-### Remarks
-
-{{ page.remarks }}
-{% endif %}
+{% include format-entry.md summary=summary %}

--- a/registries/_format/uri.md
+++ b/registries/_format/uri.md
@@ -8,22 +8,8 @@ source_label: JSON Schema
 source: https://json-schema.org/draft/2020-12/json-schema-validation.html#name-resource-identifiers
 ---
 
-# <a href="..">{{ page.collection }}</a>
-
-## {{ page.slug }} - {{ page.description }}
-
-Base type: `{{ page.base_type }}`.
-
+{% capture summary %}
 The `{{page.slug}}` format is a Uniform Resource Identifier as defined in [RFC3986](https://www.rfc-editor.org/rfc/rfc3986.html).
+{% endcapture %}
 
-{% if page.issue %}
-### GitHub Issue
-
-* [#{{ page.issue }}](https://github.com/OAI/OpenAPI-Specification/issues/{{ page.issue }})
-{% endif %}
-
-{% if page.remarks %}
-### Remarks
-
-{{ page.remarks }}
-{% endif %}
+{% include format-entry.md summary=summary %}

--- a/registries/_format/uuid.md
+++ b/registries/_format/uuid.md
@@ -8,22 +8,8 @@ source_label: JSON Schema
 source: https://json-schema.org/draft/2020-12/json-schema-validation.html#name-resource-identifiers
 ---
 
-# <a href="..">{{ page.collection }}</a>
-
-## {{ page.slug }} - {{ page.description }}
-
-Base type: `{{ page.base_type }}`.
-
+{% capture summary %}
 The `{{page.slug}}` format a Universally Unique IDentifier as defined in [RFC4122](https://www.rfc-editor.org/rfc/rfc4122).
+{% endcapture %}
 
-{% if page.issue %}
-### GitHub Issue
-
-* [#{{ page.issue }}](https://github.com/OAI/OpenAPI-Specification/issues/{{ page.issue }})
-{% endif %}
-
-{% if page.remarks %}
-### Remarks
-
-{{ page.remarks }}
-{% endif %}
+{% include format-entry.md summary=summary %}


### PR DESCRIPTION
Partially addresses: https://github.com/OAI/OpenAPI-Specification/issues/1823

A rendered result can be seen here: https://bellangelo.github.io/OpenAPI-Specification/registry/format/index.html

This is the part 4 and the last one of a series of PRs to address the formats.

Part 1: https://github.com/OAI/OpenAPI-Specification/pull/3830
Part 2: https://github.com/OAI/OpenAPI-Specification/pull/3831
Part 3: https://github.com/OAI/OpenAPI-Specification/pull/3832