### PR TITLE
Arazzo: add markdown wrapper for schema file

### DIFF
--- a/arazzo/1.0/schema/2024-12-16.md
+++ b/arazzo/1.0/schema/2024-12-16.md
@@ -1,0 +1,9 @@
+---
+title: JSON Schema for Arazzo 1.0
+layout: default
+parent: Schemas
+---
+
+```json
+{% include_relative {{ page.name | remove: ".md" }} %}
+```


### PR DESCRIPTION
Add markdown wrapper file for Arazzo schema.

This fixes the currently broken link on the landing page in the [Arazzo Schemas](https://spec.openapis.org/#arazzo-schemas) section:
* view [schema/2024-12-16](https://spec.openapis.org/arazzo/1.0/schema/2024-12-16.html)


