### PR TITLE
v3.0.4 schema updates

### DIFF
--- a/schemas/v3.0/schema.json
+++ b/schemas/v3.0/schema.json
@@ -1,5 +1,5 @@
 {
-  "id": "https://spec.openapis.org/oas/3.0/schema/2021-09-28",
+  "id": "https://spec.openapis.org/oas/3.0/schema/2024-10-10",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "The description of OpenAPI v3.0.x documents, as defined by https://spec.openapis.org/oas/v3.0.4",
   "type": "object",

--- a/schemas/v3.0/schema.json
+++ b/schemas/v3.0/schema.json
@@ -810,6 +810,30 @@
         "description": {
           "type": "string"
         },
+        "get": {
+          "$ref": "#/definitions/Operation"
+        },
+        "put": {
+          "$ref": "#/definitions/Operation"
+        },
+        "post": {
+          "$ref": "#/definitions/Operation"
+        },
+        "delete": {
+          "$ref": "#/definitions/Operation"
+        },
+        "options": {
+          "$ref": "#/definitions/Operation"
+        },
+        "head": {
+          "$ref": "#/definitions/Operation"
+        },
+        "patch": {
+          "$ref": "#/definitions/Operation"
+        },
+        "trace": {
+          "$ref": "#/definitions/Operation"
+        },
         "servers": {
           "type": "array",
           "items": {
@@ -832,9 +856,6 @@
         }
       },
       "patternProperties": {
-        "^(get|put|post|delete|options|head|patch|trace)$": {
-          "$ref": "#/definitions/Operation"
-        },
         "^x-": {
         }
       },

--- a/schemas/v3.0/schema.json
+++ b/schemas/v3.0/schema.json
@@ -1,7 +1,7 @@
 {
   "id": "https://spec.openapis.org/oas/3.0/schema/2021-09-28",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "description": "The description of OpenAPI v3.0.x documents, as defined by https://spec.openapis.org/oas/v3.0.3",
+  "description": "The description of OpenAPI v3.0.x documents, as defined by https://spec.openapis.org/oas/v3.0.4",
   "type": "object",
   "required": [
     "openapi",

--- a/schemas/v3.0/schema.json
+++ b/schemas/v3.0/schema.json
@@ -1160,93 +1160,99 @@
         },
         {
           "$ref": "#/definitions/SchemaXORContent"
+        }
+      ],
+      "oneOf": [
+        {
+          "$ref": "#/definitions/PathParameter"
         },
         {
-          "$ref": "#/definitions/ParameterLocation"
+          "$ref": "#/definitions/QueryParameter"
+        },
+        {
+          "$ref": "#/definitions/HeaderParameter"
+        },
+        {
+          "$ref": "#/definitions/CookieParameter"
         }
       ]
     },
-    "ParameterLocation": {
-      "description": "Parameter location",
-      "oneOf": [
-        {
-          "description": "Parameter in path",
-          "required": [
-            "required"
+    "PathParameter": {
+      "description": "Parameter in path",
+      "required": [
+        "required"
+      ],
+      "properties": {
+        "in": {
+          "enum": [
+            "path"
+          ]
+        },
+        "style": {
+          "enum": [
+            "matrix",
+            "label",
+            "simple"
           ],
-          "properties": {
-            "in": {
-              "enum": [
-                "path"
-              ]
-            },
-            "style": {
-              "enum": [
-                "matrix",
-                "label",
-                "simple"
-              ],
-              "default": "simple"
-            },
-            "required": {
-              "enum": [
-                true
-              ]
-            }
-          }
+          "default": "simple"
         },
-        {
-          "description": "Parameter in query",
-          "properties": {
-            "in": {
-              "enum": [
-                "query"
-              ]
-            },
-            "style": {
-              "enum": [
-                "form",
-                "spaceDelimited",
-                "pipeDelimited",
-                "deepObject"
-              ],
-              "default": "form"
-            }
-          }
-        },
-        {
-          "description": "Parameter in header",
-          "properties": {
-            "in": {
-              "enum": [
-                "header"
-              ]
-            },
-            "style": {
-              "enum": [
-                "simple"
-              ],
-              "default": "simple"
-            }
-          }
-        },
-        {
-          "description": "Parameter in cookie",
-          "properties": {
-            "in": {
-              "enum": [
-                "cookie"
-              ]
-            },
-            "style": {
-              "enum": [
-                "form"
-              ],
-              "default": "form"
-            }
-          }
+        "required": {
+          "enum": [
+            true
+          ]
         }
-      ]
+      }
+    },
+    "QueryParameter": {
+      "description": "Parameter in query",
+      "properties": {
+        "in": {
+          "enum": [
+            "query"
+          ]
+        },
+        "style": {
+          "enum": [
+            "form",
+            "spaceDelimited",
+            "pipeDelimited",
+            "deepObject"
+          ],
+          "default": "form"
+        }
+      }
+    },
+    "HeaderParameter": {
+      "description": "Parameter in header",
+      "properties": {
+        "in": {
+          "enum": [
+            "header"
+          ]
+        },
+        "style": {
+          "enum": [
+            "simple"
+          ],
+          "default": "simple"
+        }
+      }
+    },
+    "CookieParameter": {
+      "description": "Parameter in cookie",
+      "properties": {
+        "in": {
+          "enum": [
+            "cookie"
+          ]
+        },
+        "style": {
+          "enum": [
+            "form"
+          ],
+          "default": "form"
+        }
+      }
     },
     "RequestBody": {
       "type": "object",

--- a/schemas/v3.0/schema.yaml
+++ b/schemas/v3.0/schema.yaml
@@ -43,6 +43,7 @@ definitions:
       '^\$ref$':
         type: string
         format: uri-reference
+
   Info:
     type: object
     required:
@@ -65,7 +66,6 @@ definitions:
     patternProperties:
       '^x-': {}
     additionalProperties: false
-
 
   Contact:
     type: object
@@ -592,7 +592,6 @@ definitions:
       '^x-': {}
     minProperties: 1
     additionalProperties: false
-
 
   SecurityRequirement:
     type: object

--- a/schemas/v3.0/schema.yaml
+++ b/schemas/v3.0/schema.yaml
@@ -1,4 +1,4 @@
-id: https://spec.openapis.org/oas/3.0/schema/2021-09-28
+id: https://spec.openapis.org/oas/3.0/schema/2024-10-10
 $schema: http://json-schema.org/draft-04/schema#
 description: The description of OpenAPI v3.0.x documents, as defined by https://spec.openapis.org/oas/v3.0.4
 type: object

--- a/schemas/v3.0/schema.yaml
+++ b/schemas/v3.0/schema.yaml
@@ -1,6 +1,6 @@
 id: https://spec.openapis.org/oas/3.0/schema/2021-09-28
 $schema: http://json-schema.org/draft-04/schema#
-description: The description of OpenAPI v3.0.x documents, as defined by https://spec.openapis.org/oas/v3.0.3
+description: The description of OpenAPI v3.0.x documents, as defined by https://spec.openapis.org/oas/v3.0.4
 type: object
 required:
   - openapi

--- a/scripts/compare
+++ b/scripts/compare
@@ -1,0 +1,40 @@
+#!/usr/bin/env perl
+# vim: set ts=8 sts=2 sw=2 tw=100 et :
+
+# given a filename base, compare the .yaml and .json versions of the file for differences.
+# to run:
+#   apt-get libjson-schema-modern-perl # (or equivalent on your distribution)
+#   scripts/compare schemas/v3.0/schema
+#   scripts/compare schemas/v3.1/schema
+#   scripts/compare schemas/v3.1/schema-base
+
+# Author: Karen Etheridge - karen@etheridge.ca, ether@cpan.org
+# see also https://github.com/karenetheridge/JSON-Schema-Modern
+
+use 5.020;
+use warnings;
+use Path::Tiny;
+use YAML::PP;
+use JSON::Schema::Modern ();
+use JSON::Schema::Modern::Utilities 0.591 'is_equal';
+
+my $base = shift; # the filename, without .yaml or .json extension
+
+my $yaml_decoder = YAML::PP->new(boolean => 'JSON::PP');
+my $json_decoder = JSON::Schema::Modern::_JSON_BACKEND()->new->utf8(1);
+
+my $yaml_path = path($base.'.yaml');
+my $json_path = path($base.'.json');
+
+my $yaml_data = $yaml_decoder->load_string($yaml_path->slurp_raw);
+my $json_data = $json_decoder->decode($json_path->slurp_raw);
+
+if (not is_equal($yaml_data, $json_data, my $state = {})) {
+  say "$yaml_path and $json_path are not identical.";
+  say "first difference is at $state->{path}: $state->{error}";
+  exit 1;
+}
+else {
+  say "files are identical.";
+  exit 0;
+}

--- a/scripts/yaml2json/yaml2json.pl
+++ b/scripts/yaml2json/yaml2json.pl
@@ -1,0 +1,8 @@
+#!/bin/env perl
+use strict;
+use warnings;
+use YAML::XS;
+use JSON::PP;
+
+print JSON::PP->new->pretty->indent_length(2)->canonical->encode(Load(do { local $/; <> }));
+print "\n";


### PR DESCRIPTION
Brings the schemas up to date for the v3.0.4 release (see #4125), and adds some support scripts which are used to check for validation errors and inconsistencies between the yaml and json versions of the files.

```
$ json-schema-eval --validate-schema schemas/v3.0/schema.json
{
  "valid": true
}

$ scripts/compare schemas/v3.0/schema
schemas/v3.0/schema.yaml and schemas/v3.0/schema.json are identical.
```