### PR TITLE
sync workflows: use app token to trigger PR event

### DIFF
--- a/.github/workflows/sync-dev-to-vX.Y-dev.yaml
+++ b/.github/workflows/sync-dev-to-vX.Y-dev.yaml
@@ -16,6 +16,13 @@ jobs:
   sync-branches:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate access token
+        id: generate-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.OAI_SPEC_PUBLISHER_APPID }}
+          private-key: ${{ secrets.OAI_SPEC_PUBLISHER_PRIVATE_KEY }}
+    
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -41,5 +48,5 @@ jobs:
               --body "Merge \`$HEAD\` into \`$BASE\`."
           done
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
           HEAD: dev

--- a/.github/workflows/sync-main-to-dev.yaml
+++ b/.github/workflows/sync-main-to-dev.yaml
@@ -16,6 +16,13 @@ jobs:
   sync-branch:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate access token
+        id: generate-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.OAI_SPEC_PUBLISHER_APPID }}
+          private-key: ${{ secrets.OAI_SPEC_PUBLISHER_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -35,6 +42,6 @@ jobs:
             --title "$BASE: update from $HEAD" \
             --body "Merge \`$HEAD\` into \`$BASE\`."
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
           HEAD: main
           BASE: dev


### PR DESCRIPTION
Using an app token instead of the default GitHub token triggers the `pull_request` event when creating a PR in a workflow.

This will trigger the `schema-test` status check which needs to know the base branch of its PR.

Without this change the sync PRs are stuck due to the missing status check until either closed and reopened or a second change arrives in the head branch.

<!--
Thank you for contributing to the OpenAPI Specification!

Please make certain you are submitting your PR on the correct
branch, to the files under the "src/" directory (which is not
present on the main branch, only on the development branches).

* 3.1.x spec and schemas: v3.1-dev branch
* 3.2.x spec and schemas: v3.2-dev branch
* registry templates: gh-pages branch, registry/...
* registry contents: gh-pages branch, registries/...
* process documentation and build infrastructure: main

Note that we do not accept changes to published specifications.
-->

<!-- Tick one of the following options: -->

- [ ] schema changes are included in this pull request
- [ ] schema changes are needed for this pull request but not done yet
- [x] no schema changes are needed for this pull request
