### PR TITLE
Clarify complete vs self-contained documents

### DIFF
--- a/versions/3.0.4.md
+++ b/versions/3.0.4.md
@@ -121,7 +121,9 @@ In order to preserve the ability to round-trip between YAML and JSON formats, YA
 
 An OpenAPI Description (OAD) MAY be made up of a single document or be divided into multiple, connected parts at the discretion of the author. In the latter case, [Reference Object](#reference-object) and [Path Item Object](#path-item-object) `$ref` keywords, as well as the [Link Object](#link-object) `operationRef` keyword, are used.
 
-Any document consisting entirely of an [OpenAPI Object](#openapi-object) is known as a **complete OpenAPI document**.
+Any document consisting entirely of an [OpenAPI Object](#openapi-object) is known as a **syntactically complete OpenAPI document**.
+An OpenAPI document that does ***not*** reference any other documents is known as a **self-contained OpenAPI document.***
+A single-document description is therefore _both_ syntactically complete _and_ self-contained.
 In a multi-document description, the document containing the OpenAPI Object where parsing begins for a specific API's description is known as that API's **entry OpenAPI document**, or simply **entry document**.
 
 It is RECOMMENDED that the entry OpenAPI document be named: `openapi.json` or `openapi.yaml`.
@@ -130,7 +132,7 @@ It is RECOMMENDED that the entry OpenAPI document be named: `openapi.json` or `o
 
 When parsing an OAD, JSON or YAML objects are parsed into specific Objects (such as [Operation Objects](#operation-object), [Response Objects](#response-object), [Reference Objects](#reference-object), etc.) based on the parsing context. Depending on how references are arranged, a given JSON or YAML object can be parsed in multiple different contexts:
 
-* As a complete OpenAPI Description document
+* As a syntactically complete OpenAPI Description document
 * As the Object type implied by its parent Object within the document
 * As a reference target, with the Object type matching the reference source's context
 

--- a/versions/3.0.4.md
+++ b/versions/3.0.4.md
@@ -122,7 +122,7 @@ In order to preserve the ability to round-trip between YAML and JSON formats, YA
 An OpenAPI Description (OAD) MAY be made up of a single document or be divided into multiple, connected parts at the discretion of the author. In the latter case, [Reference Object](#reference-object) and [Path Item Object](#path-item-object) `$ref` keywords, as well as the [Link Object](#link-object) `operationRef` keyword, are used.
 
 Any document consisting entirely of an [OpenAPI Object](#openapi-object) is known as a **syntactically complete OpenAPI document**.
-An OpenAPI document that does ***not*** reference any other documents is known as a **self-contained OpenAPI document.***
+An OpenAPI document that does _not_ reference any other documents is known as a **self-contained OpenAPI document**.
 A single-document description is therefore _both_ syntactically complete _and_ self-contained.
 In a multi-document description, the document containing the OpenAPI Object where parsing begins for a specific API's description is known as that API's **entry OpenAPI document**, or simply **entry document**.
 


### PR DESCRIPTION
With apologies for the last-minute change, I encountered some confusion around the term "complete document", where it was mistaken for a single, self-contained OpenAPI Description.  This is an attempt to solve that- we don't use "complete document" outside of this bit, so the awkward "syntactically complete" (with "self-contained" defined separately for clarity) probably does what we need.  It is a bit awkward, though, so if anyone else can think of better words here please do speak up.

<!--
Thank you for contributing to the OpenAPI Specification!

Please make certain you are submitting your PR on the correct
branch and file:

* 3.0.x spec: v3.0.4-dev branch, versions/3.0.4.md
* 3.1.x spec: v3.1.1-dev branch, versions/3.1.1.md
* 3.2.0 spec: v3.2.0-dev branch, versions/3.2.0.md
* 3.0 schema: main branch, schemas/v3.0/...
* 3.1 schema: main branch, schemas/v3.1/...
* registry templates: gh-pages branch, registry/...
* registry contents: gh-pages branch, registries/...

Note that we do not accept changes to published specifications.
-->
