### PR TITLE
3.0.4: fix json schema reference

### DIFF
--- a/versions/3.0.4.md
+++ b/versions/3.0.4.md
@@ -2643,7 +2643,7 @@ $ref: definitions.yaml#/Pet
 
 The Schema Object allows the definition of input and output data types.
 These types can be objects, but also primitives and arrays.
-This object is an extended subset of the [JSON Schema Specification Draft Wright-00](https://json-schema.org/).
+This object is an extended subset of the [[JSON-Schema-05|JSON Schema Specification Draft Wright-00]].
 
 For more information about the keywords, see [JSON Schema Core](https://tools.ietf.org/html/draft-wright-json-schema-00) and [JSON Schema Validation](https://tools.ietf.org/html/draft-wright-json-schema-validation-00).
 Unless stated otherwise, the keyword definitions follow those of JSON Schema and do not add any additional semantics.


### PR DESCRIPTION
Changing the link text broke our ReSpec magic in the build script.

Now use ReSpec link in source and don't rely on magic.
