### PR TITLE
3.2: schema test case and schema bug fix for device authorization

### DIFF
--- a/src/schemas/validation/schema.yaml
+++ b/src/schemas/validation/schema.yaml
@@ -960,7 +960,7 @@ $defs:
           scopes:
             $ref: '#/$defs/map-of-strings'
         required:
-          - authorizationUrl
+          - deviceAuthorizationUrl
           - tokenUrl
           - scopes
         $ref: '#/$defs/specification-extensions'

--- a/tests/schema/pass/security-scheme-object-examples.yaml
+++ b/tests/schema/pass/security-scheme-object-examples.yaml
@@ -28,13 +28,8 @@ components:
       description: Cert must be signed by example.com CA
     OAuth2:
       type: oauth2
+      oauth2MetadataUrl: https://example.com/api/oauth/metadata
       flows:
-        implicit:
-          authorizationUrl: https://example.com/api/oauth/dialog
-          scopes:
-            write:pets: modify pets in your account
-            read:pets: read your pets
-          refreshUrl: https://example.com/api/oauth/refresh
         authorizationCode:
           authorizationUrl: https://example.com/api/oauth/dialog
           refreshUrl: https://example.com/api/oauth/refresh
@@ -49,6 +44,21 @@ components:
           refreshUrl: https://example.com/api/oauth/refresh
         clientCredentials:
           tokenUrl: https://example.com/api/oauth/token
+          scopes:
+            read:pets: read your pets
+          refreshUrl: https://example.com/api/oauth/refresh
+        deviceAuthorization:
+          deviceAuthorizationUrl: https://example.com/api/oauth/device
+          tokenUrl: https://example.com/api/oauth/token
+          scopes:
+            read:pets: read your pets
+          refreshUrl: https://example.com/api/oauth/refresh
+    OAuth2Old:
+      deprecated: true
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: https://example.com/api/oauth/dialog
           scopes:
             read:pets: read your pets
           refreshUrl: https://example.com/api/oauth/refresh


### PR DESCRIPTION
This PR adds a test case for the new device authorization, bringing schema coverage back to 100%, and fixes a schema bug that was introduced with #4394.


<!--
Thank you for contributing to the OpenAPI Specification!

Please make certain you are submitting your PR on the correct
branch, to the files under the "src/" directory (which is not
present on the main branch, only on the development branches).

* 3.1.x spec and schemas: v3.1-dev branch
* 3.2.x spec and schemas: v3.2-dev branch
* registry templates: gh-pages branch, registry/...
* registry contents: gh-pages branch, registries/...
* process documentation and build infrastructure: main

Note that we do not accept changes to published specifications.
-->

Tick one of the following options:

- [x] schema changes are included in this pull request
- [ ] schema changes are needed for this pull request but not done yet
- [ ] no schema changes are needed for this pull request
