### PR TITLE
gh-pages: add Overlay

### DIFF
--- a/index.md
+++ b/index.md
@@ -46,3 +46,9 @@ This site contains the OpenAPI Initiative Registry and content for the HTML vers
 {%- assign separator = ", " -%}
 {%- endif -%}
 {%- endfor %}
+
+## Overlay Specification
+
+### Versions
+
+{% include specification-version-list.md specification="overlay" %}


### PR DESCRIPTION
This PR adds the Overlay specification to the landing page of https://spec.openapis.org.

Note: merge only after the Overlay specification has been published!

Overlay publishing PR:
* **To be created**
