### PR TITLE
3.0.4: use specific custom languages uri and uritemplate

### DIFF
--- a/versions/3.0.4.md
+++ b/versions/3.0.4.md
@@ -1649,7 +1649,7 @@ With this example, consider an `id` of `f81d4fae-7dec-11d0-a765-00a0c91e6bf6` an
 
 Assuming the most compact representation of the JSON value (with unnecessary whitespace removed), we would expect to see the following request body, where space characters have been replaced with `+` and `+`, `"`, `{`, and `}` have been percent-encoded to `%2B`, `%22`, `%7B`, and `%7D`, respectively:
 
-```urlencoded
+```uri
 id=f81d4fae-7dec-11d0-a765-00a0c91e6bf6&address=%7B%22streetAddress%22:%22123+Example+Dr.%22,%22city%22:%22Somewhere%22,%22state%22:%22CA%22,%22zip%22:%2299999%2B1234%22%7D
 ```
 
@@ -1658,7 +1658,7 @@ If it were treated as `application/json`, then the serialized value would be a J
 
 Here is the `id` parameter (without `address`) serialized as `application/json` instead of `text/plain`, and then encoded per RFC1866:
 
-```urlencoded
+```uri
 id=%22f81d4fae-7dec-11d0-a765-00a0c91e6bf6%22
 ```
 
@@ -1688,7 +1688,7 @@ requestBody:
 Given a name of `example` and a solid red 2x2-pixel PNG for `icon`, this
 would produce a request body of:
 
-```urlencoded
+```uri
 name=example&icon=iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAABGdBTUEAALGPC%2FxhBQAAADhlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAAqACAAQAAAABAAAAAqADAAQAAAABAAAAAgAAAADO0J6QAAAAEElEQVQIHWP8zwACTGCSAQANHQEDqtPptQAAAABJRU5ErkJggg%3D%3D
 ```
 
@@ -4005,13 +4005,13 @@ parameters:
 
 This translates to the following URI Template:
 
-```urlencoded
+```uritemplate
 {?formulas*,words}
 ```
 
 when expanded with the data given earlier, we get:
 
-```urlencoded
+```uri
 ?a=x%2By&b=x%2Fy&c=x%5Ey&words=math,is,fun
 ```
 
@@ -4045,7 +4045,7 @@ So we need to restructure the data to fit a manually constructed URI Template th
 
 Here is one such template, using a made-up convention of `words.0` for the first entry in the words value, `words.1` for the second, and `words.2` for the third:
 
-```urlencoded
+```uritemplate
 ?a={+a}&b={+b}&c={+c}&words={words.0} {words.1} {words.2}
 ```
 
@@ -4071,7 +4071,7 @@ words.2: fun
 
 Expanding our manually assembled template with our restructured data yields the following query string:
 
-```urlencoded
+```uri
 ?a=x%2By&b=x/y&c=x%5Ey&words=math%20is%20fun
 ```
 
@@ -4090,7 +4090,7 @@ words:
 
 Using this data with our original RFC6570-friendly URI Template, `{?formulas*,words}`, produces the following:
 
-```urlencoded
+```uri
 ?words=hello,world
 ```
 
@@ -4105,13 +4105,13 @@ words.1: world
 
 Manually constructed URI Template:
 
-```urlencoded
+```uritemplate
 ?words={words.0} {words.1}
 ```
 
 Result:
 
-```urlencoded
+```uri
 ?words=hello%20world
 ```
 
@@ -4134,13 +4134,13 @@ Instead, we have to pre-percent-encode the name (which is a six-octet UTF-8 sequ
 "%E2%9D%A4%EF%B8%8F": love!
 ```
 
-```urlencoded
+```uritemplate
 {?%E2%9D%A4%EF%B8%8F}
 ```
 
 This will expand to the result:
 
-```urlencoded
+```uri
 ?%E2%9D%A4%EF%B8%8F=love%21
 ```
 


### PR DESCRIPTION
Use different custom languages for (partial) URIs and URI templates.

The custom languages are defined via
* #4107 