### PR TITLE
highlight.js: support for JSONL, JSON-Seq, basic multipart, improve text/event-stream

### DIFF
--- a/scripts/md2html/md2html.js
+++ b/scripts/md2html/md2html.js
@@ -52,18 +52,70 @@ hljs.registerLanguage('eventstream', function() {
     return {
       contains: [
           {
-              scope: "attr",
-              begin: /^/,
-              end: ":",
+              scope: "comment",
+              begin: /^:/,
+              end: /$/,
           },
           {
-              scope: "literal",
-              begin: /: */,
-              end: /$/,
+              scope: "attr",
+              match: /^[^:]+/
           },
       ],
     }
   });
+hljs.registerLanguage('jsonseq', function() {
+    return {
+      keywords: ["true", "false", "null"],
+      contains: [
+          {
+              scope: "meta",
+              match: /0[xX]1[eE]/,
+          },
+          {
+              scope: "attr",
+              begin: /"(\\.|[^\\"\r\n])*"(?=\s*:)/,
+              relevance: 1.01
+          },
+          {
+              scope: "punctuation",
+              match: /[{}[\],:]/,
+              relevance: 0
+          },
+          {
+              scope: "literals",
+              beginKeywords: ["true", "false" , "null"].join(" "),
+          },
+          hljs.QUOTE_STRING_MODE,
+          hljs.C_NUMBER_MODE
+      ]
+    }
+  });
+hljs.registerLanguage('jsonl', function() {
+    return {
+      aliases: ["ndjson"],
+      keywords: ["true", "false", "null"],
+      contains: [
+          {
+              scope: 'attr',
+              begin: /"(\\.|[^\\"\r\n])*"(?=\s*:)/,
+              relevance: 1.01
+          },
+          {
+              scope: "punctuation",
+              match: /[{}[\],:]/,
+              relevance: 0
+          },
+          {
+              scope: "literals",
+              beginKeywords: ["true", "false" , "null"].join(" "),
+          },
+          hljs.QUOTE_STRING_MODE,
+          hljs.C_NUMBER_MODE
+      ]
+    }
+  });
+
+
 const cheerio = require('cheerio');
 
 let argv = require('yargs')

--- a/scripts/md2html/md2html.js
+++ b/scripts/md2html/md2html.js
@@ -48,6 +48,31 @@ hljs.registerLanguage('uri', function() {
       ],
     }
   });
+hljs.registerLanguage('multipart', function() {
+    return {
+      // This is a very limited approach that only
+      // detects boundaries and headers that start
+      // with "Content-"
+      contains: [
+          {
+              scope: "meta",
+              match: /^--.*$/,
+          },
+          {
+              scope: "literal",
+              begin: /^Content-/,
+              end: /$/,
+              contains: [
+                {
+                    scope: "attr",
+                    begin: " ",
+                    end: /$/,
+                },
+              ]
+          },
+      ],
+    }
+  });
 hljs.registerLanguage('eventstream', function() {
     return {
       contains: [

--- a/tests/md2html/fixtures/basic-new.html
+++ b/tests/md2html/fixtures/basic-new.html
@@ -45,14 +45,38 @@
 </code></pre>
 <pre class="nohighlight" tabindex="0"><code>https://foo.com/bar{<span class="hljs-attr">?baz*</span>,<span class="hljs-attr">qux</span>}
 </code></pre>
-<pre class="nohighlight" tabindex="0"><code><span class="hljs-attr">data:</span> This data is formatted
-<span class="hljs-attr">data:</span> across two lines
-<span class="hljs-attr">retry:</span> 5
+<pre class="nohighlight" tabindex="0"><code><span class="hljs-attr">event</span>: addString
+<span class="hljs-attr">data</span>: This data is formatted
+<span class="hljs-attr">data</span>: across two lines
+<span class="hljs-attr">retry</span>: 5
 <span class="hljs-attr">
-event:</span> add
-<span class="hljs-attr">data:</span> 1234.5678
-<span class="hljs-attr">unknown-field:</span> this is ignored
-<span class="hljs-attr"></span></code></pre>
+event</span>: addNumber
+<span class="hljs-attr">data</span>: 1234.5678
+<span class="hljs-attr">unknownField</span>: this is ignored
+<span class="hljs-attr">
+</span><span class="hljs-comment">: This is a comment</span>
+<span class="hljs-attr">event</span>: addJSON
+<span class="hljs-attr">data</span>: {&quot;foo&quot;: 42}
+</code></pre>
+<pre class="nohighlight" tabindex="0"><code><span class="hljs-punctuation">{</span><span class="hljs-attr">&quot;event&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-string">&quot;addString&quot;</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">&quot;data&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-string">&quot;This data is formatted\nacross two lines&quot;</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">&quot;retry&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-number">5</span><span class="hljs-punctuation">}</span>
+<span class="hljs-punctuation">{</span><span class="hljs-attr">&quot;event&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-string">&quot;addNumber&quot;</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">&quot;data&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-string">&quot;1234.5678&quot;</span><span class="hljs-punctuation">}</span>
+<span class="hljs-punctuation">{</span><span class="hljs-attr">&quot;event&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-string">&quot;addJSON&quot;</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">&quot;data&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-string">&quot;{\&quot;foo\&quot;: 42}&quot;</span><span class="hljs-punctuation">}</span>
+</code></pre>
+<pre class="nohighlight" tabindex="0"><code><span class="hljs-punctuation">{</span><span class="hljs-attr">&quot;event&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-string">&quot;addString&quot;</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">&quot;data&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-string">&quot;This data is formatted\nacross two lines&quot;</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">&quot;retry&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-number">5</span><span class="hljs-punctuation">}</span>
+<span class="hljs-punctuation">{</span><span class="hljs-attr">&quot;event&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-string">&quot;addNumber&quot;</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">&quot;data&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-string">&quot;1234.5678&quot;</span><span class="hljs-punctuation">}</span>
+<span class="hljs-punctuation">{</span><span class="hljs-attr">&quot;event&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-string">&quot;addJSON&quot;</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">&quot;data&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-string">&quot;{\&quot;foo\&quot;: 42}&quot;</span><span class="hljs-punctuation">}</span>
+</code></pre>
+<pre class="nohighlight" tabindex="0"><code><span class="hljs-meta">0x1E</span><span class="hljs-punctuation">{</span>
+  <span class="hljs-attr">&quot;timestamp&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-string">&quot;1985-04-12T23:20:50.52Z&quot;</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">&quot;level&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-number">1</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">&quot;message&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-string">&quot;Hi!&quot;</span>
+<span class="hljs-punctuation">}</span>
+<span class="hljs-meta">0x1E</span><span class="hljs-punctuation">{</span>
+  <span class="hljs-attr">&quot;timestamp&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-string">&quot;1985-04-12T23:20:51.37Z&quot;</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">&quot;level&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-number">1</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">&quot;message&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-string">&quot;Bye!&quot;</span>
+<span class="hljs-punctuation">}</span>
+</code></pre>
 </section></section><section class="appendix"><h1>Appendix A: Revision History</h1>
 <table>
 <thead>

--- a/tests/md2html/fixtures/basic-new.html
+++ b/tests/md2html/fixtures/basic-new.html
@@ -45,6 +45,30 @@
 </code></pre>
 <pre class="nohighlight" tabindex="0"><code>https://foo.com/bar{<span class="hljs-attr">?baz*</span>,<span class="hljs-attr">qux</span>}
 </code></pre>
+<pre class="nohighlight" tabindex="0"><code><span class="hljs-meta">--boundary-example</span>
+<span class="hljs-literal">Content-Type:<span class="hljs-attr"> application/openapi+yaml</span></span>
+<span class="hljs-literal">Content-Location:<span class="hljs-attr"> https://inaccessible-domain.com/api/openapi.yaml</span></span>
+
+openapi: 3.2.0
+info:
+  title: Example API
+  version: 1.0
+  externalDocs:
+    url: docs.html
+
+<span class="hljs-meta">--boundary-example</span>
+<span class="hljs-literal">Content-Type:<span class="hljs-attr"> text/html</span></span>
+<span class="hljs-literal">Content-Location:<span class="hljs-attr"> https://example.com/api/docs.html</span></span>
+
+&lt;html&gt;
+  &lt;head&gt;
+    &lt;title&gt;API Documentation&lt;/title&gt;
+  &lt;/head&gt;
+  &lt;body&gt;
+    &lt;p&gt;Awesome documentation goes here&lt;/p&gt;
+  &lt;/body&gt;
+&lt;/html&gt;
+</code></pre>
 <pre class="nohighlight" tabindex="0"><code><span class="hljs-attr">event</span>: addString
 <span class="hljs-attr">data</span>: This data is formatted
 <span class="hljs-attr">data</span>: across two lines

--- a/tests/md2html/fixtures/basic-new.md
+++ b/tests/md2html/fixtures/basic-new.md
@@ -63,13 +63,43 @@ https://foo.com/bar{?baz*,qux}
 ```
 
 ```eventstream
+event: addString
 data: This data is formatted
 data: across two lines
 retry: 5
 
-event: add
+event: addNumber
 data: 1234.5678
-unknown-field: this is ignored
+unknownField: this is ignored
+
+: This is a comment
+event: addJSON
+data: {"foo": 42}
+```
+
+```jsonl
+{"event": "addString", "data": "This data is formatted\nacross two lines", "retry": 5}
+{"event": "addNumber", "data": "1234.5678"}
+{"event": "addJSON", "data": "{\"foo\": 42}"}
+```
+
+```ndjson
+{"event": "addString", "data": "This data is formatted\nacross two lines", "retry": 5}
+{"event": "addNumber", "data": "1234.5678"}
+{"event": "addJSON", "data": "{\"foo\": 42}"}
+```
+
+```jsonseq
+0x1E{
+  "timestamp": "1985-04-12T23:20:50.52Z",
+  "level": 1,
+  "message": "Hi!"
+}
+0x1E{
+  "timestamp": "1985-04-12T23:20:51.37Z",
+  "level": 1,
+  "message": "Bye!"
+}
 ```
 
 ## Appendix A: Revision History

--- a/tests/md2html/fixtures/basic-new.md
+++ b/tests/md2html/fixtures/basic-new.md
@@ -62,6 +62,32 @@ https://foo.com/bar?baz=qux&fred=waldo#fragment
 https://foo.com/bar{?baz*,qux}
 ```
 
+```multipart
+--boundary-example
+Content-Type: application/openapi+yaml
+Content-Location: https://inaccessible-domain.com/api/openapi.yaml
+
+openapi: 3.2.0
+info:
+  title: Example API
+  version: 1.0
+  externalDocs:
+    url: docs.html
+
+--boundary-example
+Content-Type: text/html
+Content-Location: https://example.com/api/docs.html
+
+<html>
+  <head>
+    <title>API Documentation</title>
+  </head>
+  <body>
+    <p>Awesome documentation goes here</p>
+  </body>
+</html>
+```
+
 ```eventstream
 event: addString
 data: This data is formatted


### PR DESCRIPTION
Improve text/event-stream `highlight.js` support with comment support and generally better configuration (one rule wasn't doing anything).

Add support for JSONL/NDJSON (basically JSON without the check for values separated only by whitespace) and JSON Text Sequences (which requires using `0x1E` as the record separator, and highlighting it separately).

Multipart support is very basic, and only supports `Content-` part headers (which is what you generally use anyway).

Examples from the updated test fixtures:

<img width="709" alt="Screen Shot 2025-04-28 at 8 56 37 PM" src="https://github.com/user-attachments/assets/3fa58f26-5bfc-4a4a-b356-7fc619786c91" />

