### PR TITLE
v3.2: makes the versioning and deprecation non-breaking for minor versions

### DIFF
--- a/src/oas.md
+++ b/src/oas.md
@@ -147,7 +147,7 @@ Unlike undefined behavior, it is safe to rely on implementation-defined behavior
 
 The OpenAPI Specification is versioned using a `major`.`minor`.`patch` versioning scheme. The `major`.`minor` portion of the version string (for example `3.1`) SHALL designate the OAS feature set. _`.patch`_ versions address errors in, or provide clarifications to, this document, not the feature set. Tooling which supports OAS 3.1 SHOULD be compatible with all OAS 3.1.\* versions. The patch version SHOULD NOT be considered by tooling, making no distinction between `3.1.0` and `3.1.1` for example.
 
-Occasionally, non-backwards compatible changes may be made in `minor` versions of the OAS where impact is believed to be low relative to the benefit provided.
+New `minor` or `patch` versions after 3.1 WILL NOT introduce non-backwards compatible changes.
 
 ### Deprecation
 
@@ -155,7 +155,7 @@ Certain fields or features may be marked **Deprecated**.
 These fields and features remain part of the specification and can be used like any other field or feature.
 However, OpenAPI Description authors should use newer fields and features documented to replace the deprecated ones whenever possible.
 
-At this time, such elements are expected to remain part of the OAS until the next major version, although a future minor version of this specification may define a policy for later removal of deprecated elements.
+At this time, such elements are expected to remain part of the OAS until the next major version.
 
 ### Format
 


### PR DESCRIPTION
motivation: having 3.1 being a minor version on paper but in reality bringing a lot of breaking changes caused confusion and friction for consumers, tools implementers etc...
This is partly due because nowadays, a lot of the industry is following, and expects others to follow semver.
This pull request updates the verbiage of the versioning and deprecation policies so it forbids making breaking changes in minor/patch versions, so we can conform to semver, after 3.1.