### PR TITLE
Typo in discriminator example

### DIFF
--- a/versions/3.0.4.md
+++ b/versions/3.0.4.md
@@ -2826,7 +2826,7 @@ MyResponseType:
       monster: https://gigantic-server.com/schemas/Monster/schema.json
 ```
 
-Here the discriminator _value_ of `dog` will map to the schema `#/components/schemas/Dog`, rather than the default (implicit) value of `Dog`.  If the discriminator _value_ does not match an implicit or explicit mapping, no schema can be determined and validation SHOULD fail.
+Here the discriminator _value_ of `dog` will map to the schema `#/components/schemas/Dog`, rather than the default (implicit) value of `#/components/schemas/dog`.  If the discriminator _value_ does not match an implicit or explicit mapping, no schema can be determined and validation SHOULD fail.
 
 When used in conjunction with the `anyOf` construct, the use of the discriminator can avoid ambiguity where multiple schemas may satisfy a single payload.
 


### PR DESCRIPTION
Based on the proposed change to 3.1.1 in #3846 the 3.0.4 text seems to be wrong. 
