### PR TITLE
Gather data modeling sections into a "Modeling Data" top-level section

### DIFF
--- a/src/oas.md
+++ b/src/oas.md
@@ -1548,6 +1548,8 @@ application/json:
       $ref: '#/components/examples/frog-example'
 ```
 
+For additional techniques and examples, see [Modeling Non-JSON Data](#modeling-non-json-data).
+
 #### Encoding Object
 
 A single encoding definition applied to a single schema property.
@@ -1598,6 +1600,8 @@ See also [Appendix C: Using RFC6570 Implementations](#appendix-c-using-rfc6570-b
 
 Note that the presence of at least one of `style`, `explode`, or `allowReserved` with an explicit value is equivalent to using `schema` with `in: "query"` Parameter Objects.
 The absence of all three of those fields is the equivalent of using `content`, but with the media type specified in `contentType` rather than through a Media Type Object.
+
+For additional techniques and examples, see [Modeling Non-JSON Data](#modeling-non-json-data).
 
 #### Responses Object
 
@@ -2512,6 +2516,8 @@ JSON Schema implementations MAY choose to treat keywords defined by the OpenAPI 
 
 This object MAY be extended with [Specification Extensions](#specification-extensions), though as noted, additional properties MAY omit the `x-` prefix within this object.
 
+For additional techniques and examples, see [Schema Modeling Techniques](#schema-modeling-techniques).
+
 ##### Extended Validation with Annotations
 
 JSON Schema Draft 2020-12 supports [collecting annotations](https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-00#section-7.7.1), including [treating unrecognized keywords as annotations](https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-00#section-6.5).
@@ -2547,6 +2553,8 @@ For standalone JSON Schema documents that do not set `$schema`, or for Schema Ob
 However, for maximum interoperability, it is RECOMMENDED that OpenAPI description authors explicitly set the dialect through `$schema` in such documents.
 
 ##### Schema Object Examples
+
+For additional techniques and examples, see [Schema Modeling Techniques](#schema-modeling-techniques).
 
 ###### Primitive Example
 
@@ -3531,6 +3539,8 @@ Two examples of this:
 
 ## Modeling Data
 
+This section collects guidance on various data modeling and encoding scenarios that are either very general, or are more complex than those needed to illustrate basic Object usage.
+
 ### Data Types
 
 Data types in the OAS are based on the types defined by the [JSON Schema Validation Specification Draft 2020-12](https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-validation-00#section-6.1.1):
@@ -3599,7 +3609,9 @@ The following table shows how to migrate from OAS 3.0 binary data descriptions, 
 | <code style="white-space:nowrap">type: string</code><br /><code style="white-space:nowrap">format: binary</code> | <code style="white-space:nowrap">contentMediaType: image/png</code> | if redundant, can be omitted, often resulting in an empty [Schema Object](#schema-object) |
 | <code style="white-space:nowrap">type: string</code><br /><code style="white-space:nowrap">format: byte</code> | <code style="white-space:nowrap">type: string</code><br /><code style="white-space:nowrap">contentMediaType: image/png</code><br /><code style="white-space:nowrap">contentEncoding: base64</code> | note that `base64url` can be used to avoid re-encoding the base64 string to be URL-safe |
 
-### Data Modeling Techniques
+### Schema Modeling Techniques
+
+These techniques are all based on the [Schema Object](#schema-object).
 
 #### Composition and Inheritance (Polymorphism)
 
@@ -4002,12 +4014,18 @@ oneOf:
     description: Specify colors with the cyan, magenta, yellow, and black subtractive color model
 ```
 
+### Modeling Non-JSON Data
+
+This section describes how to model non-JSON formats, either by mapping the format into the
+[JSON Schema data model](https://www.ietf.org/archive/id/draft-bhutton-json-schema-01.html#name-instance-data-model)
+or by using additional Objects such as the [Encoding Object](#encoding-object).
+
 #### XML Modeling
 
 The [xml](#schema-xml) field allows extra definitions when translating the JSON definition to XML.
 The [XML Object](#xml-object) contains additional information about the available options.
 
-### Considerations for File Uploads
+#### Considerations for File Uploads
 
 In contrast to OpenAPI 2.0, `file` input/output content in OAS 3.x is described with the same semantics as any other schema type.
 
@@ -4058,14 +4076,14 @@ requestBody:
 
 To upload multiple files, a `multipart` media type MUST be used as shown under [Example: Multipart Form with Multiple Files](#example-multipart-form-with-multiple-files).
 
-### Encoding the `x-www-form-urlencoded` Media Type
+#### Encoding the `x-www-form-urlencoded` Media Type
 
 To submit content using form url encoding via [RFC1866](https://tools.ietf.org/html/rfc1866), use the `application/x-www-form-urlencoded` media type in the [Media Type Object](#media-type-object) under the [Request Body Object](#request-body-object).
 This configuration means that the request body MUST be encoded per [RFC1866](https://tools.ietf.org/html/rfc1866) when passed to the server, after any complex objects have been serialized to a string representation.
 
 See [Appendix E](#appendix-e-percent-encoding-and-form-media-types) for a detailed examination of percent-encoding concerns for form media types.
 
-#### Example: URL Encoded Form with JSON Values
+##### Example: URL Encoded Form with JSON Values
 
 When there is no [`encoding`](#media-type-encoding) field, the serialization strategy is based on the Encoding Object's default values:
 
@@ -4111,7 +4129,7 @@ Here is the `id` parameter (without `address`) serialized as `application/json` 
 id=%22f81d4fae-7dec-11d0-a765-00a0c91e6bf6%22
 ```
 
-#### Example: URL Encoded Form with Binary Values
+##### Example: URL Encoded Form with Binary Values
 
 Note that `application/x-www-form-urlencoded` is a text format, which requires base64-encoding any binary data:
 
@@ -4145,7 +4163,7 @@ Note that the `=` padding characters at the end need to be percent-encoded, even
 Some base64-decoding implementations may be able to use the string without the padding per [RFC4648](https://datatracker.ietf.org/doc/html/rfc4648#section-3.2).
 However, this is not guaranteed, so it may be more interoperable to keep the padding and rely on percent-decoding.
 
-### Encoding `multipart` Media Types
+#### Encoding `multipart` Media Types
 
 It is common to use `multipart/form-data` as a `Content-Type` when transferring forms as request bodies. In contrast to OpenAPI 2.0, a `schema` is REQUIRED to define the input parameters to the operation when using `multipart` content. This supports complex structures as well as supporting mechanisms for multiple file uploads.
 
@@ -4168,7 +4186,7 @@ Because of this, and because the Encoding Object's `contentType` defaulting rule
 
 See [Appendix E](#appendix-e-percent-encoding-and-form-media-types) for a detailed examination of percent-encoding concerns for form media types.
 
-#### Example: Basic Multipart Form
+##### Example: Basic Multipart Form
 
 When the `encoding` field is _not_ used, the encoding is determined by the Encoding Object's defaults:
 
@@ -4195,7 +4213,7 @@ requestBody:
               $ref: '#/components/schemas/Address'
 ```
 
-#### Example: Multipart Form with Encoding Objects
+##### Example: Multipart Form with Encoding Objects
 
 Using `encoding`, we can set more specific types for binary data, or non-JSON formats for complex values.
 We can also describe headers for each part:
@@ -4240,7 +4258,7 @@ requestBody:
                 type: integer
 ```
 
-#### Example: Multipart Form with Multiple Files
+##### Example: Multipart Form with Multiple Files
 
 In accordance with [RFC7578](https://www.rfc-editor.org/rfc/rfc7578.html#section-4.3), multiple files for a single form field are uploaded using the same name (`file` in this example) for each file's part:
 

--- a/src/oas.md
+++ b/src/oas.md
@@ -3540,29 +3540,29 @@ Two examples of this:
 ## Modeling Data
 
 Modeling data in the OpenAPI Specification starts with the [[JSON]] data model of strings, numbers, booleans, arrays, objects, and `null`.
-This is further refined and constrained by the [Schema Object](#schema-object), which uses [JSON Schema Draft 2020-12](https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-01) with several extensions, most notably the [Discriminator Object](#discriminator-object) and the [XML Object](#xml-object).
+This is further refined and constrained by the [Schema Object](#schema-object), which uses [JSON Schema Draft 2020-12](https://www.ietf.org/archive/id/draft-bhutton-json-schema-01) with several extensions, most notably the [Discriminator Object](#discriminator-object) and the [XML Object](#xml-object).
 Several additional Objects determine how to map between in-memory data, which is subject to schema validation, and on-the-wire formats, including the [Parameter Object](#parameter-object), [Header Object](#header-object), [Media Type Object](#media-type-object), and [Encoding Object](#encoding-object).
 
 This section collects guidance on both the basics of data types, and on how to use these Objects to handle more complex scenarios.
 
 ### Data Types
 
-Data types in the OAS are based on the types defined by the [JSON Schema Validation Specification Draft 2020-12](https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-validation-00#section-6.1.1):
+Data types in the OAS are based on the types defined by the [JSON Schema Validation Specification Draft 2020-12](https://www.ietf.org/archive/id/draft-bhutton-json-schema-validation-01#section-6.1.1):
 "null", "boolean", "object", "array", "number", "string", or "integer".
 Models are defined using the [Schema Object](#schema-object), which is a superset of the JSON Schema Specification Draft 2020-12.
 
 JSON Schema keywords and `format` values operate on JSON "instances" which may be one of the six JSON data types, "null", "boolean", "object", "array", "number", or "string", with certain keywords and formats only applying to a specific type. For example, the `pattern` keyword and the `date-time` format only apply to strings, and treat any instance of the other five types as _automatically valid._ This means JSON Schema keywords and formats do **NOT** implicitly require the expected type. Use the `type` keyword to explicitly constrain the type.
 
-Note that the `type` keyword allows `"integer"` as a value for convenience, but keyword and format applicability does not recognize integers as being of a distinct JSON type from other numbers because [[RFC7159|JSON]] itself does not make that distinction. Since there is no distinct JSON integer type, JSON Schema defines integers mathematically. This means that both `1` and `1.0` are [equivalent](https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-00#section-4.2.2), and are both considered to be integers.
+Note that the `type` keyword allows `"integer"` as a value for convenience, but keyword and format applicability does not recognize integers as being of a distinct JSON type from other numbers because [[RFC7159|JSON]] itself does not make that distinction. Since there is no distinct JSON integer type, JSON Schema defines integers mathematically. This means that both `1` and `1.0` are [equivalent](https://www.ietf.org/archive/id/draft-bhutton-json-schema-00#section-4.2.2), and are both considered to be integers.
 
 #### Data Type Format
 
-As defined by the [JSON Schema Validation specification](https://tools.ietf.org/html/draft-bhutton-json-schema-validation-00#section-7.3), data types can have an optional modifier keyword: `format`. As described in that specification, `format` is treated as a non-validating annotation by default; the ability to validate `format` varies across implementations.
+As defined by the [JSON Schema Validation specification](https://www.ietf.org/archive/id/draft-bhutton-json-schema-validation-01#section-7.3), data types can have an optional modifier keyword: `format`. As described in that specification, `format` is treated as a non-validating annotation by default; the ability to validate `format` varies across implementations.
 
 The OpenAPI Initiative also hosts a [Format Registry](https://spec.openapis.org/registry/format/) for formats defined by OAS users and other specifications. Support for any registered format is strictly OPTIONAL, and support for one registered format does not imply support for any others.
 
 Types that are not accompanied by a `format` keyword follow the type definition in the JSON Schema. Tools that do not recognize a specific `format` MAY default back to the `type` alone, as if the `format` is not specified.
-For the purpose of [JSON Schema validation](https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-validation-00#section-7.1), each format should specify the set of JSON data types for which it applies. In this registry, these types are shown in the "JSON Data Type" column.
+For the purpose of [JSON Schema validation](https://www.ietf.org/archive/id/draft-bhutton-json-schema-validation-01#section-7.1), each format should specify the set of JSON data types for which it applies. In this registry, these types are shown in the "JSON Data Type" column.
 
 The formats defined by the OAS are:
 
@@ -4006,9 +4006,9 @@ In the following table showing how to use Schema Object keywords for binary data
 
 | Keyword | Raw | Encoded | Comments |
 | ---- | ---- | ---- | ---- |
-| `type` | _omit_ | `string` | raw binary is [outside of `type`](https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-00#section-4.2.3) |
+| `type` | _omit_ | `string` | raw binary is [outside of `type`](https://www.ietf.org/archive/id/draft-bhutton-json-schema-01#section-4.2.3) |
 | `contentMediaType` | `image/png` | `image/png` | can sometimes be omitted if redundant (see below) |
-| `contentEncoding` | _omit_ | `base64`&nbsp;or&nbsp;`base64url` | other encodings are [allowed](https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-validation-00#section-8.3) |
+| `contentEncoding` | _omit_ | `base64`&nbsp;or&nbsp;`base64url` | other encodings are [allowed](https://www.ietf.org/archive/id/draft-bhutton-json-schema-validation-01#section-8.3) |
 
 Note that the encoding indicated by `contentEncoding`, which inflates the size of data in order to represent it as 7-bit ASCII text, is unrelated to HTTP's `Content-Encoding` header, which indicates whether and how a message body has been compressed and is applied after all content serialization described in this section has occurred. Since HTTP allows unencoded binary message bodies, there is no standardized HTTP header for indicating base64 or similar encoding of an entire message body.
 

--- a/src/oas.md
+++ b/src/oas.md
@@ -3572,42 +3572,8 @@ The formats defined by the OAS are:
 
 As noted under [Data Type](#data-types), both `type: number` and `type: integer` are considered to be numbers in the data model.
 
-#### Working with Binary Data
-
-The OAS can describe either _raw_ or _encoded_ binary data.
-
-* **raw binary** is used where unencoded binary data is allowed, such as when sending a binary payload as the entire HTTP message body, or as part of a `multipart/*` payload that allows binary parts
-* **encoded binary** is used where binary data is embedded in a text-only format such as `application/json` or `application/x-www-form-urlencoded` (either as a message body or in the URL query string).
-
-In the following table showing how to use Schema Object keywords for binary data, we use `image/png` as an example binary media type. Any binary media type, including `application/octet-stream`, is sufficient to indicate binary content.
-
-| Keyword | Raw | Encoded | Comments |
-| ---- | ---- | ---- | ---- |
-| `type` | _omit_ | `string` | raw binary is [outside of `type`](https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-00#section-4.2.3) |
-| `contentMediaType` | `image/png` | `image/png` | can sometimes be omitted if redundant (see below) |
-| `contentEncoding` | _omit_ | `base64`&nbsp;or&nbsp;`base64url` | other encodings are [allowed](https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-validation-00#section-8.3) |
-
-Note that the encoding indicated by `contentEncoding`, which inflates the size of data in order to represent it as 7-bit ASCII text, is unrelated to HTTP's `Content-Encoding` header, which indicates whether and how a message body has been compressed and is applied after all content serialization described in this section has occurred. Since HTTP allows unencoded binary message bodies, there is no standardized HTTP header for indicating base64 or similar encoding of an entire message body.
-
-Using a `contentEncoding` of `base64url` ensures that URL encoding (as required in the query string and in message bodies of type `application/x-www-form-urlencoded`) does not need to further encode any part of the already-encoded binary data.
-
-The `contentMediaType` keyword is redundant if the media type is already set:
-
-* as the key for a [MediaType Object](#media-type-object)
-* in the `contentType` field of an [Encoding Object](#encoding-object)
-
-If the [Schema Object](#schema-object) will be processed by a non-OAS-aware JSON Schema implementation, it may be useful to include `contentMediaType` even if it is redundant. However, if `contentMediaType` contradicts a relevant Media Type Object or Encoding Object, then `contentMediaType` SHALL be ignored.
-
-The `maxLength` keyword MAY be used to set an expected upper bound on the length of a streaming payload. The keyword can be applied to either string data, including encoded binary data, or to unencoded binary data. For unencoded binary, the length is the number of octets.
-
-##### Migrating binary descriptions from OAS 3.0
-
-The following table shows how to migrate from OAS 3.0 binary data descriptions, continuing to use `image/png` as the example binary media type:
-
-| OAS < 3.1 | OAS >= 3.1 | Comments |
-| ---- | ---- | ---- |
-| <code style="white-space:nowrap">type: string</code><br /><code style="white-space:nowrap">format: binary</code> | <code style="white-space:nowrap">contentMediaType: image/png</code> | if redundant, can be omitted, often resulting in an empty [Schema Object](#schema-object) |
-| <code style="white-space:nowrap">type: string</code><br /><code style="white-space:nowrap">format: byte</code> | <code style="white-space:nowrap">type: string</code><br /><code style="white-space:nowrap">contentMediaType: image/png</code><br /><code style="white-space:nowrap">contentEncoding: base64</code> | note that `base64url` can be used to avoid re-encoding the base64 string to be URL-safe |
+See [Working with Binary Data](#working-with-binary-data) for guidance on modeling binary data in different places and scenarios.
+Note that binary data modeling changed between OAS 3.0 and 3.1.
 
 ### Schema Modeling Techniques
 
@@ -4024,6 +3990,43 @@ or by using additional Objects such as the [Encoding Object](#encoding-object).
 
 The [xml](#schema-xml) field allows extra definitions when translating the JSON definition to XML.
 The [XML Object](#xml-object) contains additional information about the available options.
+
+#### Working with Binary Data
+
+The OAS can describe either _raw_ or _encoded_ binary data.
+
+* **raw binary** is used where unencoded binary data is allowed, such as when sending a binary payload as the entire HTTP message body, or as part of a `multipart/*` payload that allows binary parts
+* **encoded binary** is used where binary data is embedded in a text-only format such as `application/json` or `application/x-www-form-urlencoded` (either as a message body or in the URL query string).
+
+In the following table showing how to use Schema Object keywords for binary data, we use `image/png` as an example binary media type. Any binary media type, including `application/octet-stream`, is sufficient to indicate binary content.
+
+| Keyword | Raw | Encoded | Comments |
+| ---- | ---- | ---- | ---- |
+| `type` | _omit_ | `string` | raw binary is [outside of `type`](https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-00#section-4.2.3) |
+| `contentMediaType` | `image/png` | `image/png` | can sometimes be omitted if redundant (see below) |
+| `contentEncoding` | _omit_ | `base64`&nbsp;or&nbsp;`base64url` | other encodings are [allowed](https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-validation-00#section-8.3) |
+
+Note that the encoding indicated by `contentEncoding`, which inflates the size of data in order to represent it as 7-bit ASCII text, is unrelated to HTTP's `Content-Encoding` header, which indicates whether and how a message body has been compressed and is applied after all content serialization described in this section has occurred. Since HTTP allows unencoded binary message bodies, there is no standardized HTTP header for indicating base64 or similar encoding of an entire message body.
+
+Using a `contentEncoding` of `base64url` ensures that URL encoding (as required in the query string and in message bodies of type `application/x-www-form-urlencoded`) does not need to further encode any part of the already-encoded binary data.
+
+The `contentMediaType` keyword is redundant if the media type is already set:
+
+* as the key for a [MediaType Object](#media-type-object)
+* in the `contentType` field of an [Encoding Object](#encoding-object)
+
+If the [Schema Object](#schema-object) will be processed by a non-OAS-aware JSON Schema implementation, it may be useful to include `contentMediaType` even if it is redundant. However, if `contentMediaType` contradicts a relevant Media Type Object or Encoding Object, then `contentMediaType` SHALL be ignored.
+
+The `maxLength` keyword MAY be used to set an expected upper bound on the length of a streaming payload. The keyword can be applied to either string data, including encoded binary data, or to unencoded binary data. For unencoded binary, the length is the number of octets.
+
+##### Migrating binary descriptions from OAS 3.0
+
+The following table shows how to migrate from OAS 3.0 binary data descriptions, continuing to use `image/png` as the example binary media type:
+
+| OAS < 3.1 | OAS >= 3.1 | Comments |
+| ---- | ---- | ---- |
+| <code style="white-space:nowrap">type: string</code><br /><code style="white-space:nowrap">format: binary</code> | <code style="white-space:nowrap">contentMediaType: image/png</code> | if redundant, can be omitted, often resulting in an empty [Schema Object](#schema-object) |
+| <code style="white-space:nowrap">type: string</code><br /><code style="white-space:nowrap">format: byte</code> | <code style="white-space:nowrap">type: string</code><br /><code style="white-space:nowrap">contentMediaType: image/png</code><br /><code style="white-space:nowrap">contentEncoding: base64</code> | note that `base64url` can be used to avoid re-encoding the base64 string to be URL-safe |
 
 #### Considerations for File Uploads
 

--- a/src/oas.md
+++ b/src/oas.md
@@ -2635,35 +2635,6 @@ additionalProperties:
   $ref: '#/components/schemas/ComplexModel'
 ```
 
-###### Model with Annotated Enumeration
-
-```json
-{
-  "oneOf": [
-    {
-      "const": "RGB",
-      "title": "Red, Green, Blue",
-      "description": "Specify colors with the red, green, and blue additive color model"
-    },
-    {
-      "const": "CMYK",
-      "title": "Cyan, Magenta, Yellow, Black",
-      "description": "Specify colors with the cyan, magenta, yellow, and black subtractive color model"
-    }
-  ]
-}
-```
-
-```yaml
-oneOf:
-  - const: RGB
-    title: Red, Green, Blue
-    description: Specify colors with the red, green, and blue additive color model
-  - const: CMYK
-    title: Cyan, Magenta, Yellow, Black
-    description: Specify colors with the cyan, magenta, yellow, and black subtractive color model
-```
-
 ###### Model with Example
 
 ```json
@@ -2701,343 +2672,6 @@ required:
 examples:
   - name: Puma
     id: 1
-```
-
-###### Models with Composition
-
-```json
-{
-  "components": {
-    "schemas": {
-      "ErrorModel": {
-        "type": "object",
-        "required": ["message", "code"],
-        "properties": {
-          "message": {
-            "type": "string"
-          },
-          "code": {
-            "type": "integer",
-            "minimum": 100,
-            "maximum": 600
-          }
-        }
-      },
-      "ExtendedErrorModel": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/ErrorModel"
-          },
-          {
-            "type": "object",
-            "required": ["rootCause"],
-            "properties": {
-              "rootCause": {
-                "type": "string"
-              }
-            }
-          }
-        ]
-      }
-    }
-  }
-}
-```
-
-```yaml
-components:
-  schemas:
-    ErrorModel:
-      type: object
-      required:
-        - message
-        - code
-      properties:
-        message:
-          type: string
-        code:
-          type: integer
-          minimum: 100
-          maximum: 600
-    ExtendedErrorModel:
-      allOf:
-        - $ref: '#/components/schemas/ErrorModel'
-        - type: object
-          required:
-            - rootCause
-          properties:
-            rootCause:
-              type: string
-```
-
-###### Models with Polymorphism Support
-
-The following example describes a `Pet` model that can represent either a cat or a dog, as distinguished by the `petType` property. Each type of pet has other properties beyond those of the base `Pet` model. An instance without a `petType` property, or with a `petType` property that does not match either `cat` or `dog`, is invalid.
-
-```yaml
-components:
-  schemas:
-    Pet:
-      type: object
-      properties:
-        name:
-          type: string
-      required:
-        - name
-        - petType
-      oneOf:
-        - $ref: '#/components/schemas/Cat'
-        - $ref: '#/components/schemas/Dog'
-    Cat:
-      description: A pet cat
-      type: object
-      properties:
-        petType:
-          const: 'cat'
-        huntingSkill:
-          type: string
-          description: The measured skill for hunting
-          enum:
-            - clueless
-            - lazy
-            - adventurous
-            - aggressive
-      required:
-        - huntingSkill
-    Dog:
-      description: A pet dog
-      type: object
-      properties:
-        petType:
-          const: 'dog'
-        packSize:
-          type: integer
-          format: int32
-          description: the size of the pack the dog is from
-          default: 0
-          minimum: 0
-      required:
-        - packSize
-```
-
-###### Models with Polymorphism Support and a Discriminator Object
-
-The following example extends the example of the previous section by adding a [Discriminator Object](#discriminator-object) to the `Pet` schema. Note that the Discriminator Object is only a hint to the consumer of the API and does not change the validation outcome of the schema.
-
-```yaml
-components:
-  schemas:
-    Pet:
-      type: object
-      discriminator:
-        propertyName: petType
-        mapping:
-          cat: '#/components/schemas/Cat'
-          dog: '#/components/schemas/Dog'
-      properties:
-        name:
-          type: string
-      required:
-        - name
-        - petType
-      oneOf:
-        - $ref: '#/components/schemas/Cat'
-        - $ref: '#/components/schemas/Dog'
-    Cat:
-      description: A pet cat
-      type: object
-      properties:
-        petType:
-          const: 'cat'
-        huntingSkill:
-          type: string
-          description: The measured skill for hunting
-          enum:
-            - clueless
-            - lazy
-            - adventurous
-            - aggressive
-      required:
-        - huntingSkill
-    Dog:
-      description: A pet dog
-      type: object
-      properties:
-        petType:
-          const: 'dog'
-        packSize:
-          type: integer
-          format: int32
-          description: the size of the pack the dog is from
-          default: 0
-          minimum: 0
-      required:
-        - petType
-        - packSize
-```
-
-###### Models with Polymorphism Support using allOf and a Discriminator Object
-
-It is also possible to describe polymorphic models using `allOf`. The following example uses `allOf` with a [Discriminator Object](#discriminator-object) to describe a polymorphic `Pet` model.
-
-```yaml
-components:
-  schemas:
-    Pet:
-      type: object
-      discriminator:
-        propertyName: petType
-      properties:
-        name:
-          type: string
-        petType:
-          type: string
-      required:
-        - name
-        - petType
-    Cat: # "Cat" will be used as the discriminating value
-      description: A representation of a cat
-      allOf:
-        - $ref: '#/components/schemas/Pet'
-        - type: object
-          properties:
-            huntingSkill:
-              type: string
-              description: The measured skill for hunting
-              enum:
-                - clueless
-                - lazy
-                - adventurous
-                - aggressive
-          required:
-            - huntingSkill
-    Dog: # "Dog" will be used as the discriminating value
-      description: A representation of a dog
-      allOf:
-        - $ref: '#/components/schemas/Pet'
-        - type: object
-          properties:
-            packSize:
-              type: integer
-              format: int32
-              description: the size of the pack the dog is from
-              default: 0
-              minimum: 0
-          required:
-            - packSize
-```
-
-###### Generic Data Structure Model
-
-```JSON
-{
-  "components": {
-    "schemas": {
-      "genericArrayComponent": {
-        "$id": "fully_generic_array",
-        "type": "array",
-        "items": {
-          "$dynamicRef": "#generic-array"
-        },
-        "$defs": {
-          "allowAll": {
-            "$dynamicAnchor": "generic-array"
-          }
-        }
-      },
-      "numberArray": {
-        "$id": "array_of_numbers",
-        "$ref": "fully_generic_array",
-        "$defs": {
-          "numbersOnly": {
-            "$dynamicAnchor": "generic-array",
-            "type": "number"
-          }
-        }
-      },
-      "stringArray": {
-        "$id": "array_of_strings",
-        "$ref": "fully_generic_array",
-        "$defs": {
-          "stringsOnly": {
-            "$dynamicAnchor": "generic-array",
-            "type": "string"
-          }
-        }
-      },
-      "objWithTypedArray": {
-        "$id": "obj_with_typed_array",
-        "type": "object",
-        "required": ["dataType", "data"],
-        "properties": {
-          "dataType": {
-            "enum": ["string", "number"]
-          }
-        },
-        "oneOf": [{
-          "properties": {
-            "dataType": {"const": "string"},
-            "data": {"$ref": "array_of_strings"}
-          }
-        }, {
-          "properties": {
-            "dataType": {"const": "number"},
-            "data": {"$ref": "array_of_numbers"}
-          }
-        }]
-      }
-    }
-  }
-}
-```
-
-```YAML
-components:
-  schemas:
-    genericArrayComponent:
-      $id: fully_generic_array
-      type: array
-      items:
-        $dynamicRef: '#generic-array'
-      $defs:
-        allowAll:
-          $dynamicAnchor: generic-array
-    numberArray:
-      $id: array_of_numbers
-      $ref: fully_generic_array
-      $defs:
-        numbersOnly:
-          $dynamicAnchor: generic-array
-          type: number
-    stringArray:
-      $id: array_of_strings
-      $ref: fully_generic_array
-      $defs:
-        stringsOnly:
-          $dynamicAnchor: generic-array
-          type: string
-    objWithTypedArray:
-      $id: obj_with_typed_array
-      type: object
-      required:
-      - dataType
-      - data
-      properties:
-        dataType:
-          enum:
-          - string
-          - number
-      oneOf:
-      - properties:
-          dataType:
-            const: string
-          data:
-            $ref: array_of_strings
-      - properties:
-          dataType:
-            const: number
-          data:
-            $ref: array_of_numbers
 ```
 
 #### Discriminator Object
@@ -3987,6 +3621,230 @@ There are two ways to define the value of a discriminating property for an inher
 * Use the schema name.
 * [Override the schema name](#discriminator-mapping) by overriding the property with a new value. If a new value exists, this takes precedence over the schema name.
 
+##### Models with Composition
+
+```json
+{
+  "components": {
+    "schemas": {
+      "ErrorModel": {
+        "type": "object",
+        "required": ["message", "code"],
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "code": {
+            "type": "integer",
+            "minimum": 100,
+            "maximum": 600
+          }
+        }
+      },
+      "ExtendedErrorModel": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ErrorModel"
+          },
+          {
+            "type": "object",
+            "required": ["rootCause"],
+            "properties": {
+              "rootCause": {
+                "type": "string"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+```yaml
+components:
+  schemas:
+    ErrorModel:
+      type: object
+      required:
+        - message
+        - code
+      properties:
+        message:
+          type: string
+        code:
+          type: integer
+          minimum: 100
+          maximum: 600
+    ExtendedErrorModel:
+      allOf:
+        - $ref: '#/components/schemas/ErrorModel'
+        - type: object
+          required:
+            - rootCause
+          properties:
+            rootCause:
+              type: string
+```
+
+##### Models with Polymorphism Support
+
+The following example describes a `Pet` model that can represent either a cat or a dog, as distinguished by the `petType` property. Each type of pet has other properties beyond those of the base `Pet` model. An instance without a `petType` property, or with a `petType` property that does not match either `cat` or `dog`, is invalid.
+
+```yaml
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        name:
+          type: string
+      required:
+        - name
+        - petType
+      oneOf:
+        - $ref: '#/components/schemas/Cat'
+        - $ref: '#/components/schemas/Dog'
+    Cat:
+      description: A pet cat
+      type: object
+      properties:
+        petType:
+          const: 'cat'
+        huntingSkill:
+          type: string
+          description: The measured skill for hunting
+          enum:
+            - clueless
+            - lazy
+            - adventurous
+            - aggressive
+      required:
+        - huntingSkill
+    Dog:
+      description: A pet dog
+      type: object
+      properties:
+        petType:
+          const: 'dog'
+        packSize:
+          type: integer
+          format: int32
+          description: the size of the pack the dog is from
+          default: 0
+          minimum: 0
+      required:
+        - packSize
+```
+
+##### Models with Polymorphism Support and a Discriminator Object
+
+The following example extends the example of the previous section by adding a [Discriminator Object](#discriminator-object) to the `Pet` schema. Note that the Discriminator Object is only a hint to the consumer of the API and does not change the validation outcome of the schema.
+
+```yaml
+components:
+  schemas:
+    Pet:
+      type: object
+      discriminator:
+        propertyName: petType
+        mapping:
+          cat: '#/components/schemas/Cat'
+          dog: '#/components/schemas/Dog'
+      properties:
+        name:
+          type: string
+      required:
+        - name
+        - petType
+      oneOf:
+        - $ref: '#/components/schemas/Cat'
+        - $ref: '#/components/schemas/Dog'
+    Cat:
+      description: A pet cat
+      type: object
+      properties:
+        petType:
+          const: 'cat'
+        huntingSkill:
+          type: string
+          description: The measured skill for hunting
+          enum:
+            - clueless
+            - lazy
+            - adventurous
+            - aggressive
+      required:
+        - huntingSkill
+    Dog:
+      description: A pet dog
+      type: object
+      properties:
+        petType:
+          const: 'dog'
+        packSize:
+          type: integer
+          format: int32
+          description: the size of the pack the dog is from
+          default: 0
+          minimum: 0
+      required:
+        - petType
+        - packSize
+```
+
+##### Models with Polymorphism Support using allOf and a Discriminator Object
+
+It is also possible to describe polymorphic models using `allOf`. The following example uses `allOf` with a [Discriminator Object](#discriminator-object) to describe a polymorphic `Pet` model.
+
+```yaml
+components:
+  schemas:
+    Pet:
+      type: object
+      discriminator:
+        propertyName: petType
+      properties:
+        name:
+          type: string
+        petType:
+          type: string
+      required:
+        - name
+        - petType
+    Cat: # "Cat" will be used as the discriminating value
+      description: A representation of a cat
+      allOf:
+        - $ref: '#/components/schemas/Pet'
+        - type: object
+          properties:
+            huntingSkill:
+              type: string
+              description: The measured skill for hunting
+              enum:
+                - clueless
+                - lazy
+                - adventurous
+                - aggressive
+          required:
+            - huntingSkill
+    Dog: # "Dog" will be used as the discriminating value
+      description: A representation of a dog
+      allOf:
+        - $ref: '#/components/schemas/Pet'
+        - type: object
+          properties:
+            packSize:
+              type: integer
+              format: int32
+              description: the size of the pack the dog is from
+              default: 0
+              minimum: 0
+          required:
+            - packSize
+```
+
 #### Generic (Template) Data Structures
 
 Implementations MAY support defining generic or template data structures using JSON Schema's dynamic referencing feature:
@@ -3996,11 +3854,153 @@ Implementations MAY support defining generic or template data structures using J
 
 An example is included in the "Schema Object Examples" section below, and further information can be found on the Learn OpenAPI site's ["Dynamic References"](https://learn.openapis.org/referencing/dynamic.html) page.
 
+##### Generic Data Structure Model
+
+```JSON
+{
+  "components": {
+    "schemas": {
+      "genericArrayComponent": {
+        "$id": "fully_generic_array",
+        "type": "array",
+        "items": {
+          "$dynamicRef": "#generic-array"
+        },
+        "$defs": {
+          "allowAll": {
+            "$dynamicAnchor": "generic-array"
+          }
+        }
+      },
+      "numberArray": {
+        "$id": "array_of_numbers",
+        "$ref": "fully_generic_array",
+        "$defs": {
+          "numbersOnly": {
+            "$dynamicAnchor": "generic-array",
+            "type": "number"
+          }
+        }
+      },
+      "stringArray": {
+        "$id": "array_of_strings",
+        "$ref": "fully_generic_array",
+        "$defs": {
+          "stringsOnly": {
+            "$dynamicAnchor": "generic-array",
+            "type": "string"
+          }
+        }
+      },
+      "objWithTypedArray": {
+        "$id": "obj_with_typed_array",
+        "type": "object",
+        "required": ["dataType", "data"],
+        "properties": {
+          "dataType": {
+            "enum": ["string", "number"]
+          }
+        },
+        "oneOf": [{
+          "properties": {
+            "dataType": {"const": "string"},
+            "data": {"$ref": "array_of_strings"}
+          }
+        }, {
+          "properties": {
+            "dataType": {"const": "number"},
+            "data": {"$ref": "array_of_numbers"}
+          }
+        }]
+      }
+    }
+  }
+}
+```
+
+```YAML
+components:
+  schemas:
+    genericArrayComponent:
+      $id: fully_generic_array
+      type: array
+      items:
+        $dynamicRef: '#generic-array'
+      $defs:
+        allowAll:
+          $dynamicAnchor: generic-array
+    numberArray:
+      $id: array_of_numbers
+      $ref: fully_generic_array
+      $defs:
+        numbersOnly:
+          $dynamicAnchor: generic-array
+          type: number
+    stringArray:
+      $id: array_of_strings
+      $ref: fully_generic_array
+      $defs:
+        stringsOnly:
+          $dynamicAnchor: generic-array
+          type: string
+    objWithTypedArray:
+      $id: obj_with_typed_array
+      type: object
+      required:
+      - dataType
+      - data
+      properties:
+        dataType:
+          enum:
+          - string
+          - number
+      oneOf:
+      - properties:
+          dataType:
+            const: string
+          data:
+            $ref: array_of_strings
+      - properties:
+          dataType:
+            const: number
+          data:
+            $ref: array_of_numbers
+```
+
 #### Annotated Enumerations
 
 The Schema Object's `enum` keyword does not allow associating descriptions or other information with individual values.
 
 Implementations MAY support recognizing a `oneOf` or `anyOf` where each subschema in the keyword's array consists of a `const` keyword and annotations such as `title` or `description` as an enumerated type with additional information. The exact behavior of this pattern beyond what is required by JSON Schema is implementation-defined.
+
+##### Model with Annotated Enumeration
+
+```json
+{
+  "oneOf": [
+    {
+      "const": "RGB",
+      "title": "Red, Green, Blue",
+      "description": "Specify colors with the red, green, and blue additive color model"
+    },
+    {
+      "const": "CMYK",
+      "title": "Cyan, Magenta, Yellow, Black",
+      "description": "Specify colors with the cyan, magenta, yellow, and black subtractive color model"
+    }
+  ]
+}
+```
+
+```yaml
+oneOf:
+  - const: RGB
+    title: Red, Green, Blue
+    description: Specify colors with the red, green, and blue additive color model
+  - const: CMYK
+    title: Cyan, Magenta, Yellow, Black
+    description: Specify colors with the cyan, magenta, yellow, and black subtractive color model
+```
 
 #### XML Modeling
 

--- a/src/oas.md
+++ b/src/oas.md
@@ -3574,7 +3574,7 @@ The formats defined by the OAS are:
 | `double` | number | |
 | `password` | string | A hint to obscure the value. |
 
-As noted under [Data Type](#data-types), both `type: number` and `type: integer` are considered to be numbers in the data model.
+As noted under [Data Types](#data-types), both `type: number` and `type: integer` are considered to be numbers in the data model.
 
 See [Working with Binary Data](#working-with-binary-data) for guidance on modeling binary data in different places and scenarios.
 Note that binary data modeling changed between OAS 3.0 and 3.1.

--- a/src/oas.md
+++ b/src/oas.md
@@ -3539,7 +3539,11 @@ Two examples of this:
 
 ## Modeling Data
 
-This section collects guidance on various data modeling and encoding scenarios that are either very general, or are more complex than those needed to illustrate basic Object usage.
+Modeling data in the OpenAPI Specification starts with the [[JSON]] data model of strings, numbers, booleans, arrays, objects, and `null`.
+This is further refined and constrained by the [Schema Object](#schema-object), which uses [JSON Schema Draft 2020-12](https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-01) with several extensions, most notably the [Discriminator Object](#discriminator-object) and the [XML Object](#xml-object).
+Several additional Objects determine how to map between in-memory data, which is subject to schema validation, and on-the-wire formats, including the [Parameter Object](#parameter-object), [Header Object](#header-object), [Media Type Object](#media-type-object), and [Encoding Object](#encoding-object).
+
+This section collects guidance on both the basics of data types, and on how to use these Objects to handle more complex scenarios.
 
 ### Data Types
 
@@ -3988,7 +3992,7 @@ or by using additional Objects such as the [Encoding Object](#encoding-object).
 
 #### XML Modeling
 
-The [xml](#schema-xml) field allows extra definitions when translating the JSON definition to XML.
+The [xml](#schema-xml) field in the [Schema Object](#schema-object) allows extra definitions when translating the JSON definition to XML.
 The [XML Object](#xml-object) contains additional information about the available options.
 
 #### Working with Binary Data


### PR DESCRIPTION
I went to add streaming JSON support to 3.2 and was struck again at how scattered various bits of guidance on data modeling are.

This mostly just moves sections (big sections in the first commit, then some examples in the second) and then does a tiny bit of renaming, re-indenting, and linking to make it flow.  It is a draft because (assuming we go this route), it is not clear where to draw the line, particularly with examples.

There is significant overlap between the examples moved from the Schema Object and the examples still in the Discriminator Object section.  I also left the XML Object Examples where they were, which makes the Modeling XML section rather perfunctory.

If folks like this general idea, we can work out how to balance what goes where.

Note that I also slightly moved "Rich Text Formatting" as taking the data modeling sections out of the introduction left it sandwiched awkwardly between the Document Structure section and the Resolving URIs/URLs sections, which really ought to be next to each other anyway.  (***Please*** do not discuss re-organizing other sections.  In particular, @karenetheridge and I are already planning to reorganize Document Structure and the Resolving sections, so please wait for that effort to open that topic).

-----
- [ ] schema changes are included in this pull request
- [ ] schema changes are needed for this pull request but not done yet
- [X] no schema changes are needed for this pull request
