### PR TITLE
Add highlight.js support for text/event-stream

### DIFF
--- a/scripts/md2html/md2html.js
+++ b/scripts/md2html/md2html.js
@@ -48,6 +48,22 @@ hljs.registerLanguage('uri', function() {
       ],
     }
   });
+hljs.registerLanguage('eventstream', function() {
+    return {
+      contains: [
+          {
+              scope: "attr",
+              begin: /^/,
+              end: ":",
+          },
+          {
+              scope: "literal",
+              begin: /: */,
+              end: /$/,
+          },
+      ],
+    }
+  });
 const cheerio = require('cheerio');
 
 let argv = require('yargs')

--- a/tests/md2html/fixtures/basic-new.html
+++ b/tests/md2html/fixtures/basic-new.html
@@ -45,6 +45,14 @@
 </code></pre>
 <pre class="nohighlight" tabindex="0"><code>https://foo.com/bar{<span class="hljs-attr">?baz*</span>,<span class="hljs-attr">qux</span>}
 </code></pre>
+<pre class="nohighlight" tabindex="0"><code><span class="hljs-attr">data:</span> This data is formatted
+<span class="hljs-attr">data:</span> across two lines
+<span class="hljs-attr">retry:</span> 5
+<span class="hljs-attr">
+event:</span> add
+<span class="hljs-attr">data:</span> 1234.5678
+<span class="hljs-attr">unknown-field:</span> this is ignored
+<span class="hljs-attr"></span></code></pre>
 </section></section><section class="appendix"><h1>Appendix A: Revision History</h1>
 <table>
 <thead>

--- a/tests/md2html/fixtures/basic-new.md
+++ b/tests/md2html/fixtures/basic-new.md
@@ -62,6 +62,16 @@ https://foo.com/bar?baz=qux&fred=waldo#fragment
 https://foo.com/bar{?baz*,qux}
 ```
 
+```eventstream
+data: This data is formatted
+data: across two lines
+retry: 5
+
+event: add
+data: 1234.5678
+unknown-field: this is ignored
+```
+
 ## Appendix A: Revision History
 
 Version | Date


### PR DESCRIPTION
This is relevant for a soon-to-be posted OAS 3.2 PR.  See Discussion #4171.
MDN has much  more readable [`text/event-stream` documentation](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#event_stream_format) than WHATWG.


<!--
Thank you for contributing to the OpenAPI Specification!

Please make certain you are submitting your PR on the correct
branch, to the files under the "src/" directory (which is not
present on the main branch, only on the development branches).

* 3.1.x spec and schemas: v3.1-dev branch
* 3.2.x spec and schemas: v3.2-dev branch
* registry templates: gh-pages branch, registry/...
* registry contents: gh-pages branch, registries/...
* process documentation and build infrastructure: main

Note that we do not accept changes to published specifications.
-->

<!-- Tick one of the following options: -->

- [ ] schema changes are included in this pull request
- [ ] schema changes are needed for this pull request but not done yet
- [X] no schema changes are needed for this pull request
