### PR TITLE
3.1.1: File Upload - difference also to 3.0.x

### DIFF
--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -1572,7 +1572,7 @@ application/json:
 
 In contrast to OpenAPI 2.0, `file` input/output content in OpenAPI 3 is described with the same semantics as any other schema type.
 
-In contrast to OpenAPI 2.0, the `format` keyword has no effect on the content-encoding of the schema. Instead, JSON Schema's `contentEncoding` and `contentMediaType` keywords are used. See [Working With Binary Data](#working-with-binary-data) for how to model various scenarios with these keywords, and how to migrate from the previous `format` usage.
+In contrast to OpenAPI 3.0, the `format` keyword has no effect on the content-encoding of the schema. Instead, JSON Schema's `contentEncoding` and `contentMediaType` keywords are used. See [Working With Binary Data](#working-with-binary-data) for how to model various scenarios with these keywords, and how to migrate from the previous `format` usage.
 
 Examples:
 

--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -1570,9 +1570,9 @@ application/json:
 
 ##### Considerations for File Uploads
 
-In contrast to OpenAPI 2.0, `file` input/output content in OpenAPI 3 is described with the same semantics as any other schema type.
+In contrast to OpenAPI 2.0, `file` input/output content in OAS 3.x is described with the same semantics as any other schema type.
 
-In contrast to OpenAPI 3.0, the `format` keyword has no effect on the content-encoding of the schema. Instead, JSON Schema's `contentEncoding` and `contentMediaType` keywords are used. See [Working With Binary Data](#working-with-binary-data) for how to model various scenarios with these keywords, and how to migrate from the previous `format` usage.
+In contrast to OAS 3.0, the `format` keyword has no effect on the content-encoding of the schema in OAS 3.1. Instead, JSON Schema's `contentEncoding` and `contentMediaType` keywords are used. See [Working With Binary Data](#working-with-binary-data) for how to model various scenarios with these keywords, and how to migrate from the previous `format` usage.
 
 Examples:
 


### PR DESCRIPTION
- The contrast here is due to the different JSON Schema version and also affects 3.0
- Stylistic harmonization: we use "OAS 3" everywhere else instead of "OpenAPI 3"
- We use "OpenAPI 2.0" eight times