### PR TITLE
3.2: bring schema test coverage back to 100%

### DIFF
--- a/tests/schema/pass/info-object-example.yaml
+++ b/tests/schema/pass/info-object-example.yaml
@@ -1,5 +1,6 @@
 # including External Documentation Object Example
 openapi: 3.2.0
+$self: https://example.com/openapi
 info:
   title: Example Pet Store App
   summary: A pet store manager.

--- a/tests/schema/pass/parameter-object-examples.yaml
+++ b/tests/schema/pass/parameter-object-examples.yaml
@@ -52,3 +52,17 @@ paths:
                   type: number
                 long:
                   type: number
+  /user:
+    parameters:
+      - in: querystring
+        name: json
+        content:
+          application/json:
+            schema:
+              # Allow an arbitrary JSON object to keep
+              # the example simple
+              type: object
+            example: {
+              "numbers": [1, 2],
+              "flag": null
+            }

--- a/tests/schema/pass/response-object-examples.yaml
+++ b/tests/schema/pass/response-object-examples.yaml
@@ -5,6 +5,7 @@ info:
 components:
   responses:
     complex-object-array:
+      summary: Complex object array
       description: A complex object array response
       content:
         application/json:


### PR DESCRIPTION
Test cases for
- Response Object with `summary`
- OpenAPI document with `$self`
- Parameter Object with `in: querystring`

<!--
Thank you for contributing to the OpenAPI Specification!

Please make certain you are submitting your PR on the correct
branch, to the files under the "src/" directory (which is not
present on the main branch, only on the development branches).

* 3.1.x spec and schemas: v3.1-dev branch
* 3.2.x spec and schemas: v3.2-dev branch
* registry templates: gh-pages branch, registry/...
* registry contents: gh-pages branch, registries/...
* process documentation and build infrastructure: main

Note that we do not accept changes to published specifications.
-->

<!-- Tick one of the following options: -->

- [ ] schema changes are included in this pull request
- [ ] schema changes are needed for this pull request but not done yet
- [x] no schema changes are needed for this pull request
