### PR TITLE
Link all specs and all versions

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 # theme: just-the-docs
 remote_theme: just-the-docs/just-the-docs
 color_scheme: oai
-title: OpenAPI Initiative Registry
+title: OpenAPI Initiative Publications
 description: Extensible data value repository
 show_downloads: true
 collections_dir: /registries

--- a/arazzo/index.md
+++ b/arazzo/index.md
@@ -1,0 +1,23 @@
+---
+title: The Arazzo Specification
+layout: default
+permalink: /arazzo
+has_children: true
+children:
+- link: ./v1.0.0
+has_toc: false
+---
+
+# Arazzo
+
+The Arazzo specification documents API workflows:  Sequences of calls and their dependencies to be woven together and expressed in the context of delivering a particular outcome.
+
+# Specification History
+
+Version | Date
+------- | ----
+[Arazzo 1.0.0](./v1.0.0) | 2024-05-29
+
+# Specification Repositories
+
+* [OAI/Arazzo-Specification](https://github.com/OAI/Arazzo-Specification)

--- a/index.md
+++ b/index.md
@@ -4,17 +4,25 @@ description: HTML Spec. and extensible registry
 layout: default
 ---
 
-# OpenAPI Initiative Registry
+# OpenAPI Initiative Specifications and Registries
 
-This site contains the OpenAPI Initiative Registry and content for the HTML versions of specifications managed by the OpenAPI Initiative such as the OpenAPI Specification and the Arazzo Specification.
+This site contains the OpenAPI Initiative Specifications, as well as a registry for each way in which those specifications can be extended.
 
-## Registry
+For additional documentation and examples, please visit the [Learn OpenAPI](https://learn.openapis.org/) site.
 
-* Proceed to [Registry](./registry/index.html)
+## OpenAPI Initiative Registry
+
+Each OpenAPI Initiative Specification allows for one or more types of extensions.  There is a registry for each type of extension, plus a registry for draft features being considered for future specification versions.
+
+* [View Registries](./registry/index.html)
+
+Note that implementations are _not_ required to support extensions just because they are in the registry.
 
 ## OpenAPI Initiative Specifications
 
-| Specification  | Markdown Repository | HTML Version  |
-| :--------------| :------------------ | :------- |
-| `OpenAPI Specification` | [View](https://github.com/OAI/OpenAPI-Specification)|[View](oas/latest.html)|
-| `Arazzo Specification` | [View](https://github.com/OAI/Arazzo-Specification) | [View](arazzo/latest.html)|
+The HTML renderings are the only complete versions of the published specifications, and should be used for formal citations.
+
+| Specification  | Purpose | Repository | Latest | History |
+| :--------------| :------------------ | :------- | :----- |
+| `OpenAPI Specification` | API Description | [OAI/OpenAPI-Specification](https://github.com/OAI/OpenAPI-Specification)|[Latest](oas/latest.html) | [All Versions](oas)
+| `Arazzo Specification` | Workflow Description | [OAI/Arazzo-Specification](https://github.com/OAI/Arazzo-Specification) | [Latest](arazzo/latest.html) | [All Versions](arazzo)

--- a/oas/index.md
+++ b/oas/index.md
@@ -1,0 +1,33 @@
+---
+title: The OpenAPI Specification
+layout: default
+permalink: /oas
+has_children: true
+children:
+- v3.1.0
+- v3.0.0
+- v3.0.1
+- v3.0.2
+- v3.0.3
+- v3.1.0
+has_toc: false
+---
+
+# The OpenAPI Specification (OAS)
+
+The OpenAPI Specification is used to describe HTTP APIs.
+
+## Specification History
+
+Version | Date
+------- | ----
+[OAS 3.1.0](./v3.1.0) | 2021-02-15
+[OAS 3.0.3](./v3.0.3) | 2020-02-20
+[OAS 3.0.2](./v3.0.2) | 2018-10-08
+[OAS 3.0.1](./v3.0.1) | 2017-12-06
+[OAS 3.0.0](./v3.0.0) | 2017-07-26
+[OAS 2.0](./v2.0)     | 2014-09-08
+
+## Specification Repository
+
+* [OAI/OpenAPI-Specification](https://github.com/OAI/OpenAPI-Specification)


### PR DESCRIPTION
Change the site to "Publications" as it is both specs and registries.

<!--
Thank you for contributing to the OpenAPI Specification!

Please make certain you are submitting your PR on the correct
branch and file:

* 3.0.x spec: v3.0.4-dev branch, versions/3.0.4.md
* 3.1.x spec: v3.1.1-dev branch, versions/3.1.1.md
* 3.2.0 spec: v3.2.0-dev branch, versions/3.2.0.md
* 3.0 schema: main branch, schemas/v3.0/...
* 3.1 schema: main branch, schemas/v3.1/...
* registry templates: gh-pages branch, registry/...
* registry contents: gh-pages branch, registries/...

Note that we do not accept changes to published specifications.
-->
