### PR TITLE
main: new workflow that syncs dev to vX.Y-dev

### DIFF
--- a/.github/workflows/sync-dev-to-vX.Y-dev.yaml
+++ b/.github/workflows/sync-dev-to-vX.Y-dev.yaml
@@ -1,0 +1,45 @@
+name: sync-dev-to-vX.Y-dev
+
+# author: @ralfhandl
+
+#
+# This workflow creates PRs to update the vX.Y-dev branch with the latest changes from dev
+#
+
+# run this on push to dev
+on:
+  push:
+    branches:
+      - dev
+
+jobs:
+  sync-branches:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create pull requests
+        id: pull_requests
+        shell: bash
+        run: |
+          DEV_BRANCHES=$(git branch -r --list origin/v?.?-dev)
+          for DEV_BRANCH in $DEV_BRANCHES; do
+            BASE=${DEV_BRANCH:7}
+            EXISTS=$(gh pr list --base $BASE --head $HEAD \
+              --json number --jq '.[] | .number')
+            if [ ! -z "$EXISTS" ]; then
+              echo "PR #$EXISTS already wants to merge $HEAD into $BASE"
+              continue
+            fi
+
+            gh pr create --base $BASE --head $HEAD \
+              --label "Housekeeping" \
+              --title "$BASE: update from $HEAD" \
+              --body "Merge \`$HEAD\` into \`$BASE\`."
+          done
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD: dev

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -429,9 +429,11 @@ gitGraph TB:
 To keep changes in sync, we have some GitHub actions that open pull requests to take changes from `main` onto the `dev` branch, and from `dev` to each active version branch.
 
 - `sync-main-to-dev` opens a pull request with all the changes from the `main` branch that aren't yet included on `dev`.
-  This needs a single approval from either maintainers or TSC and can be merged.
-  The aim is to bring build script and repository documentation changes to the other branches.
-  Published versions of the specifications and schemas will also move across branches with this approach.
+- `sync-dev-to-vX.Y-dev` opens pull requests with all the changes from `dev` that aren't yet included on the corresponding `vX.Y-dev` branch.
+
+These need a single approval from either maintainers or TSC and can be merged.
+The aim is to bring build script and repository documentation changes to the other branches.
+Published versions of the specifications and schemas will also move across branches with this approach.
 
 ## Appendix: Issue Automation
 


### PR DESCRIPTION
New workflow to sync changes from `dev` to `vX.Y-dev`. This workflow will trigger on push to `dev` and create PRs for merging `dev` into `vX.Y-dev` unless such a PR already exists.

The sync PR's author is the `github-actions` bot, so a single maintainer or TSC member can approve and merge it. An example PR created by this action is
* #4397

This is a low-key solution to https://github.com/OAI/OpenAPI-Specification/issues/4373#issuecomment-2688614056 that only relies on GitHub tools without third-party dependencies.

Tick one of the following options:

- [ ] schema changes are included in this pull request
- [ ] schema changes are needed for this pull request but not done yet
- [x] no schema changes are needed for this pull request

