### PR TITLE
v3.2: Add "summary" field to Response Object

### DIFF
--- a/src/oas.md
+++ b/src/oas.md
@@ -1831,6 +1831,7 @@ Describes a single response from an API operation, including design-time, static
 
 | Field Name | Type | Description |
 | ---- | :----: | ---- |
+| <a name="response-summary"></a>summary | `string` | A short summary of the meaning of the response. |
 | <a name="response-description"></a>description | `string` | A description of the response. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation. |
 | <a name="response-headers"></a>headers | Map[`string`, [Header Object](#header-object) \| [Reference Object](#reference-object)] | Maps a header name to its definition. [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.1) states header names are case insensitive. If a response header is defined with the name `"Content-Type"`, it SHALL be ignored. |
 | <a name="response-content"></a>content | Map[`string`, [Media Type Object](#media-type-object)] | A map containing descriptions of potential response payloads. The key is a media type or [media type range](https://www.rfc-editor.org/rfc/rfc9110.html#appendix-A) and the value describes it. For responses that match multiple keys, only the most specific key is applicable. e.g. `"text/plain"` overrides `"text/*"` |

--- a/src/schemas/validation/schema.yaml
+++ b/src/schemas/validation/schema.yaml
@@ -567,6 +567,8 @@ $defs:
     $comment: https://spec.openapis.org/oas/v3.2#response-object
     type: object
     properties:
+      summary:
+        type: string
       description:
         type: string
       headers:


### PR DESCRIPTION
Fixes #1591 (the initial request, not the expanded idea for more `summary` fields).

This is extracted from #4610 where @lornajane noted that we were not considering actual usage with the broader proposal, but that a `summary` field on the Response Object would be reasonable.  So this is just for the Response Object.

- [X] schema changes are included in this pull request
- [ ] schema changes are needed for this pull request but not done yet
- [ ] no schema changes are needed for this pull request
