### PR TITLE
Minor webhooks/callbacks and schema `examples` improvements (3.1.1)

### DIFF
--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -2587,10 +2587,12 @@ additionalProperties:
   "required": [
     "name"
   ],
-  "example": {
-    "name": "Puma",
-    "id": 1
-  }
+  "examples": [
+    {
+      "name": "Puma",
+      "id": 1
+    }
+  ]
 }
 ```
 
@@ -2604,8 +2606,8 @@ properties:
     type: string
 required:
 - name
-example:
-  name: Puma
+examples:
+- name: Puma
   id: 1
 ```
 

--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -2021,7 +2021,7 @@ $response.header.Location | https://example.org/subscription/1
 
 ##### Callback Object Examples
 
-The following example uses the user provided `queryUrl` query string parameter to define the callback URL.  This is similar to a [`webhooks`](#oasWebhooks), but differs in that the callback only occurs because of the initial request that sent the `queryUrl`.
+The following example uses the user provided `queryUrl` query string parameter to define the callback URL.  This is similar to a [webhook](#oasWebhooks), but differs in that the callback only occurs because of the initial request that sent the `queryUrl`.
 
 ```yaml
 myCallback:

--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -2021,7 +2021,7 @@ $response.header.Location | https://example.org/subscription/1
 
 ##### Callback Object Examples
 
-The following example uses the user provided `queryUrl` query string parameter to define the callback URL.  This is an example of how to use a callback object to describe a WebHook callback that goes with the subscription operation to enable registering for the WebHook.
+The following example uses the user provided `queryUrl` query string parameter to define the callback URL.  This is similar to a [`webhooks`](#oasWebhooks), but differs in that the callback only occurs because of the initial request that sent the `queryUrl`.
 
 ```yaml
 myCallback:


### PR DESCRIPTION
Fixes:
* #2503 
* #3349 

These are the minor editorial issues that do not apply to 3.0.4 and therefore do not fit in PR #3861 (which will be forward-ported as usual, but separately to ensure no one misses the 3.1.1-specific improvements).

Hopefully I did the right thing with webhooks vs callbacks here.