### PR TITLE
Fix heading levels

### DIFF
--- a/versions/3.0.4.md
+++ b/versions/3.0.4.md
@@ -2447,7 +2447,7 @@ The Header Object follows the structure of the [Parameter Object](#parameterObje
 1. `in` MUST NOT be specified, it is implicitly in `header`.
 1. All traits that are affected by the location MUST be applicable to a location of `header` (for example, [`style`](#parameterStyle)).  This means that `allowEmptyValue` and `allowReserved` MUST NOT be used, and `style`, if used, MUST be limited to `simple`.
 
-###### Common Fixed Fields
+##### Common Fixed Fields
 
 These fields MAY be used with either `content` or `schema`.
 
@@ -2457,7 +2457,7 @@ Field Name | Type | Description
 <a name="headerRequired"></a>required | `boolean` | Determines whether this header is mandatory. The default value is `false`.
 <a name="headerDeprecated"></a> deprecated | `boolean` | Specifies that the header is deprecated and SHOULD be transitioned out of usage. Default value is `false`.
 
-###### Fixed Fields for use with `schema`
+##### Fixed Fields for use with `schema`
 
 For simpler scenarios, a [`schema`](#headerSchema) and [`style`](#headerStyle) can describe the structure and syntax of the header.
 When `example` or `examples` are provided in conjunction with the `schema` object, the example MUST follow the prescribed serialization strategy for the header.
@@ -2477,7 +2477,7 @@ Field Name | Type | Description
 
 See also [Appendix C: Using RFC6570 Implementations](#usingRFC6570Implementations) for additional guidance.
 
-###### Fixed Fields for use with `content`
+##### Fixed Fields for use with `content`
 
 For more complex scenarios, the [`content`](#headerContent) property can define the media type and schema of the header, as well as give examples of its use.
 Using `content` with a `text/plain` media type is RECOMMENDED for headers where the `schema` strategy is not appropriate.


### PR DESCRIPTION
An off-by-one caused respec to change all subsequent heading levels, starting section 5 at the Tag Object (instead of it being section 4.15).

<!--
Thank you for contributing to the OpenAPI Specification!

Please make certain you are submitting your PR on the correct
branch and file:

* 3.0.x spec: v3.0.4-dev branch, versions/3.0.4.md
* 3.1.x spec: v3.1.1-dev branch, versions/3.1.1.md
* 3.2.0 spec: v3.2.0-dev branch, versions/3.2.0.md
* 3.0 schema: main branch, schemas/v3.0/...
* 3.1 schema: main branch, schemas/v3.1/...
* registry templates: gh-pages branch, registry/...
* registry contents: gh-pages branch, registries/...

Note that we do not accept changes to published specifications.
-->
