### PR TITLE
gh-pages: fix schema links

### DIFF
--- a/index.md
+++ b/index.md
@@ -36,7 +36,7 @@ This site contains the OpenAPI Initiative Registry and content for the HTML vers
 * **v{{ last_version }}**
 {%- assign separator = ": " -%}
 {%- endif -%}
-{{ separator }}[{{ segments[3] }}]({{ file.path }})
+{{ separator }}[{{ segments[3] }}]({{ site.baseurl }}{{ file.path }})
 {%- assign separator = ", " -%}
 {%- endif -%}
 {%- endfor -%}


### PR DESCRIPTION
Make links also work if site is deployed with non-empty base URL.

Has no visible effect now as it currently is deployed to the domain root.

