### PR TITLE
v3.2: (Split and smaller!) Support ordered multipart including streaming

### DIFF
--- a/src/oas.md
+++ b/src/oas.md
@@ -1323,7 +1323,7 @@ properties:
 
 ##### Encoding Usage and Restrictions
 
-The three encoding fields define how to map each [Encoding Object](#encoding object) to a specific value in the data.
+These encoding fields define how to map each [Encoding Object](#encoding object) to a specific value in the data.
 Each field has its own set of media types with which it can be used; for all other media types all three fields SHALL be ignored.
 
 ###### Encoding By Name

--- a/src/oas.md
+++ b/src/oas.md
@@ -1330,7 +1330,7 @@ Each field has its own set of media types with which it can be used; for all oth
 
 The behavior of the `encoding` field is designed to support web forms, and is therefore only defined for media types structured as name-value pairs that allow repeat values, most notably `application/x-www-form-urlencoded` and `multipart/form-data`.
 
-To use the `encoding` field, each key under the field MUST exist in the `schema` as a property.
+To use the `encoding` field, each key under the field MUST exist as a property; `encoding` entries with no corresponding property SHALL be ignored.
 Array properties MUST be handled by applying the given Encoding Object to produce one encoded value per array item, each with the same `name`, as is recommended by [[?RFC7578]] [Section 4.3](https://www.rfc-editor.org/rfc/rfc7578.html#section-4.3) for supplying multiple values per form field.
 For all other value types for both top-level non-array properties and for values, including array values, within a top-level array, the Encoding Object MUST be applied to the entire value.
 The order of these name-value pairs in the target media type is implementation-defined.
@@ -1350,6 +1350,7 @@ Data for these media types are modeled as an array, with one item per part, in o
 
 To use the `prefixEncoding` and/or `itemEncoding` fields, either `itemSchema` or an array `schema` MUST be present.
 These fields are analogous to the `prefixItems` and `items` JSON Schema keywords, with `prefixEncoding` (if present) providing an array of Encoding Objects that are each applied to the value at the same position in the data array, and `itemEncoding` applying its single Encoding Object to all remaining items in the array.
+As with `prefixItems`, it is _not_ an error if the instance array is shorter than the `prefixEncoding` array; the additional Encoding Objects SHALL be ignored.
 
 The `itemEncoding` field can also be used with `itemSchema` to support streaming `multipart` content.
 

--- a/src/oas.md
+++ b/src/oas.md
@@ -1331,15 +1331,15 @@ Each field has its own set of media types with which it can be used; for all oth
 The behavior of the `encoding` field is designed to support web forms, and is therefore only defined for media types structured as name-value pairs that allow repeat values, most notably `application/x-www-form-urlencoded` and `multipart/form-data`.
 
 To use the `encoding` field, each key under the field MUST exist as a property; `encoding` entries with no corresponding property SHALL be ignored.
-Array properties MUST be handled by applying the given Encoding Object to produce one encoded value per array item, each with the same `name`, as is recommended by [[?RFC7578]] [Section 4.3](https://www.rfc-editor.org/rfc/rfc7578.html#section-4.3) for supplying multiple values per form field.
+Array properties MUST be handled by applying the given Encoding Object to produce one encoded value per array item, each with the same `name`, as is recommended by [[!RFC7578]] [Section 4.3](https://www.rfc-editor.org/rfc/rfc7578.html#section-4.3) for supplying multiple values per form field.
 For all other value types for both top-level non-array properties and for values, including array values, within a top-level array, the Encoding Object MUST be applied to the entire value.
 The order of these name-value pairs in the target media type is implementation-defined.
 
 For `application/x-www-form-urlencoded`, the encoding keys MUST map to parameter names, with the values produced according to the rules of the [Encoding Object](#encoding-object).
 See [Encoding the `x-www-form-urlencoded` Media Type](#encoding-the-x-www-form-urlencoded-media-type) for guidance and examples, both with and without the `encoding` field.
 
-For `multipart`, the encoding keys MUST map to the [`name` parameter](https://www.rfc-editor.org/rfc/rfc7578#section-4.2) of the `Content-Disposition: form-data` header of each part, as is defined for `multipart/form-data` in [[?RFC7578]].
-See [[?RFC7578]] [Section 5](https://www.rfc-editor.org/rfc/rfc7578.html#section-5) for guidance regarding non-ASCII part names.
+For `multipart`, the encoding keys MUST map to the [`name` parameter](https://www.rfc-editor.org/rfc/rfc7578#section-4.2) of the `Content-Disposition: form-data` header of each part, as is defined for `multipart/form-data` in [[!RFC7578]].
+See [[!RFC7578]] [Section 5](https://www.rfc-editor.org/rfc/rfc7578.html#section-5) for guidance regarding non-ASCII part names.
 
 See [Encoding `multipart` Media Types](#encoding-multipart-media-types) for further guidance and examples, both with and without the `encoding` field.
 
@@ -1359,7 +1359,7 @@ The `itemEncoding` field can also be used with `itemSchema` to support streaming
 The `prefixEncoding` field can be used with any `multipart` content to require a fixed part order.
 This includes `multipart/form-data`, for which the Encoding Object's `headers` field MUST be used to provide the `Content-Disposition` and part name, as no property names exist to provide the names automatically.
 
-Prior versions of this specification advised using the `name` [`Content-Disposition` parameter](https://www.iana.org/assignments/cont-disp/cont-disp.xhtml#cont-disp-2) of the `form-data` [`Content-Disposition` value](https://www.iana.org/assignments/cont-disp/cont-disp.xhtml#cont-disp-1) with `multipart` media types other than `multipart/form-data` in order to work around the limitations of the `encoding` field.
+Prior versions of this specification advised using the [`name` parameter](https://www.rfc-editor.org/rfc/rfc7578#section-4.2) of the `Content-Disposition: form-data` header of each part with `multipart` media types other than `multipart/form-data` in order to work around the limitations of the `encoding` field.
 Implementations MAY choose to support this workaround, but as this usage is not common, implementations of non-`form-data` `multipart` media types are unlikely to support it.
 
 ##### Media Type Examples

--- a/src/schemas/validation/schema.yaml
+++ b/src/schemas/validation/schema.yaml
@@ -539,9 +539,20 @@ $defs:
         type: object
         additionalProperties:
           $ref: '#/$defs/encoding'
+      prefixEncoding:
+        type: array
+        items:
+          $ref: '#/$defs/encoding'
+      itemEncoding:
+        $ref: '#/$defs/encoding'
     allOf:
-      - $ref: '#/$defs/specification-extensions'
       - $ref: '#/$defs/examples'
+      - $ref: '#/$defs/specification-extensions'
+      - dependentSchemas:
+          encoding:
+            properties:
+              prefixEncoding: false
+              itemEncoding: false
     unevaluatedProperties: false
 
   media-type-or-reference:

--- a/tests/schema/fail/media-type-enc-item-exclusion.yaml
+++ b/tests/schema/fail/media-type-enc-item-exclusion.yaml
@@ -4,7 +4,8 @@ info:
   version: 1.0.0
 components:
   requestBodies:
-    content:
-      multipart/mixed:
-        encoding: {}
-        itemEncoding: {}
+    encoding-with-itemEncoding-not-allowed:
+      content:
+        multipart/mixed:
+          encoding: {}
+          itemEncoding: {}

--- a/tests/schema/fail/media-type-enc-item-exclusion.yaml
+++ b/tests/schema/fail/media-type-enc-item-exclusion.yaml
@@ -1,0 +1,10 @@
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  requestBodies:
+    content:
+      multipart/mixed:
+        encoding: {}
+        itemEncoding: {}

--- a/tests/schema/fail/media-type-enc-prefix-exclusion.yaml
+++ b/tests/schema/fail/media-type-enc-prefix-exclusion.yaml
@@ -4,7 +4,8 @@ info:
   version: 1.0.0
 components:
   requestBodies:
-    content:
-      multipart/mixed:
-        encoding: {}
-        prefixEncoding: {}
+    encoding-with-prefixEncoding-not-allowed:
+      content:
+        multipart/mixed:
+          encoding: {}
+          prefixEncoding: []

--- a/tests/schema/fail/media-type-enc-prefix-exclusion.yaml
+++ b/tests/schema/fail/media-type-enc-prefix-exclusion.yaml
@@ -1,0 +1,10 @@
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  requestBodies:
+    content:
+      multipart/mixed:
+        encoding: {}
+        prefixEncoding: {}

--- a/tests/schema/pass/media-type-examples.yaml
+++ b/tests/schema/pass/media-type-examples.yaml
@@ -161,3 +161,13 @@ paths:
                 prefixEncoding:
                 - {}
                 itemEncoding: {}
+          multipart/related:
+            schema:
+              type: array
+            itemEncoding:
+              contentType: text/plain
+            prefixEncoding:
+            - headers:
+                Content-Location:
+                  schema:
+                    type: string


### PR DESCRIPTION
_**NOTE: This is just the new fields and their description, schema, and schema tests, with several things removed: 1.) the elaborate rules for determining type, which are now in PR #4743, 2.) the examples, which are in PR #4746 so they can be discussed in-depth and updated based on the pending Example Object changes.  The contents of this PR are otherwise identical to #4589._

-----

This adds support for all `multipart` media types that do not have named parts, including support for streaming such media types. Note that `multipart/mixed` defines the basic processing rules for all `multipart` types, and implementations that encounter unrecognized `multipart` subtypes are required to process them as `multipart/mixed`.  Therefore support for `multipart/mixed` addresses all other subtypes to some degree.

This builds on the recent support for sequential media types:

* `multipart/mixed` and similar meet the definition for a sequential media type, requiring it to be modeled as an array.  This does use an expansive definition of "repeating the same structure", where the structure is literally any content with a media type.
* As a sequential media type, it also supports `itemSchema`
* Adding a parallel `itemEncoding` is the obvious solution to `multipart/mixed` streams requiring an Encoding Object
* We have regularly received requests to support truly mixed `multipart/mixed` payloads, and previously claimed such support from 3.0.0 onwards, without actually supporting it. Adding `prefixEncoding` along with `itemEncoding` supports this use case with a clear parallel to `prefixItems`, which is the schema construct needed to support this case.
* There is no need for a `prefixSchema` field because the streaming use case requires a repetition of the same schema for each item. Therefore all mixed use cases can use `schema` and `prefixItems`

<!--
Thank you for contributing to the OpenAPI Specification!

Please make certain you are submitting your PR on the correct
branch, to the files under the "src/" directory (which is not
present on the main branch, only on the development branches).

* 3.1.x spec and schemas: v3.1-dev branch
* 3.2.x spec and schemas: v3.2-dev branch
* registry templates: gh-pages branch, registry/...
* registry contents: gh-pages branch, registries/...
* process documentation and build infrastructure: main

Note that we do not accept changes to published specifications.
-->

<!-- Tick one of the following options: -->

- [X] schema changes are included in this pull request
- [ ] schema changes are needed for this pull request but not done yet
- [ ] no schema changes are needed for this pull request
