### PR TITLE
main: respec workflow - same reviewers as for schema publishing

### DIFF
--- a/.github/workflows/respec.yaml
+++ b/.github/workflows/respec.yaml
@@ -49,7 +49,7 @@ jobs:
         delete-branch: true
         path: deploy
         labels: Housekeeping
-        reviewers: webron,darrelmiller
+        reviewers: darrelmiller,webron,earth2marsh,webron,lornajane,mikekistler,miqui,ralfhandl,handrews,karenetheridge
         title: Update ReSpec-rendered specification versions
         commit-message: Update ReSpec-rendered specification versions
         signoff: true


### PR DESCRIPTION
Add current TSC members and OpenAPI maintainers to explicitly mentioned reviewers
