### PR TITLE
Update dependencies to make tests run on Windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -441,13 +441,14 @@
       }
     },
     "node_modules/@hyperjump/browser": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@hyperjump/browser/-/browser-1.1.3.tgz",
-      "integrity": "sha512-H7DtqWbP3YvdbZFTLln3BGPg5gt9B9aUxblIHyFRLMYGoNyq0yJN6LYRb3ZwYcRsxytAOwL6efnEKNFzF91iQQ==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@hyperjump/browser/-/browser-1.1.6.tgz",
+      "integrity": "sha512-i27uPV7SxK1GOn7TLTRxTorxchYa5ur9JHgtl6TxZ1MHuyb9ROAnXxEeu4q4H1836Xb7lL2PGPsaa5Jl3p+R6g==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@hyperjump/json-pointer": "^1.0.1",
+        "@hyperjump/json-pointer": "^1.1.0",
         "@hyperjump/uri": "^1.2.0",
         "content-type": "^1.0.5",
         "just-curry-it": "^5.3.0"


### PR DESCRIPTION
Apply fix for https://github.com/hyperjump-io/browser/issues/4