### PR TITLE
Test Schema Object extension fields on v3.2-dev

### DIFF
--- a/tests/schema/pass/json_schema_dialect.yaml
+++ b/tests/schema/pass/json_schema_dialect.yaml
@@ -1,0 +1,15 @@
+openapi: 3.2.0
+info:
+  summary: Testing jsonSchemaDialect
+  title: My API
+  version: 1.0.0
+  license:
+    name: Apache 2.0
+    identifier: Apache-2.0
+jsonSchemaDialect: https://spec.openapis.org/oas/3.2/dialect/WORK-IN-PROGRESS
+components:
+  schemas:
+    WithDollarSchema:
+      $id: "locked-metaschema"
+      $schema: https://spec.openapis.org/oas/3.2/dialect/WORK-IN-PROGRESS
+paths: {}

--- a/tests/schema/pass/media-type-examples.yaml
+++ b/tests/schema/pass/media-type-examples.yaml
@@ -33,6 +33,26 @@ paths:
           application/jsonl:
             itemSchema:
               $ref: '#components/schemas/Pet'
+          application/xml:
+            schema:
+              type: object
+              properties:
+                foo:
+                  type: string
+                  xml:
+                    namespace: https://example.com
+                    prefix: example
+                    name: Foo
+                bar:
+                  type: array
+                  items:
+                    type: number
+                  xml:
+                    wrapped: true
+                attr:
+                  type: string
+                  xml:
+                    attribute: true
           application/x-www-form-urlencoded:
             schema:
               type: object

--- a/tests/schema/pass/mega.yaml
+++ b/tests/schema/pass/mega.yaml
@@ -19,6 +19,12 @@ components:
   securitySchemes:
     mtls:
       type: mutualTLS
+  schemas:
+    Foo:
+      type: object
+      properties:
+        type:
+          const: foo
   pathItems:
     myPathItem:
       post:
@@ -47,5 +53,9 @@ components:
                     type: ['string','null']
                 discriminator:
                   propertyName: type
+                  mapping:
+                    foo: Foo
                   x-extension: true
+                anyOf:
+                - $ref: "#/components/schemas/Foo"
                 myArbitraryKeyword: true

--- a/tests/schema/pass/mega.yaml
+++ b/tests/schema/pass/mega.yaml
@@ -27,6 +27,9 @@ components:
           content:
             'application/json':
               schema:
+                externalDocs:
+                  description: More docs!
+                  url: https://example.com/elsewhere.html
                 type: object
                 properties:
                   type:

--- a/tests/schema/pass/mega.yaml
+++ b/tests/schema/pass/mega.yaml
@@ -6,7 +6,6 @@ info:
   license:
     name: Apache 2.0
     identifier: Apache-2.0
-jsonSchemaDialect: https://spec.openapis.org/oas/3.1/dialect/base
 paths:
   /:
     get:


### PR DESCRIPTION
Port of #4703, which needs to be merged before #4701 can be merged to this branch. Note that the `jsonSchemaDialect` test has to align with the branch version number, but otherwise this is identical to the `v3.1-dev` tests (as the changes to the XML object are not yet merged).

- [ ] schema changes are included in this pull request
- [ ] schema changes are needed for this pull request but not done yet
- [X] no schema changes are needed for this pull request
