### PR TITLE
Remove duplicate reviewers

### DIFF
--- a/.github/workflows/respec.yaml
+++ b/.github/workflows/respec.yaml
@@ -47,7 +47,7 @@ jobs:
         delete-branch: true
         path: deploy
         labels: Housekeeping
-        reviewers: darrelmiller,webron,earth2marsh,webron,lornajane,mikekistler,miqui,ralfhandl,handrews,karenetheridge
+        reviewers: darrelmiller,webron,earth2marsh,lornajane,mikekistler,miqui,ralfhandl,handrews,karenetheridge
         title: Update ReSpec-rendered specification versions
         commit-message: Update ReSpec-rendered specification versions
         signoff: true

--- a/.github/workflows/schema-publish.yaml
+++ b/.github/workflows/schema-publish.yaml
@@ -52,7 +52,7 @@ jobs:
         delete-branch: true
         path: deploy
         labels: Housekeeping,Schema
-        reviewers: darrelmiller,webron,earth2marsh,webron,lornajane,mikekistler,miqui,ralfhandl,handrews,karenetheridge
+        reviewers: darrelmiller,webron,earth2marsh,lornajane,mikekistler,miqui,ralfhandl,handrews,karenetheridge
         title: '${{ github.ref_name }}: publish OpenAPI schema iterations'
         commit-message: New OpenAPI schema iterations
         signoff: true


### PR DESCRIPTION
Infra clean up on `dev` to remove duplicate PR reviewers. It can be pushed from `dev` to other `vX.Y-dev` branches (and main).

Sing with me:
"There's only one Ron Ratovsky. There's only one Ron Ratovsky. Walking along, singing a song, walking in a webron wonderland!!"

- [ ] schema changes are included in this pull request
- [ ] schema changes are needed for this pull request but not done yet
- [x] no schema changes are needed for this pull request
