### PR TITLE
gh-pages: pretty-print newest dialect and meta schema instead of "base"

### DIFF
--- a/oas/3.1/dialect/2024-10-25.md
+++ b/oas/3.1/dialect/2024-10-25.md
@@ -5,5 +5,5 @@ parent: Schemas
 ---
 
 ```json
-{% include_relative base %}
+{% include_relative {{ page.name | remove: ".md" }} %}
 ```

--- a/oas/3.1/meta/2024-10-25.md
+++ b/oas/3.1/meta/2024-10-25.md
@@ -5,5 +5,5 @@ parent: Schemas
 ---
 
 ```json
-{% include_relative base %}
+{% include_relative {{ page.name | remove: ".md" }} %}
 ```


### PR DESCRIPTION
The Markdown wrapper files for the dialect and meta schemas referenced `base` instead of the newest time-stamped schema file: 

* view [meta/2024-10-25](https://spec.openapis.org/oas/3.1/meta/2024-10-25.html)
* view [dialect/2024-10-25](https://spec.openapis.org/oas/3.1/dialect/2024-10-25.html)