### PR TITLE
format: byte also defaults to octet-stream (3.0.4)

### DIFF
--- a/versions/3.0.4.md
+++ b/versions/3.0.4.md
@@ -1717,8 +1717,8 @@ The default values for `contentType` are as follows, where an _n/a_ in the `form
 
 Property `type` | Property `format` | Default `contentType`
 ------------- | --------------- | ---------------------
-`string` | `binary` | `application/octet-stream`
-`string` | _none, or any except `binary`_ | `text/plain`
+`string` | `binary` _or_ `byte` | `application/octet-stream`
+`string` | _none, or any except `binary` or `byte`_ | `text/plain`
 `number`, `integer`, or `boolean` | _n/a_ | `text/plain`
 `object` | _n/a_ | `application/json`
 `array` | _n/a_ | according to the `type` and `format` of the `items` schema


### PR DESCRIPTION
The description of defaults in the `contentType` fixed fields table in 3.0.3 did not match the description in the Media Type Object's "Considerations for multipart" section.

The "considerations for multipart" section appears to be more complete and correct in both 3.0.3 and 3.1.1, so this adjusts that table that replaced the fixed field defaults description to match the "considerations for multipart" section.

***NOTE:** The 3.1.1 version of this is incorporated into PR #3921, which fixes a slightly different discrepancy in the same place._