### PR TITLE
respec.yaml: use older Ubuntu

### DIFF
--- a/.github/workflows/respec.yaml
+++ b/.github/workflows/respec.yaml
@@ -18,7 +18,7 @@ on:
 jobs:
   respec:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4 # checkout main branch


### PR DESCRIPTION
Respec depends on puppeteer which has a problem with the latest Ubuntu

<!--
Thank you for contributing to the OpenAPI Specification!

Please make certain you are submitting your PR on the correct
branch, to the files under the "src/" directory (which is not
present on the main branch, only on the development branches).

* 3.1.x spec and schemas: v3.1-dev branch
* 3.2.x spec and schemas: v3.2-dev branch
* registry templates: gh-pages branch, registry/...
* registry contents: gh-pages branch, registries/...
* process documentation and build infrastructure: main

Note that we do not accept changes to published specifications.
-->

Tick one of the following options:

- [ ] schema changes are included in this pull request
- [ ] schema changes are needed for this pull request but not done yet
- [x] no schema changes are needed for this pull request
