### PR TITLE
v3.2: Provide parsing and serialization guidance

### DIFF
--- a/src/oas.md
+++ b/src/oas.md
@@ -294,7 +294,7 @@ As noted under [Data Type](#data-types), both `type: number` and `type: integer`
 
 API data has several forms:
 
-1. The serialized form, which is either a document of a particular media type, part of an HTTP header value, or part of a URI.
+1. The serialized form, which is either a document of a particular media type, an HTTP header value, or part of a URI.
 2. The data form, intended for use with a [Schema Object](#schema-object).
 3. The application form, which incorporates any additional information conveyed by JSON Schema keywords such as `format` and `contentType`, and possibly additional information such as class hierarchies that are beyond the scope of this specification, although they MAY be based on specification elements such as the [Discriminator Object](#discriminator-object) or guidance regarding [Data Modeling Techniques](#data-modeling-techniques).
 


### PR DESCRIPTION
_**NOTE**: This PR is a replacement for #4743.  @whitlockjc and @baywet it is largely inspired by your questions of how far we need to go to explain how to build on schemas and other parts of the OAS, and how that fits with tools that do not work with runtime data (e.g. code gen).  This is now substantially less ambitious and I think much better for it._

This creates a "Working with Data" section that incorporates the existing "Data Types" section (with some section level adjustments) along with new guidance on mapping different kinds of data between serialized, data, and application forms.  This terminology matches the terminology currently being considered for examples.  Note that "Working with Binary Data" is just moved, but the diff got confused and sort-of makes it look like the heading got deleted.

The application form is largely out of scope for the OAS, and is mainly included to clarify this scope while acknowledging that the OAS may influence such things.

Most of the new material is on parsing and serializing, briefly addressing JSON as the common case before going into detail on non-JSON data, with examples.  This is where the requirements for schema and/or instance inspection/searching are listed.

The only additional change is no longer mentioning the property schema in the Encoding Object, in part because with the new `multipart/mixed` support Encoding Objects can be used with arrays as well as objects.

- [X] no schema changes are needed for this pull request
