### PR TITLE
main: fix schema test coverage

### DIFF
--- a/scripts/schema-test-coverage.mjs
+++ b/scripts/schema-test-coverage.mjs
@@ -95,15 +95,15 @@ const compiled = await compile(schema);
 /** @type Set<string> */
 const visitedLocations = new Set();
 const baseInterpret = Validation.interpret;
-Validation.interpret = (url, instance, ast, dynamicAnchors, quiet) => {
-  if (Array.isArray(ast[url])) {
-    for (const keywordNode of ast[url]) {
+Validation.interpret = (url, instance, context) => {
+  if (Array.isArray(context.ast[url])) {
+    for (const keywordNode of context.ast[url]) {
       if (Array.isArray(keywordNode)) {
         visitedLocations.add(keywordNode[1]);
       }
     }
   }
-  return baseInterpret(url, instance, ast, dynamicAnchors, quiet);
+  return baseInterpret(url, instance, context);
 };
 
 await runTests(argv[3]);


### PR DESCRIPTION
Measuring schema test coverage depends on decorating the function `Validation.interpret` to capture the schema nodes visited during validation. The signature of this function has changed since version 1.11.0 of package `@hyperjump/json-schema`, and the decorated function needs to change accordingly.

<!--
Thank you for contributing to the OpenAPI Specification!

Please make certain you are submitting your PR on the correct
branch, to the files under the "src/" directory (which is not
present on the main branch, only on the development branches).

* 3.1.x spec and schemas: v3.1-dev branch
* 3.2.x spec and schemas: v3.2-dev branch
* registry templates: gh-pages branch, registry/...
* registry contents: gh-pages branch, registries/...
* process documentation and build infrastructure: main

Note that we do not accept changes to published specifications.
-->

<!-- Tick one of the following options: -->

- [ ] schema changes are included in this pull request
- [ ] schema changes are needed for this pull request but not done yet
- [x] no schema changes are needed for this pull request
