### PR TITLE
Authoritative rendering; "schema" usage (3.0.4)

### DIFF
--- a/versions/3.0.4.md
+++ b/versions/3.0.4.md
@@ -14,7 +14,7 @@ An OpenAPI description can then be used by documentation generation tools to dis
 
 For examples of OpenAPI usage and additional documentation, please visit [learn.openapis.org](https://learn.openapis.org/).
 
-For extension registries and other specifications published by the OpenAPI Initiative, please visit [spec.openapis.org](https://spec.openapis.org/)
+For extension registries and other specifications published by the OpenAPI Initiative, as well as the authoritative rendering of this specification, please visit [spec.openapis.org](https://spec.openapis.org/).
 
 ## Table of Contents
 <!-- TOC depthFrom:1 depthTo:3 withLinks:1 updateOnSave:1 orderedList:0 -->
@@ -73,6 +73,12 @@ For extension registries and other specifications published by the OpenAPI Initi
 
 ##### <a name="oasDocument"></a>OpenAPI Description
 An OpenAPI Description (OAD) formally describes the surface of an API and its semantics. It is composed of an [entry document](#documentStructure) and any/all of its referenced documents. An OAD uses and conforms to the OpenAPI Specification.
+
+##### <a name="definitionsSchema"></a>Schema
+
+A "schema" is a formal description of syntax and structure.
+This document serves as the [schema](#schema) for the OpenAPI Specification format; a non-authoritative JSON Schema based on this document is also provided on [spec.openapis.org](https://spec.openapis.org) for informational purposes.
+This specification also _uses_ schemas in the form of the [Schema Object](#schemaObject).
 
 ##### <a name="pathTemplating"></a>Path Templating
 Path templating refers to the usage of template expressions, delimited by curly braces ({}), to mark a section of a URL path as replaceable using path parameters.
@@ -142,7 +148,7 @@ For example, if a field has an array value, the JSON array representation will b
 All field names in the specification are **case sensitive**.
 This includes all fields that are used as keys in a map, except where explicitly noted that keys are **case insensitive**.
 
-The schema exposes two types of fields: Fixed fields, which have a declared name, and Patterned fields, which declare a regex pattern for the field name.
+The [schema](#schema) exposes two types of fields: Fixed fields, which have a declared name, and Patterned fields, which declare a regex pattern for the field name.
 
 Patterned fields MUST have unique names within the containing object. 
 


### PR DESCRIPTION
* Fixes the spec-relevant part of #3576
* Fixes #1423 (which I thought I fixed before but I had somewhat misunderstood what it was asking for)

This adds a note about the authoritative HTML rendering and adds a definition for "Schema" to explain the three ways the term is used in or with the specification.

<!--
Thank you for contributing to the OpenAPI Specification!

Please make certain you are submitting your PR on the correct
branch and file:

* 3.0.x spec: v3.0.4-dev branch, versions/3.0.4.md
* 3.1.x spec: v3.1.1-dev branch, versions/3.1.1.md
* 3.2.0 spec: v3.2.0-dev branch, versions/3.2.0.md
* 3.0 schema: main branch, schemas/v3.0/...
* 3.1 schema: main branch, schemas/v3.1/...
* registry templates: gh-pages branch, registry/...
* registry contents: gh-pages branch, registries/...

Note that we do not accept changes to published specifications.
-->
