### PR TITLE
Introduce constraints for Server Object url fixed field

### DIFF
--- a/src/oas.md
+++ b/src/oas.md
@@ -455,7 +455,7 @@ An object representing a Server.
 
 | Field Name | Type | Description |
 | ---- | :----: | ---- |
-| <a name="server-url"></a>url | `string` | **REQUIRED**. A URL to the target host. This URL supports Server Variables and MAY be relative, to indicate that the host location is relative to the location where the document containing the Server Object is being served. Query and fragment MUST not be part of this URL. Variable substitutions will be made when a variable is named in `{`braces`}`. |
+| <a name="server-url"></a>url | `string` | **REQUIRED**. A URL to the target host. This URL supports Server Variables and MAY be relative, to indicate that the host location is relative to the location where the document containing the Server Object is being served. Query and fragment MUST NOT be part of this URL. Variable substitutions will be made when a variable is named in `{`braces`}`. |
 | <a name="server-description"></a>description | `string` | An optional string describing the host designated by the URL. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation. |
 | <a name="server-variables"></a>variables | Map[`string`, [Server Variable Object](#server-variable-object)] | A map between a variable name and its value. The value is used for substitution in the server's URL template. |
 

--- a/src/oas.md
+++ b/src/oas.md
@@ -455,7 +455,7 @@ An object representing a Server.
 
 | Field Name | Type | Description |
 | ---- | :----: | ---- |
-| <a name="server-url"></a>url | `string` | **REQUIRED**. A URL to the target host. This URL supports Server Variables and MAY be relative, to indicate that the host location is relative to the location where the document containing the Server Object is being served. Query and fragment MUST not be part of a URL. Variable substitutions will be made when a variable is named in `{`braces`}`. |
+| <a name="server-url"></a>url | `string` | **REQUIRED**. A URL to the target host. This URL supports Server Variables and MAY be relative, to indicate that the host location is relative to the location where the document containing the Server Object is being served. Query and fragment MUST not be part of this URL. Variable substitutions will be made when a variable is named in `{`braces`}`. |
 | <a name="server-description"></a>description | `string` | An optional string describing the host designated by the URL. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation. |
 | <a name="server-variables"></a>variables | Map[`string`, [Server Variable Object](#server-variable-object)] | A map between a variable name and its value. The value is used for substitution in the server's URL template. |
 

--- a/src/oas.md
+++ b/src/oas.md
@@ -455,7 +455,7 @@ An object representing a Server.
 
 | Field Name | Type | Description |
 | ---- | :----: | ---- |
-| <a name="server-url"></a>url | `string` | **REQUIRED**. A URL to the target host. This URL supports Server Variables and MAY be relative, to indicate that the host location is relative to the location where the document containing the Server Object is being served. Variable substitutions will be made when a variable is named in `{`braces`}`. |
+| <a name="server-url"></a>url | `string` | **REQUIRED**. A URL to the target host. This URL supports Server Variables and MAY be relative, to indicate that the host location is relative to the location where the document containing the Server Object is being served. Query and fragment MUST not be part of a URL. Variable substitutions will be made when a variable is named in `{`braces`}`. |
 | <a name="server-description"></a>description | `string` | An optional string describing the host designated by the URL. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation. |
 | <a name="server-variables"></a>variables | Map[`string`, [Server Variable Object](#server-variable-object)] | A map between a variable name and its value. The value is used for substitution in the server's URL template. |
 


### PR DESCRIPTION
I went ahead with this suggestion, as it is something that is not obvious from reading the OpenAPI spec, but it becomes obvious for the tooling authors during implementations.

`Server Object`.`url` field is defined as `A URL to the target host`.

OpenAPI further stipulates: 

> Unless specified otherwise, all fields that are URLs MAY be relative references as defined by [RFC3986](https://tools.ietf.org/html/rfc3986#section-4.2)

Looking at RFC 3986, the `Server Object`.`url` can be one of the following:

```abnf
URI           = scheme ":" hier-part [ "?" query ] [ "#" fragment ]
relative-ref  = relative-part [ "?" query ] [ "#" fragment ]
```

Both of these non-terminals allow `query` and `fragment`. But effectively, we cannot allow them as OpenAPI further stipulates:

> The path is appended to the URL from the [Server Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.1.md#server-object) in order to construct the full URL 

Appending to URL or resolved relative reference containing query or fragment will end up corrupting the resulting URL.

---

There is another aspect of `Server Object`.`url`, and that's being [Scheme-Based Normalization](https://datatracker.ietf.org/doc/html/rfc3986#section-6.2.3). When we define server URL as `https://exmaple.com/`, the tooling tends to remove the last character from the URL, if the character=`/` before the path from `Paths Object` is appended to it. This is possible because of equivalence as described by Scheme-Based Normalization.

```
// server URL
http://example.com/

// paths
/path1
/path2

// we want to end up here
http://example.com/path1
http://example.com/path2

// we might end up here
http://example.com//path1
http://example.com//path2
```

AFAICT we cannot apply [Scheme-Based Normalization](https://datatracker.ietf.org/doc/html/rfc3986#section-6.2.3) to URL like `http://example.com/initial-path`. `http://example.com/initial-path` is not equivalent anymore to `http://example.com/initial-path/`.

I guess my question is, if we shouldn't restrict  `Server Object`.`url` not to end with explicit `/`? 