### PR TITLE
Note relative URL-reference resolution ambiguity

### DIFF
--- a/versions/3.0.4.md
+++ b/versions/3.0.4.md
@@ -232,9 +232,14 @@ OpenAPI Description authors SHOULD consider how text using such extensions will 
 ### Relative References in URLs
 
 Unless specified otherwise, all fields that are URLs MAY be relative references as defined by [RFC3986](https://tools.ietf.org/html/rfc3986#section-4.2).
+
 Relative references are resolved using the URLs defined in the [Server Object](#server-object) as a Base URI.
 
 Relative references used in `$ref` are processed as per [JSON Reference](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03), using the URL of the current document as the base URI. See also the [Reference Object](#reference-object).
+
+The wording above is intended to distinguish between API URLs (which use the Server Object to determine the base URI or the prefix for the URL path template), and OAD URLs (which use the current document's base URI per RFC3986).
+However, only `$ref` was mentioned explicitly in versions 3.0.0 through 3.0.3 of this specification, leaving the behavior of the following fields ambiguous: the `operationRef` field of the [Link Object](#link-object), the URI form of the `mapping` field of the [Discriminator Object](#discriminator-object), the `externalValue` field of the [Example Object](#example-object), and the `url` fields of the [External Documentation](#external-documentation-object), [Contact](#contact-object), and [License](#license-object) Objects.
+Therefore, which of the above two rules is used for each of these fields is _implementation-defined_, although it is RECOMMENDED to use the `$ref` process for all of them for compatibility with future versions of this specification.
 
 Relative references in CommonMark hyperlinks are resolved in their rendered context, which might differ from the context of the API description.
 

--- a/versions/3.0.4.md
+++ b/versions/3.0.4.md
@@ -237,9 +237,7 @@ Relative references are resolved using the URLs defined in the [Server Object](#
 
 Relative references used in `$ref` are processed as per [JSON Reference](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03), using the URL of the current document as the base URI. See also the [Reference Object](#reference-object).
 
-The wording above is intended to distinguish between API URLs (which use the Server Object to determine the base URI or the prefix for the URL path template), and OAD URLs (which use the current document's base URI per RFC3986).
-However, only `$ref` was mentioned explicitly in versions 3.0.0 through 3.0.3 of this specification, leaving the behavior of the following fields ambiguous: the `operationRef` field of the [Link Object](#link-object), the URI form of the `mapping` field of the [Discriminator Object](#discriminator-object), the `externalValue` field of the [Example Object](#example-object), and the `url` fields of the [External Documentation](#external-documentation-object), [Contact](#contact-object), and [License](#license-object) Objects.
-Therefore, which of the above two rules is used for each of these fields is _implementation-defined_, although it is RECOMMENDED to use the `$ref` process for all of them for compatibility with future versions of this specification.
+It is _implementation_defined_ whether the resolution of relative references in each of the `operationRef` field of the [Link Object](#link-object), the URI form of the `mapping` field of the [Discriminator Object](#discriminator-object), the `externalValue` field of the [Example Object](#example-object), and the `url` fields of the [External Documentation](#external-documentation-object), [Contact](#contact-object), and [License](#license-object) Objects resolve by using the same process as `$ref` or by using the Server Object.  For compatibility with future versions of this specification, the `$ref` process is RECOMMENDED for all of these fields.
 
 Relative references in CommonMark hyperlinks are resolved in their rendered context, which might differ from the context of the API description.
 


### PR DESCRIPTION
This explicitly lists out the cases and notes which ones were (as far as we can recall) intended to behave like `$ref`, but could be reasonably read to behave like API URLs.

See:
* https://github.com/OAI/OpenAPI-Specification/pull/4100#discussion_r1794569584

<!--
Thank you for contributing to the OpenAPI Specification!

Please make certain you are submitting your PR on the correct
branch and file:

* 3.0.x spec: v3.0.4-dev branch, versions/3.0.4.md
* 3.1.x spec: v3.1.1-dev branch, versions/3.1.1.md
* 3.2.0 spec: v3.2.0-dev branch, versions/3.2.0.md
* 3.0 schema: main branch, schemas/v3.0/...
* 3.1 schema: main branch, schemas/v3.1/...
* registry templates: gh-pages branch, registry/...
* registry contents: gh-pages branch, registries/...

Note that we do not accept changes to published specifications.
-->
