### PR TITLE
style guide: no requirements in "Examples" sections

### DIFF
--- a/style-guide.md
+++ b/style-guide.md
@@ -21,7 +21,7 @@ The following additional rules should be followed but currently are not enforced
 9. Use [Oxford commas](https://en.wikipedia.org/wiki/Serial_comma), avoid [Shatner commas](https://www.latimes.com/archives/blogs/jacket-copy/story/2011-06-30/goodbye-oxford-comma-hello-shatner-comma).
 10. Use `<span id="thing"></span>` for link anchors. The `<a name="thing"></a>` format has been deprecated.
 11. Headings use [title case](https://en.wikipedia.org/wiki/Title_case) and are followed by a blank line.
-12. Do not add requirements in "Examples" sections, and avoid [RFC2119 key words (MUST, MAY, ...)](https://datatracker.ietf.org/doc/html/rfc2119) in these sections.
+12. Do not use [RFC2119 key words (MUST, MAY, ...)](https://datatracker.ietf.org/doc/html/rfc2119) in "Examples" sections or when explaining examples, and state requirements only in sections that are clearly normative.
 
 Plus some suggestions, rather than rules:
 

--- a/style-guide.md
+++ b/style-guide.md
@@ -21,6 +21,7 @@ The following additional rules should be followed but currently are not enforced
 9. Use [Oxford commas](https://en.wikipedia.org/wiki/Serial_comma), avoid [Shatner commas](https://www.latimes.com/archives/blogs/jacket-copy/story/2011-06-30/goodbye-oxford-comma-hello-shatner-comma).
 10. Use `<span id="thing"></span>` for link anchors. The `<a name="thing"></a>` format has been deprecated.
 11. Headings use [title case](https://en.wikipedia.org/wiki/Title_case) and are followed by a blank line.
+12. Do not add requirements in "Examples" sections, and avoid [RFC2119 key words (MUST, MAY, ...)](https://datatracker.ietf.org/doc/html/rfc2119) in these sections.
 
 Plus some suggestions, rather than rules:
 


### PR DESCRIPTION
Follow-up to https://github.com/OAI/OpenAPI-Specification/pull/4339#discussion_r1958587868.

PR #4339 added text to an "Examples" section that used requirements language with "MUST" and "MAY". In this case the text was just copied verbatim from "non-example" sections of the spec, and no new requirements were added.

Better style is to
* not to add requirements in a section called "Examples" or similar because readers may be confused whether these are really normative requirements or just explanations to the examples
* not to use requirements language in explanations to examples

<!--
Thank you for contributing to the OpenAPI Specification!

Please make certain you are submitting your PR on the correct
branch, to the files under the "src/" directory (which is not
present on the main branch, only on the development branches).

* 3.1.x spec and schemas: v3.1-dev branch
* 3.2.x spec and schemas: v3.2-dev branch
* registry templates: gh-pages branch, registry/...
* registry contents: gh-pages branch, registries/...
* process documentation and build infrastructure: main

Note that we do not accept changes to published specifications.
-->

Tick one of the following options:

- [ ] schema changes are included in this pull request
- [ ] schema changes are needed for this pull request but not done yet
- [x] no schema changes are needed for this pull request
