### PR TITLE
Improve media type serialization examples (3.0.4)

### DIFF
--- a/versions/3.0.4.md
+++ b/versions/3.0.4.md
@@ -1297,7 +1297,7 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
 
 ##### Request Body Examples
 
-A request body with a referenced model definition.
+A request body with a referenced schema definition.
 ```json
 {
   "description": "user to add to the system",
@@ -1372,35 +1372,6 @@ content:
         summary: User example in other format
         externalValue: http://foo.bar/examples/user-example.whatever
 ```
-
-A body parameter that is an array of string values:
-```json
-{
-  "description": "user to add to the system",
-  "content": {
-    "text/plain": {
-      "schema": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        }
-      }
-    }
-  }
-}
-```
-
-```yaml
-description: user to add to the system
-required: true
-content:
-  text/plain:
-    schema:
-      type: array
-      items:
-        type: string
-```
-
 
 #### <a name="mediaTypeObject"></a>Media Type Object
 Each Media Type Object provides schema and examples for the media type identified by its key.
@@ -1557,9 +1528,35 @@ requestBody:
             properties: {}
 ```
 
-In this example, the contents in the `requestBody` MUST be stringified per [RFC1866](https://tools.ietf.org/html/rfc1866) when passed to the server.  In addition, the `address` field complex object will be stringified.
+In this example, the contents in the `requestBody` MUST be encoded per [RFC1866](https://tools.ietf.org/html/rfc1866) when passed to the server.  In addition, the `address` field complex object will be serialized to a string representation prior to encoding.
 
-When passing complex objects in the `application/x-www-form-urlencoded` content type, the default serialization strategy of such properties is described in the [`Encoding Object`](#encodingObject)'s [`style`](#encodingStyle) property as `form`.
+When passing complex objects in the `application/x-www-form-urlencoded` content type, the default serialization strategy of such properties is described in the [Encoding Object](#encodingObject)'s [`style`](#encodingStyle) property as `form`.
+
+With this example, given an `id` of `f81d4fae-7dec-11d0-a765-00a0c91e6bf6` and a US-style address as follows:
+
+```json
+{
+  "streetAddress": "123 Example Dr.",
+  "city": "Somewhere",
+  "state": "CA",
+  "zip": 99999
+}
+```
+
+Assuming the most compact representation of the JSON value (with unnecessary whitespace removed), we would expect to see the following request body, where space characters have been replaced with `+` and `"`, `{`, and `}` have been percent-encoded to `%22`, `%7B`, and `%7D`, respectively:
+
+```urlencoded
+id=f81d4fae-7dec-11d0-a765-00a0c91e6bf6&address=%7B%22streetAddress%22:%22123+Example+Dr.%22,%22city%22:%22Somewhere%22,%22state%22:%22CA%22,%22zip%22:99999%7D
+```
+
+Note that the `id` keyword is treated a `text/plain` per the [Encoding Object](#encodingObject)'s default behavior, and is serialized as-is.
+If it were treated as `application/json`, then the serialized value would be a JSON string including quotation marks, which would be percent-encoded as `%22`.
+
+Here is the `id` parameter (without `address`) serialized as `application/json` instead of `text/plain`, and then encoded per RFC1866:
+
+```urlencoded
+id=%22f81d4fae-7dec-11d0-a765-00a0c91e6bf6%22
+```
 
 ##### Special Considerations for `multipart` Content
 

--- a/versions/3.0.4.md
+++ b/versions/3.0.4.md
@@ -1532,21 +1532,21 @@ In this example, the contents in the `requestBody` MUST be encoded per [RFC1866]
 
 When passing complex objects in the `application/x-www-form-urlencoded` content type, the default serialization strategy of such properties is described in the [Encoding Object](#encodingObject)'s [`style`](#encodingStyle) property as `form`.
 
-With this example, given an `id` of `f81d4fae-7dec-11d0-a765-00a0c91e6bf6` and a US-style address as follows:
+With this example, given an `id` of `f81d4fae-7dec-11d0-a765-00a0c91e6bf6` and a US-style address (with ZIP+4) as follows:
 
 ```json
 {
   "streetAddress": "123 Example Dr.",
   "city": "Somewhere",
   "state": "CA",
-  "zip": 99999
+  "zip": "99999+1234"
 }
 ```
 
-Assuming the most compact representation of the JSON value (with unnecessary whitespace removed), we would expect to see the following request body, where space characters have been replaced with `+` and `"`, `{`, and `}` have been percent-encoded to `%22`, `%7B`, and `%7D`, respectively:
+Assuming the most compact representation of the JSON value (with unnecessary whitespace removed), we would expect to see the following request body, where space characters have been replaced with `+` and `+`, `"`, `{`, and `}` have been percent-encoded to `%2B`, `%22`, `%7B`, and `%7D`, respectively:
 
 ```urlencoded
-id=f81d4fae-7dec-11d0-a765-00a0c91e6bf6&address=%7B%22streetAddress%22:%22123+Example+Dr.%22,%22city%22:%22Somewhere%22,%22state%22:%22CA%22,%22zip%22:99999%7D
+id=f81d4fae-7dec-11d0-a765-00a0c91e6bf6&address=%7B%22streetAddress%22:%22123+Example+Dr.%22,%22city%22:%22Somewhere%22,%22state%22:%22CA%22,%22zip%22:%2299999%2B1234%22%7D
 ```
 
 Note that the `id` keyword is treated as `text/plain` per the [Encoding Object](#encodingObject)'s default behavior, and is serialized as-is.

--- a/versions/3.0.4.md
+++ b/versions/3.0.4.md
@@ -1549,7 +1549,7 @@ Assuming the most compact representation of the JSON value (with unnecessary whi
 id=f81d4fae-7dec-11d0-a765-00a0c91e6bf6&address=%7B%22streetAddress%22:%22123+Example+Dr.%22,%22city%22:%22Somewhere%22,%22state%22:%22CA%22,%22zip%22:99999%7D
 ```
 
-Note that the `id` keyword is treated a `text/plain` per the [Encoding Object](#encodingObject)'s default behavior, and is serialized as-is.
+Note that the `id` keyword is treated as `text/plain` per the [Encoding Object](#encodingObject)'s default behavior, and is serialized as-is.
 If it were treated as `application/json`, then the serialized value would be a JSON string including quotation marks, which would be percent-encoded as `%22`.
 
 Here is the `id` parameter (without `address`) serialized as `application/json` instead of `text/plain`, and then encoded per RFC1866:


### PR DESCRIPTION
_I know I said I was done with PRs until the current ones and/or some blocking issues are resolved, but I realized I forgot to post this one._

Fixes:
* #3761 
* Some other issue asking about `form-urlencoded` bodies and application/json values that I cannot for the life of me find right now

* Replace the outdated "model" terminology with "schema"
* Remove the outdated `text/plain` array example, which does not correlate with current OAS requirements
* Rather than replacing the `text/plain` example direclty, enhance the example of serializing `application/json` content in `application/x-www-form-urlencoeded` request bodies.
