### PR TITLE
v3.1.2: Provide guidance on null in XML.

### DIFF
--- a/src/oas.md
+++ b/src/oas.md
@@ -3469,8 +3469,8 @@ XML does not, by default, have a concept equivalent to `null`, and to preserve c
 
 However, implementations SHOULD handle `null` values as follows:
 
-* For elements, produce an empty element with an `xsi:nil="true"` attribute
-* For attributes, omit the attribute
+* For elements, produce an empty element with an `xsi:nil="true"` attribute.
+* For attributes, omit the attribute.
 
 Note that for attributes, this makes either a `null` value or a missing property serialize to an omitted attribute.
 As the Schema Object validates the in-memory representation, this allows handling the combination of `null` and a required property.

--- a/src/oas.md
+++ b/src/oas.md
@@ -3455,11 +3455,28 @@ See examples for expected behavior.
 
 This object MAY be extended with [Specification Extensions](#specification-extensions).
 
+##### Namespace Limitations
+
 The `namespace` field is intended to match the syntax of [XML namespaces](https://www.w3.org/TR/xml-names11/), although there are a few caveats:
 
 * Versions 3.1.0, 3.0.3, and earlier of this specification erroneously used the term "absolute URI" instead of "non-relative URI", so authors using namespaces that include a fragment should check tooling support carefully.
 * XML allows but discourages relative URI-references, while this specification outright forbids them.
 * XML 1.1 allows IRIs ([RFC3987](https://datatracker.ietf.org/doc/html/rfc3987)) as namespaces, and specifies that namespaces are compared without any encoding or decoding, which means that IRIs encoded to meet this specification's URI syntax requirement cannot be compared to IRIs as-is.
+
+##### Handling `null` Values
+
+XML does not, by default, have a concept equivalent to `null`, and to preserve compatibility with version 3.1.1 and earlier of this specification, the behavior of serializing `null` values is implementation-defined.
+
+However, implementations SHOULD handle `null` values as follows:
+
+* For elements, produce an empty element with an `xsi:nil="true"` attribute
+* For attributes, omit the attribute
+
+Note that for attributes, this makes either a `null` value or a missing property serialize to an omitted attribute.
+As the Schema Object validates the in-memory representation, this allows handling the combination of `null` and a required property.
+However, because there is no distinct way to represent `null` as an attribute, it is RECOMMENDED to make attribute properties optional rather than use `null`.
+
+To ensure correct round-trip behavior, when parsing an element that omits an attribute, implementations SHOULD set the corresponding property to `null` if the schema allows for that value (e.g. `type: ["number", "null"]`), and omit the property otherwise (e.g.`type: "number"`).
 
 ##### XML Object Examples
 
@@ -3794,6 +3811,85 @@ animals:
   <aliens>value</aliens>
   <aliens>value</aliens>
 </aliens>
+```
+
+###### XML With `null` Values
+
+Recall that the schema validates the in-memory data, not the XML document itself.
+The properties of the `"metadata"` element are omitted for brevity as it is here to show how the `null` value is represented.
+
+```json
+{
+  "product": {
+    "type": "object",
+    "required": ["count", "description", "related"],
+    "properties": {
+      "count": {
+        "type": ["number", "null"],
+        "xml": {
+          "attribute": true
+        }
+      },
+      "rating": {
+        "type": "string",
+        "xml": {
+          "attribute": true
+        }
+      },
+      "description": {
+        "type": "string"
+      },
+      "related": {
+        "type": ["object", "null"]
+      }
+    }
+  }
+}
+```
+
+```yaml
+product:
+  type: object
+  required:
+  - count
+  - description
+  - related
+  properties:
+    count:
+      type:
+      - number
+      - "null"
+      xml:
+        attribute: true
+    rating:
+      type: string
+      xml:
+        attribute: true
+    description:
+      type: string
+    related:
+      type:
+      - object
+      - "null"
+```
+
+```xml
+<product>
+  <description>Thing</description>
+  <related xsi:nil="true" />
+</product>
+```
+
+The above XML example corresponds to the following in-memory instance:
+
+```json
+{
+  "product": {
+    "count": null,
+    "description": "Thing",
+    "related": null
+  }
+}
 ```
 
 #### Security Scheme Object


### PR DESCRIPTION
Fixes:
* #3959 

There really isn't a native `null` type in XML, as both elements and attributes that are empty have an empty string value.

We also need to leave the behavior implementation-defined for compatibility.

However, attaching the `xsi:nil=true` attribute to an empty element is the closest thing to a `null` element.

Attributes are harder, and the best I can come up with is letting `null` behave the same as an omitted attribute for the purpose of serialization.  This means that for round-tripping, whether a missing attribute is parsed into a `null` property or as an omitted property depends on whether the schema allows `null`.

This attribute behavior is a bit weird, but I can't come up with anything else that has a hope of round-tripping propery, and we can't outright forbid `null` in a patch release.  If PR #4592 is accepted, we _could_ forbid `type: [..., "null"]` or `type: "null"` with `xml: {nodeType: "attribute"}` and leave the behavior with the deprecated `xml: {attribute: true}` unchanged.

So I guess the question here is whether the attribute guidance is more confusing than helpful.  The fact that we got asked about it suggests that we ought to say something, though.

- [ ] schema changes are included in this pull request
- [ ] schema changes are needed for this pull request but not done yet
- [X] no schema changes are needed for this pull request
