### PR TITLE
3.0.4 formatting: don't monospace "Xxx Object"

### DIFF
--- a/versions/3.0.4.md
+++ b/versions/3.0.4.md
@@ -267,7 +267,7 @@ OpenAPI Description authors SHOULD consider how text using such extensions will 
 ### <a name="relativeReferences"></a>Relative References in URLs
 
 Unless specified otherwise, all properties that are URLs MAY be relative references as defined by [RFC3986](https://tools.ietf.org/html/rfc3986#section-4.2).
-Relative references are resolved using the URLs defined in the [`Server Object`](#serverObject) as a Base URI.
+Relative references are resolved using the URLs defined in the [Server Object](#serverObject) as a Base URI.
 
 Relative references used in `$ref` are processed as per [JSON Reference](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03), using the URL of the current document as the base URI. See also the [Reference Object](#referenceObject).
 
@@ -747,13 +747,13 @@ components:
 #### <a name="pathsObject"></a>Paths Object
 
 Holds the relative paths to the individual endpoints and their operations.
-The path is appended to the URL from the [`Server Object`](#serverObject) in order to construct the full URL.  The Paths MAY be empty, due to [ACL constraints](#securityFiltering).
+The path is appended to the URL from the [Server Object](#serverObject) in order to construct the full URL.  The Paths MAY be empty, due to [ACL constraints](#securityFiltering).
 
 ##### Patterned Fields
 
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="pathsPath"></a>/{path} | [Path Item Object](#pathItemObject) | A relative path to an individual endpoint. The field name MUST begin with a forward slash (`/`). The path is **appended** (no relative URL resolution) to the expanded URL from the [`Server Object`](#serverObject)'s `url` field in order to construct the full URL. [Path templating](#pathTemplating) is allowed. When matching URLs, concrete (non-templated) paths would be matched before their templated counterparts. Templated paths with the same hierarchy but different templated names MUST NOT exist as they are identical. In case of ambiguous matching, it's up to the tooling to decide which one to use.
+<a name="pathsPath"></a>/{path} | [Path Item Object](#pathItemObject) | A relative path to an individual endpoint. The field name MUST begin with a forward slash (`/`). The path is **appended** (no relative URL resolution) to the expanded URL from the [Server Object](#serverObject)'s `url` field in order to construct the full URL. [Path templating](#pathTemplating) is allowed. When matching URLs, concrete (non-templated) paths would be matched before their templated counterparts. Templated paths with the same hierarchy but different templated names MUST NOT exist as they are identical. In case of ambiguous matching, it's up to the tooling to decide which one to use.
 
 This object MAY be extended with [Specification Extensions](#specificationExtensions).
 
@@ -1862,7 +1862,7 @@ However, documentation is expected to cover a successful operation response and 
 The `default` MAY be used as a default response object for all HTTP codes 
 that are not covered individually by the specification.
 
-The `Responses Object` MUST contain at least one response code, and it 
+The Responses Object MUST contain at least one response code, and it 
 SHOULD be the response for a successful operation call.
 
 ##### Fixed Fields
@@ -2324,7 +2324,7 @@ In this example, the JSON string had to be serialized before encoding it into th
 
 #### <a name="linkObject"></a>Link Object
 
-The `Link object` represents a possible design-time link for a response.
+The Link Object represents a possible design-time link for a response.
 The presence of a link does not guarantee the caller's ability to successfully invoke it, rather it provides a known relationship and traversal mechanism between responses and other operations.
 
 Unlike _dynamic_ links (i.e. links provided **in** the response payload), the OAS linking mechanism does not require link information in the runtime response.


### PR DESCRIPTION
Five occurrences of Server Object, Link Object, and Responses Object were formatted in monospace, all other (hundreds) occurrences aren't.
