### PR TITLE
Resolution of relative URLs in CommonMark text (3.0.4)

### DIFF
--- a/versions/3.0.4.md
+++ b/versions/3.0.4.md
@@ -212,6 +212,8 @@ Relative references are resolved using the URLs defined in the [`Server Object`]
 
 Relative references used in `$ref` are processed as per [JSON Reference](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03), using the URL of the current document as the base URI. See also the [Reference Object](#referenceObject).
 
+Relative references in CommonMark hyperlinks are resolved in their rendered context, which might differ greatly from the context of the API description.
+
 ### Schema
 
 In the following description, if a field is not explicitly **REQUIRED** or described with a MUST or SHALL, it can be considered OPTIONAL.

--- a/versions/3.0.4.md
+++ b/versions/3.0.4.md
@@ -212,7 +212,7 @@ Relative references are resolved using the URLs defined in the [`Server Object`]
 
 Relative references used in `$ref` are processed as per [JSON Reference](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03), using the URL of the current document as the base URI. See also the [Reference Object](#referenceObject).
 
-Relative references in CommonMark hyperlinks are resolved in their rendered context, which might differ greatly from the context of the API description.
+Relative references in CommonMark hyperlinks are resolved in their rendered context, which might differ from the context of the API description.
 
 ### Schema
 


### PR DESCRIPTION
* Fixes #1701 

Note that they are resolved in their rendered context.

<!--
Thank you for contributing to the OpenAPI Specification!

Please make certain you are submitting your PR on the correct
branch and file:

* 3.0.x spec: v3.0.4-dev branch, versions/3.0.4.md
* 3.1.x spec: v3.1.1-dev branch, versions/3.1.1.md
* 3.2.0 spec: v3.2.0-dev branch, versions/3.2.0.md
* 3.0 schema: main branch, schemas/v3.0/...
* 3.1 schema: main branch, schemas/v3.1/...
* registry templates: gh-pages branch, registry/...
* registry contents: gh-pages branch, registries/...

Note that we do not accept changes to published specifications.
-->
