### PR TITLE
Sequential (Streaming) media types and link to registry

### DIFF
--- a/src/oas.md
+++ b/src/oas.md
@@ -96,6 +96,7 @@ Several media types exist to transport a sequence of values, separated by some d
 Depending on the media type, the values could either be in another existing format such as JSON, or in a custom format specific to the sequential media type.
 
 Implementations MUST support modeling sequential media types with the [Schema Object](#schema-object) by treating the sequence as an array with the same items and ordering as the sequence.
+This requirement applies to the in-memory data structure corresponding to a sequential media type document, and does not change the behavior or restrict the capabilities of the Schema Object itself.
 
 ##### Working With Indefinite-Length Streams
 


### PR DESCRIPTION
This adds a link to the forthcoming media type registry (PR #4517), and also adds support for various sequential media types:

* `application/json-seq`
* `application/jsonl`
* `application/x-ndjson`
* `text/event-stream`

Given how various modeling and encoding techniques are scattered throughout the specification, the Media Types section seemed like the best place to add these, preceded by a link to he new Media Type Registry which will essentially be a catalog of where to find the existing guidance for various media types.

Also paging @robertlagrant and @disintegrator
<!--
Thank you for contributing to the OpenAPI Specification!

Please make certain you are submitting your PR on the correct
branch, to the files under the "src/" directory (which is not
present on the main branch, only on the development branches).

* 3.1.x spec and schemas: v3.1-dev branch
* 3.2.x spec and schemas: v3.2-dev branch
* registry templates: gh-pages branch, registry/...
* registry contents: gh-pages branch, registries/...
* process documentation and build infrastructure: main

Note that we do not accept changes to published specifications.
-->

<!-- Tick one of the following options: -->

- [ ] schema changes are included in this pull request
- [ ] schema changes are needed for this pull request but not done yet
- [X] no schema changes are needed for this pull request
