### PR TITLE
main: materialize list of editors per spec version

### DIFF
--- a/scripts/md2html/build.sh
+++ b/scripts/md2html/build.sh
@@ -32,17 +32,13 @@ for filename in $(ls -1 ../../versions/[23456789].*.md | sort -r) ; do
   if [ $version = $latest ]; then
     if [[ ${version} != *"rc"* ]];then
       # version is not a Release Candidate
-      pushd ../../deploy/oas
-      ln -sf v$version.html latest.html
-      popd
+      ( cd ../../deploy/oas && ln -sf v$version.html latest.html )
       latestCopied=v$version
     fi
   fi
 
   if [ ${minorVersion} != ${lastMinor} ] && [ ${minorVersion} != 2.0 ]; then
-    pushd ../../deploy/oas
-    ln -sf v$version.html v$minorVersion.html
-    popd
+    ( cd ../../deploy/oas && ln -sf v$version.html v$minorVersion.html )
     lastMinor=$minorVersion
   fi
 done

--- a/scripts/md2html/build.sh
+++ b/scripts/md2html/build.sh
@@ -9,32 +9,6 @@ mkdir -p deploy/oas
 mkdir -p deploy/js
 
 cd scripts/md2html
-mkdir -p history
-cat > history/MAINTAINERS_v2.0.md <<EOF
-## Active
-* Jeremy Whitlock [@whitlockjc](https://github.com/whitlockjc)
-* Marsh Gardiner [@earth2marsh](https://github.com/earth2marsh)
-* Ron Ratovsky [@webron](https://github.com/webron)
-* Tony Tam [@fehguy](https://github.com/fehguy)
-EOF
-cat > history/MAINTAINERS_v3.0.0.md <<EOF
-## Active
-* Jeremy Whitlock [@whitlockjc](https://github.com/whitlockjc)
-* Marsh Gardiner [@earth2marsh](https://github.com/earth2marsh)
-* Ron Ratovsky [@webron](https://github.com/webron)
-* Tony Tam [@fehguy](https://github.com/fehguy)
-
-## Emeritus
-* Jason Harmon [@jharmn](https://github.com/jharmn)
-EOF
-git show c740e95:MAINTAINERS.md > history/MAINTAINERS_v3.0.1.md
-git show 3140640:MAINTAINERS.md > history/MAINTAINERS_v3.0.2.md
-cp history/MAINTAINERS_v3.0.2.md history/MAINTAINERS_v3.0.3.md
-cp history/MAINTAINERS_v3.0.2.md history/MAINTAINERS_v3.1.0.md
-#TODO: adjust commit for 3.0.4, 3.1.1
-git show c3b88ed:EDITORS.md > history/MAINTAINERS_v3.0.4.md
-cp history/MAINTAINERS_v3.0.4.md history/MAINTAINERS_v3.1.1.md
-# add lines for 3.2.0, ...
 
 cp -p ../../node_modules/respec/builds/respec-w3c.* ../../deploy/js/
 
@@ -42,12 +16,16 @@ latest=`git describe --abbrev=0 --tags`
 latestCopied=none
 lastMinor="-"
 for filename in $(ls -1 ../../versions/[23456789].*.md | sort -r) ; do
+  if [[ ${filename} == *-editors.md ]];then
+    continue
+  fi
+
   version=$(basename "$filename" .md)
   minorVersion=${version:0:3}
   tempfile=../../deploy/oas/v$version-tmp.html
   echo -e "\n=== v$version ==="
 
-  node md2html.js --maintainers ./history/MAINTAINERS_v$version.md ${filename} > $tempfile
+  node md2html.js --maintainers ../../versions/$version-editors.md ${filename} > $tempfile
   npx respec --use-local --src $tempfile --out ../../deploy/oas/v$version.html
   rm $tempfile
 

--- a/versions/2.0-editors.md
+++ b/versions/2.0-editors.md
@@ -1,0 +1,5 @@
+## Active
+* Jeremy Whitlock [@whitlockjc](https://github.com/whitlockjc)
+* Marsh Gardiner [@earth2marsh](https://github.com/earth2marsh)
+* Ron Ratovsky [@webron](https://github.com/webron)
+* Tony Tam [@fehguy](https://github.com/fehguy)

--- a/versions/3.0.0-editors.md
+++ b/versions/3.0.0-editors.md
@@ -1,0 +1,8 @@
+## Active
+* Jeremy Whitlock [@whitlockjc](https://github.com/whitlockjc)
+* Marsh Gardiner [@earth2marsh](https://github.com/earth2marsh)
+* Ron Ratovsky [@webron](https://github.com/webron)
+* Tony Tam [@fehguy](https://github.com/fehguy)
+
+## Emeritus
+* Jason Harmon [@jharmn](https://github.com/jharmn)

--- a/versions/3.0.1-editors.md
+++ b/versions/3.0.1-editors.md
@@ -1,0 +1,9 @@
+## Active
+* Darrel Miller [@darrelmiller](https://github.com/darrelmiller)
+* Jeremy Whitlock [@whitlockjc](https://github.com/whitlockjc)
+* Marsh Gardiner [@earth2marsh](https://github.com/earth2marsh)
+* Ron Ratovsky [@webron](https://github.com/webron)
+
+## Emeritus
+* Jason Harmon [@jharmn](https://github.com/jharmn)
+* Tony Tam [@fehguy](https://github.com/fehguy)

--- a/versions/3.0.2-editors.md
+++ b/versions/3.0.2-editors.md
@@ -1,0 +1,11 @@
+## Active
+* Darrel Miller [@darrelmiller](https://github.com/darrelmiller)
+* Jeremy Whitlock [@whitlockjc](https://github.com/whitlockjc)
+* Marsh Gardiner [@earth2marsh](https://github.com/earth2marsh)
+* Mike Ralphson [@MikeRalphson](https://github.com/MikeRalphson)
+* Ron Ratovsky [@webron](https://github.com/webron)
+* Uri Sarid [@usarid](https://github.com/usarid)
+
+## Emeritus
+* Jason Harmon [@jharmn](https://github.com/jharmn)
+* Tony Tam [@fehguy](https://github.com/fehguy)

--- a/versions/3.0.3-editors.md
+++ b/versions/3.0.3-editors.md
@@ -1,0 +1,11 @@
+## Active
+* Darrel Miller [@darrelmiller](https://github.com/darrelmiller)
+* Jeremy Whitlock [@whitlockjc](https://github.com/whitlockjc)
+* Marsh Gardiner [@earth2marsh](https://github.com/earth2marsh)
+* Mike Ralphson [@MikeRalphson](https://github.com/MikeRalphson)
+* Ron Ratovsky [@webron](https://github.com/webron)
+* Uri Sarid [@usarid](https://github.com/usarid)
+
+## Emeritus
+* Jason Harmon [@jharmn](https://github.com/jharmn)
+* Tony Tam [@fehguy](https://github.com/fehguy)

--- a/versions/3.0.4-editors.md
+++ b/versions/3.0.4-editors.md
@@ -1,0 +1,18 @@
+# OpenAPI Specification Editors
+
+## Active
+* Darrel Miller [@darrelmiller](https://github.com/darrelmiller)
+* Henry Andrews [@handrews](https://github.com/handrews)
+* Jeremy Whitlock [@whitlockjc](https://github.com/whitlockjc)
+* Lorna Mitchell [@lornajane](https://github.com/lornajane)
+* Marsh Gardiner [@earth2marsh](https://github.com/earth2marsh)
+* Miguel Quintero [@miqui](https://github.com/miqui)
+* Mike Kistler [@mikekistler](https://github.com/mikekistler)
+* Ralf Handl [@ralfhandl](https://github.com/ralfhandl)
+* Ron Ratovsky [@webron](https://github.com/webron)
+
+## Emeritus
+* Mike Ralphson [@MikeRalphson](https://github.com/MikeRalphson)
+* Uri Sarid [@usarid](https://github.com/usarid)
+* Jason Harmon [@jharmn](https://github.com/jharmn)
+* Tony Tam [@fehguy](https://github.com/fehguy)

--- a/versions/3.1.0-editors.md
+++ b/versions/3.1.0-editors.md
@@ -1,0 +1,11 @@
+## Active
+* Darrel Miller [@darrelmiller](https://github.com/darrelmiller)
+* Jeremy Whitlock [@whitlockjc](https://github.com/whitlockjc)
+* Marsh Gardiner [@earth2marsh](https://github.com/earth2marsh)
+* Mike Ralphson [@MikeRalphson](https://github.com/MikeRalphson)
+* Ron Ratovsky [@webron](https://github.com/webron)
+* Uri Sarid [@usarid](https://github.com/usarid)
+
+## Emeritus
+* Jason Harmon [@jharmn](https://github.com/jharmn)
+* Tony Tam [@fehguy](https://github.com/fehguy)

--- a/versions/3.1.1-editors.md
+++ b/versions/3.1.1-editors.md
@@ -1,0 +1,18 @@
+# OpenAPI Specification Editors
+
+## Active
+* Darrel Miller [@darrelmiller](https://github.com/darrelmiller)
+* Henry Andrews [@handrews](https://github.com/handrews)
+* Jeremy Whitlock [@whitlockjc](https://github.com/whitlockjc)
+* Lorna Mitchell [@lornajane](https://github.com/lornajane)
+* Marsh Gardiner [@earth2marsh](https://github.com/earth2marsh)
+* Miguel Quintero [@miqui](https://github.com/miqui)
+* Mike Kistler [@mikekistler](https://github.com/mikekistler)
+* Ralf Handl [@ralfhandl](https://github.com/ralfhandl)
+* Ron Ratovsky [@webron](https://github.com/webron)
+
+## Emeritus
+* Mike Ralphson [@MikeRalphson](https://github.com/MikeRalphson)
+* Uri Sarid [@usarid](https://github.com/usarid)
+* Jason Harmon [@jharmn](https://github.com/jharmn)
+* Tony Tam [@fehguy](https://github.com/fehguy)


### PR DESCRIPTION
The list of editors per specification was produced by the build script on every run.

This PR materializes these lists as additional Markdown files in the `versions` folder and removes the now obsolete code for temporarily producing them.
