### PR TITLE
gh-pages: schema wrapper for Overlay

### DIFF
--- a/overlay/1.0/schema/2024-10-22.md
+++ b/overlay/1.0/schema/2024-10-22.md
@@ -1,0 +1,9 @@
+---
+title: JSON Schema for Overlay 1.0
+layout: default
+parent: Schemas
+---
+
+```json
+{% include_relative {{ page.name | remove: ".md" }} %}
+```


### PR DESCRIPTION
The "view schema" link needs a HTML wrapper file, which is added here.