### PR TITLE
main: schema-publish workflow - fix reviewers

### DIFF
--- a/.github/workflows/schema-publish.yaml
+++ b/.github/workflows/schema-publish.yaml
@@ -48,7 +48,7 @@ jobs:
         delete-branch: true
         path: deploy
         labels: Housekeeping,Schema
-        reviewers: darrelmiller,webron,earth2marsh,webron,lornajane,mikekistler,miqui,ralfhandl,handrews
+        reviewers: darrelmiller,webron,earth2marsh,webron,lornajane,mikekistler,miqui,ralfhandl,handrews,karenetheridge
         title: Publish OpenAPI Metaschema Iterations
         commit-message: New OpenAPI metaschema iterations
         signoff: true

--- a/.github/workflows/schema-publish.yaml
+++ b/.github/workflows/schema-publish.yaml
@@ -48,7 +48,7 @@ jobs:
         delete-branch: true
         path: deploy
         labels: Housekeeping,Schema
-        team-reviewers: OAI/tsc #TODO: check if this works, or if it needs a special access token
+        reviewers: darrelmiller,webron,earth2marsh,webron,lornajane,mikekistler,miqui,ralfhandl,handrews
         title: Publish OpenAPI Metaschema Iterations
         commit-message: New OpenAPI metaschema iterations
         signoff: true


### PR DESCRIPTION
Use individual reviewers instead of team reviewers to avoid needing special access tokens