### PR TITLE
Validate fragments are allowed in path keys

### DIFF
--- a/tests/schema/pass/path-key-fragment.yaml
+++ b/tests/schema/pass/path-key-fragment.yaml
@@ -1,0 +1,7 @@
+openapi: 3.1.0
+info:
+  title: API
+  version: 1.0.0
+paths:
+  /foo#fragment:
+    get: {}


### PR DESCRIPTION
## 🗣️ Discussion

Related to [Slack Discussion](https://open-api.slack.com/archives/C1137F8HF/p1741624538482899) about valid vs lint-happy schemas.

This PR adds a test case asserting that paths entries including a URL fragment are valid, despite the fragment being functionally meaningless.

PRs which enforce rules forbidding such paths would not be compliant with the spec, so this test case makes explicit the answer to that question. 

If this PR is merged, future PRs proposing lint rules forbidding fragments in `paths` keys will fail, and be forced to address the fact that their proposal represents opinion rather than conformance to the specification.