### PR TITLE
auto-merge sync PRs from dev

### DIFF
--- a/.github/workflows/sync-dev-to-vX.Y-dev.yaml
+++ b/.github/workflows/sync-dev-to-vX.Y-dev.yaml
@@ -42,10 +42,11 @@ jobs:
               continue
             fi
 
-            gh pr create --base $BASE --head $HEAD \
+            PR=$(gh pr create --base $BASE --head $HEAD \
               --label "Housekeeping" \
               --title "$BASE: update from $HEAD" \
-              --body "Merge \`$HEAD\` into \`$BASE\`."
+              --body "Merge \`$HEAD\` into \`$BASE\`.")
+            gh pr merge $PR --merge --admin
           done
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
Automatically merge sync PRs from dev to vX.Y-dev.

After creating a sync PR the PR is merged with "admin" privileges, which works because the bot creating the sync PR is allowed to bypass the ruleset requiring PR approvals.

The bot is not allowed to bypass the branch protection rule that requires status checks, so the merge SHOULD only succeed if the status checks pass. (Now is a good time to try this out because the sync PRs currently violate a status check that should not be bypassed 😎.)

<!--
Thank you for contributing to the OpenAPI Specification!

Please make certain you are submitting your PR on the correct
branch, to the files under the "src/" directory (which is not
present on the main branch, only on the development branches).

* 3.1.x spec and schemas: v3.1-dev branch
* 3.2.x spec and schemas: v3.2-dev branch
* registry templates: gh-pages branch, registry/...
* registry contents: gh-pages branch, registries/...
* process documentation and build infrastructure: main

Note that we do not accept changes to published specifications.
-->

<!-- Tick one of the following options: -->

- [ ] schema changes are included in this pull request
- [ ] schema changes are needed for this pull request but not done yet
- [x] no schema changes are needed for this pull request
