### PR TITLE
docs: adds missing tag definition causing document to be invalid

### DIFF
--- a/_archive_/schemas/v3.0/pass/petstore.yaml
+++ b/_archive_/schemas/v3.0/pass/petstore.yaml
@@ -6,6 +6,12 @@ info:
     name: MIT
 servers:
   - url: http://petstore.swagger.io/v1
+tags:
+  - name: pets
+    description: Everything about your Pets
+    externalDocs:
+      description: Find out more
+      url: http://swagger.io
 paths:
   /pets:
     get:


### PR DESCRIPTION
reason https://github.com/microsoft/kiota/actions/runs/15145628198/job/42580662697?pr=6481
related https://github.com/microsoft/kiota/pull/6481
this description is missing the tag definition, which technically makes it invalid.
This is both an effort to "clean up the documents" and unblock our ci with upgrade of oai.net
If you don't want that change, that's fine, I'll make a local copy for our CI