### PR TITLE
docs: adds ms extensions repo link

### DIFF
--- a/registries/_namespace/ms.md
+++ b/registries/_namespace/ms.md
@@ -1,12 +1,12 @@
 ---
 owner: DarrelMiller
 issue: 
-description: Extensions [created and used by Microsoft](https://github.com/microsoft/openapi)
+description: Extensions [created and used by Microsoft](https://github.com/microsoft/OpenAPI/blob/main/extensions/index.md)
 layout: default
 ---
 
 {% capture summary %}
-The `x-{{page.slug}}-` prefix is reserved for [extensions created by Microsoft](https://github.com/microsoft/openapi). These extensions are available for use by anyone.
+The `x-{{page.slug}}-` prefix is reserved for [extensions created by Microsoft](https://github.com/microsoft/OpenAPI/blob/main/extensions/index.md). These extensions are available for use by anyone.
 {% endcapture %}
 
 {% include namespace-entry.md summary=summary %}

--- a/registries/_namespace/ms.md
+++ b/registries/_namespace/ms.md
@@ -1,12 +1,12 @@
 ---
 owner: DarrelMiller
 issue: 
-description: Extensions created and used by Microsoft
+description: Extensions [created and used by Microsoft](https://github.com/microsoft/openapi)
 layout: default
 ---
 
 {% capture summary %}
-The `x-{{page.slug}}-` prefix is reserved for extensions created by Microsoft. These extensions are available for use by anyone.
+The `x-{{page.slug}}-` prefix is reserved for [extensions created by Microsoft](https://github.com/microsoft/openapi). These extensions are available for use by anyone.
 {% endcapture %}
 
 {% include namespace-entry.md summary=summary %}


### PR DESCRIPTION
This pull request adds links to the microsoft extensions registry in the OpenAPI extensions registry for the x-ms prefix so people can better discover which extensions are defined/in use and leverage them.