### PR TITLE
build script: example links point to HTML wrapper on learn site

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "build": "bash ./scripts/md2html/build.sh",
-    "test": "c8 vitest --watch=false"
+    "test": "c8 --100 vitest --watch=false"
   },
   "readmeFilename": "README.md",
   "files": [

--- a/scripts/md2html/md2html.js
+++ b/scripts/md2html/md2html.js
@@ -209,7 +209,7 @@ for (let l in lines) {
         line = line.replace('<a name="parameterAllowEmptyValue"/>','<span id="parameterAllowEmptyValue"></span>');
     }
 
-    // replace deprecated <a name="..."></a> with <span id="..."></span>
+    // replace deprecated <a name="..."></a> with <span id="..."></span> - needed for older specs
     line = line.replace(/<a name="([^"]+)"><\/a>/g,'<span id="$1"></span>');
 
     line = line.split('\\|').join('&#124;'); // was &brvbar

--- a/scripts/md2html/md2html.js
+++ b/scripts/md2html/md2html.js
@@ -271,12 +271,14 @@ for (let l in lines) {
 
     // fix relative links (to examples)
     if (!inCodeBlock && line.indexOf('](../examples/') >= 0) {
+        // links to examples go to learn site, links to yaml files go to wrapper html
         line = line.replace(/\(\.\.\/examples\/([^)]+)\)/g,function(match,group1){
             console.warn("example link",group1);
-            //TODO: group1 = group1.replace('.yaml','.html');
+            group1 = group1.replace('.yaml','.html');
             return `(https://learn.openapis.org/examples/${group1})`;
           })
     } else if (!inCodeBlock && line.indexOf('](../') >= 0) {
+        // links to other sibling files go to github
         const regExp = /\((\.\.[^)]+)\)/g;
         line = line.replace(regExp,function(match,group1){
           console.warn('relative link',group1);

--- a/scripts/md2html/md2html.js
+++ b/scripts/md2html/md2html.js
@@ -190,7 +190,7 @@ for (let l in lines) {
 
     // remove TOC from older spec versions, respec will generate a new one
     if (line.startsWith('## Table of Contents')) inTOC = true;
-    if (line.startsWith('<!-- /TOC')) inTOC = false;
+    else if (line.startsWith('#')) inTOC = false;
     if (inTOC) line = '';
 
     // special formatting for Definitions section

--- a/tests/md2html/fixtures/basic-new.html
+++ b/tests/md2html/fixtures/basic-new.html
@@ -10,7 +10,7 @@
 <p>Definition of Foo.</p>
 </section></section><section><h1>Another Heading 2</h1>
 <p>Text for second section</p>
-<p><a href="https://learn.openapis.org/examples/foo.yaml">Relative link to example</a></p>
+<p><a href="https://learn.openapis.org/examples/foo.html">Relative link to example</a></p>
 <p><a href="https://github.com/OAI/OpenAPI-Specification/tree/main/something/else">Relative link to something else</a></p>
 <section><h2>Heading 3</h2>
 <p>Text for first subsection</p>

--- a/tests/md2html/fixtures/basic-old.html
+++ b/tests/md2html/fixtures/basic-old.html
@@ -3,7 +3,6 @@
 <p>Text for first chapter</p>
 <section class="override" id="conformance"><h2>Version 30.0.1</h2>
 <p>This is the conformance section</p>
-<!-- /TOC -->
 </section></section><section><h1>Heading 2</h1>
 <p>Text for first section</p>
 <p><span id="parameterAllowEmptyValue"></span>Broken anchor</p>

--- a/tests/md2html/fixtures/basic-old.md
+++ b/tests/md2html/fixtures/basic-old.md
@@ -10,8 +10,6 @@ This is the conformance section
 
 Will be removed
 
-<!-- /TOC -->
-
 ## Heading 2
 
 Text for first section

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    forceRerunTriggers: ['**/scripts/**', '**/tests/**'],
+  },
+})


### PR DESCRIPTION
- example links point to HTML wrapper on learn site
- `npm test` (and thus the `schema-test` workflow) will complain if test coverage drops
- added comment to `md2html.js` explaining that the anchor tweak is needed for older spec versions

Depends on
* https://github.com/OAI/learn.openapis.org/pull/105

