### PR TITLE
We do not need to see the instructions post-filing

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,7 @@ present on the main branch, only on the development branches).
 Note that we do not accept changes to published specifications.
 -->
 
-Tick one of the following options:
+<!-- Tick one of the following options: -->
 
 - [ ] schema changes are included in this pull request
 - [ ] schema changes are needed for this pull request but not done yet


### PR DESCRIPTION
It's a minor irritation but I'm getting tired of seeing the "Please tick.." in every PR.  We only need to see those instructions while filing.

<!--
Thank you for contributing to the OpenAPI Specification!

Please make certain you are submitting your PR on the correct
branch, to the files under the "src/" directory (which is not
present on the main branch, only on the development branches).

* 3.1.x spec and schemas: v3.1-dev branch
* 3.2.x spec and schemas: v3.2-dev branch
* registry templates: gh-pages branch, registry/...
* registry contents: gh-pages branch, registries/...
* process documentation and build infrastructure: main

Note that we do not accept changes to published specifications.
-->


- [ ] schema changes are included in this pull request
- [ ] schema changes are needed for this pull request but not done yet
- [X] no schema changes are needed for this pull request
