### PR TITLE
gh-pages: specification version lists on landing page

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "editor.formatOnSave": false
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "editor.formatOnSave": false
-}

--- a/README.md
+++ b/README.md
@@ -4,12 +4,23 @@ This site contains the OpenAPI Initiative Registry and content for the HTML vers
 
 ## Registry
 
-* Proceed to [Registry](./registry/index.html)
+* Proceed to [Registry](https://spec.openapis.org/registry/index.html)
 
 ## OpenAPI Initiative Specifications
 
-| Specification  | Markdown Repository | HTML Version  |
+| Specification  | Markdown Repository | Versions |
 | :--------------| :------------------ | :------- |
-| `OpenAPI Specification` | [View](https://github.com/OAI/OpenAPI-Specification)|[**Latest (3.1.0)**](oas/latest.html), [3.0.3](https://spec.openapis.org/oas/v3.0.3.html), [3.0.2](https://spec.openapis.org/oas/v3.0.2.html), [3.0.1](https://spec.openapis.org/oas/v3.0.1.html), [**3.0.0**](https://spec.openapis.org/oas/v3.0.0.html), [**2.0**](https://spec.openapis.org/oas/v2.0.html)|
-| `Arazzo Specification` | [View](https://github.com/OAI/Arazzo-Specification) | [1.0.0](https://spec.openapis.org/arazzo/v1.0.0.html)|
+| OpenAPI Specification | [View](https://github.com/OAI/OpenAPI-Specification/versions)|[**3.1.0 (latest)**](oas/latest.html)<br> [**3.0.3**](https://spec.openapis.org/oas/v3.0.3.html), [3.0.2](https://spec.openapis.org/oas/v3.0.2.html), [3.0.1](https://spec.openapis.org/oas/v3.0.1.html), [3.0.0](https://spec.openapis.org/oas/v3.0.0.html)<br> [**2.0**](https://spec.openapis.org/oas/v2.0.html) |
+| Arazzo Specification | [View](https://github.com/OAI/Arazzo-Specification) | [1.0.0](https://spec.openapis.org/arazzo/v1.0.0.html) |
 
+## Development
+
+Install [jekyll](https://jekyllrb.com/docs/installation/) for your platform, install the site
+~~~sh
+bundle install
+~~~
+run it
+~~~sh
+bundle exec jekyll serve --livereload
+~~~
+and change it to your heart's content :sunglasses:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This site contains the OpenAPI Initiative Registry and content for the HTML vers
 
 | Specification  | Markdown Repository | Versions |
 | :--------------| :------------------ | :------- |
-| OpenAPI Specification | [View](https://github.com/OAI/OpenAPI-Specification/versions)|[**3.1.0**](https://spec.openapis.org/oas/v3.1.0.html)<br> [**3.0.3**](https://spec.openapis.org/oas/v3.0.3.html), [3.0.2](https://spec.openapis.org/oas/v3.0.2.html), [3.0.1](https://spec.openapis.org/oas/v3.0.1.html), [3.0.0](https://spec.openapis.org/oas/v3.0.0.html)<br> [**2.0**](https://spec.openapis.org/oas/v2.0.html) |
+| OpenAPI Specification | [View](https://github.com/OAI/OpenAPI-Specification)|[**3.1.0**](https://spec.openapis.org/oas/v3.1.0.html)<br> [**3.0.3**](https://spec.openapis.org/oas/v3.0.3.html), [3.0.2](https://spec.openapis.org/oas/v3.0.2.html), [3.0.1](https://spec.openapis.org/oas/v3.0.1.html), [3.0.0](https://spec.openapis.org/oas/v3.0.0.html)<br> [**2.0**](https://spec.openapis.org/oas/v2.0.html) |
 | Arazzo Specification | [View](https://github.com/OAI/Arazzo-Specification) | [1.0.0](https://spec.openapis.org/arazzo/v1.0.0.html) |
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This site contains the OpenAPI Initiative Registry and content for the HTML vers
 
 | Specification  | Markdown Repository | Versions |
 | :--------------| :------------------ | :------- |
-| OpenAPI Specification | [View](https://github.com/OAI/OpenAPI-Specification/versions)|[**3.1.0 (latest)**](oas/latest.html)<br> [**3.0.3**](https://spec.openapis.org/oas/v3.0.3.html), [3.0.2](https://spec.openapis.org/oas/v3.0.2.html), [3.0.1](https://spec.openapis.org/oas/v3.0.1.html), [3.0.0](https://spec.openapis.org/oas/v3.0.0.html)<br> [**2.0**](https://spec.openapis.org/oas/v2.0.html) |
+| OpenAPI Specification | [View](https://github.com/OAI/OpenAPI-Specification/versions)|[**3.1.0**](oas/latest.html)<br> [**3.0.3**](https://spec.openapis.org/oas/v3.0.3.html), [3.0.2](https://spec.openapis.org/oas/v3.0.2.html), [3.0.1](https://spec.openapis.org/oas/v3.0.1.html), [3.0.0](https://spec.openapis.org/oas/v3.0.0.html)<br> [**2.0**](https://spec.openapis.org/oas/v2.0.html) |
 | Arazzo Specification | [View](https://github.com/OAI/Arazzo-Specification) | [1.0.0](https://spec.openapis.org/arazzo/v1.0.0.html) |
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This site contains the OpenAPI Initiative Registry and content for the HTML vers
 
 | Specification  | Markdown Repository | Versions |
 | :--------------| :------------------ | :------- |
-| OpenAPI Specification | [View](https://github.com/OAI/OpenAPI-Specification/versions)|[**3.1.0**](oas/latest.html)<br> [**3.0.3**](https://spec.openapis.org/oas/v3.0.3.html), [3.0.2](https://spec.openapis.org/oas/v3.0.2.html), [3.0.1](https://spec.openapis.org/oas/v3.0.1.html), [3.0.0](https://spec.openapis.org/oas/v3.0.0.html)<br> [**2.0**](https://spec.openapis.org/oas/v2.0.html) |
+| OpenAPI Specification | [View](https://github.com/OAI/OpenAPI-Specification/versions)|[**3.1.0**](https://spec.openapis.org/oas/v3.1.0.html)<br> [**3.0.3**](https://spec.openapis.org/oas/v3.0.3.html), [3.0.2](https://spec.openapis.org/oas/v3.0.2.html), [3.0.1](https://spec.openapis.org/oas/v3.0.1.html), [3.0.0](https://spec.openapis.org/oas/v3.0.0.html)<br> [**2.0**](https://spec.openapis.org/oas/v2.0.html) |
 | Arazzo Specification | [View](https://github.com/OAI/Arazzo-Specification) | [1.0.0](https://spec.openapis.org/arazzo/v1.0.0.html) |
 
 ## Development

--- a/_config.yml
+++ b/_config.yml
@@ -4,6 +4,7 @@ color_scheme: oai
 title: OpenAPI Initiative Registry
 description: Extensible data value repository
 show_downloads: true
+excerpt_separator: ""
 collections_dir: /registries
 collections:
   posts:

--- a/_includes/specification-version-list.md
+++ b/_includes/specification-version-list.md
@@ -1,0 +1,15 @@
+{% assign html_files = site.static_files | where: "extname", ".html" | sort: "basename" | reverse %}
+{% assign last_version = "" %}
+{%- for file in html_files -%}
+{%- assign segments = file.path | split: "/" -%}
+{%- assign firstchar = file.basename | slice: 0 -%}
+{%- if segments[1] == include.specification and firstchar == "v" -%}
+{%- assign minor_version = file.basename | slice: 1, 3 -%}
+{%- if minor_version != last_version -%}
+{% assign last_version = minor_version %}
+* **[{{ file.basename }}]({{ site.baseurl }}{{ file.path }})**
+{%- else -%}
+, [{{ file.basename }}]({{ site.baseurl }}{{ file.path }})
+{%- endif -%}
+{%- endif -%}
+{%- endfor- %}

--- a/index.md
+++ b/index.md
@@ -14,10 +14,15 @@ This site contains the OpenAPI Initiative Registry and content for the HTML vers
 
 ## OpenAPI Initiative Specifications
 
-| Specification  | Markdown Repository | HTML Version  |
-| :--------------| :------------------ | :------- |
-| `OpenAPI Specification` | [View](https://github.com/OAI/OpenAPI-Specification)|[View](oas/latest.html)|
-| `Arazzo Specification` | [View](https://github.com/OAI/Arazzo-Specification) | [View](arazzo/latest.html)|
+### Arazzo Specification Versions
+
+{% for file in site.static_files %}
+{% assign segments = file.path | split: "/" %}
+{% assign firstchar = file.basename | slice: 0 %}
+{% if segments[1] == "arazzo" and file.extname == ".html" and firstchar == "v" %}
+* [{{ file.basename }}]({{ site.baseurl }}{{ file.path }})
+{% endif %}
+{% endfor %}
 
 ### OpenAPI Specification Versions
 

--- a/index.md
+++ b/index.md
@@ -25,6 +25,6 @@ This site contains the OpenAPI Initiative Registry and content for the HTML vers
 {% assign segments = file.path | split: "/" %}
 {% assign firstchar = file.basename | slice: 0 %}
 {% if segments[1] == "oas" and file.extname == ".html" and firstchar == "v" %}
-* [{{ file.basename }}]({{file.path}})
+* [{{ file.basename }}]({{ site.baseurl }}{{ file.path }})
 {% endif %}
 {% endfor %}

--- a/index.md
+++ b/index.md
@@ -16,7 +16,8 @@ This site contains the OpenAPI Initiative Registry and content for the HTML vers
 
 ### Arazzo Specification Versions
 
-{% for file in site.static_files %}
+{% assign html_files = site.static_files | where: "extname", ".html" | sort: "basename" | reverse %}
+{% for file in html_files %}
 {% assign segments = file.path | split: "/" %}
 {% assign firstchar = file.basename | slice: 0 %}
 {% if segments[1] == "arazzo" and file.extname == ".html" and firstchar == "v" %}
@@ -26,10 +27,11 @@ This site contains the OpenAPI Initiative Registry and content for the HTML vers
 
 ### OpenAPI Specification Versions
 
-{% for file in site.static_files %}
+{% assign html_files = site.static_files | where: "extname", ".html" | sort: "basename" | reverse %}
+{% for file in html_files %}
 {% assign segments = file.path | split: "/" %}
 {% assign firstchar = file.basename | slice: 0 %}
-{% if segments[1] == "oas" and file.extname == ".html" and firstchar == "v" %}
+{% if segments[1] == "oas" and firstchar == "v" %}
 * [{{ file.basename }}]({{ site.baseurl }}{{ file.path }})
 {% endif %}
 {% endfor %}

--- a/index.md
+++ b/index.md
@@ -12,26 +12,59 @@ This site contains the OpenAPI Initiative Registry and content for the HTML vers
 
 * Proceed to [Registry](./registry/index.html)
 
-## OpenAPI Initiative Specifications
+## Arazzo Specification
 
-### Arazzo Specification Versions
+### Versions
 
+<!-- TODO: make include  and call with parameter "arazzo" -->
 {% assign html_files = site.static_files | where: "extname", ".html" | sort: "basename" | reverse %}
-{% for file in html_files %}
-{% assign segments = file.path | split: "/" %}
-{% assign firstchar = file.basename | slice: 0 %}
-{% if segments[1] == "arazzo" and file.extname == ".html" and firstchar == "v" %}
-* [{{ file.basename }}]({{ site.baseurl }}{{ file.path }})
-{% endif %}
-{% endfor %}
+{% assign last_version = "" %}
+{%- for file in html_files -%}
+{%- assign segments = file.path | split: "/" -%}
+{%- assign firstchar = file.basename | slice: 0 -%}
+{%- if segments[1] == "arazzo" and firstchar == "v" -%}
+{%- assign minor_version = file.basename | slice: 1, 3 -%}
+{%- if minor_version != last_version -%}
+{% assign last_version = minor_version %}
+* **[{{ file.basename }}]({{ site.baseurl }}{{ file.path }})**
+{%- else -%}
+, [{{ file.basename }}]({{ site.baseurl }}{{ file.path }})
+{%- endif -%}{%- endif -%}
+{%- endfor- %}
 
-### OpenAPI Specification Versions
+## OpenAPI Specification
 
+### Versions
+
+<!-- TODO: make include  and call with parameter "oas" -->
 {% assign html_files = site.static_files | where: "extname", ".html" | sort: "basename" | reverse %}
-{% for file in html_files %}
-{% assign segments = file.path | split: "/" %}
-{% assign firstchar = file.basename | slice: 0 %}
-{% if segments[1] == "oas" and firstchar == "v" %}
-* [{{ file.basename }}]({{ site.baseurl }}{{ file.path }})
-{% endif %}
-{% endfor %}
+{% assign last_version = "" %}
+{%- for file in html_files -%}
+{%- assign segments = file.path | split: "/" -%}
+{%- assign firstchar = file.basename | slice: 0 -%}
+{%- if segments[1] == "oas" and firstchar == "v" -%}
+{%- assign minor_version = file.basename | slice: 1, 3 -%}
+{%- if minor_version != last_version -%}
+{% assign last_version = minor_version %}
+* **[{{ file.basename }}]({{ site.baseurl }}{{ file.path }})**
+{%- else -%}
+, [{{ file.basename }}]({{ site.baseurl }}{{ file.path }})
+{%- endif -%}{%- endif -%}
+{%- endfor- %}
+
+### Non-Normative JSON Schemas
+
+{% assign schema_files = site.static_files | where: "extname", "" | sort: "path" | reverse %}
+{% assign last_version = "" %}
+{%- for file in schema_files -%}
+{%- assign segments = file.path | split: "/" -%}
+{%- if segments[1] == "oas" and file.basename contains "lat" -%}
+{%- if segments[2] != last_version -%}
+{%- assign last_version = segments[2] %}
+* **v{{ last_version }}**
+{%- assign separator = ": " -%}
+{%- endif -%}
+{{ separator }}[{{ segments[3] }}]({{ file.path }})
+{%- assign separator = ", " -%}
+{%- endif -%}
+{%- endfor -%}

--- a/index.md
+++ b/index.md
@@ -16,41 +16,13 @@ This site contains the OpenAPI Initiative Registry and content for the HTML vers
 
 ### Versions
 
-<!-- TODO: make include  and call with parameter "arazzo" -->
-{% assign html_files = site.static_files | where: "extname", ".html" | sort: "basename" | reverse %}
-{% assign last_version = "" %}
-{%- for file in html_files -%}
-{%- assign segments = file.path | split: "/" -%}
-{%- assign firstchar = file.basename | slice: 0 -%}
-{%- if segments[1] == "arazzo" and firstchar == "v" -%}
-{%- assign minor_version = file.basename | slice: 1, 3 -%}
-{%- if minor_version != last_version -%}
-{% assign last_version = minor_version %}
-* **[{{ file.basename }}]({{ site.baseurl }}{{ file.path }})**
-{%- else -%}
-, [{{ file.basename }}]({{ site.baseurl }}{{ file.path }})
-{%- endif -%}{%- endif -%}
-{%- endfor- %}
+{% include specification-version-list.md specification="arazzo" %}
 
 ## OpenAPI Specification
 
 ### Versions
 
-<!-- TODO: make include  and call with parameter "oas" -->
-{% assign html_files = site.static_files | where: "extname", ".html" | sort: "basename" | reverse %}
-{% assign last_version = "" %}
-{%- for file in html_files -%}
-{%- assign segments = file.path | split: "/" -%}
-{%- assign firstchar = file.basename | slice: 0 -%}
-{%- if segments[1] == "oas" and firstchar == "v" -%}
-{%- assign minor_version = file.basename | slice: 1, 3 -%}
-{%- if minor_version != last_version -%}
-{% assign last_version = minor_version %}
-* **[{{ file.basename }}]({{ site.baseurl }}{{ file.path }})**
-{%- else -%}
-, [{{ file.basename }}]({{ site.baseurl }}{{ file.path }})
-{%- endif -%}{%- endif -%}
-{%- endfor- %}
+{% include specification-version-list.md specification="oas" %}
 
 ### Non-Normative JSON Schemas
 

--- a/index.md
+++ b/index.md
@@ -18,3 +18,13 @@ This site contains the OpenAPI Initiative Registry and content for the HTML vers
 | :--------------| :------------------ | :------- |
 | `OpenAPI Specification` | [View](https://github.com/OAI/OpenAPI-Specification)|[View](oas/latest.html)|
 | `Arazzo Specification` | [View](https://github.com/OAI/Arazzo-Specification) | [View](arazzo/latest.html)|
+
+### OpenAPI Specification Versions
+
+{% for file in site.static_files %}
+{% assign segments = file.path | split: "/" %}
+{% assign firstchar = file.basename | slice: 0 %}
+{% if segments[1] == "oas" and file.extname == ".html" and firstchar == "v" %}
+* [{{ file.basename }}]({{file.path}})
+{% endif %}
+{% endfor %}

--- a/rss/feed.xml
+++ b/rss/feed.xml
@@ -9,17 +9,19 @@ layout: none
     <link>{{ site.url }}{{ site.baseurl }}/</link>
     <atom:link href="{{ "/rss/feed.xml" | prepend: site.baseurl | prepend: site.url }}" rel="self" type="application/rss+xml" />
     {% for reg in site.collections %}
-    {% assign name = reg.label %}
-    {% for value in reg.posts %}
-      <item>
-        <title>{{ value.slug | xml_escape }}</title>
-        <description>{{ value.description | xml_escape }}</description>
-        <category>{{ reg.label }}</category>
-        <pubDate>{% if value.date %}{{ value.date | date: "%a, %d %b %Y %H:%M:%S %z" }}{% else %}{{ 'now' | date: "%a, %d %b %Y %H:%M:%S %z" }}{% endif %}</pubDate>
-        <link>{{ value.url }}</link>
-        <guid isPermaLink="true">{{ value.url }}</guid>
-      </item>
-    {% endfor %}
+      {% if reg.output %}
+        {% assign name = reg.label %}
+        {% for value in reg.docs %}
+    <item>
+      <title>{{ value.slug | xml_escape }}</title>
+      <description>{{ value.description | xml_escape }}</description>
+      <category>{{ reg.label }}</category>
+      <link>{{ value.url }}</link>
+      <guid isPermaLink="true">{{ value.url }}</guid>
+      <pubDate>{% if value.date %}{{ value.date | date: "%a, %d %b %Y %H:%M:%S %z" }}{% else %}{{ 'now' | date: "%a, %d %b %Y %H:%M:%S %z" }}{% endif %}</pubDate>
+    </item>
+        {% endfor %}
+      {% endif %}
     {% endfor %}
   </channel>
 </rss>

--- a/rss/feed.xml
+++ b/rss/feed.xml
@@ -16,9 +16,9 @@ layout: none
       <title>{{ value.slug | xml_escape }}</title>
       <description>{{ value.description | xml_escape }}</description>
       <category>{{ reg.label }}</category>
+      <pubDate>{% if value.date %}{{ value.date | date: "%a, %d %b %Y %H:%M:%S %z" }}{% else %}{{ 'now' | date: "%a, %d %b %Y %H:%M:%S %z" }}{% endif %}</pubDate>
       <link>{{ value.url }}</link>
       <guid isPermaLink="true">{{ value.url }}</guid>
-      <pubDate>{% if value.date %}{{ value.date | date: "%a, %d %b %Y %H:%M:%S %z" }}{% else %}{{ 'now' | date: "%a, %d %b %Y %H:%M:%S %z" }}{% endif %}</pubDate>
     </item>
         {% endfor %}
       {% endif %}

--- a/rss/feed.xml
+++ b/rss/feed.xml
@@ -10,7 +10,7 @@ layout: none
     <atom:link href="{{ "/rss/feed.xml" | prepend: site.baseurl | prepend: site.url }}" rel="self" type="application/rss+xml" />
     {% for reg in site.collections %}
     {% assign name = reg.label %}
-    {% for value in site.[name] %}
+    {% for value in reg.posts %}
       <item>
         <title>{{ value.slug | xml_escape }}</title>
         <description>{{ value.description | xml_escape }}</description>


### PR DESCRIPTION
Part of #3576

- [x] List of Arazzo and OpenAPI Specification versions on landing page
- [x] Fix warnings for some registry entries
- [x] Fix error for broken RSS feed - do we want an RSS feed?

This is a preview of the adapted landing page: https://ralfhandl.github.io/OpenAPI-Specification/

This is a preview of the RSS feed: https://ralfhandl.github.io/OpenAPI-Specification/rss/feed.xml