### PR TITLE
Add 3.0.4 release date to 3.1.1

### DIFF
--- a/versions/3.1.1.md
+++ b/versions/3.1.1.md
@@ -4120,7 +4120,7 @@ Certain fields allow the use of Markdown which can contain HTML including script
 | 3.1.0 | 2021-02-15 | Release of the OpenAPI Specification 3.1.0 |
 | 3.1.0-rc1 | 2020-10-08 | rc1 of the 3.1 specification |
 | 3.1.0-rc0 | 2020-06-18 | rc0 of the 3.1 specification |
-| 3.0.4 | TBD | Patch release of the OpenAPI Specification 3.0.4 |
+| 3.0.4 | 2024-10-17 | Patch release of the OpenAPI Specification 3.0.4 |
 | 3.0.3 | 2020-02-20 | Patch release of the OpenAPI Specification 3.0.3 |
 | 3.0.2 | 2018-10-08 | Patch release of the OpenAPI Specification 3.0.2 |
 | 3.0.1 | 2017-12-06 | Patch release of the OpenAPI Specification 3.0.1 |


### PR DESCRIPTION
We should either have the release date or remove the 3.0.4 line, I don't care which.