### PR TITLE
Additional fields for the tag object

### DIFF
--- a/src/oas.md
+++ b/src/oas.md
@@ -2691,7 +2691,7 @@ It is not mandatory to have a Tag Object per tag defined in the Operation Object
 | <a name="tag-summary"></a>summary | `string` | A short summary of the tag, used for display purposes. |
 | <a name="tag-description"></a>description | `string` | A description for the tag. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation. |
 | <a name="tag-external-docs"></a>externalDocs | [External Documentation Object](#external-documentation-object) | Additional external documentation for this tag. |
-| <a name="tag-parent"></a>parent | `string` | The `name` of a tag that this tags is nested under. The named tag MUST exist in the API description, and circular references between parent and child tags MUST NOT be used. |
+| <a name="tag-parent"></a>parent | `string` | The `name` of a tag that this tag is nested under. The named tag MUST exist in the API description, and circular references between parent and child tags MUST NOT be used. |
 | <a name="tag-kind"></a>kind | `string` | A machine-readable string to categorize what sort of tag it is. Any string value can be used; common uses are `nav` for Navigation, `badge` for visible badges, `audience` for APIs used by different groups. A [registry of the most commonly used values](https://spec.openapis.org/registry/tag-kind/) is available. |
 
 This object MAY be extended with [Specification Extensions](#specification-extensions).

--- a/src/oas.md
+++ b/src/oas.md
@@ -2699,43 +2699,47 @@ This object MAY be extended with [Specification Extensions](#specification-exten
 ##### Tag Object Example
 
 ```json
-{
-  "name": "account-updates",
-  "summary": "Account Updates",
-  "description": "Account update operations",
-  "kind": "nav"
-},
-{
-  "name": "partner",
-  "summary": "Partner",
-  "description": "Operations available to the partners network",
-  "parent": "external",
-  "kind": "audience"
-},
-{
-  "name": "external",
-  "summary": "External",
-  "description": "Operations available to external consumers",
-  "kind": "audience"
-}
+"tags": [
+  {
+    "name": "account-updates",
+    "summary": "Account Updates",
+    "description": "Account update operations",
+    "kind": "nav"
+  },
+  {
+    "name": "partner",
+    "summary": "Partner",
+    "description": "Operations available to the partners network",
+    "parent": "external",
+    "kind": "audience"
+  },
+  {
+    "name": "external",
+    "summary": "External",
+    "description": "Operations available to external consumers",
+    "kind": "audience"
+  }
+]
 ```
 
 ```yaml
-- name: account-updates
-  summary: Account Updates
-  description: Account update operations
-  kind: nav
+tags:
 
-- name: partner
-  summary: Partner
-  description: Operations available to the partners network
-  parent: external
-  kind: audience
+  - name: account-updates
+    summary: Account Updates
+    description: Account update operations
+    kind: nav
 
-- name: external
-  summary: External
-  description: Operations available to external consumers
-  kind: audience
+  - name: partner
+    summary: Partner
+    description: Operations available to the partners network
+    parent: external
+    kind: audience
+
+  - name: external
+    summary: External
+    description: Operations available to external consumers
+    kind: audience
 ```
 
 #### Reference Object

--- a/src/oas.md
+++ b/src/oas.md
@@ -2687,9 +2687,12 @@ It is not mandatory to have a Tag Object per tag defined in the Operation Object
 
 | Field Name | Type | Description |
 | ---- | :----: | ---- |
-| <a name="tag-name"></a>name | `string` | **REQUIRED**. The name of the tag. |
+| <a name="tag-name"></a>name | `string` | **REQUIRED**. The name of the tag. Use this value in the `tags` array of an Operation. |
+| <a name="tag-summary"></a>summary | `string` | A short summary of the tag, used for display purposes. |
 | <a name="tag-description"></a>description | `string` | A description for the tag. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation. |
 | <a name="tag-external-docs"></a>externalDocs | [External Documentation Object](#external-documentation-object) | Additional external documentation for this tag. |
+| <a name="tag-parent"></a>parent | `string` | The `name` of a tag that this tags is nested under. The named tag MUST exist in the API description, and circular references between parent and child tags MUST NOT be used. |
+| <a name="tag-kind"></a>kind | `string` | A machine-readable string to categorize what sort of tag it is. Common uses are `nav` for Navigation, `badge` for badges, `internal` for internal APIs, but any string value can be used. |
 
 This object MAY be extended with [Specification Extensions](#specification-extensions).
 
@@ -2697,14 +2700,42 @@ This object MAY be extended with [Specification Extensions](#specification-exten
 
 ```json
 {
-  "name": "pet",
-  "description": "Pets operations"
+  "name": "account-updates",
+  "summary": "Account Updates",
+  "description": "Account update operations",
+  "kind": "nav"
+},
+{
+  "name": "partner",
+  "summary": "Partner",
+  "description": "Operations available to the partners network",
+  "parent": "external",
+  "kind": "audience"
+},
+{
+  "name": "external",
+  "summary": "External",
+  "description": "Operations available to external consumers",
+  "kind": "audience"
 }
 ```
 
 ```yaml
-name: pet
-description: Pets operations
+- name: account-updates
+  summary: Account Updates
+  description: Account update operations
+  kind: nav
+
+- name: partner
+  summary: Partner
+  description: Operations available to the partners network
+  parent: external
+  kind: audience
+
+- name: external
+  summary: External
+  description: Operations available to external consumers
+  kind: audience
 ```
 
 #### Reference Object

--- a/src/oas.md
+++ b/src/oas.md
@@ -2692,7 +2692,7 @@ It is not mandatory to have a Tag Object per tag defined in the Operation Object
 | <a name="tag-description"></a>description | `string` | A description for the tag. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation. |
 | <a name="tag-external-docs"></a>externalDocs | [External Documentation Object](#external-documentation-object) | Additional external documentation for this tag. |
 | <a name="tag-parent"></a>parent | `string` | The `name` of a tag that this tags is nested under. The named tag MUST exist in the API description, and circular references between parent and child tags MUST NOT be used. |
-| <a name="tag-kind"></a>kind | `string` | A machine-readable string to categorize what sort of tag it is. Common uses are `nav` for Navigation, `badge` for badges, `internal` for internal APIs, but any string value can be used. |
+| <a name="tag-kind"></a>kind | `string` | A machine-readable string to categorize what sort of tag it is. Any string value can be used; common uses are `nav` for Navigation, `badge` for visible badges, `audience` for APIs used by different groups. A [registry of the most commonly used values](https://spec.openapis.org/registry/tag-kind/) is available. |
 
 This object MAY be extended with [Specification Extensions](#specification-extensions).
 


### PR DESCRIPTION
Implementation of the [proposal](https://github.com/OAI/OpenAPI-Specification/blob/main/proposals/2024-09-01-Tags-Improvement.md) to extend the functionality offered by tags. The main features:
 - tags get a `summary` field in addition to their description
 - tags can have a parent tag, enabling building a tree-ish hierarchy
 - tags can have a `kind` to say what sort of tag they are, so we can use tags for many; #4287 adds a registry for the most common types

Pull request still in draft because I would like to link to the registry but it doesn't exist yet so we should not merge - review feedback very welcome though!