### PR TITLE
feat(spec): codify Encoding in specific requestBody mediatypes

### DIFF
--- a/schemas/v3.0/schema.yaml
+++ b/schemas/v3.0/schema.yaml
@@ -405,15 +405,35 @@ definitions:
           oneOf:
             - $ref: '#/definitions/Example'
             - $ref: '#/definitions/Reference'
-      encoding:
-        type: object
-        additionalProperties:
-          $ref: '#/definitions/Encoding'
     patternProperties:
       '^x-': {}
     additionalProperties: false
     allOf:
       - $ref: '#/definitions/ExampleXORExamples'
+
+    MediaTypeWithEncoding:
+      type: object
+      properties:
+        schema:
+          oneOf:
+            - $ref: '#/definitions/Schema'
+            - $ref: '#/definitions/Reference'
+        example: {}
+        examples:
+          type: object
+          additionalProperties:
+            oneOf:
+              - $ref: '#/definitions/Example'
+              - $ref: '#/definitions/Reference'
+        encoding:
+          type: object
+          additionalProperties:
+            $ref: '#/definitions/Encoding'
+      patternProperties:
+        '^x-': {}
+      additionalProperties: false
+      allOf:
+        - $ref: '#/definitions/ExampleXORExamples'
 
   Example:
     type: object
@@ -763,6 +783,9 @@ definitions:
         type: object
         additionalProperties:
           $ref: '#/definitions/MediaType'
+        patternProperties:
+          '^application/x-www-form-urlencoded$|^multipart\/.+$':
+            $ref: '#/definitions/MediaTypeWithEncoding'
       required:
         type: boolean
         default: false

--- a/schemas/v3.0/schema.yaml
+++ b/schemas/v3.0/schema.yaml
@@ -784,7 +784,7 @@ definitions:
         additionalProperties:
           $ref: '#/definitions/MediaType'
         patternProperties:
-          '\*\/\*|^application/x-www-form-urlencoded$|^multipart\/.+$':
+          '^\*\/\*$|^application/x-www-form-urlencoded$|^multipart\/.+$':
             $ref: '#/definitions/MediaTypeWithEncoding'
       required:
         type: boolean

--- a/schemas/v3.0/schema.yaml
+++ b/schemas/v3.0/schema.yaml
@@ -784,7 +784,7 @@ definitions:
         additionalProperties:
           $ref: '#/definitions/MediaType'
         patternProperties:
-          '^application/x-www-form-urlencoded$|^multipart\/.+$':
+          '\*\/\*|^application/x-www-form-urlencoded$|^multipart\/.+$':
             $ref: '#/definitions/MediaTypeWithEncoding'
       required:
         type: boolean

--- a/schemas/v3.1/schema.yaml
+++ b/schemas/v3.1/schema.yaml
@@ -480,7 +480,7 @@ $defs:
     propertyNames:
       format: media-range
 
-  media-type:
+  media-type-common:
     $comment: https://spec.openapis.org/oas/v3.1.0#media-type-object
     type: object
     properties:
@@ -489,21 +489,19 @@ $defs:
     allOf:
       - $ref: '#/$defs/specification-extensions'
       - $ref: '#/$defs/examples'
+
+  media-type:
+    $comment: https://spec.openapis.org/oas/v3.1.0#media-type-object
+    $ref: '#/$defs/media-type-common'
     unevaluatedProperties: false
 
   media-type-with-encoding:
     $comment: https://spec.openapis.org/oas/v3.1.0#media-type-object
+    $ref: '#/$defs/media-type-common'
     type: object
     properties:
-      schema:
-        $dynamicRef: '#meta'
       encoding:
-        type: object
-        additionalProperties:
-          $ref: '#/$defs/encoding'
-    allOf:
-      - $ref: '#/$defs/specification-extensions'
-      - $ref: '#/$defs/examples'
+        $ref: '#/$defs/encoding'
     unevaluatedProperties: false
 
   encoding:

--- a/schemas/v3.1/schema.yaml
+++ b/schemas/v3.1/schema.yaml
@@ -475,7 +475,7 @@ $defs:
     additionalProperties:
       $ref: '#/$defs/media-type'
     patternProperties:
-      '^application/x-www-form-urlencoded$|^multipart\/.+$':
+      '\*\/\*|^application/x-www-form-urlencoded$|^multipart\/.+$':
         $ref: '#/$defs/media-type-with-encoding'
     propertyNames:
       format: media-range

--- a/schemas/v3.1/schema.yaml
+++ b/schemas/v3.1/schema.yaml
@@ -475,7 +475,7 @@ $defs:
     additionalProperties:
       $ref: '#/$defs/media-type'
     patternProperties:
-      '\*\/\*|^application/x-www-form-urlencoded$|^multipart\/.+$':
+      '^\*\/\*$|^application/x-www-form-urlencoded$|^multipart\/.+$':
         $ref: '#/$defs/media-type-with-encoding'
     propertyNames:
       format: media-range

--- a/schemas/v3.1/schema.yaml
+++ b/schemas/v3.1/schema.yaml
@@ -474,10 +474,24 @@ $defs:
     type: object
     additionalProperties:
       $ref: '#/$defs/media-type'
+    patternProperties:
+      '^application/x-www-form-urlencoded$|^multipart\/.+$':
+        $ref: '#/$defs/media-type-with-encoding'
     propertyNames:
       format: media-range
 
   media-type:
+    $comment: https://spec.openapis.org/oas/v3.1.0#media-type-object
+    type: object
+    properties:
+      schema:
+        $dynamicRef: '#meta'
+    allOf:
+      - $ref: '#/$defs/specification-extensions'
+      - $ref: '#/$defs/examples'
+    unevaluatedProperties: false
+
+  media-type-with-encoding:
     $comment: https://spec.openapis.org/oas/v3.1.0#media-type-object
     type: object
     properties:


### PR DESCRIPTION
the specification indicates
> The encoding object SHALL only apply to requestBody objects when the media type is multipart or application/x-www-form-urlencoded.

This PR codifies that behavior in the JSON Schema to enable validation.

Per the [Development.md](https://github.com/OAI/OpenAPI-Specification/blob/main/DEVELOPMENT.md#changing-the-schemas), this change was already merged to the Specification on [this PR](https://github.com/OAI/OpenAPI-Specification/pull/3724)

<!--
Thank you for contributing to the OpenAPI Specification!

Please make certain you are submitting your PR on the correct
branch and file:

* 3.0.x spec: v3.0.4-dev branch, versions/3.0.4.md
* 3.1.x spec: v3.1.1-dev branch, versions/3.1.1.md
* 3.2.0 spec: v3.2.0-dev branch, versions/3.2.0.md
* 3.0 schema: main branch, schemas/v3.0/...
* 3.1 schema: main branch, schemas/v3.1/...
* registry templates: gh-pages branch, registry/...
* registry contents: gh-pages branch, registries/...

Note that we do not accept changes to published specifications.
-->
