### PR TITLE
gh-pages: skip dialect base & meta base

### DIFF
--- a/index.md
+++ b/index.md
@@ -37,6 +37,9 @@ This site contains the OpenAPI Initiative Registry and content for the HTML vers
 * **v{{ last_version }}**
 {%- endif -%}
 {%- if segments[3] != last_kind -%}
+{%- if segments[4] == "base" -%}
+{%- continue -%}
+{%- endif -%}
 {%- assign last_kind = segments[3] %}
   * view [**{{ last_kind }}/{{ segments[4] }}**]({{ site.baseurl }}/oas/{{ last_version }}/{{ last_kind }}/{{ segments[4] }}.html)  
     download iteration


### PR DESCRIPTION
Follow-up to
* #4162 

- [x] Only list date-stamped schema iterations for `dialect` and `meta`

Preview:
* https://ralfhandl.github.io/OpenAPI-Specification/
