### PR TITLE
Update ReSpec-rendered specification versions for Overlay

### DIFF
--- a/overlay/v1.0.0.html
+++ b/overlay/v1.0.0.html
@@ -158,7 +158,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
   "publishISODate": "2024-10-17T00:00:00.000Z",
   "generatedSubtitle": "17 October 2024"
 }</script>
-<link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2021/base.css"></head><body class="h-entry"><div class="head">
+<link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2021/base.css"></head><body class="h-entry toc-inline"><div class="head">
     <p class="logos"><a class="logo" href="https://openapis.org/"><img crossorigin="" alt="OpenAPI Initiative" height="48" src="https://raw.githubusercontent.com/OAI/OpenAPI-Style-Guide/master/graphics/bitmap/OpenAPI_Logo_Pantone.png">
   </a></p>
     <h1 id="title" class="title">Overlay Specification v1.0.0 </h1> <h2 id="subtitle" class="subtitle">Version 1.0.0</h2>


### PR DESCRIPTION
This pull request is automatically triggered by GitHub action `respec` in the OAI/Overlay-Specification repo.

The `versions/*.md` files have changed, so the HTML files are automatically being regenerated.