### PR TITLE
v3.1.2: Allow `xml` field/keyword in any schema as a MAY

### DIFF
--- a/src/oas.md
+++ b/src/oas.md
@@ -2749,7 +2749,7 @@ JSON Schema implementations MAY choose to treat keywords defined by the OpenAPI 
 | Field Name | Type | Description |
 | ---- | :----: | ---- |
 | <a name="schema-discriminator"></a>discriminator | [Discriminator Object](#discriminator-object) | Adds support for polymorphism. The discriminator is used to determine which of a set of schemas a payload is expected to satisfy. See [Composition and Inheritance](#composition-and-inheritance-polymorphism) for more details. |
-| <a name="schema-xml"></a>xml | [XML Object](#xml-object) | This MAY be used only on property schemas. It has no effect on root schemas. Adds additional metadata to describe the XML representation of this property. |
+| <a name="schema-xml"></a>xml | [XML Object](#xml-object) | Implementations MUST support this field on property schemas, and MAY support it in other kinds of schemas, in which case such support SHOULD follow the guidance in version 3.2 of this specification for forward compatibility. Adds additional metadata to describe the XML representation of this property. |
 | <a name="schema-external-docs"></a>externalDocs | [External Documentation Object](#external-documentation-object) | Additional external documentation for this schema. |
 | <a name="schema-example"></a>example | Any | A free-form field to include an example of an instance for this schema. To represent examples that cannot be naturally represented in JSON or YAML, a string value can be used to contain the example with escaping where necessary.<br><br>**Deprecated:** The `example` field has been deprecated in favor of the JSON Schema `examples` keyword. Use of `example` is discouraged, and later versions of this specification may remove it. |
 


### PR DESCRIPTION
Suggested by @ralfhandl in https://github.com/OAI/OpenAPI-Specification/pull/4576#discussion_r2090451308 on the grounds that some vendors already do this anyway.

This allows implementations to support the `xml` Schema Object field / JSON Schema extension keyword in any Schema Object, with a recommendation that the behavior be forward-compatible with OAS 3.2.

This does not break 3.1 compatibility, but it is a bit unusual as a patch release change as it does allow for additional functionality, and unlike the additional MAY guidance on `$dynamicRef` in 3.1.1, it is not just adding guidance to an area where we were silent.

On the other hand, we can look at it as a "we're not adding a new feature, we're just telling you how you can be compatible with future changes" thing.  idk how that fits with our compatibility story.

I'm fine with including this in 3.1.2, and I'm fine rejecting it and just letting people figure out that they can, of course, "backport" 3.2 functionality as "extensions".  But I figured it was worth a quick write-up based on @ralfhandl 's comment.

- [ ] schema changes are included in this pull request
- [ ] schema changes are needed for this pull request but not done yet
- [X] no schema changes are needed for this pull request
