### PR TITLE
v3.2: Strengthen generic data types to a SHOULD

### DIFF
--- a/src/oas.md
+++ b/src/oas.md
@@ -2632,7 +2632,7 @@ There are two ways to define the value of a discriminating property for an inher
 
 ###### Generic (Template) Data Structures
 
-Implementations MAY support defining generic or template data structures using JSON Schema's dynamic referencing feature:
+Implementations SHOULD support defining generic or template data structures using JSON Schema's dynamic referencing feature:
 
 * `$dynamicAnchor` identifies a set of possible schemas (including a default placeholder schema) to which a `$dynamicRef` can resolve
 * `$dynamicRef` resolves to the first matching `$dynamicAnchor` encountered on its path from the schema entry point to the reference, as described in the JSON Schema specification


### PR DESCRIPTION
_I thought I had already done this one-word change but I guess I forgot!_

This was added as a MAY in 3.1.1 but we can make it a SHOULD in 3.2.

I'd love to make it a MUST but there might be scenarios where it is not feasible, or where alternate interpretations are valid.  For example, the OAS schema and the JSON Schema metaschema use `$dynamicRef`, but to support a recursive data structure rather than a generic one.

This is the minimum change to more strongly encourage support for this much-demanded feature (it closed 5 separate issues when we added it) that currently is one of the least-supported JSON Schema keywords despite high demand.

- [ ] schema changes are included in this pull request
- [ ] schema changes are needed for this pull request but not done yet
- [X] no schema changes are needed for this pull request
