### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,18 @@
+---
+name: Bug report
+about: Create a report to help us improve the specification
+title: 'vX.Y: ...'
+labels: ''
+assignees: ''
+
+---
+
+**Describe the error in the specification**
+A clear and concise description of
+- what the error is, 
+- which specification versions are affected, 
+- what you would expect the specification to say instead,  and 
+- a link to the corresponding specification section in the "oldest" affected version.
+
+**Additional context**
+Add any other context about the problem here.


### PR DESCRIPTION
Pressing the "New issue" button leads to an endless loop:
- It shows a "Create new issue popup" with many options, the second and third to last are "Please open an issue in this repository!".
- Pressing one of these redirects to https://github.com/OAI/OpenAPI-Specification/issues/new/choose, which is a full-page version of the popup, and in turn only opens additional tabs with the same page.

I hope that adding a "Bug report" template will break that loop.

Note: it is still possible to create an issue with the Github CLI `gh issue create`.