### PR TITLE
gh-pages: show OAS 2.0 spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 _site/
+coverage/
 deploy/
+deploy-preview/
 node_modules/
 scripts/
 package-lock.json

--- a/_includes/specification-version-list.md
+++ b/_includes/specification-version-list.md
@@ -13,4 +13,4 @@
 , [{{ file.basename }}]({{ site.baseurl }}{{ file.path }})
 {%- endif -%}
 {%- endif -%}
-{%- endfor- %}
+{%- endfor -%}

--- a/index.md
+++ b/index.md
@@ -19,6 +19,7 @@ Please see the [Learn OpenAPI](https://learn.openapis.org) site for additional d
 ### OpenAPI Specification
 
 {% include specification-version-list.md specification="oas" %}
+* **[v2.0]({{ site.baseurl }}/oas/v2.0.html)**
 
 ### Overlay Specification
 


### PR DESCRIPTION
It got lost with the introduction of minor-version symlinks

- index page: add bullet point for OAS 2.0 - `specification-version-list` include intentionally ignores files without patch version
- `specification-version-list` include: remove unwanted whitespace at end of list - messes up spacing of bullet list if items are added on index page (typo that escaped notice so far)
- `.gitignore`: add local folders needed by build scripts on `main` and `dev` branches

<!--
Thank you for contributing to the OpenAPI Specification!

Please make certain you are submitting your PR on the correct
branch, to the files under the "src/" directory (which is not
present on the main branch, only on the development branches).

* 3.1.x spec and schemas: v3.1-dev branch
* 3.2.x spec and schemas: v3.2-dev branch
* registry templates: gh-pages branch, registry/...
* registry contents: gh-pages branch, registries/...
* process documentation and build infrastructure: main

Note that we do not accept changes to published specifications.
-->

Tick one of the following options:

- [ ] schema changes are included in this pull request
- [ ] schema changes are needed for this pull request but not done yet
- [x] no schema changes are needed for this pull request
