### PR TITLE
ReSpec build script: no automatic syntax highlighting for unspecified or "unknown" languages

### DIFF
--- a/scripts/md2html/md2html.js
+++ b/scripts/md2html/md2html.js
@@ -36,7 +36,7 @@ const md = require('markdown-it')({
       '</code></pre>';
     }
 
-    return '<pre class="highlight '+lang+'" tabindex="0"><code>' + md.utils.escapeHtml(str) + '</code></pre>';
+    return '<pre class="nohighlight" tabindex="0"><code>' + md.utils.escapeHtml(str) + '</code></pre>';
   }
 });
 

--- a/scripts/md2html/md2html.js
+++ b/scripts/md2html/md2html.js
@@ -13,6 +13,41 @@ const path = require('path');
 const url = require('url');
 
 const hljs = require('highlight.js');
+hljs.registerLanguage('uritemplate', function() {
+    return {
+      case_insensitive: true,
+      contains: [
+          {
+              scope: "attr", 
+              match: /(?<=[{,])[^,}\n\r]+/,
+          }
+      ],
+    }
+  });
+hljs.registerLanguage('uri', function() {
+    return {
+      case_insensitive: true,
+      classNameAliases: {
+          pathsegment: "attr",
+          option: "attr",
+          value: "literal"
+      },
+      contains: [
+          {
+              scope: "pathsegment", 
+              match: /(?<=[/])[^/?#\n\r]+/,
+          },
+          {
+              scope: "option", 
+              match: /(?<=[?&#])[^=?&#\n\r]+/,
+          },
+          {
+              scope: "value",
+              match: /(?<=\=)[^?&#\n\r]+/,
+          }
+      ],
+    }
+  });
 const cheerio = require('cheerio');
 
 let argv = require('yargs')

--- a/scripts/md2html/md2html.js
+++ b/scripts/md2html/md2html.js
@@ -36,6 +36,7 @@ const md = require('markdown-it')({
       '</code></pre>';
     }
 
+    if (lang) console.warn('highlight.js does not support language',lang);
     return '<pre class="nohighlight" tabindex="0"><code>' + md.utils.escapeHtml(str) + '</code></pre>';
   }
 });

--- a/tests/md2html/fixtures/basic-new.html
+++ b/tests/md2html/fixtures/basic-new.html
@@ -26,6 +26,8 @@
 </code></pre>
 <pre class="nohighlight" tabindex="0"><code>no language
 </code></pre>
+<pre class="nohighlight" tabindex="0"><code>unknown language
+</code></pre>
 </section></section><section class="appendix"><h1>Appendix A: Revision History</h1>
 <table>
 <thead>

--- a/tests/md2html/fixtures/basic-new.html
+++ b/tests/md2html/fixtures/basic-new.html
@@ -28,6 +28,10 @@
 </code></pre>
 <pre class="nohighlight" tabindex="0"><code>unknown language
 </code></pre>
+<pre class="nohighlight" tabindex="0"><code>https://<span class="hljs-attr">foo.com</span>/<span class="hljs-attr">bar</span>?<span class="hljs-attr">baz</span>=<span class="hljs-literal">qux</span>&amp;<span class="hljs-attr">fred</span>=<span class="hljs-literal">waldo</span>#<span class="hljs-attr">fragment</span>
+</code></pre>
+<pre class="nohighlight" tabindex="0"><code>https://foo.com/bar{<span class="hljs-attr">?baz*</span>,<span class="hljs-attr">qux</span>}
+</code></pre>
 </section></section><section class="appendix"><h1>Appendix A: Revision History</h1>
 <table>
 <thead>

--- a/tests/md2html/fixtures/basic-new.html
+++ b/tests/md2html/fixtures/basic-new.html
@@ -24,7 +24,7 @@
 </code></pre>
 <pre class="nohighlight" tabindex="0"><code>text/plain
 </code></pre>
-<pre class="highlight " tabindex="0"><code>no language
+<pre class="nohighlight" tabindex="0"><code>no language
 </code></pre>
 </section></section><section class="appendix"><h1>Appendix A: Revision History</h1>
 <table>

--- a/tests/md2html/fixtures/basic-new.md
+++ b/tests/md2html/fixtures/basic-new.md
@@ -50,6 +50,10 @@ text/plain
 no language
 ```
 
+```unknown
+unknown language
+```
+
 ## Appendix A: Revision History
 
 Version | Date

--- a/tests/md2html/fixtures/basic-new.md
+++ b/tests/md2html/fixtures/basic-new.md
@@ -54,6 +54,14 @@ no language
 unknown language
 ```
 
+```uri
+https://foo.com/bar?baz=qux&fred=waldo#fragment
+```
+
+```uritemplate
+https://foo.com/bar{?baz*,qux}
+```
+
 ## Appendix A: Revision History
 
 Version | Date


### PR DESCRIPTION
We intentionally format code blocks with `highlight.js` if the explicitly specified language of the code block is known to this package.

Formerly we left highlighting of unknown languages or code blocks with unspecified language to ReSpec, which now leads to erratic results, see #4103.

This PR suppresses automatic syntax highlighting by ReSpec for code blocks whose language is not specified or unknown to `highlight.js`.

It also adds two custom languages `uri` and `uritemplate` that are used in
* #4110 
* #4109 

Preview:
* https://ralfhandl.github.io/OpenAPI-Specification/oas/v3.1.1.html#rfc6570-equivalent-expansion

![image](https://github.com/user-attachments/assets/39a28069-3714-41ec-9f57-70c921b8e190)

