### PR TITLE
Run respec without sandbox

### DIFF
--- a/scripts/md2html/build.sh
+++ b/scripts/md2html/build.sh
@@ -54,7 +54,7 @@ for specification in $specifications; do
   echo === Building $version to $destination
 
   node scripts/md2html/md2html.js --maintainers $maintainers $specification > $tempfile
-  npx respec --use-local --src $tempfile --out $destination
+  npx respec --no-sandbox --use-local --src $tempfile --out $destination
   rm $tempfile
 
   echo === Built $destination


### PR DESCRIPTION
Alternative to
* #4337

Respec depends on puppeteer which does not support running in a sandbox with the latest Ubuntu. Official recommendation:

> **[What if I don‘t have root access to the machine and can’t install anything?](https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md#what-if-i-dont-have-root-access-to-the-machine-and-cant-install-anything)**
>
> You will need to run developer builds with the `--no-sandbox` command line flag, but be aware that this disables critical security features of Chromium and should never be used when browsing the open web.

I don't want to mess with the GitHub Ubuntu image, we are not browsing the open web, and we only tell puppeteer to access local HTML files that we generated ourselves, so this should be safe enough.

Tick one of the following options:

- [ ] schema changes are included in this pull request
- [ ] schema changes are needed for this pull request but not done yet
- [x] no schema changes are needed for this pull request
