### PR TITLE
main: status check for changes to `versions` and `schemas` folder

### DIFF
--- a/.github/workflows/check-restricted-files.yaml
+++ b/.github/workflows/check-restricted-files.yaml
@@ -1,6 +1,6 @@
 name: check-restricted-files
 
-# Autor: @ralfhandl
+# Author: @ralfhandl
 # Issue: https://github.com/OAI/OpenAPI-Specification/issues/3432
 
 # This workflow checks for changes of restricted files in a pull request

--- a/.github/workflows/check-restricted-files.yaml
+++ b/.github/workflows/check-restricted-files.yaml
@@ -1,0 +1,30 @@
+name: check-restricted-files
+
+# Autor: @ralfhandl
+# Issue: https://github.com/OAI/OpenAPI-Specification/issues/3432
+
+# This workflow checks for changes of restricted files in a pull request
+
+on:
+  - pull_request
+
+jobs:
+  check-files:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check changed files
+        shell: bash
+        run: |
+          set +e
+
+          git diff --exit-code --name-only ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.base.sha }} \
+              -- schemas versions
+          if [[ $? -ne 0 ]]; then
+            echo This PR contains changes to files that should not be changed on ${{ github.event.pull_request.base.ref }}
+            exit 1
+          fi


### PR DESCRIPTION
Part of #3432

This PR adds a workflow that checks for changes to files in the `schemas` and `versions` folder.

This workflow SHOULD NOT become a required check because
* we still need to add future spec versions to the `versions` folder
* we want to propagate new spec versions from `main` to `dev` and `vX.Y-dev` etc.

So this will be a "red flag" that can be disregarded, which is better than no warning, and may help to prevent accidents such as #4328 targeting the wrong file.

<!--
Thank you for contributing to the OpenAPI Specification!

Please make certain you are submitting your PR on the correct
branch, to the files under the "src/" directory (which is not
present on the main branch, only on the development branches).

* 3.1.x spec and schemas: v3.1-dev branch
* 3.2.x spec and schemas: v3.2-dev branch
* registry templates: gh-pages branch, registry/...
* registry contents: gh-pages branch, registries/...
* process documentation and build infrastructure: main

Note that we do not accept changes to published specifications.
-->

Tick one of the following options:

- [ ] schema changes are included in this pull request
- [ ] schema changes are needed for this pull request but not done yet
- [ ] no schema changes are needed for this pull request
