### PR TITLE
v3.2: Allow Parameter/Header "examples" field with "content" field

### DIFF
--- a/src/oas.md
+++ b/src/oas.md
@@ -1185,9 +1185,14 @@ name: json
 content:
   application/json:
     schema:
-      # Allow an arbitrary JSON object to keep
-      # the example simple
       type: object
+      properties:
+        numbers:
+          type: array
+          items:
+            type: number
+        flag:
+          type: [boolean, "null"]
     examples:
       TwoNoFlag:
         description: Serialize with minimized whitespace

--- a/src/oas.md
+++ b/src/oas.md
@@ -2525,6 +2525,9 @@ ETag:
       schema:
         type: string
         pattern: ^"
+  examples:
+    dataValue: xyzzx
+    serializedValue: xyzzx
 ```
 
 #### Tag Object

--- a/src/oas.md
+++ b/src/oas.md
@@ -1175,8 +1175,7 @@ examples:
     dataValue:
       foo: a + b
       bar: true
-    serializedValue:
-          foo=a+%2B+b&bar=true
+    serializedValue: foo=a+%2B+b&bar=true
 
 A querystring parameter that uses JSON for the entire string (not as a single query parameter value):
 

--- a/src/schemas/validation/schema.yaml
+++ b/src/schemas/validation/schema.yaml
@@ -366,6 +366,8 @@ $defs:
       - required:
         - content
     allOf:
+      - $ref: '#/$defs/examples'
+      - $ref: '#/$defs/specification-extensions'
       - if:
           properties:
             in:
@@ -403,7 +405,6 @@ $defs:
             default: false
             type: boolean
         allOf:
-          - $ref: '#/$defs/examples'
           - $ref: '#/$defs/parameter/dependentSchemas/schema/$defs/styles-for-path'
           - $ref: '#/$defs/parameter/dependentSchemas/schema/$defs/styles-for-header'
           - $ref: '#/$defs/parameter/dependentSchemas/schema/$defs/styles-for-query'
@@ -474,7 +475,6 @@ $defs:
                   default: form
                   const: form
 
-    $ref: '#/$defs/specification-extensions'
     unevaluatedProperties: false
 
   parameter-or-reference:
@@ -733,6 +733,9 @@ $defs:
             type: boolean
         $ref: '#/$defs/examples'
     $ref: '#/$defs/specification-extensions'
+    allOf:
+    - $ref: '#/$defs/examples'
+    - $ref: '#/$defs/specification-extensions'
     unevaluatedProperties: false
 
   header-or-reference:


### PR DESCRIPTION
_**NOTE:** This is a companion to PR #4647 that just adds to where we can use Example Objects as the [second part](https://github.com/OAI/OpenAPI-Specification/discussions/4622#discussioncomment-13314470) of the three-part proposal.  It is written assuming that PR would be merged because that makes the benefit more clear, although it could technically be done even without that PR.  But that would be less useful since tools do not support the serialization rules for the old example fields._

Parameter and Header serialization is complex, particularly when using the `content` field to use a Media Type Object.

In such scenarios, the serialization occurs in two steps: The first step is to serialize the data to the media type, which can be captured by the `examples` field of the Media Type Object.

The second is the encoding/escaping of the media type document for use in a URI, HTTP header, or other location with its own rules.

Sometimes the part needing illustration with an example is at one level, sometimes at another, and sometimes it is helpful to show both.

For simplicity, the "data" examples are always treated as the overall input data, so they would be the same at both levels. This is also because it is not always possible to show each step, particularly when there are binary serializations. This allows showing either step (or both steps) with both data and serialization, depending on what makes sense for the use case.

- [ ] schema changes are included in this pull request
- [X] schema changes are needed for this pull request but not done yet
- [ ] no schema changes are needed for this pull request
