### PR TITLE
main: check-restricted-files.yaml reports ok for intra-repo PRs that are allowed to change these files

### DIFF
--- a/.github/workflows/check-restricted-files.yaml
+++ b/.github/workflows/check-restricted-files.yaml
@@ -18,5 +18,27 @@ jobs:
       - name: Check changed files
         shell: bash
         run: |
+          if [[ "${{ github.event.pull_request.head.repo.full_name }}" == "OAI/OpenAPI-Specification" ]] && \
+             [[ "${{ github.event.pull_request.base.repo.full_name }}" == "OAI/OpenAPI-Specification" ]]; then
+ 
+            if [[ "${{ github.event.pull_request.head.ref }}" == "main" ]] && \
+               [[ "${{ github.event.pull_request.base.ref }}" == "dev" ]]; then
+              echo Sync from main to dev
+              exit 0
+            fi
+
+            if [[ "${{ github.event.pull_request.head.ref }}" == "dev" ]] && \
+               [[ "${{ github.event.pull_request.base.ref }}" =~ ^v[0-9]+\.[0-9]+-dev$ ]]; then
+              echo Sync from dev to ${{ github.event.pull_request.base.ref }}
+              exit 0
+            fi
+
+            if [[ "${{ github.event.pull_request.head.ref }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-rel$ ]] && \
+               [[ "${{ github.event.pull_request.base.ref }}" == "main" ]]; then
+              echo Release from ${{ github.event.pull_request.head.ref }} to main
+              exit 0
+            fi
+          fi
+
           echo This PR contains changes to files that should not be changed
           exit 1


### PR DESCRIPTION
Fixes #3432 

Check in the workflow whether the PR is an intra-repo "sync PR" or "release PR" and report "ok" for these. 

Conditions are
- PR's `head` and `base` repository is `OAI/OpenAPI-Specification` and
  - `head` is `main` and `base` is `dev`, or
  - `head` is `dev` and `base` matches `v?.?-dev`, or
  - `head` matches `v?.?.?-rel` and `base` is `main`

<!--
Thank you for contributing to the OpenAPI Specification!

Please make certain you are submitting your PR on the correct
branch, to the files under the "src/" directory (which is not
present on the main branch, only on the development branches).

* 3.1.x spec and schemas: v3.1-dev branch
* 3.2.x spec and schemas: v3.2-dev branch
* registry templates: gh-pages branch, registry/...
* registry contents: gh-pages branch, registries/...
* process documentation and build infrastructure: main

Note that we do not accept changes to published specifications.
-->

Tick one of the following options:

- [ ] schema changes are included in this pull request
- [ ] schema changes are needed for this pull request but not done yet
- [x] no schema changes are needed for this pull request
