### PR TITLE
dev: schema tests output reason if "pass" test fixture fails

### DIFF
--- a/tests/schema/schema.test.mjs
+++ b/tests/schema/schema.test.mjs
@@ -37,7 +37,7 @@ describe("v3.1", () => {
         test(entry.name, () => {
           const instance = parseYamlFromFile(`${fixtures}/pass/${entry.name}`);
           const output = validateOpenApi(instance, BASIC);
-          expect(output.valid).to.equal(true);
+          expect(output).to.deep.equal({ valid: true });
         });
       });
   });


### PR DESCRIPTION
This is a quality-of-life improvement for writing "pass" test fixtures: output validation errors if a "pass" test fixture fails validation. 

Tick one of the following options:

- [ ] schema changes are included in this pull request
- [ ] schema changes are needed for this pull request but not done yet
- [x] no schema changes are needed for this pull request
