### PR TITLE
Appendix on converting data types to strings (3.0.4)

### DIFF
--- a/versions/3.0.4.md
+++ b/versions/3.0.4.md
@@ -1049,6 +1049,7 @@ There are four possible parameter locations specified by the `in` field:
 
 The rules for serialization of the parameter are specified in one of two ways.
 Parameter Objects MUST include either a `content` field or a `schema` field, but not both.
+See [Appendix B](#dataTypeConversion) for a discussion of converting values of various types to string representations.
 
 ###### Common Fixed Fields
 
@@ -1618,6 +1619,7 @@ An `encoding` attribute is introduced to give you control over the serialization
 #### <a name="encodingObject"></a>Encoding Object
 
 A single encoding definition applied to a single schema property.
+See [Appendix B](#dataTypeConversion) for a discussion of converting values of various types to string representations.
 
 ##### Fixed Fields
 Field Name | Type | Description
@@ -3699,6 +3701,29 @@ Version   | Date       | Notes
 1.0       | 2011-08-10 | First release of the Swagger Specification
 
 ## <a name="dataTypeConversion"></a>Appendix B: Data Type Conversion
+
+Serializing typed data to plain text, which can occur in `text/plain` message bodies or `multipart` parts, as well as in the `application/x-www-form-urlencoded` format in either URL query strings or message bodies, involves significant implementation- or application-defined behavior.
+
+Schema Objects validate data based on the [JSON Schema data model](https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-00#section-4.2.1), which only recognizes four primitive data types: strings (which are UTF-8 except in [extremely limited circumstances](https://datatracker.ietf.org/doc/html/rfc8259#section-8.1)), numbers, booleans, and `null`.
+Notably, integers are not a distinct type from other numbers, with `type: integer` being a convenience defined mathematically, rather than based on the presence or absence of a decimal point in any string representation.
+
+The Parameter and Encoding Objects offer features to control how to arrange values from array or object types.
+They can also be used to control how strings are further encoded to avoid reserved or illegal characters.
+However, there is no general-purpose specification for converting schema-validated non-UTF-8 primitive data types (or entire arrays or objects) to strings.
+
+Two cases do offer standards-based guidance:
+
+* [RFC3987 §3.1](https://datatracker.ietf.org/doc/html/rfc3987#section-3.1) provides guidance for converting non-Unicode strings to UTF-8, particularly in the context of URIs (and by extension, the form media types which use the same encoding rules)
+* [RFC6570 §2.3](https://www.rfc-editor.org/rfc/rfc6570#section-2.3) specifies which values, including but not limited to `null`, are considered _undefined_ and therefore treated specially in the expansion process when serializing based on that specification
+
+To control the serialization of numbers, booleans, and `null` (or other values RFC6570 deems to be undefined) more precisely, schemas can be defined as `type: string` and constrained using `pattern`, `enum`, `format`, and other keywords to communicated how applications must pre-convert their data prior to schema validation.
+The resulting strings would not require any further type conversion.
+
+The `format` keyword can assist in serialization.
+Some formats (such as `date-time` or `byte`) are unambiguous, while others (such as [`decimal`](https://spec.openapis.org/registry/format/decimal.html) in the [Format Registry](https://spec.openapis.org/registry/format/)) are less clear.
+However, care must be taken with `format` to ensure that the specific formats are supported by all relevant tools as unrecognized formats are ignored.
+
+Requiring input as pre-formatted, schema-validated strings also improves round-trip interoperability as not all programming languages and environments support the same data types.
 
 ## <a name="usingRFC6570Implementations"></a>Appendix C: Using RFC6570 Implementations
 

--- a/versions/3.0.4.md
+++ b/versions/3.0.4.md
@@ -3716,7 +3716,7 @@ Two cases do offer standards-based guidance:
 * [RFC3987 §3.1](https://datatracker.ietf.org/doc/html/rfc3987#section-3.1) provides guidance for converting non-Unicode strings to UTF-8, particularly in the context of URIs (and by extension, the form media types which use the same encoding rules)
 * [RFC6570 §2.3](https://www.rfc-editor.org/rfc/rfc6570#section-2.3) specifies which values, including but not limited to `null`, are considered _undefined_ and therefore treated specially in the expansion process when serializing based on that specification
 
-To control the serialization of numbers, booleans, and `null` (or other values RFC6570 deems to be undefined) more precisely, schemas can be defined as `type: string` and constrained using `pattern`, `enum`, `format`, and other keywords to communicated how applications must pre-convert their data prior to schema validation.
+To control the serialization of numbers, booleans, and `null` (or other values RFC6570 deems to be undefined) more precisely, schemas can be defined as `type: string` and constrained using `pattern`, `enum`, `format`, and other keywords to communicate how applications must pre-convert their data prior to schema validation.
 The resulting strings would not require any further type conversion.
 
 The `format` keyword can assist in serialization.

--- a/versions/3.0.4.md
+++ b/versions/3.0.4.md
@@ -3707,7 +3707,7 @@ Serializing typed data to plain text, which can occur in `text/plain` message bo
 Schema Objects validate data based on the [JSON Schema data model](https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-00#section-4.2.1), which only recognizes four primitive data types: strings (which are UTF-8 except in [extremely limited circumstances](https://datatracker.ietf.org/doc/html/rfc8259#section-8.1)), numbers, booleans, and `null`.
 Notably, integers are not a distinct type from other numbers, with `type: integer` being a convenience defined mathematically, rather than based on the presence or absence of a decimal point in any string representation.
 
-The Parameter and Encoding Objects offer features to control how to arrange values from array or object types.
+The [Parameter Object](#parameterObject) and [Encoding Object](#encodingObject) offer features to control how to arrange values from array or object types.
 They can also be used to control how strings are further encoded to avoid reserved or illegal characters.
 However, there is no general-purpose specification for converting schema-validated non-UTF-8 primitive data types (or entire arrays or objects) to strings.
 

--- a/versions/3.0.4.md
+++ b/versions/3.0.4.md
@@ -3716,6 +3716,9 @@ Two cases do offer standards-based guidance:
 * [RFC3987 §3.1](https://datatracker.ietf.org/doc/html/rfc3987#section-3.1) provides guidance for converting non-Unicode strings to UTF-8, particularly in the context of URIs (and by extension, the form media types which use the same encoding rules)
 * [RFC6570 §2.3](https://www.rfc-editor.org/rfc/rfc6570#section-2.3) specifies which values, including but not limited to `null`, are considered _undefined_ and therefore treated specially in the expansion process when serializing based on that specification
 
+Implementations of RFC6570 often have their own conventions for converting non-string values, but these are implementation-specific and not defined by the RFC itself.
+This is one reason for the OpenAPI Specification to leave these conversions as implementation-defined:  It allows using RFC6570 implementations regardless of how they choose to perform the conversions.
+
 To control the serialization of numbers, booleans, and `null` (or other values RFC6570 deems to be undefined) more precisely, schemas can be defined as `type: string` and constrained using `pattern`, `enum`, `format`, and other keywords to communicate how applications must pre-convert their data prior to schema validation.
 The resulting strings would not require any further type conversion.
 

--- a/versions/3.0.4.md
+++ b/versions/3.0.4.md
@@ -3704,7 +3704,7 @@ Version   | Date       | Notes
 
 Serializing typed data to plain text, which can occur in `text/plain` message bodies or `multipart` parts, as well as in the `application/x-www-form-urlencoded` format in either URL query strings or message bodies, involves significant implementation- or application-defined behavior.
 
-Schema Objects validate data based on the [JSON Schema data model](https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-00#section-4.2.1), which only recognizes four primitive data types: strings (which are UTF-8 except in [extremely limited circumstances](https://datatracker.ietf.org/doc/html/rfc8259#section-8.1)), numbers, booleans, and `null`.
+Schema Objects validate data based on the [JSON Schema data model](https://datatracker.ietf.org/doc/html/draft-wright-json-schema-00#section-4.2), which only recognizes four primitive data types: strings (which are [only broadly interoperable as UTF-8](https://datatracker.ietf.org/doc/html/rfc7159#section-8.1)), numbers, booleans, and `null`.
 Notably, integers are not a distinct type from other numbers, with `type: integer` being a convenience defined mathematically, rather than based on the presence or absence of a decimal point in any string representation.
 
 The [Parameter Object](#parameterObject) and [Encoding Object](#encodingObject) offer features to control how to arrange values from array or object types.


### PR DESCRIPTION
***Rendering with all currently open 3.0.4 changes (as of the timestamp of this edit - use the dropdown on the word "edited" in the bar for this comment) can be [found here](https://handrews.github.io/renderings/oas/deploy/oas/v3.0.4.html#appendix-b-data-type-conversion).***

Fixes:
* #2045 
* https://github.com/OAI/OpenAPI-Specification/issues/2840#issuecomment-1449417246 (but not the parts about interactions with `explode` which are 3.1-specific and will be addressed separately)
* #2037 (perhaps not ideally, but I think the best we can do without inventing a new standard)

_This is an appendix because it's pretty much just advice for things that otherwise feel like an erroneous gap in the spec - but as with PR #3818, this is stuff where it's hard to know where to look or what to ask, so having it in the spec is important._

It's very unclear how numbers, booleans, and other non-UTF-8-string values are converted to strings, particularly for the form media types. This adds a brief appendix that acknowledges the lack of standardization, and points to resources for the few cases that do have specifications.

It highlights concerns with relying on certain JSON Schema keywords or values for serialization, and suggests defining schemas of type string and requiring applications to perform the conversion prior to schema validation as a way to control the results.

This also clarifies that schema validation occurs before serialization.

**QUESTION:** I was pretty casual about where I put the "See Appendix C" notes - are there better places?

<!--
Thank you for contributing to the OpenAPI Specification!

Please make certain you are submitting your PR on the correct
branch and file:

* 3.0.x spec: v3.0.4-dev branch, versions/3.0.4.md
* 3.1.x spec: v3.1.1-dev branch, versions/3.1.1.md
* 3.2.0 spec: v3.2.0-dev branch, versions/3.2.0.md
* 3.0 schema: main branch, schemas/v3.0/...
* 3.1 schema: main branch, schemas/v3.1/...
* registry templates: gh-pages branch, registry/...
* registry contents: gh-pages branch, registries/...

Note that we do not accept changes to published specifications.
-->
