### PR TITLE
gh-pages: Generalize registry site to publications

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -59,11 +59,11 @@ plugins:
   - jekyll-remote-theme
   - jekyll-sitemap
 aux_links:
-  "Latest OpenAPI Specification":
+  "Latest OpenAPI Spec":
     - "https://spec.openapis.org/oas/latest.html"
-  "Latest Arazzo Specification":
+  "Latest Arazzo Spec":
     - "https://spec.openapis.org/arazzo/latest.html"
-  "Latest Overlay Specification":
+  "Latest Overlay Spec":
     - "https://spec.openapis.org/overlay/latest.html"
 footer_content: "\xA9 2024 OpenAPI Initiative.
  <br />This work is licensed under the <a rel=\"license\" href=\"https://www.apache.org/licenses/LICENSE-2.0\"\

--- a/_config.yml
+++ b/_config.yml
@@ -1,8 +1,8 @@
 # theme: just-the-docs
 remote_theme: just-the-docs/just-the-docs
 color_scheme: oai
-title: OpenAPI Initiative Registry
-description: Extensible data value repository
+title: OpenAPI Initiative Publications
+description: Specifications, registries, and schemas
 show_downloads: true
 excerpt_separator: ""
 collections_dir: /registries
@@ -63,6 +63,8 @@ aux_links:
     - "https://spec.openapis.org/oas/latest.html"
   "Latest Arazzo Specification":
     - "https://spec.openapis.org/arazzo/latest.html"
+  "Latest Overlay Specification":
+    - "https://spec.openapis.org/overlay/latest.html"
 footer_content: "\xA9 2024 OpenAPI Initiative.
  <br />This work is licensed under the <a rel=\"license\" href=\"https://www.apache.org/licenses/LICENSE-2.0\"\
   >Apache 2.0 License</a>. This site is\

--- a/index.md
+++ b/index.md
@@ -4,27 +4,43 @@ description: HTML Spec. and extensible registry
 layout: default
 ---
 
-# OpenAPI Initiative Registry
+# OpenAPI Initiative Publications
 
-This site contains the OpenAPI Initiative Registry and content for the HTML versions of specifications managed by the OpenAPI Initiative such as the OpenAPI Specification and the Arazzo Specification.
+This site contains the authoritative HTML renderings of the OpenAPI Initiative's [specifications](#specifications) and [extension registries](#registries), as well as official (but non-[normative](https://en.wikipedia.org/wiki/Normativity#Standards_documents)) [schemas](#non-normative-json-schemas) for those specifications that provide them.
 
-## Registry
+Please see the [Learn OpenAPI](https://learn.openapis.org) site for additional documentation and [examples](https://learn.openapis.org/examples/), and the [OpenAPI Tooling](https://tools.openapis.org/) site for community-provided lists of tools implementing the specifications.
 
-* Proceed to [Registry](./registry/index.html)
+## Specifications
 
-## Arazzo Specification
-
-### Versions
+### Arazzo Specification
 
 {% include specification-version-list.md specification="arazzo" %}
 
-## OpenAPI Specification
-
-### Versions
+### OpenAPI Specification
 
 {% include specification-version-list.md specification="oas" %}
 
-### Non-Normative JSON Schemas
+### Overlay Specification
+
+{% include specification-version-list.md specification="overlay" %}
+
+## Registries
+
+The [Registry Page](./registry/index.html) includes documentation as well as API and RSS access for all registries
+
+Registry shortcuts:
+{% for registry in site.collections %}{% unless registry.hidden %}
+* <a href="registry/{{ registry.slug }}">{{ registry.name }}</a>{% endunless %}{% endfor %}
+
+## Non-Normative JSON Schemas
+
+_Note that while schemas can catch many errors, they are not guaranteed to catch all specification violations.  In the event of a disagreement between the schemas and the corresponding specificaton text, the specification text is presumed to be correct._
+
+### Arazzo Schemas
+
+_TBD_
+
+### OpenAPI Specification Schemas
 
 {% assign schema_files = site.static_files | where: "extname", "" | sort: "path" | reverse %}
 {% assign last_version = "" %}
@@ -50,8 +66,6 @@ This site contains the OpenAPI Initiative Registry and content for the HTML vers
 {%- endif -%}
 {%- endfor %}
 
-## Overlay Specification
+### Overlay Specification Schemas
 
-### Versions
-
-{% include specification-version-list.md specification="overlay" %}
+_TBD_

--- a/index.md
+++ b/index.md
@@ -42,6 +42,10 @@ _TBD_
 
 ### OpenAPI Specification Schemas
 
+Note that the OAS 3.1 `schema/YYYY-MM-DD` schema does _not_ validate the Schema Object, as it makes no assumptions about the JSON Schema dialect in use.  The OAS 3.1 `schema-base/YYYY-MM-DD` schema _does_ validate the Schema Object, and requires that if `jsonSchemaDialect` or `$schema` are present, that they use the appropriate `dialect/YYYY-MM-DD`.  The name `schema-base` comes from the JSON Schema dialect including the OAS extensions being referred to as the "base dialect" in the specification.
+
+See [issue #4147](https://github.com/OAI/OpenAPI-Specification/issues/4147) for discussion of other possible JSON Schema dialect options, [issue #4152](https://github.com/OAI/OpenAPI-Specification/issues/4152) for programmatic access to the latest schemas, and [issue #4141](https://github.com/OAI/OpenAPI-Specification/issues/4141) for discussions on possibly providing linting schemas that could catch likely problems that do not directly violate the specification.
+
 {% assign schema_files = site.static_files | where: "extname", "" | sort: "path" | reverse %}
 {% assign last_version = "" %}
 {% assign last_kind = "" %}


### PR DESCRIPTION
The spec site main page had gotten a bit muddled.  This organizes it into three distinct sections (Specifications, Registries, and Non-normative JSON Schemas) and adds an intro paragraph that links to each section as well as the Learn and Tools site.

The reason for moving the schemas is that I almost couldn't find the Overlay specification (I added Overlay to the shortcut links at the top as well as it was missing).

The registries are in-between as they are less-well-known, and I added shortcuts to the individual registries as it made the sections feel more similar.

I renamed the overall site "Publications" instead of "Registry", as it does a lot more now.  It could be "Specifications" if we would rather stick with the "spec site" terminology.

**Partial preview:** https://handrews.github.io/renderings/oas/spec/ (_Note that while the page-local and registry page links work, because they are relative, the spec and schema links do not because they use absolute paths and I can't figure out how to fix that without editing the generated html- you can insert_ `/renderings/oas/spec` _between the domain and the beginning of the path for pages that 404 to see what they should be; the spec shortcut buttons at the top use absolute URLs and go to the production spec site_)