### PR TITLE
v3.2: Clarify template variable uniqueness

### DIFF
--- a/src/oas.md
+++ b/src/oas.md
@@ -62,6 +62,8 @@ sub-delims          = "!" / "$" / "&" / "'" / "(" / ")"
 
 Here, `pchar`, `unreserved`, `pct-encoded` and `sub-delims` definitions are taken from [RFC 3986](https://tools.ietf.org/html/rfc3986). The `path-template` is directly derived from [RFC 3986, section 3.3](https://datatracker.ietf.org/doc/html/rfc3986#section-3.3).
 
+Each template expression MUST NOT appear more than once in a single path template.
+
 See also [Appendix C: Using RFC6570-Based Serialization](#appendix-c-using-rfc6570-based-serialization) for additional guidance.
 
 ### Media Types
@@ -596,6 +598,8 @@ iprivate       =  %xE000-F8FF / %xF0000-FFFFD / %x100000-10FFFD
 
 Here, `literals`, `pct-encoded`, `ucschar` and `iprivate` definitions are taken from [RFC 6570](https://www.rfc-editor.org/rfc/rfc6570), incorporating the corrections specified in [Errata 6937](https://www.rfc-editor.org/errata/eid6937) for `literals`.
 
+Each server variable MUST NOT appear more than once in the URL template.
+
 See the [Paths Object](#paths-object) for guidance on constructing full request URLs.
 
 ##### Fixed Fields
@@ -967,7 +971,7 @@ These fields MAY be used with either `content` or `schema`.
 
 | Field Name | Type | Description |
 | ---- | :----: | ---- |
-| <a name="parameter-name"></a>name | `string` | **REQUIRED**. The name of the parameter. Parameter names are _case sensitive_. <ul><li>If [`in`](#parameter-in) is `"path"`, the `name` field MUST correspond to a template expression occurring within the [path](#paths-path) field in the [Paths Object](#paths-object). See [Path Templating](#path-templating) for further information.<li>If [`in`](#parameter-in) is `"header"` and the `name` field is `"Accept"`, `"Content-Type"` or `"Authorization"`, the parameter definition SHALL be ignored.<li>If `in` is `"querystring"`, or for [certain combinations](#style-examples) of [`style`](#parameter-style) and [`explode`](#parameter-explode), the value of `name` is not used in the parameter serialization.<li>For all other cases, the `name` corresponds to the parameter name used by the [`in`](#parameter-in) field.</ul> |
+| <a name="parameter-name"></a>name | `string` | **REQUIRED**. The name of the parameter. Parameter names are _case sensitive_. <ul><li>If [`in`](#parameter-in) is `"path"`, the `name` field MUST correspond to a single template expression occurring within the [path](#paths-path) field in the [Paths Object](#paths-object). See [Path Templating](#path-templating) for further information.<li>If [`in`](#parameter-in) is `"header"` and the `name` field is `"Accept"`, `"Content-Type"` or `"Authorization"`, the parameter definition SHALL be ignored.<li>If `in` is `"querystring"`, or for [certain combinations](#style-examples) of [`style`](#parameter-style) and [`explode`](#parameter-explode), the value of `name` is not used in the parameter serialization.<li>For all other cases, the `name` corresponds to the parameter name used by the [`in`](#parameter-in) field.</ul> |
 | <a name="parameter-in"></a>in | `string` | **REQUIRED**. The location of the parameter. Possible values are `"query"`, `"querystring"`, `"header"`, `"path"` or `"cookie"`. |
 | <a name="parameter-description"></a>description | `string` | A brief description of the parameter. This could contain examples of use. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation. |
 | <a name="parameter-required"></a>required | `boolean` | Determines whether this parameter is mandatory. If the [parameter location](#parameter-in) is `"path"`, this field is **REQUIRED** and its value MUST be `true`. Otherwise, the field MAY be included and its default value is `false`. |


### PR DESCRIPTION
_NOTE: This takes the opposite view as the thread in https://github.com/OAI/OpenAPI-Specification/issues/4763#issuecomment-3074650101 based on continued slack conversations where we dug deeper into the spec wording.  Please see the note after the list as well:_

This clarifies that variables in both path and server URL templates MUST be unique.  This is justified as compatible with our minor release policy on the following grounds:

* Due to Parameter Object `name` + `in` constraints and the Server Object's `variables` field being a map, each variable can only map to one paramater or server variable (although the "one" paramater might be defined separately yet uniquely for each Operation).
* The Path Templating section uses the phrase "Each template expression in the path MUST correspond to ***a*** path parameter" (emphasis added).
* The Parameter Object uses similar language in the other direction: "If in is "path", the name field MUST correspond to ***a*** template expression".
* The word "a" is interpreted to mean an unknown but unique thing in both directions.
* The Server Object's `url` template has always been assumed to function in an analogous way to path templating.

_Note: I think this is reasonably solid, and no one has actually presented a use case or known use of duplicate fields, but it does rely on interpreting language in a very specific way.  I am very much interested in whether people see this as a clarification or change, as my intent is for it to be a clarification._

- [X] no schema changes are needed for this pull request
