### PR TITLE
Update schema-publish.sh

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "build": "bash ./scripts/md2html/build.sh",
-    "build-src": "npm run validate-markdown && bash ./scripts/md2html/build.sh src",
+    "build-src": "npm run validate-markdown && bash ./scripts/md2html/build.sh src && bash ./scripts/schema-publish.sh src",
     "test": "c8 --100 vitest --watch=false && bash scripts/schema-test-coverage.sh",
     "format-markdown": "bash ./scripts/format-markdown.sh ./src/oas.md",
     "validate-markdown": "npx mdv src/oas.md && npx markdownlint-cli src/oas.md"

--- a/scripts/schema-publish.sh
+++ b/scripts/schema-publish.sh
@@ -6,15 +6,61 @@
 
 schemaDir="src/schemas/validation"
 branch=$(git branch --show-current)
-version=${branch:1:3}
-echo === Building schemas into ./deploy/oas/$version
+
+
+if [ -z "$1" ]; then
+  if [[ $branch =~ ^v([0-9]+\.[0-9]+)-dev$ ]]; then
+    deploydir="./deploy/oas/${BASH_REMATCH[1]}"
+  else
+    echo "Unable to determine version from branch name; should be vMAJOR.MINOR.PATCH-dev"
+    exit 1
+  fi
+elif [ $1 = "src" ]; then
+  deploydir="./deploy-preview"
+else
+  echo "Unrecognized argument"
+  exit 1
+fi
+
+# create the date-stamped schemas
+publish_schema() {
+  local schema="$1"
+  local date="$2"
+  local sedCmd="$3"
+
+  local base=$(basename $schema '.yaml')
+  local target=$deploydir/$base/$date
+
+  mkdir -p $deploydir/$base
+  # replace the WORK-IN-PROGRESS placeholders
+  sed -e $sedCmd $schemaDir/$schema > $target.yaml
+
+  node scripts/yaml2json/yaml2json.js "$target.yaml"
+  rm "$target.yaml"
+  mv "$target.json" "$target"
+
+  # Find the jekyll lander markdown file for this iteration.
+  local jekyllLander=$(find "$deploydir/$base" -maxdepth 1 -name "*.md")
+
+  # Move the jekyll lander markdown for this iteration to the deploy destination.
+  # The lander files only exist in the gh-pages branch.
+  if [ ! -z "$jekyllLander" ]; then
+    mv $jekyllLander $target.md
+    echo " * $newestCommitDate: $schema & jekyll lander $(basename $jekyllLander)"
+  else
+    echo " * $newestCommitDate: $schema"
+  fi
+
+}
+
+echo === Building schemas into $deploydir
 
 # list of schemas to process, dependent schemas come first
 schemas=(meta.yaml dialect.yaml schema.yaml schema-base.yaml)
 
-# find the newest commit date for each schema
+# publish each schema using its or any of its dependencies newest commit date.
 maxDate=""
-declare -A datesHash
+sedCmds=()
 for schema in "${schemas[@]}"; do
   if [ -f  "$schemaDir/$schema" ]; then
     newestCommitDate=$(git log -1 --format="%ad" --date=short "$schemaDir/$schema")
@@ -23,31 +69,13 @@ for schema in "${schemas[@]}"; do
     if [ "$newestCommitDate" \> "$maxDate" ]; then
       maxDate=$newestCommitDate
     fi
-    datesHash["$schema"]=$maxDate
-    echo $schema changed at $newestCommitDate
+
+    base=$(basename $schema '.yaml')
+    # Add the replacement for this schema's placeholder to list of sed commands.
+    sedCmds+=("s/${base}\/WORK-IN-PROGRESS/${base}\/${maxDate}/g")
+
+    publish_schema "$schema" "$maxDate" $(printf '%s;' "${sedCmds[@]}")
   fi
-done
-
-# construct sed command
-sedCmd=()
-for schema in "${!datesHash[@]}"; do
-  base=$(basename "$schema" .yaml)
-  sedCmd+=("-e s/$base\/WORK-IN-PROGRESS/$base\/${datesHash[$schema]}/g")
-done
-
-# create the date-stamped schemas
-for schema in "${!datesHash[@]}"; do
-  base=$(basename "$schema" .yaml)
-  target=deploy/oas/$version/$base/${datesHash[$schema]}
-
-  mkdir -p "deploy/oas/$version/$base"
-
-  sed ${sedCmd[@]} $schemaDir/$schema > $target.yaml
-  node scripts/yaml2json/yaml2json.js $target.yaml
-  rm $target.yaml
-  mv $target.json $target
-
-  mv deploy/oas/$version/$base/*.md $target.md
 done
 
 echo === Built


### PR DESCRIPTION
Fixes #4223

## 🗣️ Discussion

This PR brings the schema publishing workflow into closer alignment with the specification publishing workflow.

### 🔧 Under-the-hood changes

* Configure deploydir based on branch name
* Check branch name for conformance to vX.Y-dev structure
  * build to `/deploy/oas/$version` if branch name is conformant
  * build to `/deploy-preview` if branch name is non-conformant
* Perform only one traversal of schemas structure
* Remove `datesHash` data structure
* Accumulate sed sub-commands & invoke with sed single -e argument

### 🧑 Contributor-facing Changes

* <details><summary>Schema publishing process works out-of-the-box on macOS</summary>A side-effect of removing intermediate data structures is that we avoid bash-4-isms, enabling out-of-the-box builds on modern macOS versions which ship an old 3.2.57 bash version.</details>
* Schema publishing process from ad-hoc branch names produces sensible artifacts

## 🚗 Demo

This screenshot demonstrates running the `scripts/schema-publish.sh` script from different branch names.
It also includes an interrogation of a generated schema file in order to validate that all of its placeholders are replaced correctly. (Thanks [@ralfhandl](https://github.com/OAI/OpenAPI-Specification/pull/4376#discussion_r1964152528)!)

<img width="740" alt="Screenshot demonstrating running the schemas build process in different branch names, showing how the deploy directory changes, and also showing how multiple different placeholders are replaced with their correct values." src="https://github.com/user-attachments/assets/e51123b3-0f5b-44ac-9c70-e24c2cc058ea" />