### PR TITLE
Allow IRIs for XML namespaces

### DIFF
--- a/src/oas.md
+++ b/src/oas.md
@@ -3968,7 +3968,7 @@ See examples for expected behavior.
 | Field Name | Type | Description |
 | ---- | :----: | ---- |
 | <a name="xml-name"></a>name | `string` | Replaces the name of the element/attribute used for the described schema property. When defined within `items`, it will affect the name of the individual XML elements within the list. When defined alongside `type` being `"array"` (outside the `items`), it will affect the wrapping element if and only if `wrapped` is `true`. If `wrapped` is `false`, it will be ignored. |
-| <a name="xml-namespace"></a>namespace | `string` | The URI of the namespace definition. Value MUST be in the form of a non-relative URI. |
+| <a name="xml-namespace"></a>namespace | `string` | The IRI ([[RFC3987]]) of the namespace definition. Value MUST be in the form of a non-relative IRI. |
 | <a name="xml-prefix"></a>prefix | `string` | The prefix to be used for the [name](#xml-name). |
 | <a name="xml-attribute"></a>attribute | `boolean` | Declares whether the property definition translates to an attribute instead of an element. Default value is `false`. |
 | <a name="xml-wrapped"></a>wrapped | `boolean` | MAY be used only for an array definition. Signifies whether the array is wrapped (for example, `<books><book/><book/></books>`) or unwrapped (`<book/><book/>`). Default value is `false`. The definition takes effect only when defined alongside `type` being `"array"` (outside the `items`). |
@@ -3977,9 +3977,8 @@ This object MAY be extended with [Specification Extensions](#specification-exten
 
 The `namespace` field is intended to match the syntax of [XML namespaces](https://www.w3.org/TR/xml-names11/), although there are a few caveats:
 
-* Versions 3.1.0, 3.0.3, and earlier of this specification erroneously used the term "absolute URI" instead of "non-relative URI", so authors using namespaces that include a fragment should check tooling support carefully.
-* XML allows but discourages relative URI-references, while this specification outright forbids them.
-* XML 1.1 allows IRIs ([RFC3987](https://datatracker.ietf.org/doc/html/rfc3987)) as namespaces, and specifies that namespaces are compared without any encoding or decoding, which means that IRIs encoded to meet this specification's URI syntax requirement cannot be compared to IRIs as-is.
+* Versions 3.1.0, 3.0.3, and earlier of this specification erroneously used the term "absolute URI" instead of "non-relative URI" ("non-relative IRI" as of OAS v3.2.0), so authors using namespaces that include a fragment should check tooling support carefully.
+* XML allows but discourages relative IRI-references, while this specification outright forbids them.
 
 ##### XML Object Examples
 

--- a/src/schemas/validation/meta.yaml
+++ b/src/schemas/validation/meta.yaml
@@ -60,7 +60,7 @@ $defs:
       name:
         type: string
       namespace:
-        format: uri
+        format: iri
         type: string
       prefix:
         type: string


### PR DESCRIPTION
XML allows IRIs for namespaces, and compares them without any encoding or decoding.  This means that our requirement that namespaces are URIs will cause comparisons with other tools that use IRIs (without mapping them down to URIs) to fail.

This change relaxes the description and allows the use of unencoded IRIs, which allows us to remove a cumbersome warning.

<!--
Thank you for contributing to the OpenAPI Specification!

Please make certain you are submitting your PR on the correct
branch, to the files under the "src/" directory (which is not
present on the main branch, only on the development branches).

* 3.1.x spec and schemas: v3.1-dev branch
* 3.2.x spec and schemas: v3.2-dev branch
* registry templates: gh-pages branch, registry/...
* registry contents: gh-pages branch, registries/...
* process documentation and build infrastructure: main

Note that we do not accept changes to published specifications.
-->

<!-- Tick one of the following options: -->

- [X] schema changes are included in this pull request
- [ ] schema changes are needed for this pull request but not done yet
- [ ] no schema changes are needed for this pull request
