### PR TITLE
Fail if schema test coverage is below 100%, except on dev

### DIFF
--- a/scripts/schema-test-coverage.mjs
+++ b/scripts/schema-test-coverage.mjs
@@ -131,3 +131,7 @@ console.log(
   allLocations.length,
   "(" + Math.floor((visitedLocations.size / allLocations.length) * 100) + "%)",
 );
+
+if (visitedLocations.size != allLocations.length) {
+  process.exitCode = 1;
+}

--- a/scripts/schema-test-coverage.sh
+++ b/scripts/schema-test-coverage.sh
@@ -6,8 +6,13 @@
 
 [[ ! -e src/schemas ]] && exit 0
 
+branch=$(git branch --show-current)
+
 echo
 echo "Schema Test Coverage"
 echo
 
 node scripts/schema-test-coverage.mjs src/schemas/validation/schema.yaml tests/schema/pass
+rc=$?
+
+[[ "$branch" == "dev" ]] || exit $rc


### PR DESCRIPTION
The `schema-test-coverage.sh` script will now exit with code 1 if schema coverage falls below 100%, except on the `dev` branch, where we have insufficient test cases.

This will prevent schema additions without accompanying test cases, which we recently had on `v3.2-dev`.

Tested with dummy PRs:
- #4687 has [green checks](https://github.com/OAI/OpenAPI-Specification/pull/4687/checks) because test coverage is 100%
- #4686 has [red `schema-test` check](https://github.com/OAI/OpenAPI-Specification/pull/4686/checks) because coverage is only 98%

<!--
Thank you for contributing to the OpenAPI Specification!

Please make certain you are submitting your PR on the correct
branch, to the files under the "src/" directory (which is not
present on the main branch, only on the development branches).

* 3.1.x spec and schemas: v3.1-dev branch
* 3.2.x spec and schemas: v3.2-dev branch
* registry templates: gh-pages branch, registry/...
* registry contents: gh-pages branch, registries/...
* process documentation and build infrastructure: main

Note that we do not accept changes to published specifications.
-->

<!-- Tick one of the following options: -->

- [ ] schema changes are included in this pull request
- [ ] schema changes are needed for this pull request but not done yet
- [x] no schema changes are needed for this pull request
