### PR TITLE
schema test coverage: set exit code only if base branch is not dev

### DIFF
--- a/.github/workflows/schema-tests.yaml
+++ b/.github/workflows/schema-tests.yaml
@@ -9,8 +9,7 @@ name: schema-test
 #
 
 # run this on push to any branch and creation of pull-requests
-on: 
-  push: {}
+on:
   pull_request: {}
   workflow_dispatch: {}
 
@@ -33,3 +32,5 @@ jobs:
 
     - name: Run tests
       run: npm run test
+      env:
+        BASE: ${{ github.event.pull_request.base.ref }}

--- a/scripts/schema-test-coverage.sh
+++ b/scripts/schema-test-coverage.sh
@@ -6,8 +6,6 @@
 
 [[ ! -e src/schemas ]] && exit 0
 
-branch=$(git branch --show-current)
-
 echo
 echo "Schema Test Coverage"
 echo
@@ -15,4 +13,4 @@ echo
 node scripts/schema-test-coverage.mjs src/schemas/validation/schema-base.yaml tests/schema/pass
 rc=$?
 
-[[ "$branch" == "dev" ]] || exit $rc
+[[ "$BASE" == "dev" ]] || exit $rc


### PR DESCRIPTION
<!--
Thank you for contributing to the OpenAPI Specification!

Please make certain you are submitting your PR on the correct
branch, to the files under the "src/" directory (which is not
present on the main branch, only on the development branches).

* 3.1.x spec and schemas: v3.1-dev branch
* 3.2.x spec and schemas: v3.2-dev branch
* registry templates: gh-pages branch, registry/...
* registry contents: gh-pages branch, registries/...
* process documentation and build infrastructure: main

Note that we do not accept changes to published specifications.
-->

<!-- Tick one of the following options: -->

- [ ] schema changes are included in this pull request
- [ ] schema changes are needed for this pull request but not done yet
- [x] no schema changes are needed for this pull request
