### PR TITLE
The schemas are (mostly) not metaschemas

### DIFF
--- a/.github/workflows/schema-publish.yaml
+++ b/.github/workflows/schema-publish.yaml
@@ -49,8 +49,8 @@ jobs:
         path: deploy
         labels: Housekeeping,Schema
         reviewers: darrelmiller,webron,earth2marsh,webron,lornajane,mikekistler,miqui,ralfhandl,handrews,karenetheridge
-        title: Publish OpenAPI Metaschema Iterations
-        commit-message: New OpenAPI metaschema iterations
+        title: Publish OpenAPI Schema Iterations
+        commit-message: New OpenAPI schema iterations
         signoff: true
         body: |
           This pull request is automatically triggered by GitHub action `schema-publish`.


### PR DESCRIPTION
OpenAPI schemas are not metaschemas.  Well, the bits for the Schema Object are, but the overall OAS is more important and it's already driving me bonkers to see these described as "metaschemas."  An OAD is not a JSON Schema, so these schemas are just schemas. _(yes, I am fixating on something fundamentally unimportant, please let me have this small nitpick thx)_