### PR TITLE
main: run `respec` workflow only on changes to relevant files

### DIFF
--- a/.github/workflows/respec.yaml
+++ b/.github/workflows/respec.yaml
@@ -8,11 +8,17 @@ name: respec
 # on the gh-pages branch when the corresponding markdown files change.
 #
 
-# run this on push to main
+# run this on push to main for spec-relevant files
 on:
   push:
     branches:
       - main
+    paths:
+      - 'versions/*.md'
+      - 'scripts/md2html/**'
+      - '.github/workflows/respec.yaml'
+      - 'package.json'
+      - 'package-lock.json'
   workflow_dispatch: {}
 
 jobs:

--- a/scripts/md2html/build.sh
+++ b/scripts/md2html/build.sh
@@ -58,9 +58,11 @@ for specification in $specifications; do
 
   node scripts/md2html/md2html.js --maintainers $maintainers $specification "$allVersions" > $tempfile
   npx respec --no-sandbox --use-local --src $tempfile --out $tempfile2
-  # remove unwanted Google Tag Manager and Google Analytics scripts
+  # remove unwanted Google Tag Manager and Google Analytics scripts, non-deterministic changes, and ReSpec minor version
   sed -e 's/<script type="text\/javascript" async="" src="https:\/\/www.google-analytics.com\/analytics.js"><\/script>//' \
       -e 's/<script type="text\/javascript" async="" src="https:\/\/www.googletagmanager.com\/gtag\/js?id=G-[^"]*"><\/script>//' \
+      -e 's/ toc-inline//' -e 's/ darkmode//' \
+      -e 's/"ReSpec \([0-9]*\)[.0-9]*"/"ReSpec \1"/' \
       $tempfile2 > $destination
 
   echo === Built $destination


### PR DESCRIPTION
Getting tired of re-reviewing spec publishing PRs on every change to unrelated files on `main`:
- only run the respec workflow if itself, one of its scripts, or one of its inputs change
- filter out "random" changes to the produced HTML
- filter out ReSpec minor & patch version part - it changes more often than we publish specs

Tick one of the following options:

- [ ] schema changes are included in this pull request
- [ ] schema changes are needed for this pull request but not done yet
- [x] no schema changes are needed for this pull request
