### PR TITLE
v3.2: Support all common XML node types (element, attribute, text, cdata)

### DIFF
--- a/src/oas.md
+++ b/src/oas.md
@@ -3192,7 +3192,7 @@ See examples for expected behavior.
 
 | Field Name | Type | Description |
 | ---- | :----: | ---- |
-| <a name="xml-name"></a>name | `string` | Replaces the name of the element/attribute used for the described schema property. When defined within `items`, it will affect the name of the individual XML elements within the list. When defined alongside `type` being `"array"` (outside the `items`), it will affect the wrapping element if and only if `wrapped` is `true`. If `wrapped` is `false`, it will be ignored. |
+| <a name="xml-name"></a>name | `string` | Replaces the inferred name of the element/attribute used for the described schema property. For the root schema object of a [schema component](#components-schemas), the inferred name is the name of the component; for other schemas the name is inferred from the parent property name.  When defined within `items`, it will affect the name of the individual XML elements within the list. When defined alongside `type` being `"array"` (outside the `items`), it will affect the wrapping element if and only if `wrapped` is `true`. If `wrapped` is `false`, it will be ignored. |
 | <a name="xml-namespace"></a>namespace | `string` | The IRI ([[RFC3987]]) of the namespace definition. Value MUST be in the form of a non-relative IRI. |
 | <a name="xml-prefix"></a>prefix | `string` | The prefix to be used for the [name](#xml-name). |
 | <a name="xml-attribute"></a>attribute | `boolean` | Declares whether the property definition translates to an attribute instead of an element. Default value is `false`. |

--- a/src/oas.md
+++ b/src/oas.md
@@ -3474,12 +3474,13 @@ properties:
       nodeType: element
       name: animals
     items:
+      xml:
+        name: animal
       properties:
         kind:
           type: string
           xml:
             nodeType: attribute
-            name: animal
         content:
           type: string
           xml:

--- a/src/oas.md
+++ b/src/oas.md
@@ -3191,11 +3191,11 @@ When using a Schema Object with XML, if no XML Object is present, the behavior i
 | Field Name | Type | Description |
 | ---- | :----: | ---- |
 | <a name="xml-node-type"></a>nodeType | `string` | One of `element`, `attribute`, `text`, `cdata`, or `none`, as explained under [XML Node Types](#xml-node-types).  The default value is `none` if `$ref`, `$dynamicRef`, or `type: array` is present in the [Schema Object](#schema-object) containing the XML Object, and `element` otherwise. |
-| <a name="xml-name"></a>name | `string` | Sets the name of the element/attribute used for the described schema property, replacing name that was inferred as described under [XML Node Names](#xml-node-names). This field SHALL be ignored if the `nodeType` is `text`, `cdata`, or `none`. |
+| <a name="xml-name"></a>name | `string` | Sets the name of the element/attribute corresponding to the schema, replacing name that was inferred as described under [XML Node Names](#xml-node-names). This field SHALL be ignored if the `nodeType` is `text`, `cdata`, or `none`. |
 | <a name="xml-namespace"></a>namespace | `string` | The IRI ([[RFC3987]]) of the namespace definition. Value MUST be in the form of a non-relative IRI. |
 | <a name="xml-prefix"></a>prefix | `string` | The prefix to be used for the [name](#xml-name). |
-| <a name="xml-attribute"></a>attribute | `boolean` | Declares whether the property definition translates to an attribute instead of an element. Default value is `false`. If `nodeType` is present, this field MUST NOT be present.<br /><br />**Deprecated:** Use `nodeType: attribute` in place of `attribute: true` |
-| <a name="xml-wrapped"></a>wrapped | `boolean` | MAY be used only for an array definition. Signifies whether the array is wrapped (for example, `<books><book/><book/></books>`) or unwrapped (`<book/><book/>`). Default value is `false`. The definition takes effect only when defined alongside `type` being `"array"` (outside the `items`). If `nodeType` is present, this field MUST NOT be present.<br /><br />**Deprecated:** Set `nodeType: element` explicitly in place of `wrapped: true` |
+| <a name="xml-attribute"></a>attribute | `boolean` | Declares whether the property definition translates to an attribute instead of an element. Default value is `false`. If `nodeType` is present, this field MUST NOT be present.<br /><br />**Deprecated:** Use `nodeType: "attribute"` in place of `attribute: true` |
+| <a name="xml-wrapped"></a>wrapped | `boolean` | MAY be used only for an array definition. Signifies whether the array is wrapped (for example, `<books><book/><book/></books>`) or unwrapped (`<book/><book/>`). Default value is `false`. The definition takes effect only when defined alongside `type` being `"array"` (outside the `items`). If `nodeType` is present, this field MUST NOT be present.<br /><br />**Deprecated:** Set `nodeType: "element"` explicitly in place of `wrapped: true` |
 
 Note that when generating an XML document from object data, the order of the nodes is undefined.
 Use `prefixItems` to control node ordering.
@@ -3219,10 +3219,10 @@ The `none` type is useful for JSON Schema constructs that require more Schema Ob
 
 ###### Modeling Element Lists
 
-For historical compatibility, schemas of `type: array` default to `nodeType: none`, placing the nodes for each array item directly under the parent node.
+For historical compatibility, schemas of `type: array` default to `nodeType: "none"`, placing the nodes for each array item directly under the parent node.
 This also aligns with the inferred naming behavior defined under [XML Node Names](#xml-node-names).
 
-To produce an element wrapping the list, set an explicit `nodeType: element` on the `type: array` schema.
+To produce an element wrapping the list, set an explicit `nodeType: "element"` on the `type: array` schema.
 When doing so, it is advisable to set an explicit name on either the wrapping element or the item elements to avoid them having the same inferred name.
 See examples for expected behavior.
 

--- a/src/oas.md
+++ b/src/oas.md
@@ -3191,7 +3191,7 @@ When using a Schema Object with XML, if no XML Object is present, the behavior i
 | Field Name | Type | Description |
 | ---- | :----: | ---- |
 | <a name="xml-node-type"></a>nodeType | `string` | One of `element`, `attribute`, `text`, `cdata`, or `none`, as explained under [XML Node Types](#xml-node-types).  The default value is `none` if `$ref`, `$dynamicRef`, or `type: "array"` is present in the [Schema Object](#schema-object) containing the XML Object, and `element` otherwise. |
-| <a name="xml-name"></a>name | `string` | Sets the name of the element/attribute corresponding to the schema, replacing name that was inferred as described under [XML Node Names](#xml-node-names). This field SHALL be ignored if the `nodeType` is `text`, `cdata`, or `none`. |
+| <a name="xml-name"></a>name | `string` | Sets the name of the element/attribute corresponding to the schema, replacing the name that was inferred as described under [XML Node Names](#xml-node-names). This field SHALL be ignored if the `nodeType` is `text`, `cdata`, or `none`. |
 | <a name="xml-namespace"></a>namespace | `string` | The IRI ([[RFC3987]]) of the namespace definition. Value MUST be in the form of a non-relative IRI. |
 | <a name="xml-prefix"></a>prefix | `string` | The prefix to be used for the [name](#xml-name). |
 | <a name="xml-attribute"></a>attribute | `boolean` | Declares whether the property definition translates to an attribute instead of an element. Default value is `false`. If `nodeType` is present, this field MUST NOT be present.<br /><br />**Deprecated:** Use `nodeType: "attribute"` in place of `attribute: true` |

--- a/src/oas.md
+++ b/src/oas.md
@@ -3213,7 +3213,7 @@ Except for the special value `none`, these values have numeric equivalents in th
 * `attribute` (2): The schema represents an attribute and describes its value
 * `text` (3): The schema represents a text node (parsed character data)
 * `cdata` (4): The schema represents a CDATA section
-* `none`: The schema does not correspond to any node in the XML document, and its contents are included directly under the parent schema's node
+* `none`: The schema does not correspond to any node in the XML document, and the nodes corresponding to its subschema(s) are included directly under its parent schema's node
 
 The `none` type is useful for JSON Schema constructs that require more Schema Objects than XML nodes, such as a schema containing only `$ref` that exists to facilitate re-use rather than imply any structure.
 

--- a/src/oas.md
+++ b/src/oas.md
@@ -3253,22 +3253,25 @@ animals:
 
 ###### XML Attribute, Prefix and Namespace
 
-In this example, a full model definition is shown.
+In this example, a full [schema component](#components-schemas) definition is shown.
+Note that the name of the root XML element comes from the component name.
 
 ```yaml
-Person:
-  type: object
-  properties:
-    id:
-      type: integer
-      format: int32
-      xml:
-        attribute: true
-    name:
-      type: string
-      xml:
-        namespace: https://example.com/schema/sample
-        prefix: sample
+components:
+  schemas:
+    Person:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+          xml:
+            attribute: true
+        name:
+          type: string
+          xml:
+            namespace: https://example.com/schema/sample
+            prefix: sample
 ```
 
 ```xml

--- a/src/oas.md
+++ b/src/oas.md
@@ -3190,7 +3190,7 @@ When using a Schema Object with XML, if no XML Object is present, the behavior i
 
 | Field Name | Type | Description |
 | ---- | :----: | ---- |
-| <a name="xml-node-type"></a>nodeType | `string` | One of `element`, `attribute`, `text`, `cdata`, or `none`, as explained under [XML Node Types](#xml-node-types).  The default value is `none` if `$ref`, `$dynamicRef`, or `type: array` is present in the [Schema Object](#schema-object) containing the XML Object, and `element` otherwise. |
+| <a name="xml-node-type"></a>nodeType | `string` | One of `element`, `attribute`, `text`, `cdata`, or `none`, as explained under [XML Node Types](#xml-node-types).  The default value is `none` if `$ref`, `$dynamicRef`, or `type: "array"` is present in the [Schema Object](#schema-object) containing the XML Object, and `element` otherwise. |
 | <a name="xml-name"></a>name | `string` | Sets the name of the element/attribute corresponding to the schema, replacing name that was inferred as described under [XML Node Names](#xml-node-names). This field SHALL be ignored if the `nodeType` is `text`, `cdata`, or `none`. |
 | <a name="xml-namespace"></a>namespace | `string` | The IRI ([[RFC3987]]) of the namespace definition. Value MUST be in the form of a non-relative IRI. |
 | <a name="xml-prefix"></a>prefix | `string` | The prefix to be used for the [name](#xml-name). |
@@ -3219,10 +3219,10 @@ The `none` type is useful for JSON Schema constructs that require more Schema Ob
 
 ###### Modeling Element Lists
 
-For historical compatibility, schemas of `type: array` default to `nodeType: "none"`, placing the nodes for each array item directly under the parent node.
+For historical compatibility, schemas of `type: "array"` default to `nodeType: "none"`, placing the nodes for each array item directly under the parent node.
 This also aligns with the inferred naming behavior defined under [XML Node Names](#xml-node-names).
 
-To produce an element wrapping the list, set an explicit `nodeType: "element"` on the `type: array` schema.
+To produce an element wrapping the list, set an explicit `nodeType: "element"` on the `type: "array"` schema.
 When doing so, it is advisable to set an explicit name on either the wrapping element or the item elements to avoid them having the same inferred name.
 See examples for expected behavior.
 
@@ -3347,7 +3347,7 @@ properties:
 <animal>value</animal>
 ```
 
-The `name` field for the `type: array` schema has no effect because the default `nodeType` for that object is `none`:
+The `name` field for the `type: "array"` schema has no effect because the default `nodeType` for that object is `none`:
 
 ```yaml
 properties:

--- a/src/oas.md
+++ b/src/oas.md
@@ -3330,7 +3330,7 @@ components:
           type: integer
           format: int32
           xml:
-            attribute: true
+            nodeType: attribute
         name:
           type: string
           xml:
@@ -3507,7 +3507,8 @@ paths:
         "200":
           content:
             application/xml:
-              $ref: "#/components/schemas/Documentation"
+              schema:
+                $ref: "#/components/schemas/Documentation"
 components:
   schemas:
     Documentation:
@@ -3536,19 +3537,21 @@ paths:
         "200":
           content:
             application/xml:
-              xml:
-                nodeType: element
-                name: StoredDocument
-              $ref: "#/components/schemas/Documentation"
+              schema:
+                xml:
+                  nodeType: element
+                  name: StoredDocument
+                $ref: "#/components/schemas/Documentation"
     put:
       requestBody:
         required: true
         content:
           application/xml:
-            xml:
-              nodeType: element
-              name: UpdatedDocument
-            $ref: "#/components/schemas/Documentation"
+            schema:
+              xml:
+                nodeType: element
+                name: UpdatedDocument
+              $ref: "#/components/schemas/Documentation"
       responses:
         "201": {}
 components:

--- a/src/oas.md
+++ b/src/oas.md
@@ -3259,6 +3259,7 @@ However, implementations SHOULD handle `null` values as follows:
 
 * For elements, produce an empty element with an `xsi:nil="true"` attribute.
 * For attributes, omit the attribute.
+* For text and CDATA sections, see [Appendix B](#appendix-b-data-type-conversion) for a discussion of serializing non-text values to text
 
 Note that for attributes, this makes either a `null` value or a missing property serialize to an omitted attribute.
 As the Schema Object validates the in-memory representation, this allows handling the combination of `null` and a required property.

--- a/src/oas.md
+++ b/src/oas.md
@@ -3694,7 +3694,7 @@ The in-memory instance data structure for the above example would be:
 ###### XML With `null` Values
 
 Recall that the schema validates the in-memory data, not the XML document itself.
-The properties of the `"metadata"` element are omitted for brevity as it is here to show how the `null` value is represented.
+The properties of the `"related"` element object are omitted for brevity as it is here to show how the `null` value is represented.
 
 ```yaml
 product:

--- a/src/oas.md
+++ b/src/oas.md
@@ -3206,8 +3206,8 @@ This object MAY be extended with [Specification Extensions](#specification-exten
 
 ##### XML Node Types
 
-Each Schema Object describes a particular type of XML [node](https://dom.spec.whatwg.org/#interface-node) which is specified by the `nodeType` field, which has the following possible values.
-Except for the special value `none`, these values have numeric equivalents in the DOM [specification](https://dom.spec.whatwg.org/#interface-node) which are given in parentheses after the name:
+Each Schema Object describes a particular type of XML [[!DOM]] [node](https://dom.spec.whatwg.org/#interface-node) which is specified by the `nodeType` field, which has the following possible values.
+Except for the special value `none`, these values have numeric equivalents in the DOM specification which are given in parentheses after the name:
 
 * `element` (1): The schema represents an element and describes its contents
 * `attribute` (2): The schema represents an attribute and describes its value

--- a/src/schemas/validation/meta.yaml
+++ b/src/schemas/validation/meta.yaml
@@ -55,8 +55,14 @@ $defs:
   xml:
     $ref: '#/$defs/extensible'
     properties:
-      attribute:
-        type: boolean
+      nodeType:
+        type: string
+        enum:
+          - element
+          - attribute
+          - text
+          - cdata
+          - none
       name:
         type: string
       namespace:
@@ -64,7 +70,14 @@ $defs:
         type: string
       prefix:
         type: string
+      attribute:
+        type: boolean
       wrapped:
         type: boolean
     type: object
+    dependentSchemas:
+      nodeType:
+        properties:
+          attribute: false
+          wrapped: false
     unevaluatedProperties: false

--- a/tests/schema/fail/xml-attr-exclusion.yaml
+++ b/tests/schema/fail/xml-attr-exclusion.yaml
@@ -1,0 +1,11 @@
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  schemas:
+    Attr:
+      type: string
+      xml:
+        attribute: true
+        nodeType: attribute

--- a/tests/schema/fail/xml-wrapped-exclusion.yaml
+++ b/tests/schema/fail/xml-wrapped-exclusion.yaml
@@ -1,0 +1,11 @@
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  schemas:
+    List:
+      type: array
+      xml:
+        wrapped: true
+        nodeType: element

--- a/tests/schema/pass/media-type-examples.yaml
+++ b/tests/schema/pass/media-type-examples.yaml
@@ -53,6 +53,26 @@ paths:
                   type: string
                   xml:
                     attribute: true
+                elementNode:
+                  $ref: "#/components/schemas/Pet"
+                  xml:
+                    nodeType: element
+                attributeNode:
+                  type: string
+                  xml:
+                    nodeType: attribute
+                textNode:
+                  type: string
+                  xml:
+                    nodeType: text
+                cdataNode:
+                  type: string
+                  xml:
+                    nodeType: cdata
+                noneNode:
+                  type: object
+                  xml:
+                    nodeType: none
           application/x-www-form-urlencoded:
             schema:
               type: object


### PR DESCRIPTION
* Fixes:
    * #630 (elements with attributes and content)
    * #1435 (root schemas — This fix incorporates the spirit of the 3.1.2 PR #4576)
* As of the latest commit (28 May 2025 10:45AM Pacific time) also fixes:
    * #3959 (handling `null` values) 

-----

This change removes the restriction on where the `xml` field and XML Object can appear, and adds a `nodeType` field to support the four most commonly used XML node types: `element`, `attribute`, `text`, and `cdata`. A fifth nodetype, `none`, is used to prevent a Schema Object from producing a node.

It also adds many examples of how to model different XML scenarios, including using `prefixItems` for complex ordered nodes.

While this could have been made much simpler by always defaulting `nodeType` to `element`, a more complex requirement was needed to preserve compatibility with the existing (but now deprecated - see also PR #4591) `attribute` and `wrapped` fields.  This way, the behavior of an XML object that is empty or uses only `name`, `prefix`, and/or `namespace` behaves the same whether you look at defaults for `nodeType` or for `attribute` and `wrapped`.

Finally, this PR ports the guidance on handling `null` attributes and elements to 3.2.

-----

I expect the deprecation of `attribute` and `wrapped` to be controversial, but there are several reasons for doing it:

* The solution proposed in #630 was to add another boolean field, `text`, to indicate text nodes.  But if we are going to support text nodes, we definitely also want to support CDATA sections, which would require three fields (`attribute`, `text`, and `cdata`) that were all mutually exclusive.  One boolean is fine, but three to manage a single state is more design smell than I can handle.
* The `wrapped` field is a very specific case of a more general problem, which is Schema Objects that do not correspond to XML nodes.  The old wording only acknowledged "property" and "root" schemas, and ignored the many other sorts of Schema Objects that might appear, and the complex ways in which they might map (or not) to XML nodes.  The `nodeType: none` construct allows controlling this in a generalized way.
* It becomes much more straightforward to define the `name` behavior, as certain types have names and others do not.  This is much more intuitive than logic involving `wrapped`.
* We might want to support additional node types in the future.  I just don't know enough about any of them to know what might be worth supporting, much less how to model them, and no one has asked for those (yet).
* The `null`-handling problems in #3959 are tricky, and this allows us to (if we want) define clear behavior for `nodeType: attribute` without breaking existing support for `attribute: true`.  _[NOTE: I ended up not trying to put restrictions on `null` and `nodeType: attribute` because there isn't really any good option but "don't use `null` with this" and forbidding that rather than just discouraging it seems problematic.]_

I came up with several other possible caveats to call out or clarify, but I wanted to keep this as minimal as possible.  If the related concerns come up in review I can add them, otherwise I will do it as a follow-on if it seems useful.  But let's see how this lands first.

-----

- [X] schema changes are included in this pull request
- [ ] schema changes are needed for this pull request but not done yet
- [ ] no schema changes are needed for this pull request
