### PR TITLE
v3.2: Provide guidance for the `Set-Cookie` response header

### DIFF
--- a/src/oas.md
+++ b/src/oas.md
@@ -2559,10 +2559,9 @@ components:
       content:
         text/plain:
           schema:
+            # Due to lack of support for multiline regular expressions
+            # in the `pattern` keyword, not much validation can be done.
             type: string
-            allOf:
-            - pattern: "^lang=[^;];.*Expires="
-            - pattern: "^foo=[^;];.*Expires="
       examples:
         WithExpires:
           # This demonstrates that the text is required to be provided
@@ -2582,7 +2581,7 @@ components:
         - foo
         additionalProperties:
           type: string
-          pattern: "^[^[:space:]]$"
+          pattern: "^[^[:space:]]*$"
       style: simple
       explode: true
       examples:


### PR DESCRIPTION
Partially addresses issue #1237 

The Set-Cookie response header breaks the normal rules for headers with multiple values and requires special handling.

There are two options here:

1. Rework how we handle headers to accommodate `Set-Cookie` in a consistent manner
2. Treat `Set-Cookie` as a special case and define how it relates to normal behavior

Since [RFC9110 §5.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3) advises clients to treat `Set-Cookie` as a special case, I went with special-casing it.   This assumes the approach to header serialization that is described in PR #4648 and discussed in one of its comment threads (specifically, that it does not include the header name which is required for it to be consistent with how `style: "simple"` and `explode` are treated elsewhere and are defined in RFC6570).


- [X] no schema changes are needed for this pull request
