### PR TITLE
main: determine OAS Base Vocab name from meta.yaml for schema test coverage

### DIFF
--- a/scripts/schema-test-coverage.mjs
+++ b/scripts/schema-test-coverage.mjs
@@ -3,9 +3,9 @@ import { readdir, readFile } from "node:fs/promises";
 import YAML from "yaml";
 import { join } from "node:path";
 import { argv } from "node:process";
-import { registerSchema, validate } from "@hyperjump/json-schema/draft-2020-12";
+import { registerSchema, validate } from "@hyperjump/json-schema/openapi-3-1";
 import "@hyperjump/json-schema/draft-04";
-import { BASIC, addKeyword, defineVocabulary } from "@hyperjump/json-schema/experimental";
+import { BASIC, defineVocabulary } from "@hyperjump/json-schema/experimental";
 
 /**
  * @import { EvaluationPlugin } from "@hyperjump/json-schema/experimental"
@@ -118,65 +118,22 @@ const runTests = async (schemaUri, testDirectory) => {
   };
 };
 
-addKeyword({
-  id: "https://spec.openapis.org/oas/schema/vocab/keyword/discriminator",
-  interpret: (discriminator, instance, context) => {
-    return true;
-  },
-  /* discriminator is not exactly an annotation, but it's not allowed
-   * to change the validation outcome (hence returing true from interopret())
-   * and for our purposes of testing, this is sufficient.
-   */
-  annotation: (discriminator) => {
-    return discriminator;
-  },
-});
-
-addKeyword({
-  id: "https://spec.openapis.org/oas/schema/vocab/keyword/example",
-  interpret: (example, instance, context) => {
-    return true;
-  },
-  annotation: (example) => {
-    return example;
-  },
-});
-
-addKeyword({
-  id: "https://spec.openapis.org/oas/schema/vocab/keyword/externalDocs",
-  interpret: (externalDocs, instance, context) => {
-    return true;
-  },
-  annotation: (externalDocs) => {
-    return externalDocs;
-  },
-});
-
-addKeyword({
-  id: "https://spec.openapis.org/oas/schema/vocab/keyword/xml",
-  interpret: (xml, instance, context) => {
-    return true;
-  },
-  annotation: (xml) => {
-    return xml;
-  },
-});
-
-defineVocabulary(
-  "https://spec.openapis.org/oas/3.1/vocab/base",
-  {
-    "discriminator": "https://spec.openapis.org/oas/schema/vocab/keyword/discriminator",
-    "example": "https://spec.openapis.org/oas/schema/vocab/keyword/example",
-    "externalDocs": "https://spec.openapis.org/oas/schema/vocab/keyword/externalDocs",
-    "xml": "https://spec.openapis.org/oas/schema/vocab/keyword/xml",
-  },
-);
-
 const parseYamlFromFile = (filePath) => {
   const schemaYaml = readFileSync(filePath, "utf8");
   return YAML.parse(schemaYaml, { prettyErrors: true });
 };
-registerSchema(parseYamlFromFile("./src/schemas/validation/meta.yaml"));
+
+const meta = parseYamlFromFile("./src/schemas/validation/meta.yaml");
+const oasBaseVocab = Object.keys(meta.$vocabulary)[0];
+
+defineVocabulary(oasBaseVocab, {
+  "discriminator": "https://spec.openapis.org/oas/3.0/keyword/discriminator",
+  "example": "https://spec.openapis.org/oas/3.0/keyword/example",
+  "externalDocs": "https://spec.openapis.org/oas/3.0/keyword/externalDocs",
+  "xml": "https://spec.openapis.org/oas/3.0/keyword/xml"
+});
+
+registerSchema(meta);
 registerSchema(parseYamlFromFile("./src/schemas/validation/dialect.yaml"));
 registerSchema(parseYamlFromFile("./src/schemas/validation/schema.yaml"));
 


### PR DESCRIPTION
Counterpart to 
* #4719 

<!--
Thank you for contributing to the OpenAPI Specification!

Please make certain you are submitting your PR on the correct
branch, to the files under the "src/" directory (which is not
present on the main branch, only on the development branches).

* 3.1.x spec and schemas: v3.1-dev branch
* 3.2.x spec and schemas: v3.2-dev branch
* registry templates: gh-pages branch, registry/...
* registry contents: gh-pages branch, registries/...
* process documentation and build infrastructure: main

Note that we do not accept changes to published specifications.
-->

<!-- Tick one of the following options: -->

- [ ] schema changes are included in this pull request
- [ ] schema changes are needed for this pull request but not done yet
- [x] no schema changes are needed for this pull request
