### PR TITLE
gh-pages: schema list on landing page: call out "view" and "download" links

### DIFF
--- a/index.md
+++ b/index.md
@@ -31,7 +31,7 @@ This site contains the OpenAPI Initiative Registry and content for the HTML vers
 {% assign last_kind = "" %}
 {%- for file in schema_files -%}
 {%- assign segments = file.path | split: "/" -%}
-{%- if segments[1] == "oas" and file.basename contains "-" -%}
+{%- if segments[1] == "oas" -%}
 {%- if segments[2] != last_version -%}
 {%- assign last_version = segments[2] %}
 * **v{{ last_version }}**

--- a/index.md
+++ b/index.md
@@ -38,10 +38,11 @@ This site contains the OpenAPI Initiative Registry and content for the HTML vers
 {%- endif -%}
 {%- if segments[3] != last_kind -%}
 {%- assign last_kind = segments[3] %}
-  * [**{{ last_kind }}**]({{ site.baseurl }}/oas/{{ last_version }}/{{ last_kind }}/latest.html)
+  * [**view latest {{ last_kind }}**]({{ site.baseurl }}/oas/{{ last_version }}/{{ last_kind }}/latest.html)  
+    download iteration
 {%- assign separator = ": " -%}
 {%- endif -%}
-{{ separator }} [{{ file.basename }}]({{ site.baseurl }}{{ file.path }})
+{{ separator }} [{{ file.basename | replace: "-", "&#8209;" }}]({{ site.baseurl }}{{ file.path }})
 {%- assign separator = ", " -%}
 {%- endif -%}
 {%- endfor %}

--- a/oas/3.1/dialect/latest.md
+++ b/oas/3.1/dialect/latest.md
@@ -1,0 +1,9 @@
+---
+title: JSON Schema dialect for OpenAPI
+layout: default
+parent: Schemas
+---
+
+```json
+{% include_relative base %}
+```

--- a/oas/3.1/meta/latest.md
+++ b/oas/3.1/meta/latest.md
@@ -1,0 +1,9 @@
+---
+title: JSON Schema Vocabulary used in OpenAPI
+layout: default
+parent: Schemas
+---
+
+```json
+{% include_relative base %}
+```


### PR DESCRIPTION
Attempted UX improvement:
- call out which links are "view", which are "download", and what can be viewed or downloaded
- also list "meta" and "dialect" for v3.1

![image](https://github.com/user-attachments/assets/d56c2e7f-fc00-4b22-a055-c1959c37ca9a)

Live preview:
* https://ralfhandl.github.io/OpenAPI-Specification/
