### PR TITLE
Test Schema Object extension fields on v3.1-dev

### DIFF
--- a/tests/schema/pass/json_schema_dialect.yaml
+++ b/tests/schema/pass/json_schema_dialect.yaml
@@ -1,0 +1,15 @@
+openapi: 3.1.0
+info:
+  summary: Testing jsonSchemaDialect
+  title: My API
+  version: 1.0.0
+  license:
+    name: Apache 2.0
+    identifier: Apache-2.0
+jsonSchemaDialect: https://spec.openapis.org/oas/3.1/dialect/WORK-IN-PROGRESS
+components:
+  schemas:
+    WithDollarSchema:
+      $id: "locked-metaschema"
+      $schema: https://spec.openapis.org/oas/3.1/dialect/WORK-IN-PROGRESS
+paths: {}

--- a/tests/schema/pass/media-type-examples.yaml
+++ b/tests/schema/pass/media-type-examples.yaml
@@ -30,6 +30,26 @@ paths:
                   breed: Mixed
               frog:
                 $ref: '#/components/examples/frog-example'
+          application/xml:
+            schema:
+              type: object
+              properties:
+                foo:
+                  type: string
+                  xml:
+                    namespace: https://example.com
+                    prefix: example
+                    name: Foo
+                bar:
+                  type: array
+                  items:
+                    type: number
+                  xml:
+                    wrapped: true
+                attr:
+                  type: string
+                  xml:
+                    attribute: true
           application/x-www-form-urlencoded:
             schema:
               type: object

--- a/tests/schema/pass/mega.yaml
+++ b/tests/schema/pass/mega.yaml
@@ -19,6 +19,12 @@ components:
   securitySchemes:
     mtls:
       type: mutualTLS
+  schemas:
+    Foo:
+      type: object
+      properties:
+        type:
+          const: foo
   pathItems:
     myPathItem:
       post:
@@ -47,5 +53,9 @@ components:
                     type: ['string','null']
                 discriminator:
                   propertyName: type
+                  mapping:
+                    foo: Foo
                   x-extension: true
+                anyOf:
+                - $ref: "#/components/schemas/Foo"
                 myArbitraryKeyword: true

--- a/tests/schema/pass/mega.yaml
+++ b/tests/schema/pass/mega.yaml
@@ -27,6 +27,9 @@ components:
           content:
             'application/json':
               schema:
+                externalDocs:
+                  description: More docs!
+                  url: https://example.com/elsewhere.html
                 type: object
                 properties:
                   type:

--- a/tests/schema/pass/mega.yaml
+++ b/tests/schema/pass/mega.yaml
@@ -6,7 +6,6 @@ info:
   license:
     name: Apache 2.0
     identifier: Apache-2.0
-jsonSchemaDialect: https://spec.openapis.org/oas/3.1/dialect/base
 paths:
   /:
     get:


### PR DESCRIPTION
This PR will need to be on `v3.1-dev` before PR #4701 can be ported to the branch.  The same tests need to be added to `v3.2-dev`, which I will do separately (`dev` is too different to make it easy to add from there and auto-merge out).

- [ ] schema changes are included in this pull request
- [ ] schema changes are needed for this pull request but not done yet
- [X] no schema changes are needed for this pull request
