### PR TITLE
main: CONTRIBUTING note on `buid-src` for Windows users

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,11 +172,12 @@ To do this locally, please
 2. Check out this repo, go to the repo root, and switch to a development branch
 3. Execute `npm install` (once, repeat after merging upstream changes)
 4. Execute `npm run build-src` after changing `src/oas.md` (this first executes `npm run validate-markdown`, which can also be run separately)
-   > [!NOTE] Use Git Bash on Windows
-   > This npm script calls bash scripts. Run it from [Git Bash](https://gitforwindows.org/) on Windows, or use the Windows Subsystem for Linux (WSL).
 5. Open output file `deploy-preview/oas.html` with a browser and check your changes
 
 Please make sure the markdown validates and builds using the above steps before creating a pull request or marking a draft pull request as ready for review.
+
+> [!NOTE]
+> `npm run build-src` calls bash scripts. Use [Git Bash](https://gitforwindows.org/) on Windows, or use the Windows Subsystem for Linux (WSL).
 
 ## Reviewers
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,6 +165,9 @@ Draft pull requests can still be reviewed while in draft state.
 
 ### Preview specification HTML locally
 
+> [!NOTE]
+> `npm run build-src` calls bash scripts. Use [Git Bash](https://gitforwindows.org/) on Windows, or use the Windows Subsystem for Linux (WSL).
+
 The markdown source files are converted to HTML before publishing.
 To do this locally, please
 
@@ -175,9 +178,6 @@ To do this locally, please
 5. Open output file `deploy-preview/oas.html` with a browser and check your changes
 
 Please make sure the markdown validates and builds using the above steps before creating a pull request or marking a draft pull request as ready for review.
-
-> [!NOTE]
-> `npm run build-src` calls bash scripts. Use [Git Bash](https://gitforwindows.org/) on Windows, or use the Windows Subsystem for Linux (WSL).
 
 ## Reviewers
 


### PR DESCRIPTION
Note callouts apparently can't be within bullet lists.

Moving it to the end of the section.

> [!NOTE] 
> Note for VS Code users: the local preview nicely renders Note callouts in bullet lists and allows changing the callout title to something other than "Note". This doesn't work in Github.

Tick one of the following options:

- [ ] schema changes are included in this pull request
- [ ] schema changes are needed for this pull request but not done yet
- [x] no schema changes are needed for this pull request
