### PR TITLE
main: add guidance on bullet lists to style guide

### DIFF
--- a/style-guide.md
+++ b/style-guide.md
@@ -22,6 +22,12 @@ The following additional rules should be followed but currently are not enforced
 10. Use `<span id="thing"></span>` for link anchors. The `<a name="thing"></a>` format has been deprecated.
 11. Headings use [title case](https://en.wikipedia.org/wiki/Title_case) and are followed by a blank line.
 12. Do not use [RFC2119 key words (MUST, MAY, ...)](https://datatracker.ietf.org/doc/html/rfc2119) in "Examples" sections or when explaining examples, and state requirements only in sections that are clearly normative.
+13. Bullet lists and punctuation:
+    - If a bullet list item is a complete sentence or paragraph, start it with an uppercase letter and end it with a period.
+    - If a bullet list item is a word or short phrase, start it with an uppercase letter and do not end it with a punctuation character.
+    - If a bullet list item completes a stem sentence immediately preceding the bullet list, start it with a lowercase letter and end it with a period.
+    - Use a consistent bullet list item style for each bullet list.
+    - If in doubt which style to use for a new bullet list, look for similar lists in the same section or nearby sections and choose the same style.
 
 Plus some suggestions, rather than rules:
 


### PR DESCRIPTION
Fixes #4502

Checked the first ten search results on "bullet lists and periods" and came up with the included recommendation.

The checked guidelines agree on the first rule (full sentences) and second rule (words and short phrases).

The third rule (complete a stem sentence) is the majority recommendation. Another mentioned style is to end each completing bullet list item except the last two with a semicolon, end the second to last with a semicolon followed by the word "and" or "or", depending on which kind of logic the list expresses, and end the last bullet list item with a period. I find this style as difficult to read as it is to describe, so I opted against it 😎 

Tick one of the following options:

- [ ] schema changes are included in this pull request
- [ ] schema changes are needed for this pull request but not done yet
- [x] no schema changes are needed for this pull request
