### PR TITLE
main: avoid unconventional use of yargs

### DIFF
--- a/scripts/md2html/md2html.js
+++ b/scripts/md2html/md2html.js
@@ -143,12 +143,12 @@ hljs.registerLanguage('jsonl', function() {
 
 const cheerio = require('cheerio');
 
-let argv = require('yargs')
+let argv = require('yargs')(process.argv.slice(2))
     .string('maintainers')
     .alias('m','maintainers')
     .describe('maintainers','path to MAINTAINERS.md')
     .demandCommand(1)
-    .argv;
+    .parse();
 const abstract = 'What is the OpenAPI Specification?';
 let maintainers = [];
 let emeritus = [];

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -3,5 +3,6 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   test: {
     forceRerunTriggers: ['**/scripts/**', '**/tests/**'],
+    testTimeout: 10000, // 10 seconds
   },
 })


### PR DESCRIPTION
The `yargs` package was used in a (now?) unconventional way in script `md2html.js` which no longer works with version 18 of `yargs`. Switched to more conventional use following the yargs documentation.

Increased vitest timeout for tests to avoid occasional problems.

<!--
Thank you for contributing to the OpenAPI Specification!

Please make certain you are submitting your PR on the correct
branch, to the files under the "src/" directory (which is not
present on the main branch, only on the development branches).

* 3.1.x spec and schemas: v3.1-dev branch
* 3.2.x spec and schemas: v3.2-dev branch
* registry templates: gh-pages branch, registry/...
* registry contents: gh-pages branch, registries/...
* process documentation and build infrastructure: main

Note that we do not accept changes to published specifications.
-->

<!-- Tick one of the following options: -->

- [ ] schema changes are included in this pull request
- [ ] schema changes are needed for this pull request but not done yet
- [x] no schema changes are needed for this pull request
