### PR TITLE
Resolution of relative URLs in CommonMark text (3.1.1 port of #3858)

### DIFF
--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -278,6 +278,8 @@ API endpoints are by definition accessed as locations, and are described by this
 Unless specified otherwise, all properties that are URLs MAY be relative references as defined by [RFC3986](https://tools.ietf.org/html/rfc3986#section-4.2).
 Unless specified otherwise, relative references are resolved using the URLs defined in the [`Server Object`](#serverObject) as a Base URL. Note that these themselves MAY be relative to the referring document.
 
+Relative references in CommonMark hyperlinks are resolved in their rendered context, which might differ greatly from the context of the API description.
+
 ### Schema
 
 In the following description, if a field is not explicitly **REQUIRED** or described with a MUST or SHALL, it can be considered OPTIONAL.

--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -278,7 +278,7 @@ API endpoints are by definition accessed as locations, and are described by this
 Unless specified otherwise, all properties that are URLs MAY be relative references as defined by [RFC3986](https://tools.ietf.org/html/rfc3986#section-4.2).
 Unless specified otherwise, relative references are resolved using the URLs defined in the [`Server Object`](#serverObject) as a Base URL. Note that these themselves MAY be relative to the referring document.
 
-Relative references in CommonMark hyperlinks are resolved in their rendered context, which might differ greatly from the context of the API description.
+Relative references in CommonMark hyperlinks are resolved in their rendered context, which might differ from the context of the API description.
 
 ### Schema
 


### PR DESCRIPTION
_**NOTE:** I am not posting a 3.2.0 port right now because I am batching up all of the 3.1.1 referencing-related changes for a single 3.2.0 PR (with individual ported commits), which I will post once the implicit connections PRs are resolved._

* Fixes #1701 
* Ports #3858 
