### PR TITLE
fix: removes string type for large numbers as it's the wrong level of abstraction

### DIFF
--- a/registries/_format/decimal.md
+++ b/registries/_format/decimal.md
@@ -2,7 +2,7 @@
 owner: baywet
 issue: 889
 description: A fixed point decimal number of unspecified precision and range
-base_type: [string, number]
+base_type: number
 layout: default
 remarks: This format is used in a variety of conflicting ways and is not interoperable.
 ---

--- a/registries/_format/decimal128.md
+++ b/registries/_format/decimal128.md
@@ -2,7 +2,7 @@
 owner:
 issue:
 description: A decimal floating-point number with 34 significant decimal digits
-base_type: [string, number]
+base_type: number
 layout: default
 ---
 

--- a/registries/_format/int64.md
+++ b/registries/_format/int64.md
@@ -2,7 +2,7 @@
 owner: DarrelMiller
 issue: 
 description: signed 64-bit integer
-base_type: [number, string]
+base_type: number
 layout: default
 source: https://spec.openapis.org/oas/latest.html#data-types
 source_label: OAS

--- a/registries/_format/uint64.md
+++ b/registries/_format/uint64.md
@@ -2,7 +2,7 @@
 owner: baywet
 issue: 4564
 description: unsigned 64-bit integer
-base_type: [number, string]
+base_type: number
 layout: default
 source: https://spec.openapis.org/oas/latest.html#data-types
 source_label: OAS


### PR DESCRIPTION
rationale https://github.com/OAI/OpenAPI-Specification/pull/4585#issuecomment-2884505701