### PR TITLE
v3.2: Ordered `multipart` examples

### DIFF
--- a/src/oas.md
+++ b/src/oas.md
@@ -2017,6 +2017,7 @@ The nested parts are XML, plain text, and a PNG image.
 ```yaml
 multipart/mixed:
   schema:
+    type: array
     prefixItems:
     - type: array
     - type: array


### PR DESCRIPTION
These are the examples that go with PRs #4745 and #4744.

This includes the recently (this past week) updated `multipart/related` example that was provoking a lot of discussion.  Otherwise, the examples are the same as in the old PR #4589.


- [X] no schema changes are needed for this pull request
