### PR TITLE
Appendix for percent-encoding concerns (3.0.4)

### DIFF
--- a/versions/3.0.4.md
+++ b/versions/3.0.4.md
@@ -1057,6 +1057,8 @@ Describes a single operation parameter.
 
 A unique parameter is defined by a combination of a [name](#parameterName) and [location](#parameterIn).
 
+See [Appendix E](#percentEncodingAndFormMediaTypes) for a detailed examination of percent-encoding concerns, including interactions with the `application/x-www-form-urlencoded` query string format.
+
 ##### Parameter Locations
 There are four possible parameter locations specified by the `in` field:
 * path - Used together with [Path Templating](#pathTemplating), where the parameter value is actually part of the operation's URL. This does not include the host or base path of the API. For example, in `/items/{itemId}`, the path parameter is `itemId`.
@@ -1128,7 +1130,7 @@ spaceDelimited | `array`, `object` | `query` | Space separated array values or o
 pipeDelimited | `array`, `object` | `query` | Pipe separated array values or object properties and values. This option replaces `collectionFormat` equal to `pipes` from OpenAPI 2.0.
 deepObject | `object` | `query` | Allows objects with scalar properties to be represented using form parameters. The representation of array or object properties is not defined.
 
-The behavior of applying a style that uses a delimiter to data containing that delimiter is not defined, and is therefore NOT RECOMMENDED.  To ensure interoperability, any such delimiter characters need to be escaped prior to serializing with the style, and unescaped after parsing.  In the case of `spaceDelimited`, care must be taken to avoid confusing interactions with URL parameter encoding of spaces.
+See [Appendix E](#percentEncodingAndFormMediaTypes) for a discussion of percent-encoding, including when delimiters need to be percent-encoded and options for handling collisions with percent-encoded data.
 
 ##### Style Examples
 
@@ -1140,6 +1142,7 @@ Assume a parameter named `color` has one of the following values:
    object -> { "R": 100, "G": 200, "B": 150 }
 ```
 The following table shows examples of rendering differences for each value.
+The examples are percent-encoded as required by RFC6570 and RFC3986; see [Appendix E](#percentEncodingAndFormMediaTypes) for a thorough discussion of percent-encoding concerns, including why unencoded `|` (`%7C`), `[` (`%5B`), and `]` (`%5D`) seem to work in some environments despite not being compliant.
 
 [`style`](#dataTypeFormat) | `explode` | `empty` | `string` | `array` | `object`
 ----------- | ------ | -------- | -------- | -------- | -------
@@ -1152,8 +1155,8 @@ simple | true | n/a | blue | blue,black,brown | R=100,G=200,B=150
 form | false | color= | color=blue | color=blue,black,brown | color=R,100,G,200,B,150
 form | true | color= | color=blue | color=blue&color=black&color=brown | R=100&G=200&B=150
 spaceDelimited | false | n/a | n/a | color=blue%20black%20brown | color=R%20100%20G%20200%20B%20150
-pipeDelimited | false | n/a | n/a | color=blue\|black\|brown | color=R\|100\|G\|200\|B\|150
-deepObject | true | n/a | n/a | n/a | color[R]=100&color[G]=200&color[B]=150
+pipeDelimited | false | n/a | n/a | color=blue%7Cblack%7Cbrown | color=R%7C100%7CG%7C200%7CB%7C150
+deepObject | true | n/a | n/a | n/a | color%5BR%5D=100&color%5BG%5D=200&color%5BB%5D=150
 
 This object MAY be extended with [Specification Extensions](#specificationExtensions).
 
@@ -1595,6 +1598,8 @@ Here is the `id` parameter (without `address`) serialized as `application/json` 
 id=%22f81d4fae-7dec-11d0-a765-00a0c91e6bf6%22
 ```
 
+See [Appendix E](#percentEncodingAndFormMediaTypes) for a detailed examination of percent-encoding concerns for form media types.
+
 ##### Special Considerations for `multipart` Content
 
 It is common to use `multipart/form-data` as a `Content-Type` when transferring request bodies to operations.  In contrast to 2.0, a `schema` is REQUIRED to define the input parameters to the operation when using `multipart` content.  This supports complex structures as well as supporting mechanisms for multiple file uploads.
@@ -1648,6 +1653,8 @@ See [Appendix B](#dataTypeConversion) for a discussion of converting values of v
 
 Properties are correlated with `multipart` parts using the `name` parameter to `Content-Disposition: form-data`, and with `application/x-www-form-urlencoded` using the query string paramter names.
 In both cases, their order is implementation-defined.
+
+See [Appendix E](#percentEncodingAndFormMediaTypes) for a detailed examination of percent-encoding concerns for form media types.
 
 ###### Common Fixed Fields
 
@@ -4104,3 +4111,90 @@ Because implementations that rely on an RFC6570 implementation and those that pe
 For multiple values, `style: form` is always incorrect as name=value pairs in cookies are delimited by `; ` (a semicolon followed by a space character) rather than `&`.
 
 ## <a name="percentEncodingAndFormMediaTypes"></a>Appendix E: Percent-Encoding and Form Media Types
+
+_**NOTE:** In this section, the `application/x-www-form-urlencoded` and `multipart/form-data` media types are abbreviated as `form-urlencoded` and `form-data`, respectively, for readability._
+
+Percent-encoding is used in URIs and media types that derive their syntax from URIs.
+This process is concerned with three sets of characters, the names of which vary among specifications but are defined as follows for the purposes of this section:
+
+* _unreserved_ characters do not need to be percent-encoded; while it is safe to percent-encode them, doing so produces a URI that is [not normalized](https://datatracker.ietf.org/doc/html/rfc3986#section-6.2.2.2)
+* _reserved_ characters either have special behavior in the URI syntax (such as delimiting components) or are reserved for other specifications that need to define special behavior (e.g. `form-urlencoded` defines special behavior for `=`, `&`, and `+`)
+* _unsafe_ characters are known to cause problems when parsing URIs in certain environments
+
+Unless otherwise specified, this section uses RFC3986's definition of [reserved](https://datatracker.ietf.org/doc/html/rfc3986#section-2.2) and [unreserved](https://datatracker.ietf.org/doc/html/rfc3986#section-2.3), and defines the unsafe set as all characters not included in either of those sets.
+
+### Percent-Encoding and `form-urlencoded`
+
+Each URI component (such as the query string) considers some of the reserved characters to be unsafe, either because they serve as delimiters between the components (e.g. `#`), or (in the case of `[` and `]`) were historically considered globally unsafe but were later given reserved status for limited purposes.
+
+Reserved characters with no special meaning defined within a component can be left un-percent encoded.
+However, other specifications can define special meanings, requiring percent-encoding for those characters outside of the additional special meanings.
+
+The `form-urlencoded` media type defines special meanings for `=` and `&` as delimiters, and `+` as the replacement for the space character (instead of its percent-encoded form of `%20`).
+This means that while these three characters are reserved-but-allowed in query strings by RFC3986, the must be percent-encoded in `form-urlencoded` query strings except when used for their `form-urlencoded` purposes; see Appendix C for an example of handling `+` in form values.
+
+### Percent-Encoding and `form-data`
+
+[RFC7578 §2](https://datatracker.ietf.org/doc/html/rfc7578#section-2) suggests RFC3986-based percent-encoding as a mechanism to keep text-based per-part header data such as file names within the ASCII character set.
+This suggestion was not part of older (pre-2015) specifications for `form-data`, so care must be taken to ensure interoperability.
+
+The `form-data` media type allows arbitrary text or binary data in its parts, so percent-encoding is not needed and is likely to cause interoperability problems unless the `Content-Type` of the part is defined to require it.
+
+### Generating and Validating URIs and `form-urlencoded` Strings
+
+URI percent encoding and the `form-urlencoded` media type have complex specification histories spanning multiple revisions and, in some cases, conflicting claims of ownership by different standards bodies.
+Unfortunately, these specifications each define slightly different percent-encoding rules, which need to be taken into account if the URIs or `form-urlencoded` message bodies will be subject to strict validation.
+(Note that many URI parsers do not perform validation by default.)
+
+This specification normatively cites the following relevant standards:
+
+Specification | Date | OAS Usage | Percent-Encoding | Notes
+------------- | ---- | --------- | ----- | -----
+[RFC3986 URI&nbsp;Generic&nbsp;Syntax](https://datatracker.ietf.org/doc/html/rfc3986) | 01/2005 | URI/URL syntax | RFC3986 | obsoletes RFC1738, RFC2396
+[RFC6570 URI&nbsp;Template](https://datatracker.ietf.org/doc/html/rfc6570) | 03/2012 | style-based serialization | RFC3986 | does not use `+` for <code>form&#8209;urlencoded</code>
+[RFC1866&nbsp;§8.2.1 form&#8209;urlencoded](https://datatracker.ietf.org/doc/html/rfc1866#section-8.2.1) | 11/1995 | content-based serialization | RFC1738 | obsoleted by [HTML&nbsp;4.01&nbsp;§17.13.4.1](https://www.w3.org/TR/html401/interact/forms.html#h-17.13.4.1), [WHATWG&nbsp;URL&nbsp;§5](https://url.spec.whatwg.org/#urlencoded-serializing)
+
+Style-based serialization is used in the [Parameter Object](#parameterObject) when `schema` is present, and in the [Encoding Object](#encodingObject) when at least one of `style`, `explode`, or `allowReserved` is present.
+See [Appendix C]() for more details of RFC6570's two different approaches to percent-encoding, including an example involving `+`.
+
+Content-based serialization is defined by the [Media Type Object](#mediaTypeObject), and used with the [Parameter Object](#parameterObject) when the `content` field is present, and with the [Encoding Object](#encodingObject) based on the `contentType` field when the style fields listed in the previous section are absent.
+Each part is encoded based on the media type (e.g. `text/plain` or `application/json`), and must then be percent-encoded for use in a `form-urlencoded` string.
+
+Note that content-based serialization for `form-data` does not expect or require percent-encoding in the data, only in per-part header values.
+
+#### Interoperability with Historical Specifications
+
+In most cases, generating query strings in strict compliance with RFC3986 is sufficient to pass validation (including JSON Schema's `format: uri` and `format: uri-reference`), but some `form-urlencoded` implementations still expect the slightly more restrictive RFC1738 rules to be used.
+
+Since all RFC1738-compliant URIs are compliant with RFC3986, applications needing to ensure historical interoperability SHOULD use RFC1738's rules.
+
+#### Interoperability with Web Browser Environments
+
+WHATWG is a [web browser-oriented](https://whatwg.org/faq#what-is-the-whatwg-working-on) standards group that has defined a "URL Living Standard" for parsing and serializing URLs in a browser context, including parsing and serializing `form-urlencoded` data.
+WHATWG's percent-encoding rules for query strings are different depending on whether the query string is [being treated as `form-urlencoded`](https://url.spec.whatwg.org/#application-x-www-form-urlencoded-percent-encode-set) (where it requires more percent-encoding than RFC1738) or [as part of the generic syntax](https://url.spec.whatwg.org/#query-percent-encode-set), where it allows characters that RFC3986 forbids.
+
+Implementations needing maximum compatibility with web browsers SHOULD use WHATWG's `form-urlencoded` percent-encoding rules.
+However, they SHOULD NOT rely on WHATWG's less stringent generic query string rules, as the resulting URLs would fail RFC3986 validation, including JSON Schema's `format: uri` and `format: uri-reference`.
+
+### Decoding URIs and `form-urlencoded` Strings
+
+The percent-decoding algorithm does not care which characters were or were not percent-decoded, which means that URIs percent-encoded according to any specification will be decoded correctly.
+
+Similarly, all `form-urlencoded` decoding algorithms simply add `+`-for-space handling on top of the percent-decoding algorithm, and will work regardless of the encoding specification used.
+
+However, care must be taken to use `form-urlencoded` decoding if `+` represents a space, and to use regular percent-decoding if `+` represents itself as a literal value.
+
+### Percent-Encoding and Illegal or Reserved Delimiters
+
+The `[` and `]`, `|`, and space characters, which are used as delimiters for the `deepObject`, `pipeDelimited`, and `spaceDelimited` styles, respectively, all MUST be percent-encoded to comply with RFC3986.
+This requires users to pre-encode the character(s) in some other way in parameter names and values to distinguish them from the delimiter usage when using one of these styles.
+
+The space character is always illegal and encoded in some way by all implementations of all versions of the relevant standards.
+While one could use the `form-urlencoded` convention of `+` to distinguish spaces in parameter names and values from `spaceDelimited` delimiters encoded as `%20`, the specifications define the decoding as a single pass, making it impossible to distinguish the different usages in the decoded result.
+
+Some environments use `[`, `]`, and possibly `|` unencoded in query strings without apparent difficulties, and WHATWG's generic query string rules do not require percent-encoding them.
+Code that relies on leaving these delimiters unencoded, while using regular percent-encoding for them within names and values, is not guaranteed to be interoperable across all implementations.
+
+For maximum interoperability, it is RECOMMENDED to either define and document an additional escape convention while percent-encoding the delimiters for these styles, or to avoid these styles entirely.
+The exact method of additional encoding/escaping is left to the API designer, and is expected to be performed before serialization and encoding described in this specification, and reversed after this specification's encoding and serialization steps are reversed.
+This keeps it outside of the processes governed by this specification.

--- a/versions/3.0.4.md
+++ b/versions/3.0.4.md
@@ -2464,13 +2464,16 @@ When `example` or `examples` are provided in conjunction with the `schema` objec
 
 Serializing with `schema` is NOT RECOMMENDED for headers with parameters (name=value pairs following a `;`) in their values, or where values might have non-URL-safe characters; see [Appendix D](#serializingHeadersAndCookies) for details.
 
+When `example` or `examples` are provided in conjunction with the `schema` object, the example SHOULD match the specified schema and follow the prescribed serialization strategy for the parameter.
+The `example` and `examples` fields are mutually exclusive, and if either is present it SHALL _override_ any `example` in the schema.
+
 Field Name | Type | Description
 ---|:---:|---
 <a name="headerStyle"></a>style | `string` | Describes how the header value will be serialized.  The default (and only legal value for headers) is `simple`.
-<a name="headerExplode"></a>explode | `boolean` | When this is true, header values of type `array` or `object` generate a single header whose value is a comma-separated list of the array items or key-value pairs of the map, see [Style Examples](#style-examples). For other data types this property has no effect. The default value is `false`.
+<a name="headerExplode"></a>explode | `boolean` | When this is true, header values of type `array` or `object` generate a single header whose value is a comma-separated list of the array items or key-value pairs of the map, see [Style Examples](#style-examples). For other data types this property has no effect. The default value is `false`. Note that despite `false` being the default for `deepObject`, the combination of `false` with `deepObject` is undefined.
 <a name="headerSchema"></a>schema | [Schema Object](#schemaObject) \| [Reference Object](#referenceObject) | The schema defining the type used for the header.
-<a name="headerExample"></a>example | Any | Example of the header's potential value. The example SHOULD match the specified schema and encoding properties if present. The `example` field is mutually exclusive of the `examples` field. Furthermore, if referencing a `schema` that contains an example, the `example` value SHALL _override_ the example provided by the schema. To represent examples of media types that cannot naturally be represented in JSON or YAML, a string value can contain the example with escaping where necessary.
-<a name="headerExamples"></a>examples | Map[ `string`, [Example Object](#exampleObject) \| [Reference Object](#referenceObject)] | Examples of the header's potential value. Each example SHOULD contain a value in the correct format as specified in the header encoding. The `examples` field is mutually exclusive of the `example` field. Furthermore, if referencing a `schema` that contains an example, the `examples` value SHALL _override_ the example provided by the schema.
+<a name="headerExample"></a>example | Any | Example of the header's potential value; see [Working With Examples](#working-with-examples).
+<a name="headerExamples"></a>examples | Map[ `string`, [Example Object](#exampleObject) \| [Reference Object](#referenceObject)] | Examples of the header's potential value; see [Working With Examples](#working-with-examples).
 
 See also [Appendix C: Using RFC6570 Implementations](#usingRFC6570Implementations) for additional guidance.
 

--- a/versions/3.0.4.md
+++ b/versions/3.0.4.md
@@ -4131,7 +4131,7 @@ Reserved characters with no special meaning defined within a component can be le
 However, other specifications can define special meanings, requiring percent-encoding for those characters outside of the additional special meanings.
 
 The `form-urlencoded` media type defines special meanings for `=` and `&` as delimiters, and `+` as the replacement for the space character (instead of its percent-encoded form of `%20`).
-This means that while these three characters are reserved-but-allowed in query strings by RFC3986, the must be percent-encoded in `form-urlencoded` query strings except when used for their `form-urlencoded` purposes; see Appendix C for an example of handling `+` in form values.
+This means that while these three characters are reserved-but-allowed in query strings by RFC3986, the must be percent-encoded in `form-urlencoded` query strings except when used for their `form-urlencoded` purposes; see [Appendix C](#usingRFC6570Implementations) for an example of handling `+` in form values.
 
 ### Percent-Encoding and `form-data`
 
@@ -4155,7 +4155,7 @@ Specification | Date | OAS Usage | Percent-Encoding | Notes
 [RFC1866&nbsp;§8.2.1 form&#8209;urlencoded](https://datatracker.ietf.org/doc/html/rfc1866#section-8.2.1) | 11/1995 | content-based serialization | RFC1738 | obsoleted by [HTML&nbsp;4.01&nbsp;§17.13.4.1](https://www.w3.org/TR/html401/interact/forms.html#h-17.13.4.1), [WHATWG&nbsp;URL&nbsp;§5](https://url.spec.whatwg.org/#urlencoded-serializing)
 
 Style-based serialization is used in the [Parameter Object](#parameterObject) when `schema` is present, and in the [Encoding Object](#encodingObject) when at least one of `style`, `explode`, or `allowReserved` is present.
-See [Appendix C]() for more details of RFC6570's two different approaches to percent-encoding, including an example involving `+`.
+See [Appendix C](#usingRFC6570Implementations) for more details of RFC6570's two different approaches to percent-encoding, including an example involving `+`.
 
 Content-based serialization is defined by the [Media Type Object](#mediaTypeObject), and used with the [Parameter Object](#parameterObject) when the `content` field is present, and with the [Encoding Object](#encodingObject) based on the `contentType` field when the style fields listed in the previous section are absent.
 Each part is encoded based on the media type (e.g. `text/plain` or `application/json`), and must then be percent-encoded for use in a `form-urlencoded` string.

--- a/versions/3.0.4.md
+++ b/versions/3.0.4.md
@@ -1072,6 +1072,8 @@ The rules for serialization of the parameter are specified in one of two ways.
 Parameter Objects MUST include either a `content` field or a `schema` field, but not both.
 See [Appendix B](#dataTypeConversion) for a discussion of converting values of various types to string representations.
 
+This object MAY be extended with [Specification Extensions](#specificationExtensions).
+
 ###### Common Fixed Fields
 
 These fields MAY be used with either `content` or `schema`.
@@ -1083,7 +1085,7 @@ Field Name | Type | Description
 <a name="parameterDescription"></a>description | `string` | A brief description of the parameter. This could contain examples of use. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
 <a name="parameterRequired"></a>required | `boolean` | Determines whether this parameter is mandatory. If the [parameter location](#parameterIn) is `"path"`, this property is **REQUIRED** and its value MUST be `true`. Otherwise, the property MAY be included and its default value is `false`.
 <a name="parameterDeprecated"></a> deprecated | `boolean` | Specifies that a parameter is deprecated and SHOULD be transitioned out of usage. Default value is `false`.
-<a name="parameterAllowEmptyValue"></a> allowEmptyValue | `boolean` | If `true`, clients MAY pass a zero-length string value in place of parameters that would otherwise be omitted entirely, which the server SHOULD interpret as the parameter being unused. Default value is `false`. If [`style`](#parameterStyle) is used, and if behavior is `n/a` (cannot be serialized), the value of `allowEmptyValue` SHALL be ignored. Interactions between this field and the parameter's [Schema Object](#schemaObject) are implementation-defined. This field is valid only for `query` parameters. Use of this property is NOT RECOMMENDED, and it is likely to be removed in a later revision.
+<a name="parameterAllowEmptyValue"></a> allowEmptyValue | `boolean` | If `true`, clients MAY pass a zero-length string value in place of parameters that would otherwise be omitted entirely, which the server SHOULD interpret as the parameter being unused. Default value is `false`. If [`style`](#parameterStyle) is used, and if [behavior is _n/a_ (cannot be serialized)](#style-examples), the value of `allowEmptyValue` SHALL be ignored. Interactions between this field and the parameter's [Schema Object](#schemaObject) are implementation-defined. This field is valid only for `query` parameters. Use of this property is NOT RECOMMENDED, and it is likely to be removed in a later revision.
 
 Note that while `"Cookie"` as a `name` is not forbidden with `in: header`, the effect of defining a cookie parameter that way is undefined; use `in: cookie` instead.
 
@@ -1098,7 +1100,7 @@ Serializing with `schema` is NOT RECOMMENDED for `in: cookie` parameters, `in: h
 Field Name | Type | Description
 ---|:---:|---
 <a name="parameterStyle"></a>style | `string` | Describes how the parameter value will be serialized depending on the type of the parameter value. Default values (based on value of `in`): for `query` - `form`; for `path` - `simple`; for `header` - `simple`; for `cookie` - `form`.
-<a name="parameterExplode"></a>explode | `boolean` | When this is true, parameter values of type `array` or `object` generate separate parameters for each value of the array or key-value pair of the map. For other types of parameters this property has no effect. When [`style`](#parameterStyle) is `form`, the default value is `true`. For all other styles, the default value is `false`.
+<a name="parameterExplode"></a>explode | `boolean` | When this is true, parameter values of type `array` or `object` generate separate parameters for each value of the array or key-value pair of the map. For other types of parameters this property has no effect. When [`style`](#parameterStyle) is `form`, the default value is `true`. For all other styles, the default value is `false`. Note that despite `false` being the default for `deepObject`, the combination of `false` with `deepObject` is undefined.
 <a name="parameterAllowReserved"></a>allowReserved | `boolean` | When this is true, parameter values are serialized  using reserved expansion, as defined by [RFC6570](https://datatracker.ietf.org/doc/html/rfc6570#autoid-20), which allows [RFC3986's reserved character set](https://datatracker.ietf.org/doc/html/rfc3986#autoid-13), as well as percent-encoded triples, to pass through unchanged, while still percent-encoding all other disallowed characters (including `%` outside of percent-encoded triples). Applications are still responsible for percent-encoding reserved characters that are [not allowed in the query string](https://datatracker.ietf.org/doc/html/rfc3986#autoid-24) (`[`, `]`, `#`), or have a special meaning in `application/x-www-form-urlencoded` (`-`, `&`, `+`); see Appendices [C](#usingRFC6570Implementations) and [E](#percentEncodingAndFormMediaTypes) for details. This property only applies to parameters with an `in` value of `query`. The default value is `false`.
 <a name="parameterSchema"></a>schema | [Schema Object](#schemaObject) \| [Reference Object](#referenceObject) | The schema defining the type used for the parameter.
 <a name="parameterExample"></a>example | Any | Example of the parameter's potential value; see [Working With Examples](#working-with-examples).
@@ -1141,8 +1143,14 @@ Assume a parameter named `color` has one of the following values:
    array -> ["blue","black","brown"]
    object -> { "R": 100, "G": 200, "B": 150 }
 ```
-The following table shows examples of the different serializations for each value.
-The examples are percent-encoded as required by RFC6570 and RFC3986; see [Appendix E](#percentEncodingAndFormMediaTypes) for a thorough discussion of percent-encoding concerns, including why unencoded `|` (`%7C`), `[` (`%5B`), and `]` (`%5D`) seem to work in some environments despite not being compliant.
+
+The following table shows examples, as would be shown with the `example` or `examples` keywords, of the different serializations for each value.
+
+* The value _e/s_ denotes the empty string
+* The behavior of combinations marked _n/a_ is undefined
+* The `empty` column refers to values that [RFC6570 §2.3](https://www.rfc-editor.org/rfc/rfc6570.html#section-2.3) describes as "undefined", and is unrelated to the `allowEmptyValues` field
+* For `form` and the non-RFC6570 query string styles `spaceDelimited`, `pipeDelimited`, and `deepObject`, each example is shown prefixed with `?` as if it were the only query parameter; see [Appendix C](#usingRFC6570Implementations) for more information on constructing query strings from multiple parameters, and [Appendix D](#serializingHeadersAndCookies) for warnings regarding `form` and cookie parameters
+* The examples are percent-encoded as required by RFC6570 and RFC3986; see [Appendix E](#percentEncodingAndFormMediaTypes) for a thorough discussion of percent-encoding concerns, including why unencoded `|` (`%7C`), `[` (`%5B`), and `]` (`%5D`) seem to work in some environments despite not being compliant.
 
 [`style`](#dataTypeFormat) | `explode` | `empty` | `string` | `array` | `object`
 ----------- | ------ | -------- | -------- | -------- | -------
@@ -1150,15 +1158,16 @@ matrix | false | ;color | ;color=blue | ;color=blue,black,brown | ;color=R,100,G
 matrix | true | ;color | ;color=blue | ;color=blue;color=black;color=brown | ;R=100;G=200;B=150
 label | false | . | .blue | .blue,black,brown | .R,100,G,200,B,150
 label | true | . | .blue | .blue.black.brown | .R=100.G=200.B=150
-simple | false | n/a | blue | blue,black,brown | R,100,G,200,B,150
-simple | true | n/a | blue | blue,black,brown | R=100,G=200,B=150
-form | false | color= | color=blue | color=blue,black,brown | color=R,100,G,200,B,150
-form | true | color= | color=blue | color=blue&color=black&color=brown | R=100&G=200&B=150
-spaceDelimited | false | n/a | n/a | color=blue%20black%20brown | color=R%20100%20G%20200%20B%20150
-pipeDelimited | false | n/a | n/a | color=blue%7Cblack%7Cbrown | color=R%7C100%7CG%7C200%7CB%7C150
-deepObject | true | n/a | n/a | n/a | color%5BR%5D=100&color%5BG%5D=200&color%5BB%5D=150
-
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+simple | false | _e/s_ | blue | blue,black,brown | R,100,G,200,B,150
+simple | true | _e/s_ | blue | blue,black,brown | R=100,G=200,B=150
+form | false | ?color= | ?color=blue | ?color=blue,black,brown | ?color=R,100,G,200,B,150
+form | true | ?color= | ?color=blue | ?color=blue&color=black&color=brown | ?R=100&G=200&B=150
+spaceDelimited | false | _n/a_ | _n/a_ | ?color=blue%20black%20brown | ?color=R%20100%20G%20200%20B%20150
+spaceDelimited | true | _n/a_ | _n/a_ | _n/a_ | _n/a_
+pipeDelimited | false | _n/a_ | _n/a_ | ?color=blue%7Cblack%7Cbrown | ?color=R%7C100%7CG%7C200%7CB%7C150
+pipeDelimited | true | _n/a_ | _n/a_ | _n/a_ | _n/a_
+deepObject | false | _n/a_ | _n/a_ | _n/a_ | _n/a_
+deepObject | true | _n/a_ | _n/a_ | _n/a_ | ?color%5BR%5D=100&color%5BG%5D=200&color%5BB%5D=150
 
 ##### Parameter Object Examples
 
@@ -1685,9 +1694,9 @@ See [Appendix B](#dataTypeConversion) for a discussion of data type conversion o
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="encodingStyle"></a>style | `string` | Describes how a specific property value will be serialized depending on its type.  See [Parameter Object](#parameterObject) for details on the [`style`](#parameterStyle) property. The behavior follows the same values as `query` parameters, including default values. This property SHALL be ignored if the request body media type is not `application/x-www-form-urlencoded`.
-<a name="encodingExplode"></a>explode | `boolean` | When this is true, property values of type `array` or `object` generate separate parameters for each value of the array, or key-value-pair of the map.  For other types of properties this property has no effect. When [`style`](#encodingStyle) is `form`, the default value is `true`. For all other styles, the default value is `false`. This property SHALL be ignored if the request body media type is not `application/x-www-form-urlencoded`.
-<a name="encodingAllowReserved"></a>allowReserved | `boolean` | When this is true, parameter values are serialized  using reserved expansion, as defined by [RFC6570](https://datatracker.ietf.org/doc/html/rfc6570#autoid-20), which allows [RFC3986's reserved character set](https://datatracker.ietf.org/doc/html/rfc3986#autoid-13), as well as percent-encoded triples, to pass through unchanged, while still percent-encoding all other disallowed characters (including `%` outside of percent-encoded triples). Applications are still responsible for percent-encoding reserved characters that are [not allowed in the query string](https://datatracker.ietf.org/doc/html/rfc3986#autoid-24) (`[`, `]`, `#`), or have a special meaning in `application/x-www-form-urlencoded` (`-`, `&`, `+`); see Appendices [C](#usingRFC6570Implementations) and [E](#percentEncodingAndFormMediaTypes) for details. This property only applies to parameters with an `in` value of `query`. The default value is `false`.
+<a name="encodingStyle"></a>style | `string` | Describes how a specific property value will be serialized depending on its type.  See [Parameter Object](#parameterObject) for details on the [`style`](#parameterStyle) property. The behavior follows the same values as `query` parameters, including default values. Note that the initial `?` using in query strings is not used in `applcation/x-www-form-urlencoded` message bodies, and MUST be removed (if using an RFC6570 implementation) or simply not added (if constructing the string manually). This property SHALL be ignored if the request body media type is not `application/x-www-form-urlencoded`.
+<a name="encodingExplode"></a>explode | `boolean` | When this is true, property values of type `array` or `object` generate separate parameters for each value of the array, or key-value-pair of the map.  For other types of properties this property has no effect. When [`style`](#encodingStyle) is `form`, the default value is `true`. For all other styles, the default value is `false`. Note that despite `false` being the default for `deepObject`, the combination of `false` with `deepObject` is undefined. This property SHALL be ignored if the request body media type is not `application/x-www-form-urlencoded`.
+<a name="encodingAllowReserved"></a>allowReserved | `boolean` | When this is true, parameter values are serialized using reserved expansion, as defined by [RFC6570](https://datatracker.ietf.org/doc/html/rfc6570#autoid-20), which allows [RFC3986's reserved character set](https://datatracker.ietf.org/doc/html/rfc3986#autoid-13), as well as percent-encoded triples, to pass through unchanged, while still percent-encoding all other disallowed characters (including `%` outside of percent-encoded triples). Applications are still responsible for percent-encoding reserved characters that are [not allowed in the query string](https://datatracker.ietf.org/doc/html/rfc3986#autoid-24) (`[`, `]`, `#`), or have a special meaning in `application/x-www-form-urlencoded` (`-`, `&`, `+`); see Appendices [C](#usingRFC6570Implementations) and [E](#percentEncodingAndFormMediaTypes) for details. This property only applies to parameters with an `in` value of `query`. The default value is `false`. This property SHALL be ignored if the request body media type is not `application/x-www-form-urlencoded`.
 
 See also [Appendix C: Using RFC6570 Implementations](#usingRFC6570Implementations) for additional guidance.
 

--- a/versions/3.0.4.md
+++ b/versions/3.0.4.md
@@ -1146,10 +1146,11 @@ Assume a parameter named `color` has one of the following values:
 
 The following table shows examples, as would be shown with the `example` or `examples` keywords, of the different serializations for each value.
 
-* The value _e/s_ denotes the empty string
+* The value _empty_ denotes the empty string, and is unrelated to the `allowEmptyValue` field
 * The behavior of combinations marked _n/a_ is undefined
-* The `empty` column refers to values that [RFC6570 §2.3](https://www.rfc-editor.org/rfc/rfc6570.html#section-2.3) describes as "undefined", and is unrelated to the `allowEmptyValues` field
+* The `undefined` replaces the `empty` column in previous versions of this specification in order to better align with [RFC6570 §2.3](https://www.rfc-editor.org/rfc/rfc6570.html#section-2.3) terminology, which describes certain values including but not limited to `null` as "undefined" values with special handling; notably, the empty string is _not_ undefined
 * For `form` and the non-RFC6570 query string styles `spaceDelimited`, `pipeDelimited`, and `deepObject`, each example is shown prefixed with `?` as if it were the only query parameter; see [Appendix C](#usingRFC6570Implementations) for more information on constructing query strings from multiple parameters, and [Appendix D](#serializingHeadersAndCookies) for warnings regarding `form` and cookie parameters
+* Note that the `?` prefix is not appropriate for serializing `application/x-www-form-urlencoded` HTTP message bodies, and MUST be stripped or (if constructing the string manually) not added when used in that context; see the [Encoding Object](#encodingObject) for more information
 * The examples are percent-encoded as required by RFC6570 and RFC3986; see [Appendix E](#percentEncodingAndFormMediaTypes) for a thorough discussion of percent-encoding concerns, including why unencoded `|` (`%7C`), `[` (`%5B`), and `]` (`%5D`) seem to work in some environments despite not being compliant.
 
 [`style`](#dataTypeFormat) | `explode` | `empty` | `string` | `array` | `object`
@@ -1158,8 +1159,8 @@ matrix | false | ;color | ;color=blue | ;color=blue,black,brown | ;color=R,100,G
 matrix | true | ;color | ;color=blue | ;color=blue;color=black;color=brown | ;R=100;G=200;B=150
 label | false | . | .blue | .blue,black,brown | .R,100,G,200,B,150
 label | true | . | .blue | .blue.black.brown | .R=100.G=200.B=150
-simple | false | _e/s_ | blue | blue,black,brown | R,100,G,200,B,150
-simple | true | _e/s_ | blue | blue,black,brown | R=100,G=200,B=150
+simple | false | _empty_ | blue | blue,black,brown | R,100,G,200,B,150
+simple | true | _empty_ | blue | blue,black,brown | R=100,G=200,B=150
 form | false | ?color= | ?color=blue | ?color=blue,black,brown | ?color=R,100,G,200,B,150
 form | true | ?color= | ?color=blue | ?color=blue&color=black&color=brown | ?R=100&G=200&B=150
 spaceDelimited | false | _n/a_ | _n/a_ | ?color=blue%20black%20brown | ?color=R%20100%20G%20200%20B%20150

--- a/versions/3.0.4.md
+++ b/versions/3.0.4.md
@@ -1141,7 +1141,7 @@ Assume a parameter named `color` has one of the following values:
    array -> ["blue","black","brown"]
    object -> { "R": 100, "G": 200, "B": 150 }
 ```
-The following table shows examples of rendering differences for each value.
+The following table shows examples of the different serializations for each value.
 The examples are percent-encoded as required by RFC6570 and RFC3986; see [Appendix E](#percentEncodingAndFormMediaTypes) for a thorough discussion of percent-encoding concerns, including why unencoded `|` (`%7C`), `[` (`%5B`), and `]` (`%5D`) seem to work in some environments despite not being compliant.
 
 [`style`](#dataTypeFormat) | `explode` | `empty` | `string` | `array` | `object`

--- a/versions/3.0.4.md
+++ b/versions/3.0.4.md
@@ -2470,7 +2470,7 @@ The `example` and `examples` fields are mutually exclusive, and if either is pre
 Field Name | Type | Description
 ---|:---:|---
 <a name="headerStyle"></a>style | `string` | Describes how the header value will be serialized.  The default (and only legal value for headers) is `simple`.
-<a name="headerExplode"></a>explode | `boolean` | When this is true, header values of type `array` or `object` generate a single header whose value is a comma-separated list of the array items or key-value pairs of the map, see [Style Examples](#style-examples). For other data types this property has no effect. The default value is `false`. Note that despite `false` being the default for `deepObject`, the combination of `false` with `deepObject` is undefined.
+<a name="headerExplode"></a>explode | `boolean` | When this is true, header values of type `array` or `object` generate a single header whose value is a comma-separated list of the array items or key-value pairs of the map, see [Style Examples](#style-examples). For other data types this property has no effect. The default value is `false`.
 <a name="headerSchema"></a>schema | [Schema Object](#schemaObject) \| [Reference Object](#referenceObject) | The schema defining the type used for the header.
 <a name="headerExample"></a>example | Any | Example of the header's potential value; see [Working With Examples](#working-with-examples).
 <a name="headerExamples"></a>examples | Map[ `string`, [Example Object](#exampleObject) \| [Reference Object](#referenceObject)] | Examples of the header's potential value; see [Working With Examples](#working-with-examples).

--- a/versions/3.0.4.md
+++ b/versions/3.0.4.md
@@ -4180,7 +4180,7 @@ However, they SHOULD NOT rely on WHATWG's less stringent generic query string ru
 
 The percent-decoding algorithm does not care which characters were or were not percent-decoded, which means that URIs percent-encoded according to any specification will be decoded correctly.
 
-Similarly, all `form-urlencoded` decoding algorithms simply add `+`-for-space handling on top of the percent-decoding algorithm, and will work regardless of the encoding specification used.
+Similarly, all `form-urlencoded` decoding algorithms simply add `+`-for-space handling to the percent-decoding algorithm, and will work regardless of the encoding specification used.
 
 However, care must be taken to use `form-urlencoded` decoding if `+` represents a space, and to use regular percent-decoding if `+` represents itself as a literal value.
 

--- a/versions/3.0.4.md
+++ b/versions/3.0.4.md
@@ -4131,7 +4131,7 @@ Reserved characters with no special meaning defined within a component can be le
 However, other specifications can define special meanings, requiring percent-encoding for those characters outside of the additional special meanings.
 
 The `form-urlencoded` media type defines special meanings for `=` and `&` as delimiters, and `+` as the replacement for the space character (instead of its percent-encoded form of `%20`).
-This means that while these three characters are reserved-but-allowed in query strings by RFC3986, the must be percent-encoded in `form-urlencoded` query strings except when used for their `form-urlencoded` purposes; see [Appendix C](#usingRFC6570Implementations) for an example of handling `+` in form values.
+This means that while these three characters are reserved-but-allowed in query strings by RFC3986, they must be percent-encoded in `form-urlencoded` query strings except when used for their `form-urlencoded` purposes; see [Appendix C](#usingRFC6570Implementations) for an example of handling `+` in form values.
 
 ### Percent-Encoding and `form-data`
 


### PR DESCRIPTION
***Rendering with all currently open 3.0.4 changes (as of the posting of this PR) can be [found here](https://handrews.github.io/renderings/oas/deploy/oas/v3.0.4.html#appendix-e-percent-encoding-and-form-media-types).***

If you feel this is too much detail, you should have seen the first seven drafts I wrote... do feel free to help edit this down, but it's the sort of mind-numbingly tedious thing that is ideal for an appendix as most people will not care, but the people who care will need it spelled out because it doesn't make any sense and requires slogging through compelx IETF/W3C/WHATWG history to even figure out which specs might be relevant.

Fixes:
* #1778
* #1942 
* #1663
* #1322 
* #3849 
* also further fixes whatever issue caused us to add the bit about percent-encoding and `spaceDelimited`

Percent-encoding is a minefield, although in practice it mostly works.

This appendix attempts to acknowledge the concerns and then define enough terminology and link to enough other specifications that interested readers will be able to research further details.

