### PR TITLE
Clarify discriminator + oneOf/anyOf/allOf usage (3.1.1 modified port of #3822)

### DIFF
--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -193,8 +193,6 @@ If the same JSON/YAML object is parsed multiple times and the respective context
 
 #### <a name="resolvingImplicitConnections"></a>Resolving Implicit Connections
 
-***TODO: In another PR***
-
 ### <a name="dataTypes"></a>Data Types
 
 Data types in the OAS are based on the types supported by the [JSON Schema Specification Draft 2020-12](https://tools.ietf.org/html/draft-bhutton-json-schema-00#section-4.2.1).
@@ -2710,7 +2708,7 @@ components:
         ]
       },
       "Cat": {
-        "description": "A representation of a cat. Note that `Cat` will be used as the discriminator value.",
+        "description": "A representation of a cat. Note that `Cat` will be used as the discriminating value.",
         "allOf": [
           {
             "$ref": "#/components/schemas/Pet"
@@ -2737,7 +2735,7 @@ components:
         ]
       },
       "Dog": {
-        "description": "A representation of a dog. Note that `Dog` will be used as the discriminator value.",
+        "description": "A representation of a dog. Note that `Dog` will be used as the discriminating value.",
         "allOf": [
           {
             "$ref": "#/components/schemas/Pet"
@@ -2779,7 +2777,7 @@ components:
       required:
       - name
       - petType
-    Cat:  # "Cat" will be used as the discriminator value
+    Cat:  # "Cat" will be used as the discriminating value
       description: A representation of a cat
       allOf:
       - $ref: '#/components/schemas/Pet'
@@ -2795,7 +2793,7 @@ components:
             - aggressive
         required:
         - huntingSkill
-    Dog:  # "Dog" will be used as the discriminator value
+    Dog:  # "Dog" will be used as the discriminating value
       description: A representation of a dog
       allOf:
       - $ref: '#/components/schemas/Pet'
@@ -2933,7 +2931,7 @@ The Discriminator Object does this by implicitly or explicitly associating the p
 ##### Fixed Fields
 Field Name | Type | Description
 ---|:---:|---
-<a name="propertyName"></a>propertyName | `string` | **REQUIRED**. The name of the property in the payload that will hold the discriminator value. This property SHOULD be required in the payload schema, as the behavior when the property is absent is undefined.
+<a name="propertyName"></a>propertyName | `string` | **REQUIRED**. The name of the property in the payload that will hold the discriminating value. This property SHOULD be required in the payload schema, as the behavior when the property is absent is undefined.
 <a name="discriminatorMapping"></a> mapping | Map[`string`, `string`] | An object to hold mappings between payload values and schema names or URI references.
 
 This object MAY be extended with [Specification Extensions](#specificationExtensions).
@@ -3008,7 +3006,7 @@ MyResponseType:
       monster: https://gigantic-server.com/schemas/Monster/schema.json
 ```
 
-Here the discriminator property _value_ of `dog` will map to the schema `#/components/schemas/Dog`, rather than the default (implicit) value of `#/components/schemas/dog`.  If the discriminator property _value_ does not match an implicit or explicit mapping, no schema can be determined and validation SHOULD fail.
+Here the discriminating value of `dog` will map to the schema `#/components/schemas/Dog`, rather than the default (implicit) value of `#/components/schemas/dog`.  If the discriminating value does not match an implicit or explicit mapping, no schema can be determined and validation SHOULD fail.
 
 When used in conjunction with the `anyOf` construct, the use of the discriminator can avoid ambiguity for serializers/deserializers where multiple schemas may satisfy a single payload.
 

--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -191,6 +191,10 @@ When parsing an OAD, JSON or YAML objects are parsed into specific Objects (such
 
 If the same JSON/YAML object is parsed multiple times and the respective contexts require it to be parsed as _different_ Object types, the resulting behavior is _implementation defined_, and MAY be treated as an error if detected.  An example would be referencing an empty Schema Object under `#/components/schemas` where a Path Item Object is expected, as an empty object is valid for both types.  For maximum interoperability, it is RECOMMENDED that OpenAPI Description authors avoid such scenarios.
 
+#### <a name="resolvingImplicitConnections"></a>Resolving Implicit Connections
+
+***TODO: In another PR***
+
 ### <a name="dataTypes"></a>Data Types
 
 Data types in the OAS are based on the types supported by the [JSON Schema Specification Draft 2020-12](https://tools.ietf.org/html/draft-bhutton-json-schema-00#section-4.2.1).
@@ -2922,24 +2926,38 @@ components:
 
 #### <a name="discriminatorObject"></a>Discriminator Object
 
-When request bodies or response payloads may be one of a number of different schemas, a `discriminator` object gives a hint about the expected schema of the document. It can be used to aid in serialization, deserialization, and validation.
-
-`discriminator` uses a schema's "name" to automatically map a property value to
-a schema. The schema's "name" is the property name used when declaring the
-schema as a component in an OpenAPI document. For example, the name of the
-schema at `#/components/schemas/Cat` is "Cat". Therefore, when using
-`discriminator`, _inline_ schemas will not be considered because they don't have
-a "name".
+When request bodies or response payloads may be one of a number of different schemas, a Discriminator Object gives a hint about the expected schema of the document.
+This hint can be used to aid in serialization, deserialization, and validation.
+The Discriminator Object does this by implicitly or explicitly associating the possible values of a named property with alternative schemas.
 
 ##### Fixed Fields
 Field Name | Type | Description
 ---|:---:|---
-<a name="propertyName"></a>propertyName | `string` | **REQUIRED**. The name of the property in the payload that will hold the discriminator value. This property MUST be required in the payload schema.
-<a name="discriminatorMapping"></a> mapping | Map[`string`, `string`] | An object to hold mappings between payload values and schema names or references.
+<a name="propertyName"></a>propertyName | `string` | **REQUIRED**. The name of the property in the payload that will hold the discriminator value. This property SHOULD be required in the payload schema, as the behavior when the property is absent is undefined.
+<a name="discriminatorMapping"></a> mapping | Map[`string`, `string`] | An object to hold mappings between payload values and schema names or URI references.
 
 This object MAY be extended with [Specification Extensions](#specificationExtensions).
 
-The discriminator object is legal only when using one of the composite keywords `oneOf`, `anyOf`, `allOf`.  Note that because the discriminating property's value is used as a component name and/or as the key in the `mapping` object, the behavior of any value that is not a string is undefined.
+##### Conditions for Using the Discriminator Object
+The Discriminator Object is legal only when using one of the composite keywords `oneOf`, `anyOf`, `allOf`.
+In both the `oneOf` and `anyOf` use cases, where those keywords are adjacent to `discriminator`, all possible schemas MUST be listed explicitly.
+To avoid redundancy, the discriminator MAY be added to a parent schema definition, and all schemas building on the parent schema via an `allOf` construct may be used as an alternate schema.
+
+The behavior of any configuration of `oneOf`, `anyOf`, `allOf` and `discriminator` that is not described above is undefined.
+
+##### Options for Mapping Values to Schemas
+The value of the property named in `propertyName` is used as the name of the associated schema under the [Components Object](#componentsObject), _unless_ a `mapping` is present for that value.
+The `mapping` entry maps a specific property value to either a different schema component name, or to a schema identified by a URI.
+When using implicit or explicit schema component names, inline `oneOf` or `anyOf` subschemas are not considered.
+The behavior of a `mapping` value that is both a valid schema name and a valid relative URI reference is implementation-defined, but it is RECOMMENDED that it be treated as a schema name.
+To ensure that an ambiguous value (e.g. `"foo"`) is treated as a relative URI reference by all implementations, authors MUST prefix it with the `"."` path segment (e.g. `"./foo"`).
+
+Mapping keys MUST be string values, but tooling MAY convert response values to strings for comparison.
+However, the exact nature of such conversions are implementation-defined.
+
+##### <a name="discriminatorExamples"></a>Examples
+
+For these examples, assume all schemas are in the entry OpenAPI document; for handling of `discriminator` in referenced documents see [Resolving Implicit Connections](#resolvingImplicitConnections).
 
 In OAS 3.x, a response payload MAY be described to be exactly one of any number of types:
 
@@ -2990,13 +3008,11 @@ MyResponseType:
       monster: https://gigantic-server.com/schemas/Monster/schema.json
 ```
 
-Here the discriminator _value_ of `dog` will map to the schema `#/components/schemas/Dog`, rather than the default (implicit) `#/components/schemas/dog`.  If the discriminator _value_ does not match an implicit or explicit mapping, no schema can be determined and validation SHOULD fail. Mapping keys MUST be string values, but tooling MAY convert response values to strings for comparison.
+Here the discriminator property _value_ of `dog` will map to the schema `#/components/schemas/Dog`, rather than the default (implicit) value of `#/components/schemas/dog`.  If the discriminator property _value_ does not match an implicit or explicit mapping, no schema can be determined and validation SHOULD fail.
 
 When used in conjunction with the `anyOf` construct, the use of the discriminator can avoid ambiguity for serializers/deserializers where multiple schemas may satisfy a single payload.
 
-In both the `oneOf` and `anyOf` use cases, all possible schemas MUST be listed explicitly.  To avoid redundancy, the discriminator MAY be added to a parent schema definition, and all schemas comprising the parent schema in an `allOf` construct may be used as an alternate schema.
-
-For example:
+This example shows the `allOf` usage, which avoids needing to reference all child schemas in the parent:
 
 ```yaml
 components:


### PR DESCRIPTION
This is not a direct port of #3822 (although it is close), for two reasons:

1.  Full-document parsing (#3758) and 3.1.1-specific implicit component resolution (PR #3823) means that the 3.0.4 guidance on finding `allOf`-using schemas is not needed in 3.1.1
2. @jdesrosiers made some improvements and bug-fixes to the Discriminator Object language in 3.1.1 (PR #2618) but not 3.0.4 (because when he submitted the PR, we hadn't decided to do a 3.0.4 yet)

I have tried to merge the improvements as best I can.  There were two notable changes to the improved text:

* A paragraph at the beginning was dropped because it's points are now all addressed elsewhere:
    * The definition of "name" is superseded by the definition of the term "component name" in PR #3823, which we've been using consistently in several PRs now; I added an example in PR #3823 to ensure that it is as clear as what @jdesrosiers wrote in the removed paragraph
    * The bit about implicit schemas not being considered (which might not have been changed in the previous 3.1.1 PR) moved down into text that I rewrote substantially in PR #3822 
* The MUST wording on requiring the `propertyName` property sadly has to be weakened to a "SHOULD but the behavior is otherwise undefined" due to our tightened compatibility requirements for patch releases - this is how we have handled other problematic ambiguities – in practice, this is essentially as strong since disregarding the SHOULD is clearly not interoperable (see PR #3805 for the meaning of "undefined" and "implementation-defined"

I also revived some of @jdesrosiers 's ideas that were taken out for compatibility reasons and included a co-author credit; see the commit message below.

Once this PR is accepted, I will backport @jdesrosiers 's changes, as merged here, to 3.0.4 and include a co-author credit (unless you'd rather do it yourself, Jason).

Fixes:
* #2520 
* #3424 
* #3591 

------
Commit message:

This moves some guidance up to the fixed fields section where
it is more obvious, and explicitly designates other configurations
as having undefined behavior.

It also creates subsections to organize the different topics, pulls
key guidance out of the examples and up into those sections,
and provides clarification on the ambiguity of names and URIs.

Finally, it incorporates ideas from @jdesrosiers regarding
the ambiguous `mapping` syntax submitted in a prior PR, but
does so in a way that meets our compatibility requirements
for patch releases.
For the same compatibility reasons, the MUST wording for
requiring the named discriminator property in the schema
was (regrettably) weakened to a "SHOULD but otherwise undefined",
as we have done for other problematic ambiguities.

Co-authored-by: Jason Desrosiers <jdesrosi@gmail.com>
