### PR TITLE
Remove namespace prefix from the XML Object

### DIFF
--- a/versions/3.2.0.md
+++ b/versions/3.2.0.md
@@ -3369,7 +3369,6 @@ See examples for expected behavior.
 | ---- | :----: | ---- |
 | <a name="xml-name"></a>name | `string` | Replaces the name of the element/attribute used for the described schema property. When defined within `items`, it will affect the name of the individual XML elements within the list. When defined alongside `type` being `"array"` (outside the `items`), it will affect the wrapping element if and only if `wrapped` is `true`. If `wrapped` is `false`, it will be ignored. |
 | <a name="xml-namespace"></a>namespace | `string` | The URI of the namespace definition. Value MUST be in the form of a non-relative URI. |
-| <a name="xml-prefix"></a>prefix | `string` | The prefix to be used for the [name](#xml-name). |
 | <a name="xml-attribute"></a>attribute | `boolean` | Declares whether the property definition translates to an attribute instead of an element. Default value is `false`. |
 | <a name="xml-wrapped"></a>wrapped | `boolean` | MAY be used only for an array definition. Signifies whether the array is wrapped (for example, `<books><book/><book/></books>`) or unwrapped (`<book/><book/>`). Default value is `false`. The definition takes effect only when defined alongside `type` being `"array"` (outside the `items`). |
 
@@ -3377,7 +3376,8 @@ This object MAY be extended with [Specification Extensions](#specification-exten
 
 The `namespace` field is intended to match the syntax of [XML namespaces](https://www.w3.org/TR/xml-names11/), although there are a few caveats:
 
-* Versions 3.1.0, 3.0.3, and earlier of this specification erroneously used the term "absolute URI" instead of "non-relative URI", so authors using namespaces that include a fragment should check tooling support carefully.
+* Versions 3.1.1 and earlier of this specification errorneously allowed to specify the namespace prefix. Only namespace URIs should be used to identify the namespaces used. The prefix functions only as a placeholder and has a meaning exclusively in the context of the XML document ([Namespaces in XML 1.0 (Third Edition)](https://www.w3.org/TR/REC-xml-names/#ns-qualnames)).
+* Versions 3.1.0, 3.0.3, and earlier of this specification errorneously used the term "absolute URI" instead of "non-relative URI", so authors using namespaces that include a fragment should check tooling support carefully.
 * XML allows but discourages relative URI-references, while this specification outright forbids them.
 * XML 1.1 allows IRIs ([RFC3987](https://datatracker.ietf.org/doc/html/rfc3987)) as namespaces, and specifies that namespaces are compared without any encoding or decoding, which means that IRIs encoded to meet this specification's URI syntax requirement cannot be compared to IRIs as-is.
 
@@ -3457,7 +3457,7 @@ animals:
 <animal>...</animal>
 ```
 
-###### XML Attribute, Prefix and Namespace
+###### XML Attribute and Namespace
 
 In this example, a full model definition is shown.
 
@@ -3476,8 +3476,7 @@ In this example, a full model definition is shown.
       "name": {
         "type": "string",
         "xml": {
-          "namespace": "https://example.com/schema/sample",
-          "prefix": "sample"
+          "namespace": "https://example.com/schema/sample"
         }
       }
     }
@@ -3498,12 +3497,21 @@ Person:
       type: string
       xml:
         namespace: https://example.com/schema/sample
-        prefix: sample
 ```
 
 ```xml
-<Person id="123">
-    <sample:name xmlns:sample="https://example.com/schema/sample">example</sample:name>
+<Person id="123" xmlns:sample="https://example.com/schema/sample">
+    <sample:name>example</sample:name>
+</Person>
+```
+
+Another document that uses a different namespace prefix
+will also match the specification and therefore
+is considered equivalent to the example above:
+
+```xml
+<Person id="123" xmlns:personal="https://example.com/schema/sample">
+    <personal:name>example</personal:name>
 </Person>
 ```
 


### PR DESCRIPTION
Do not allow to specify the namespace prefix for the XML object. Only namespace URIs should be used to identify the namespaces used.

The prefix functions only as a placeholder and has a meaning exclusively in the context of the XML document

Namespaces in XML 1.0 (Third Edition)
https://www.w3.org/TR/REC-xml-names/#ns-qualnames
