### PR TITLE
Add tag kinds registry to the spec site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -38,6 +38,11 @@ collections:
     name: Extension Namespace Registry
     output: true
     permalink: /registry/:collection/:title
+  tag-kind:
+    slug: tag-kind
+    name: Tag Kind Registry
+    output: true
+    permalink: /registry/:collection/:title
 exclude:
   - Gemfile
   - Gemfile.lock

--- a/_includes/tag-kind-entry.md
+++ b/_includes/tag-kind-entry.md
@@ -1,0 +1,17 @@
+# <a href="..">{{ page.collection }}</a>
+
+## {{ page.slug }} - {{ page.description }}
+
+{{ include.summary }}
+
+{% if page.issue %}
+### GitHub Issue
+
+* [#{{ page.issue }}](https://github.com/OAI/OpenAPI-Specification/issues/{{ page.issue }})
+{% endif %}
+
+{% if page.remarks %}
+### Remarks
+
+{{ page.remarks }}
+{% endif %}

--- a/registries/_tag-kind/audience.md
+++ b/registries/_tag-kind/audience.md
@@ -1,0 +1,13 @@
+---
+owner: lornajane
+issue:
+description: "Tags with `kind: audience` indicate the intended audience for an operation."
+layout: default
+---
+
+{% capture summary %}
+Tags with `kind: audience` indicate the intended audience for an operation.
+Common uses might be to tag internal, admin-level, or partner endpoints. 
+{% endcapture %}
+
+{% include tag-kind-entry.md summary=summary %}  

--- a/registries/_tag-kind/badge.md
+++ b/registries/_tag-kind/badge.md
@@ -1,0 +1,13 @@
+---
+owner: lornajane
+issue:
+description: " Tags with `kind: badge` are applied as visible badges in documentation."
+layout: default
+---
+
+{% capture summary %}
+Tags with `kind: badge` are applied as visible badges in documentation.
+It is expected that an operation might have many badges.
+{% endcapture %}
+
+{% include tag-kind-entry.md summary=summary %}  

--- a/registries/_tag-kind/nav.md
+++ b/registries/_tag-kind/nav.md
@@ -7,7 +7,7 @@ layout: default
 
 {% capture summary %}
 Tags with `kind: nav` are used in documentation to group operations into sections.
-In most cases, an operation only has one tag of this tag so it belongs in one section.
+In most cases, an operation only has one tag of this type so it belongs in one section.
 {% endcapture %}
 
 {% include tag-kind-entry.md summary=summary %}  

--- a/registries/_tag-kind/nav.md
+++ b/registries/_tag-kind/nav.md
@@ -1,0 +1,13 @@
+---
+owner: lornajane
+issue:
+description: "Tags with `kind: nav` are used in documentation to group operations into sections"
+layout: default
+---
+
+{% capture summary %}
+Tags with `kind: nav` are used in documentation to group operations into sections.
+In most cases, an operation only has one tag of this tag so it belongs in one section.
+{% endcapture %}
+
+{% include tag-kind-entry.md summary=summary %}  

--- a/registry/index.md
+++ b/registry/index.md
@@ -8,6 +8,7 @@ children:
 - title: Draft Features Registry
 - title: Format Registry
 - title: Namespace Registry
+- title: Tag Kinds Registry
 has_toc: false
 ---
 

--- a/registry/tag-kind.md
+++ b/registry/tag-kind.md
@@ -7,6 +7,10 @@ parent: Registry
 
 # Tag Kinds Registry
 
+## Unreleased feature
+
+The `kind` addition to OpenAPI tags is planned for release in OpenAPI 3.2, so support for the values here should not be expected until tools officially support the 3.2 version.
+
 ## Contributing
 
 Please raise a [Pull-Request](https://github.com/OAI/OpenAPI-Specification/pulls) or [Issue](https://github.com/OAI/OpenAPI-Specification/issues) to contribute or discuss a registry value.

--- a/registry/tag-kind.md
+++ b/registry/tag-kind.md
@@ -1,0 +1,20 @@
+---
+title: Tag Kinds Registry
+layout: default
+permalink: /registry/tag-kind/index.html
+parent: Registry
+---
+
+# Tag Kinds Registry
+
+## Contributing
+
+Please raise a [Pull-Request](https://github.com/OAI/OpenAPI-Specification/pulls) or [Issue](https://github.com/OAI/OpenAPI-Specification/issues) to contribute or discuss a registry value.
+
+## Values
+
+|Value|Description
+|---|---|---|
+{% for value in site.tag-kind %}| <a href="./{{ value.slug }}.html">{{ value.slug }}</a> | {{ value.description }} |
+{% endfor %}
+


### PR DESCRIPTION
This goes with #4288 , the additions to the Tag object. We agreed that we should have a registry of some common values for the `kind` field, so this pull request adds that registry with some starter values and a warning about the feature not being released yet