### PR TITLE
adds links to annex C in path and server templating sections

### DIFF
--- a/src/oas.md
+++ b/src/oas.md
@@ -602,7 +602,7 @@ iprivate       =  %xE000-F8FF / %xF0000-FFFFD / %x100000-10FFFD
 
 Here, `literals`, `pct-encoded`, `ucschar` and `iprivate` definitions are taken from [RFC 6570](https://www.rfc-editor.org/rfc/rfc6570), incorporating the corrections specified in [Errata 6937](https://www.rfc-editor.org/errata/eid6937) for `literals`.
 
-See also [Appendix C: Using RFC6570-Based Serialization](#appendix-c-using-rfc6570-based-serialization) for additional guidance.
+See the [Paths Object](#paths-object) for guidance on constructing full request URLs.
 
 ##### Fixed Fields
 


### PR DESCRIPTION
fixes #3256
This continues the work started in #4244 and #4264 to add links to annex C in the path and server templating sections.
CC @char0n 