### PR TITLE
v3.1: Clarify how to describe no content

### DIFF
--- a/src/oas.md
+++ b/src/oas.md
@@ -2079,16 +2079,27 @@ headers:
       type: integer
 ```
 
-Response with no return value:
+Response with no return value (note that the `Content-Length` header is not marked as required, as some implementations might not set it at all if there is no content):
 
 ```json
 {
   "description": "object created"
+  "headers": {
+    "Content-Length": {
+      "schema": {
+        "const": 0
+      }
+    }
+  }
 }
 ```
 
 ```yaml
 description: object created
+headers:
+  Content-Length:
+    schema:
+      const: 0
 ```
 
 #### Callback Object


### PR DESCRIPTION
Fixes #3536.

We decided that the lack of `content` doesn't guarantee a lack of response content, but that noting a `Content-Length` of `0` does.  @karenetheridge pointed out that we can set the `Content-Length` header to clarify this.

- [ ] schema changes are included in this pull request
- [ ] schema changes are needed for this pull request but not done yet
- [X] no schema changes are needed for this pull request
