### PR TITLE
Consisent x- Param/Encoding/Header wording (3.0.4)

### DIFF
--- a/versions/3.0.4.md
+++ b/versions/3.0.4.md
@@ -1108,8 +1108,6 @@ The rules for serialization of the parameter are specified in one of two ways.
 Parameter Objects MUST include either a `content` field or a `schema` field, but not both.
 See [Appendix B](#dataTypeConversion) for a discussion of converting values of various types to string representations.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
-
 ###### Common Fixed Fields
 
 These fields MAY be used with either `content` or `schema`.
@@ -1122,6 +1120,8 @@ Field Name | Type | Description
 <a name="parameterRequired"></a>required | `boolean` | Determines whether this parameter is mandatory. If the [parameter location](#parameterIn) is `"path"`, this property is **REQUIRED** and its value MUST be `true`. Otherwise, the property MAY be included and its default value is `false`.
 <a name="parameterDeprecated"></a> deprecated | `boolean` | Specifies that a parameter is deprecated and SHOULD be transitioned out of usage. Default value is `false`.
 <a name="parameterAllowEmptyValue"></a> allowEmptyValue | `boolean` | If `true`, clients MAY pass a zero-length string value in place of parameters that would otherwise be omitted entirely, which the server SHOULD interpret as the parameter being unused. Default value is `false`. If [`style`](#parameterStyle) is used, and if [behavior is _n/a_ (cannot be serialized)](#style-examples), the value of `allowEmptyValue` SHALL be ignored. Interactions between this field and the parameter's [Schema Object](#schemaObject) are implementation-defined. This field is valid only for `query` parameters. Use of this property is NOT RECOMMENDED, and it is likely to be removed in a later revision.
+
+This object MAY be extended with [Specification Extensions](#specificationExtensions).
 
 Note that while `"Cookie"` as a `name` is not forbidden with `in: header`, the effect of defining a cookie parameter that way is undefined; use `in: cookie` instead.
 
@@ -2492,6 +2492,8 @@ Field Name | Type | Description
 <a name="headerDescription"></a>description | `string` | A brief description of the header. This could contain examples of use. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
 <a name="headerRequired"></a>required | `boolean` | Determines whether this header is mandatory. The default value is `false`.
 <a name="headerDeprecated"></a> deprecated | `boolean` | Specifies that the header is deprecated and SHOULD be transitioned out of usage. Default value is `false`.
+
+This object MAY be extended with [Specification Extensions](#specificationExtensions).
 
 ##### Fixed Fields for use with `schema`
 


### PR DESCRIPTION
It was a bit challenging to figure out where to put the wording about allowing extension parameters when there are multiple fixed fields tables, each in their own subsection.

For the Parameter Object (the only one with multiple tables in past releases), it had been after the last table, but that got further and further away from what felt like the main part of the Object description.

I thought I had put it consistently after the initial "Common Fixed Fields" table, but I put it even before that in one place (which we don't do anywhere), and I forgot to include it in the Header Object at all.

This change puts it after the Common Fixed Fields table for all three, which means that for all Objects it is immediately after the first Fixed Fields table.  Note that the Encoding Object is not in this diff as the line was in the right place already for that Object.

<!--
Thank you for contributing to the OpenAPI Specification!

Please make certain you are submitting your PR on the correct
branch and file:

* 3.0.x spec: v3.0.4-dev branch, versions/3.0.4.md
* 3.1.x spec: v3.1.1-dev branch, versions/3.1.1.md
* 3.2.0 spec: v3.2.0-dev branch, versions/3.2.0.md
* 3.0 schema: main branch, schemas/v3.0/...
* 3.1 schema: main branch, schemas/v3.1/...
* registry templates: gh-pages branch, registry/...
* registry contents: gh-pages branch, registries/...

Note that we do not accept changes to published specifications.
-->
