### PR TITLE
main: package.json is only for infrastructure

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "oas-schemas",
-  "version": "2.0.0",
-  "description": "OpenAPI Specification JSON schemas",
+  "name": "oas-infra",
+  "version": "0.0.0",
+  "description": "OpenAPI Specification Automation & Infrastructure",
   "author": {
     "name": "OpenAPI Initiative TSC",
     "email": "tsc@openapis.org",
@@ -16,11 +16,6 @@
     "build": "bash ./scripts/md2html/build.sh",
     "test": "c8 --100 vitest --watch=false && bash scripts/schema-test-coverage.sh"
   },
-  "readmeFilename": "README.md",
-  "files": [
-    "README.md",
-    "schemas/*"
-  ],
   "dependencies": {
     "cheerio": "^1.0.0-rc.5",
     "highlight.js": "^11.11.1",


### PR DESCRIPTION
Adjust
- `name` - we don't publish schemas from `main`
- `description` - this file only describes the automation & infrastructure
- `version` - reset to zero, it is not intended for public/productive use
- `readmeFileName` - this property is no longer part of [`package.json`](https://github.com/npm/npm/issues/3573#issuecomment-19550501) 
- `files` - only needed if we ever want to publish the infrastructure as a package

Tick one of the following options:

- [ ] schema changes are included in this pull request
- [ ] schema changes are needed for this pull request but not done yet
- [x] no schema changes are needed for this pull request
