### PR TITLE
v3.1-dev: schema tests use src/schemas/validation

### DIFF
--- a/tests/v3.1/schema.test.mjs
+++ b/tests/v3.1/schema.test.mjs
@@ -26,7 +26,7 @@ const parseYamlFromFile = (filePath) => {
 
 setMetaSchemaOutputFormat(BASIC);
 
-const validateOpenApi = await validate("./schemas/v3.1/schema.yaml");
+const validateOpenApi = await validate("./src/schemas/validation/schema.yaml");
 
 describe("v3.1", () => {
   describe("Pass", () => {


### PR DESCRIPTION
Run schema tests with current work-in-progress schema in `src/schemas/validation` folder

Open:
- [ ] Should the `pass` and `fail` folders with schema test instances also be copied into the `src/schemas/validation` folder?