### PR TITLE
Markdown links are API Description, not API URLs

### DIFF
--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -294,14 +294,14 @@ In practice, this is usually the retrieval URI of the document, which MAY be det
 
 If a URI contains a fragment identifier, then the fragment should be resolved per the fragment resolution mechanism of the referenced document. If the representation of the referenced document is JSON or YAML, then the fragment identifier SHOULD be interpreted as a JSON-Pointer as per [RFC6901](https://tools.ietf.org/html/rfc6901).
 
+Relative references in CommonMark hyperlinks are resolved in their rendered context, which might differ from the context of the API description.
+
 ### Relative References in API URLs
 
 API endpoints are by definition accessed as locations, and are described by this specification as **_URLs_**.
 
 Unless specified otherwise, all fields that are URLs MAY be relative references as defined by [RFC3986](https://tools.ietf.org/html/rfc3986#section-4.2).
 Unless specified otherwise, relative references are resolved using the URLs defined in the [Server Object](#server-object) as a Base URL. Note that these themselves MAY be relative to the referring document.
-
-Relative references in CommonMark hyperlinks are resolved in their rendered context, which might differ from the context of the API description.
 
 ### Schema
 


### PR DESCRIPTION
_Another last-minute fix found while drafting release notes – this isn't a problem in 3.0.4 as there is only one section for relative references in 3.0_

While the Markdown links don't behave quite like either category, they definitely belong more in the "API Description URIs" part as the text even compares their behavior to "the context of the API description" rather than the actual API's server URL.

<!--
Thank you for contributing to the OpenAPI Specification!

Please make certain you are submitting your PR on the correct
branch and file:

* 3.0.x spec: v3.0.4-dev branch, versions/3.0.4.md
* 3.1.x spec: v3.1.1-dev branch, versions/3.1.1.md
* 3.2.0 spec: v3.2.0-dev branch, versions/3.2.0.md
* 3.0 schema: main branch, schemas/v3.0/...
* 3.1 schema: main branch, schemas/v3.1/...
* registry templates: gh-pages branch, registry/...
* registry contents: gh-pages branch, registries/...

Note that we do not accept changes to published specifications.
-->
