### PR TITLE
Clarify interaction of format: byte and Content-Transfer-Encoding header definition

### DIFF
--- a/versions/3.0.4.md
+++ b/versions/3.0.4.md
@@ -1754,8 +1754,8 @@ Note that there are significant restrictions on what headers can be used with `m
 
 Note also that `Content-Transfer-Encoding` is deprecated for `multipart/form-data` ([RFC7578 §4.7](https://www.rfc-editor.org/rfc/rfc7578.html#section-4.7)) where binary data is supported, as it is in HTTP.
 
-Using `format: byte` for a multipart field is equivalent to specifying an Encoding Object with a `headers` field containing `Content-Transfer-Encoding` with a schema that requires the value `base64`.
-If `format: byte` is used for a multipart field that has an encoding object with a `headers` field containing `Content-Transfer-Encoding` with a schema that disallows "base64", the result is undefined for serialization and parsing.
+Using `format: byte` for a multipart field is equivalent to specifying an [Encoding Object](#encodingObject) with a `headers` field containing `Content-Transfer-Encoding` with a schema that requires the value `base64`.
+If `format: byte` is used for a multipart field that has an Encoding Object with a `headers` field containing `Content-Transfer-Encoding` with a schema that disallows `base64`, the result is undefined for serialization and parsing.
 
 Per the JSON Schema specification, `contentMediaType` without `contentEncoding` present is treated as if `contentEncoding: identity` were present.  While useful for embedding text documents such as `text/html` into JSON strings, it is not useful for a `multipart/form-data` part, as it just causes the document to be treated as `text/plain` instead of its actual media type.  Use the Encoding Object without `contentMediaType` if no `contentEncoding` is required.
 

--- a/versions/3.0.4.md
+++ b/versions/3.0.4.md
@@ -1755,7 +1755,7 @@ Note that there are significant restrictions on what headers can be used with `m
 Note also that `Content-Transfer-Encoding` is deprecated for `multipart/form-data` ([RFC7578 §4.7](https://www.rfc-editor.org/rfc/rfc7578.html#section-4.7)) where binary data is supported, as it is in HTTP.
 
 Using `format: byte` for a multipart field is equivalent to specifying an `encoding` object with a `headers` field containing `Content-Transfer-Encoding: { schema: { enum: [base64] } }`.
-If `format: byte` is used for a multipart field that has an encoding object with a `headers` field containing `Content-Transfer-Encoding` with a schema that permits values other than "base64", the result is undefined.
+If `format: byte` is used for a multipart field that has an encoding object with a `headers` field containing `Content-Transfer-Encoding` with a schema that disallows "base64", the result is undefined for serialization and parsing.
 
 Per the JSON Schema specification, `contentMediaType` without `contentEncoding` present is treated as if `contentEncoding: identity` were present.  While useful for embedding text documents such as `text/html` into JSON strings, it is not useful for a `multipart/form-data` part, as it just causes the document to be treated as `text/plain` instead of its actual media type.  Use the Encoding Object without `contentMediaType` if no `contentEncoding` is required.
 

--- a/versions/3.0.4.md
+++ b/versions/3.0.4.md
@@ -1753,8 +1753,9 @@ It is not currently possible to correlate schema properties with unnamed, ordere
 Note that there are significant restrictions on what headers can be used with `multipart` media types in general ([RFC2046 §5.1](https://www.rfc-editor.org/rfc/rfc2046.html#section-5.1)) and `multi-part/form-data` in particular ([RFC7578 §4.8](https://www.rfc-editor.org/rfc/rfc7578.html#section-4.8)).
 
 Note also that `Content-Transfer-Encoding` is deprecated for `multipart/form-data` ([RFC7578 §4.7](https://www.rfc-editor.org/rfc/rfc7578.html#section-4.7)) where binary data is supported, as it is in HTTP.
-Using `format: byte` for a multipart field is equivalent to setting `Content-Transfer-Encoding: base64`.
-If `format: byte` is used along with setting a different `Content-Transfer-Encoding` value with the `headers` field, the result is undefined.
+
+Using `format: byte` for a multipart field is equivalent to specifying an `encoding` object with a `headers` field containing `Content-Transfer-Encoding: enum: ["base64"]`.
+If `format: byte` is used for a multipart field that has an encoding object with a `headers` field containing `Content-Transfer-Encoding` with a schema that permits values other than "base64", the result is undefined.
 
 Per the JSON Schema specification, `contentMediaType` without `contentEncoding` present is treated as if `contentEncoding: identity` were present.  While useful for embedding text documents such as `text/html` into JSON strings, it is not useful for a `multipart/form-data` part, as it just causes the document to be treated as `text/plain` instead of its actual media type.  Use the Encoding Object without `contentMediaType` if no `contentEncoding` is required.
 

--- a/versions/3.0.4.md
+++ b/versions/3.0.4.md
@@ -1754,7 +1754,7 @@ Note that there are significant restrictions on what headers can be used with `m
 
 Note also that `Content-Transfer-Encoding` is deprecated for `multipart/form-data` ([RFC7578 §4.7](https://www.rfc-editor.org/rfc/rfc7578.html#section-4.7)) where binary data is supported, as it is in HTTP.
 
-Using `format: byte` for a multipart field is equivalent to specifying an `encoding` object with a `headers` field containing `Content-Transfer-Encoding: { schema: { enum: [base64] } }`.
+Using `format: byte` for a multipart field is equivalent to specifying an Encoding Object with a `headers` field containing `Content-Transfer-Encoding` with a schema that requires the value `base64`.
 If `format: byte` is used for a multipart field that has an encoding object with a `headers` field containing `Content-Transfer-Encoding` with a schema that disallows "base64", the result is undefined for serialization and parsing.
 
 Per the JSON Schema specification, `contentMediaType` without `contentEncoding` present is treated as if `contentEncoding: identity` were present.  While useful for embedding text documents such as `text/html` into JSON strings, it is not useful for a `multipart/form-data` part, as it just causes the document to be treated as `text/plain` instead of its actual media type.  Use the Encoding Object without `contentMediaType` if no `contentEncoding` is required.

--- a/versions/3.0.4.md
+++ b/versions/3.0.4.md
@@ -1754,7 +1754,7 @@ Note that there are significant restrictions on what headers can be used with `m
 
 Note also that `Content-Transfer-Encoding` is deprecated for `multipart/form-data` ([RFC7578 §4.7](https://www.rfc-editor.org/rfc/rfc7578.html#section-4.7)) where binary data is supported, as it is in HTTP.
 
-Using `format: byte` for a multipart field is equivalent to specifying an `encoding` object with a `headers` field containing `Content-Transfer-Encoding: enum: ["base64"]`.
+Using `format: byte` for a multipart field is equivalent to specifying an `encoding` object with a `headers` field containing `Content-Transfer-Encoding: { schema: { enum: [base64] } }`.
 If `format: byte` is used for a multipart field that has an encoding object with a `headers` field containing `Content-Transfer-Encoding` with a schema that permits values other than "base64", the result is undefined.
 
 Per the JSON Schema specification, `contentMediaType` without `contentEncoding` present is treated as if `contentEncoding: identity` were present.  While useful for embedding text documents such as `text/html` into JSON strings, it is not useful for a `multipart/form-data` part, as it just causes the document to be treated as `text/plain` instead of its actual media type.  Use the Encoding Object without `contentMediaType` if no `contentEncoding` is required.


### PR DESCRIPTION
This PR clarifies (IMO) the interaction of `format: byte` in the schema of a multipart/form-data body with the `Content-Transfer-Encoding` header definition in the corresponding field of an Encoding Object.

I found the original text confusing because it talked about "setting the `Content-Transfer-Encoding` header", which I could not tell if this meant in the OpenAPI description or in the HTTP flow.  I think the new language makes clear that this is in the Encoding Object in the OpenAPI description.

I also made this its own paragraph since I think this is independent of the note about `Content-Transfer-Encoding` now being deprecated.
