### PR TITLE
dev: format src/oas.md

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "build": "bash ./scripts/md2html/build.sh",
     "build-src": "npm run validate-markdown && bash ./scripts/md2html/build-src.sh",
     "test": "c8 --100 vitest --watch=false && bash scripts/schema-test-coverage.sh",
+    "format-markdown": "bash ./scripts/format-markdown.sh ./src/oas.md",
     "validate-markdown": "npx mdv src/oas.md && npx markdownlint-cli src/oas.md"
   },
   "readmeFilename": "README.md",


### PR DESCRIPTION
Part of
* #4223

New npm script `format-markdown` formats `src/oas.md`.

Tick one of the following options:

- [ ] schema changes are included in this pull request
- [ ] schema changes are needed for this pull request but not done yet
- [x] no schema changes are needed for this pull request
