### PR TITLE
v3.1-dev: Validate src/oas.md

### DIFF
--- a/.github/workflows/validate-markdown.yaml
+++ b/.github/workflows/validate-markdown.yaml
@@ -28,6 +28,6 @@ jobs:
       with:
         node-version: '20.x'
     - name: Validate markdown
-      run: npx --yes mdv versions/3.*.md
+      run: npx --yes mdv versions/3.*.md src/oas.md
     - name: Lint markdown 3.0.4, 3.1.1, and later
-      run: npx --yes markdownlint-cli --config .markdownlint.yaml versions/3.0.4.md versions/3.1.[^0].md versions/3.[2-9].*.md
+      run: npx --yes markdownlint-cli --config .markdownlint.yaml versions/3.0.4.md versions/3.1.[^0].md versions/3.[2-9].*.md src/oas.md

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "license": "Apache-2.0",
   "scripts": {
     "build": "bash ./scripts/md2html/build.sh",
-    "test": "c8 --100 vitest --watch=false"
+    "test": "c8 --100 vitest --watch=false",
+    "validate-markdown": "npx mdv src/oas.md && npx markdownlint-cli src/oas.md"
   },
   "readmeFilename": "README.md",
   "files": [


### PR DESCRIPTION
- Validate new `src/oas.md` file on push and on pull requests
- Add npm script for easy local validation

Note:
- needs cross-port to branch `v3.2-dev`
