### PR TITLE
Media Types Registry

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,6 +18,11 @@ collections:
     name: Format Registry
     output: true
     permalink: /registry/:collection/:title
+  media-type:
+    slug: media-type
+    name: Media Type Registry
+    output: true
+    permalink: /registry/:collection/:title
   extension:
     slug: extension
     name: Specification Extension Registry

--- a/_includes/media-type-entry.md
+++ b/_includes/media-type-entry.md
@@ -1,4 +1,6 @@
-# <a href=".">Media Type Registry</a>
+{% assign registry = site.collections | where:"label", page.collection  | first %}
+# <a href=".">{{ registry.name }}</a>
+
 
 ## {{ page.name }}: {{ page.description }}
 
@@ -13,7 +15,7 @@ This page also applies to any unrecognized {{ page.default_for }} media type.
 {% if page.references %}
 **OAS References:**
 
-{% for ref in page.references %}• [{{ ref.section }}](https://spec.openapis.org/oas/latest.html#{{ ref.anchor }}){% if ref.parent %} ([{{ ref.parent }}](https://spec.openapis.org/oas/latest.html#{{ ref.parentAnchor }})){% endif %}{% unless forloop.last %}<br />{% endunless %}{% endfor %}
+{% for ref in page.references %}• [{{ ref.section }}](https://spec.openapis.org/oas/latest.html#{{ ref.anchor }}){% if ref.parentObject %} ([{{ ref.parentObject }}](https://spec.openapis.org/oas/latest.html#{{ ref.parentAnchor }})){% endif %}{% unless forloop.last %}<br />{% endunless %}{% endfor %}
 {% endif %}
 
 ## Summary

--- a/_includes/media-type-entry.md
+++ b/_includes/media-type-entry.md
@@ -1,19 +1,19 @@
-# <a href=".">{{ page.collection }}</a>
+# <a href=".">Media Type Registry</a>
 
-## {{ page.description }}
+## {{ page.name }}: {{ page.description }}
 
 **Media Type(s):**
 
-{% for media_type in page.media_types %}• <tt>{{ media_type.name }}</tt>{% unless media_type.registered %} _<small>(not IANA-registered)</small>_{% endunless %}{% unless forloop.last %}<br />{% endunless %}{% endfor %}
+{% for media_type in page.media_types %}• <tt>{{ media_type.name }}</tt> <small>({% if media_type.iana %}[IANA]({{ media_type.iana }}){% else %}not IANA-registered{% endif %})</small> – {% for spec in media_type.specifications %}[{{ spec.name }}]({{ spec.url }}){% if spec.note %} <small>({{ spec.note }})</small>{% endif %}{% unless forloop.last %}, {% endunless %}{% endfor %}{% unless forloop.last %}<br />{% endunless %}{% endfor %}
 {% if page.default_for %}
 
-This page also applies to any unknown {{ page.default_for }} media type.
+This page also applies to any unrecognized {{ page.default_for }} media type.
 {% endif %}
 
 {% if page.references %}
 **OAS References:**
 
-{% for ref in page.references %}• [{{ ref.section }}](https://spec.openapis.org/oas/latest.html#{{ ref.anchor }})<br />{% endfor %}
+{% for ref in page.references %}• [{{ ref.section }}](https://spec.openapis.org/oas/latest.html#{{ ref.anchor }}){% if ref.parent %} ([{{ ref.parent }}](https://spec.openapis.org/oas/latest.html#{{ ref.parentAnchor }})){% endif %}{% unless forloop.last %}<br />{% endunless %}{% endfor %}
 {% endif %}
 
 ## Summary

--- a/_includes/media-type-entry.md
+++ b/_includes/media-type-entry.md
@@ -1,0 +1,28 @@
+# <a href=".">{{ page.collection }}</a>
+
+## {{ page.description }}
+
+**Media Type(s):**
+
+{% for media_type in page.media_types %}• <tt>{{ media_type.name }}</tt>{% unless media_type.registered %} _<small>(not IANA-registered)</small>_{% endunless %}{% unless forloop.last %}<br />{% endunless %}{% endfor %}
+{% if page.default_for %}
+
+This page also applies to any unknown {{ page.default_for }} media type.
+{% endif %}
+
+{% if page.references %}
+**OAS References:**
+
+{% for ref in page.references %}• [{{ ref.section }}](https://spec.openapis.org/oas/latest.html#{{ ref.anchor }})<br />{% endfor %}
+{% endif %}
+
+## Summary
+
+{{ include.summary }}
+
+{% if include.remarks %}
+## Remarks
+
+{{ include.remarks }}
+{% endif %}
+

--- a/registries/_media-type/binary.md
+++ b/registries/_media-type/binary.md
@@ -53,7 +53,7 @@ As of OAS v3.1, binary data is modeled using an empty Schema Object, in accordan
 {% endcapture %}
 
 {% capture remarks %}
-As specified in [Working with Binary Data](https://spec.openapis.org/oas/latest.html#working-with-binary-data), modeling binary data that has been encoded into a string is handled differently from raw binary data, with two variations: With the [Schema Object](https://spec.openapis.org/oas/latest.html#schema-object)'s `contentMediaType` and `contentEncoding`, or with a `Content-Transfer-Encoding` header in the [Encoding Object](https://spec.openapis.org/oas/latest.html#encoding-object) (for media types that use Encoding Objects).  Consult the specification for how these two mechanisms interact when they both apply.
+As specified in [Working with Binary Data](https://spec.openapis.org/oas/latest.html#working-with-binary-data), modeling binary data that has been encoded into a string is handled differently from raw binary data, with two variations: with the [Schema Object](https://spec.openapis.org/oas/latest.html#schema-object)'s `contentMediaType` and `contentEncoding`, or with a `Content-Transfer-Encoding` header in the [Encoding Object](https://spec.openapis.org/oas/latest.html#encoding-object) (for media types that use Encoding Objects).  Consult the specification for how these two mechanisms interact when they both apply.
 
 In OAS v3.0, raw binary content was modeled as `type: string, format: binary`, while `type: string, format: byte` was used for base64-encoded binary.  This was dropped in favor of JSON Schema draft 2020-12's support because it did not allow specifying the media type along with the binary encoding.
 {% endcapture %}

--- a/registries/_media-type/binary.md
+++ b/registries/_media-type/binary.md
@@ -1,0 +1,32 @@
+---
+owner: handrews
+description: Binary
+media_types:
+  - name: application/octet-stream
+    registered: true
+  - name: audio/*
+    registered: true
+  - name: image/*
+    registered: true
+  - name: video/*
+    registered: true
+default_for: binary
+references:
+  - section: Working with Binary Data
+    anchor: working-with-binary-data
+  - section: Binary Streams
+    anchor: binary-streams
+layout: default
+---
+
+{% capture summary %}
+As of OAS v3.1, binary data is modeled using an empty Schema Object, in accordance with JSON Schema's guidance regarding [non-JSON instances](https://www.ietf.org/archive/id/draft-bhutton-json-schema-01.html#name-non-json-instances).
+{% endcapture %}
+
+{% capture remarks %}
+As specified in the linked reference section ("Working with Binary Data"), modeling binary data that has been encoded into a string is handled differently from raw binary data, with two variations: With an Encoding Object or with the Schema Object's `contentMediaType` and `contentEncoding`.
+
+In OAS v3.0, raw binary content was modeled as `type: string, format: binary`, while `type: string, format: byte` was used for base64-encoded binary.  This was dropped in favor of JSON Schema draft 2020-12's support because it did not allow specifying the media type along with the binary encoding.
+{% endcapture %}
+
+{% include media-type-entry.md summary=summary remarks=remarks %}

--- a/registries/_media-type/binary.md
+++ b/registries/_media-type/binary.md
@@ -1,21 +1,50 @@
 ---
 owner: handrews
-description: Binary
+name: Binary
+description: Non-text-based media types
 media_types:
   - name: application/octet-stream
-    registered: true
+    iana: https://www.iana.org/assignments/media-types/application/octet-stream
+    specifications:
+    - name: RFC2045
+      url: https://www.rfc-editor.org/rfc/rfc2045
+    - name: RFC2046 §4.5.1
+      url: https://www.rfc-editor.org/rfc/rfc2046#section-4.5.1
   - name: audio/*
-    registered: true
+    iana: https://www.iana.org/assignments/media-types/media-types.xhtml#audio
+    specifications:
+    - name: RFC2045
+      url: https://www.rfc-editor.org/rfc/rfc2045
+    - name: RFC2046 §4.2
+      url: https://www.rfc-editor.org/rfc/rfc2046#section-4.3
   - name: image/*
-    registered: true
+    iana: https://www.iana.org/assignments/media-types/media-types.xhtml#image
+    specifications:
+    - name: RFC2045
+      url: https://www.rfc-editor.org/rfc/rfc2045
+    - name: RFC2046 §4.2
+      url: https://www.rfc-editor.org/rfc/rfc2046#section-4.2
   - name: video/*
-    registered: true
+    iana: https://www.iana.org/assignments/media-types/media-types.xhtml#video
+    specifications:
+    - name: RFC2045
+      url: https://www.rfc-editor.org/rfc/rfc2045
+    - name: RFC2046 §4.4
+      url: https://www.rfc-editor.org/rfc/rfc2046#section-4.4
 default_for: binary
 references:
   - section: Working with Binary Data
     anchor: working-with-binary-data
+    parent: Working with Data
+    parentAnchor: Working with Data
   - section: Binary Streams
     anchor: binary-streams
+    parent: Media Type Object
+    parentAnchor: media-type-object
+  - section: "`Content-Transfer-Encoding` and `contentEncoding`"
+    anchor: content-transfer-encoding-and-contentencoding
+    parent: Encoding Object
+    parentAnchor: encoding-object
 layout: default
 ---
 
@@ -24,7 +53,7 @@ As of OAS v3.1, binary data is modeled using an empty Schema Object, in accordan
 {% endcapture %}
 
 {% capture remarks %}
-As specified in the linked reference section ("Working with Binary Data"), modeling binary data that has been encoded into a string is handled differently from raw binary data, with two variations: With an Encoding Object or with the Schema Object's `contentMediaType` and `contentEncoding`.
+As specified in [Working with Binary Data](https://spec.openapis.org/oas/latest.html#working-with-binary-data), modeling binary data that has been encoded into a string is handled differently from raw binary data, with two variations: With the [Schema Object](https://spec.openapis.org/oas/latest.html#schema-object)'s `contentMediaType` and `contentEncoding`, or with a `Content-Transfer-Encoding` header in the [Encoding Object](https://spec.openapis.org/oas/latest.html#encoding-object) (for media types that use Encoding Objects).  Consult the specification for how these two mechanisms interact when they both apply.
 
 In OAS v3.0, raw binary content was modeled as `type: string, format: binary`, while `type: string, format: byte` was used for base64-encoded binary.  This was dropped in favor of JSON Schema draft 2020-12's support because it did not allow specifying the media type along with the binary encoding.
 {% endcapture %}

--- a/registries/_media-type/binary.md
+++ b/registries/_media-type/binary.md
@@ -35,15 +35,15 @@ default_for: binary
 references:
   - section: Working with Binary Data
     anchor: working-with-binary-data
-    parent: Working with Data
-    parentAnchor: Working with Data
+    parentObject: Schema Object
+    parentAnchor: schema-object
   - section: Binary Streams
     anchor: binary-streams
-    parent: Media Type Object
+    parentObject: Media Type Object
     parentAnchor: media-type-object
   - section: "`Content-Transfer-Encoding` and `contentEncoding`"
     anchor: content-transfer-encoding-and-contentencoding
-    parent: Encoding Object
+    parentObject: Encoding Object
     parentAnchor: encoding-object
 layout: default
 ---

--- a/registries/_media-type/forms.md
+++ b/registries/_media-type/forms.md
@@ -1,0 +1,34 @@
+---
+owner: handrews
+description: Forms
+media_types:
+  - name: application/x-www-form-urlencoded
+    registered: true
+  - name: multipart/form-data
+    registered: true
+references:
+  - section: Encoding the x-www-form-urlencoded Media Type
+    anchor: encoding-the-x-www-form-urlencoded-media-type
+  - section: Encoding By Name
+    anchor: encoding-by-name
+  - section: Encoding multipart Media Types
+    anchor: encoding-multipart-media-types
+  - section: "Appendix C: Using RFC6570-Based Serialization"
+    anchor: appendix-c-using-rfc6570-based-serialization
+  - section: "Appendix E: Percent-Encoding and Form Media Types"
+    anchor: appendix-e-percent-encoding-and-form-media-types
+layout: default
+---
+
+{% capture summary %}
+Web-style form data consists of name-value pairs, with duplicate names allowed, and are structured either in a way compatible with URI form query strings or as a `multipart` document.
+{% endcapture %}
+
+{% capture remarks %}
+Both form media types use the Encoding Object to map object properties from schema-ready data structures to name-value pairs, with special rules for arrays causing each array value to be treated as a separate pair with the same name.
+While the ordering of pairs is significant in these formats, the OAS does not (as of v3.2) provide a way to control such ordering.
+
+As of OAS v3.2, endpoint URL query strings can be modeled as a media type using `in: querystring` in the Parameter Object.  The query string can also be modeled using multiple `in: query` Parameter Objects through mechanisms similar to the Encoding Object.
+{% endcapture %}
+
+{% include media-type-entry.md summary=summary remarks=remarks %}

--- a/registries/_media-type/forms.md
+++ b/registries/_media-type/forms.md
@@ -1,18 +1,37 @@
 ---
 owner: handrews
-description: Forms
+name: Forms
+description: Ordered name-value pairs
 media_types:
   - name: application/x-www-form-urlencoded
-    registered: true
+    iana: https://www.iana.org/assignments/media-types/application/x-www-form-urlencoded
+    specifications:
+    - name: WHATWG URL
+      url: https://url.spec.whatwg.org/#application/x-www-form-urlencoded
+    - name: HTTP 4.01 §17.13.4.1
+      url: https://www.w3.org/TR/html401/interact/forms.html#h-17.13.4.1
+      note: historical
+    - name: RFC1866 §8.2.1
+      url: https://datatracker.ietf.org/doc/html/rfc1866#section-8.2.1
+      note: historical but cited by later RFCs and the OAS
   - name: multipart/form-data
-    registered: true
+    iana: https://www.iana.org/assignments/media-types/multipart/form-data
+    specifications:
+    - name: RFC7578
+      url: https://www.rfc-editor.org/rfc/rfc7578.html
 references:
-  - section: Encoding the x-www-form-urlencoded Media Type
-    anchor: encoding-the-x-www-form-urlencoded-media-type
   - section: Encoding By Name
     anchor: encoding-by-name
+    parent: Encoding Usage and Restrictions
+    parentAnchor: encoding-usage-and-restrictions
+  - section: Encoding the `x-www-form-urlencoded` Media Type
+    anchor: encoding-the-x-www-form-urlencoded-media-type
+    parent: Encoding Object
+    parentAnchor: encoding-object
   - section: Encoding multipart Media Types
     anchor: encoding-multipart-media-types
+    parent: Encoding Object
+    parentAnchor: encoding-object
   - section: "Appendix C: Using RFC6570-Based Serialization"
     anchor: appendix-c-using-rfc6570-based-serialization
   - section: "Appendix E: Percent-Encoding and Form Media Types"
@@ -25,10 +44,12 @@ Web-style form data consists of name-value pairs, with duplicate names allowed, 
 {% endcapture %}
 
 {% capture remarks %}
-Both form media types use the Encoding Object to map object properties from schema-ready data structures to name-value pairs, with special rules for arrays causing each array value to be treated as a separate pair with the same name.
+Both form media types use the [Encoding Object](https://spec.openapis.org/oas/latest.html#encoding-object) to map object properties from schema-ready data structures to name-value pairs, with special rules for arrays causing each array value to be treated as a separate pair with the same name.
 While the ordering of pairs is significant in these formats, the OAS does not (as of v3.2) provide a way to control such ordering.
 
-As of OAS v3.2, endpoint URL query strings can be modeled as a media type using `in: querystring` in the Parameter Object.  The query string can also be modeled using multiple `in: query` Parameter Objects through mechanisms similar to the Encoding Object.
+As of OAS v3.2, endpoint URL query strings can be modeled as a media type using `in: querystring` in the [Parameter Object](https://spec.openapis.org/oas/latest.html#parameter-object).  The query string can also be modeled using multiple `in: query` Parameter Objects through mechanisms similar to the Encoding Object.
+
+Note that URL-encoded forms have been defined by different standards organizations at different times, leading to inconsistencies regarding percent-encoding in later standards and implementations; this is addressed in detail in [Appendix E](https://spec.openapis.org/oas/latest.html#appendix-e-percent-encoding-and-form-media-types).
 {% endcapture %}
 
 {% include media-type-entry.md summary=summary remarks=remarks %}

--- a/registries/_media-type/linksets.md
+++ b/registries/_media-type/linksets.md
@@ -1,14 +1,25 @@
 ---
 owner: handrews
-description: Link Sets
+name: Link Sets
+description: Sets of RFC8288 Web Links
 media_types:
   - name: application/linkset
-    registered: true
+    iana: https://www.iana.org/assignments/media-types/application/linkset
+    specifications:
+    - name: RFC9264
+      url: https://www.rfc-editor.org/rfc/rfc9264
+    - name: RFC8288
+      url: https://www.rfc-editor.org/rfc/rfc8288
   - name: application/linkset+json
-    registered: true
+    iana: https://www.iana.org/assignments/media-types/application/linkset+json
+    specifications:
+    - name: RFC9264
+      url: https://www.rfc-editor.org/rfc/rfc9264
 references:
   - section: Modeling Link Headers
     anchor: modeling-link-headers
+    parent: Header Object
+    parentAnchor: header-object
 layout: default
 ---
 
@@ -18,7 +29,7 @@ The JSON form for linksets is used to define the schema-ready data form for mode
 
 {% capture remarks %}
 In addition to modeling the `Link` header, these two media types are supported anywhere else a media type document is allowed.
-In all cases, the `application/linkset+json` data model is used with the Schema Object, with the choice of the parent key for the Media Type Object (with or without `+json`) determining only the serialization.
+In all cases, the `application/linkset+json` data model is used with the [Schema Object](https://spec.openapis.org/oas/latest.html#schema-object), with the choice of the parent key for the [Media Type Object](https://spec.openapis.org/oas/latest.html#media-type-object) (with or without `+json`) determining only the serialization.
 {% endcapture %}
 
 {% include media-type-entry.md summary=summary remarks=remarks %}

--- a/registries/_media-type/linksets.md
+++ b/registries/_media-type/linksets.md
@@ -24,12 +24,11 @@ layout: default
 ---
 
 {% capture summary %}
-The JSON form for linksets is used to define the schema-ready data form for modeling the HTTP `Link` header, with the rules for converting from that form to `application/linkset` and then to the single-line HTTP field syntax defining the serialization process for that data.
+The JSON form for linksets is used to define the schema-ready data form for both of these media types, with `application/linkset` being usable for HTTP `Link` header values using the conversion defined in the RFC.
 {% endcapture %}
 
 {% capture remarks %}
-In addition to modeling the `Link` header, these two media types are supported anywhere else a media type document is allowed.
-In all cases, the `application/linkset+json` data model is used with the [Schema Object](https://spec.openapis.org/oas/latest.html#schema-object), with the choice of the parent key for the [Media Type Object](https://spec.openapis.org/oas/latest.html#media-type-object) (with or without `+json`) determining only the serialization.
+The `application/linkset+json` data model is used with the [Schema Object](https://spec.openapis.org/oas/latest.html#schema-object) for both media types, with the choice of the parent key for the [Media Type Object](https://spec.openapis.org/oas/latest.html#media-type-object) (with or without `+json`) determining only the serialization format.
 {% endcapture %}
 
 {% include media-type-entry.md summary=summary remarks=remarks %}

--- a/registries/_media-type/linksets.md
+++ b/registries/_media-type/linksets.md
@@ -18,7 +18,7 @@ media_types:
 references:
   - section: Modeling Link Headers
     anchor: modeling-link-headers
-    parent: Header Object
+    parentObject: Header Object
     parentAnchor: header-object
 layout: default
 ---

--- a/registries/_media-type/linksets.md
+++ b/registries/_media-type/linksets.md
@@ -1,0 +1,24 @@
+---
+owner: handrews
+description: Link Sets
+media_types:
+  - name: application/linkset
+    registered: true
+  - name: application/linkset+json
+    registered: true
+references:
+  - section: Modeling Link Headers
+    anchor: modeling-link-headers
+layout: default
+---
+
+{% capture summary %}
+The JSON form for linksets is used to define the schema-ready data form for modeling the HTTP `Link` header, with the rules for converting from that form to `application/linkset` and then to the single-line HTTP field syntax defining the serialization process for that data.
+{% endcapture %}
+
+{% capture remarks %}
+In addition to modeling the `Link` header, these two media types are supported anywhere else a media type document is allowed.
+In all cases, the `application/linkset+json` data model is used with the Schema Object, with the choice of the parent key for the Media Type Object (with or without `+json`) determining only the serialization.
+{% endcapture %}
+
+{% include media-type-entry.md summary=summary remarks=remarks %}

--- a/registries/_media-type/sequential_json.md
+++ b/registries/_media-type/sequential_json.md
@@ -1,20 +1,38 @@
 ---
 owner: handrews
-description: Sequential JSON
+name: Sequential JSON
+description: Multiple concatenated JSON documents suitable for streaming
 media_types:
   - name: application/jsonl
     registered: false
+    specifications:
+    - name: JSON Lines
+      url: https://jsonlines.org/
+  - name: application/json-seq
+    registered: https://www.iana.org/assignments/media-types/application/json-seq
+    specifications:
+    - name: RFC7464
+      url: https://www.rfc-editor.org/rfc/rfc7464
+    - name: RFC8091
+      url: https://www.rfc-editor.org/rfc/rfc8091
   - name: application/x-ndjson
     registered: false
-  - name: application/json-seq
-    registered: true
+    specifications:
+    - name: Newline Delimited JSON
+      url: https://github.com/ndjson/ndjson-spec
 references:
   - section: Sequential Media Types
     anchor: sequential-media-types
+    parent: Media Types
+    parentAnchor: media-types
   - section: Streaming Sequential Media Types
     anchor: streaming-sequential-media-types
-  - section: Sequential JSON (examples)
+    parent: Media Type Object
+    parentAnchor: media-type-object
+  - section: Sequential JSON
     anchor: sequential-json
+    parent: Media Type Examples
+    parentAnchor: media-type-examples
 layout: default
 ---
 

--- a/registries/_media-type/sequential_json.md
+++ b/registries/_media-type/sequential_json.md
@@ -1,0 +1,31 @@
+---
+owner: handrews
+description: Sequential JSON
+media_types:
+  - name: application/jsonl
+    registered: false
+  - name: application/x-ndjson
+    registered: false
+  - name: application/json-seq
+    registered: true
+references:
+  - section: Sequential Media Types
+    anchor: sequential-media-types
+  - section: Streaming Sequential Media Types
+    anchor: streaming-sequential-media-types
+  - section: Sequential JSON (examples)
+    anchor: sequential-json
+layout: default
+---
+
+{% capture summary %}
+Sequential JSON media types concatenate multiple JSON documents into one document or stream, and only vary in their choices of delimiter and the restrictions on what whitespace is allowed between JSON syntax tokens.
+{% endcapture %}
+
+{% capture remarks %}
+All sequential JSON media types support the same two approaches:
+* Use the `schema` field to model the whole document as if it were a JSON array
+* Use `itemSchema` to model one item at a time for streaming purposes, where all items use the same schema
+{% endcapture %}
+
+{% include media-type-entry.md summary=summary remarks=remarks %}

--- a/registries/_media-type/sequential_json.md
+++ b/registries/_media-type/sequential_json.md
@@ -4,35 +4,35 @@ name: Sequential JSON
 description: Multiple concatenated JSON documents suitable for streaming
 media_types:
   - name: application/jsonl
-    registered: false
+    iana: false
     specifications:
     - name: JSON Lines
       url: https://jsonlines.org/
   - name: application/json-seq
-    registered: https://www.iana.org/assignments/media-types/application/json-seq
+    iana: https://www.iana.org/assignments/media-types/application/json-seq
     specifications:
     - name: RFC7464
       url: https://www.rfc-editor.org/rfc/rfc7464
     - name: RFC8091
       url: https://www.rfc-editor.org/rfc/rfc8091
   - name: application/x-ndjson
-    registered: false
+    iana: false
     specifications:
     - name: Newline Delimited JSON
       url: https://github.com/ndjson/ndjson-spec
 references:
   - section: Sequential Media Types
     anchor: sequential-media-types
-    parent: Media Types
-    parentAnchor: media-types
+    parentObject: Media Type Object
+    parentAnchor: media-type-object
   - section: Streaming Sequential Media Types
     anchor: streaming-sequential-media-types
-    parent: Media Type Object
+    parentObject: Media Type Object
     parentAnchor: media-type-object
   - section: Sequential JSON
     anchor: sequential-json
-    parent: Media Type Examples
-    parentAnchor: media-type-examples
+    parentObject: Media Type Object
+    parentAnchor: media-type-object
 layout: default
 ---
 

--- a/registries/_media-type/sequential_multipart.md
+++ b/registries/_media-type/sequential_multipart.md
@@ -1,22 +1,50 @@
 ---
 owner: handrews
-description: Sequential Multipart
+name: Sequential Multipart
+description: Multipart subtypes with unnamed parts
 media_types:
   - name: multipart/*
-    registered: true
+    iana: https://www.iana.org/assignments/media-types/media-types.xhtml#multipart
+    specifications:
+    - name: RFC2045
+      url: https://www.rfc-editor.org/rfc/rfc2045
+    - name: RFC2046 §5.1
+      url: https://www.rfc-editor.org/rfc/rfc2046#section-5.1
   - name: multipart/mixed
-    registered: true
+    iana: https://www.iana.org/assignments/media-types/multipart/mixed
+    specifications:
+    - name: RFC2045
+      url: https://www.rfc-editor.org/rfc/rfc2045
+    - name: RFC2046 §5.1.3
+      url: https://www.rfc-editor.org/rfc/rfc2046#section-5.1.3
   - name: multipart/alternative
-    registered: true
+    iana: https://www.iana.org/assignments/media-types/multipart/alternative
+    specifications:
+    - name: RFC2045
+      url: https://www.rfc-editor.org/rfc/rfc2045
+    - name: RFC2046 §5.1.4
+      url: https://www.rfc-editor.org/rfc/rfc2046#section-5.1.4
   - name: multipart/related
-    registered: true
+    iana: https://www.iana.org/assignments/media-types/multipart/related
+    specifications:
+    - name: RFC2389
+      url: https://www.rfc-editor.org/rfc/rfc2389
+    - name: RFC2557
+      url: https://www.rfc-editor.org/rfc/rfc2557
   - name: multipart/byteranges
-    registered: true
+    iana: https://www.iana.org/assignments/media-types/multipart/byteranges
+    specifications:
+    - name: RFC9110 §14.6
+      url: https://www.rfc-editor.org/rfc/rfc9110#name-media-type-multipart-bytera
 references:
   - section: Encoding By Position
     anchor: encoding-by-position
-  - section: Encoding multipart Media Types
+    parent: Encoding Usage and Restrictions
+    parentAnchor: encoding-usage-and-restrictions
+  - section: Encoding `multipart` Media Types
     anchor: encoding-multipart-media-types
+    parent: Encoding Object
+    parentAnchor: encoding-object
 layout: default
 ---
 

--- a/registries/_media-type/sequential_multipart.md
+++ b/registries/_media-type/sequential_multipart.md
@@ -1,0 +1,38 @@
+---
+owner: handrews
+description: Sequential Multipart
+media_types:
+  - name: multipart/*
+    registered: true
+  - name: multipart/mixed
+    registered: true
+  - name: multipart/alternative
+    registered: true
+  - name: multipart/related
+    registered: true
+  - name: multipart/byteranges
+    registered: true
+references:
+  - section: Encoding By Position
+    anchor: encoding-by-position
+  - section: Encoding multipart Media Types
+    anchor: encoding-multipart-media-types
+layout: default
+---
+
+{% capture summary %}
+All `multipart` media types are based on a common syntax defined by `multipart/mixed`, and any `multipart` subtype not explicitly registered is expected to be usable by treating it as `multipart/mixed` in accordance with [RFC2046 §5.1.3](https://www.rfc-editor.org/rfc/rfc2046.html#section-5.1.3).
+{% endcapture %}
+
+{% capture remarks %}
+All known `multipart` subtypes except `multipart/form-data` are ordered, without any names for the parts.
+They are either modeled as arrays using `schema`, or a uniform schema can be applied to each part for streaming purposes using `itemSchema` (this is particularly relevant to `multipart/byteranges`).
+In both cases, `itemEncoding` can used to manage the media type and headers of each, while if `schema` is used, `prefixEncoding` is also available for describing some fixed number of initial parts in a specific order.
+
+The `boundary` required parameter is common to all `multipart` subtypes, but does not need to be described explicitly in OpenAPI Descriptions as it is typically generated and used automatically, with a value that is not predictable in advance.
+
+Note that OAS v3.0 claimed support for `multipart/mixed`, but did not define a mechanism for doing so for reasons that are no longer known.  This claim of support was removed in OAS v3.0.4 and OAS v3.1.1, but can be seen in older patch releases of the 3.0 and 3.1 lines.
+{% endcapture %}
+
+{% include media-type-entry.md summary=summary remarks=remarks %}
+

--- a/registries/_media-type/sequential_multipart.md
+++ b/registries/_media-type/sequential_multipart.md
@@ -39,11 +39,11 @@ media_types:
 references:
   - section: Encoding By Position
     anchor: encoding-by-position
-    parent: Encoding Usage and Restrictions
-    parentAnchor: encoding-usage-and-restrictions
+    parentObject: Media Type Object
+    parentAnchor: media-type-object
   - section: Encoding `multipart` Media Types
     anchor: encoding-multipart-media-types
-    parent: Encoding Object
+    parentObject: Encoding Object
     parentAnchor: encoding-object
 layout: default
 ---

--- a/registries/_media-type/sequential_multipart.md
+++ b/registries/_media-type/sequential_multipart.md
@@ -31,7 +31,7 @@ In both cases, `itemEncoding` can used to manage the media type and headers of e
 
 The `boundary` required parameter is common to all `multipart` subtypes, but does not need to be described explicitly in OpenAPI Descriptions as it is typically generated and used automatically, with a value that is not predictable in advance.
 
-Note that OAS v3.0 claimed support for `multipart/mixed`, but did not define a mechanism for doing so for reasons that are no longer known.  This claim of support was removed in OAS v3.0.4 and OAS v3.1.1, but can be seen in older patch releases of the 3.0 and 3.1 lines.
+Note that OAS v3.0 claimed support for `multipart/mixed`, but behaviour was undefined.  The claim of support was removed in OAS v3.0.4 and OAS v3.1.1, but can be seen in older patch releases of the 3.0 and 3.1 lines.
 {% endcapture %}
 
 {% include media-type-entry.md summary=summary remarks=remarks %}

--- a/registries/_media-type/sse.md
+++ b/registries/_media-type/sse.md
@@ -1,0 +1,29 @@
+---
+owner: handrews
+description: Server-Sent Events
+media_types:
+  - name: text/event-stream
+    registered: false
+references:
+  - section: Sequential Media Types
+    anchor: sequential-media-types
+  - section: Special Considerations for `text/event-stream` Content
+    anchor: special-considerations-for-text-event-stream-conten
+  - section: Server-Sent Event Streams (example)
+    anchor: server-sent-event-streams
+layout: default
+---
+
+{% capture summary %}
+Server-Sent Events use the `text/event-stream` media type to stream events.
+Each event is modeled as if it were a JSON object with fields and types
+as given in the SSE specification, ignoring comments (fields with an empty string for the name) and any variations in serialization that represent the same event content.
+{% endcapture %}
+
+{% capture remarks %}
+A complete event stream can be modeled as if it were a JSON array of such objects in the `schema` field, but the more common use case is to use the `itemSchema` field to apply the same schema to each event as it is streamed.
+
+Note that application-level conventions regarding event usage (e.g. "sentinel events") that are not part of the media type specification are not modeled, as the OAS does not currently (as of OAS v3.2) work with semantics above the media type level.
+{% endcapture %}
+
+{% include media-type-entry.md summary=summary remarks=remarks %}

--- a/registries/_media-type/sse.md
+++ b/registries/_media-type/sse.md
@@ -13,16 +13,16 @@ media_types:
 references:
   - section: Sequential Media Types
     anchor: sequential-media-types
-    parent: Media Types
-    parentAnchor: media-types
-  - section: Special Considerations for `text/event-stream` Content
-    anchor: special-considerations-for-text-event-stream-conten
-    parent: Media Type Object
+    parentObject: Media Type Object
     parentAnchor: media-type-object
-  - section: Server-Sent Event Stream
+  - section: Special Considerations for Server-Sent Events
+    anchor: special-considerations-for-server-sent-events
+    parentObject: Media Type Object
+    parentAnchor: media-type-object
+  - section: Server-Sent Event Stream (Examples)
     anchor: server-sent-event-streams
-    parent: Media Type Examples
-    parentAnchor: media-type-examples
+    parentObject: Media Type Object
+    parentAnchor: media-type-object
 layout: default
 ---
 

--- a/registries/_media-type/sse.md
+++ b/registries/_media-type/sse.md
@@ -1,16 +1,28 @@
 ---
 owner: handrews
-description: Server-Sent Events
+name: Server-Sent Events
+description: Event streams for SSE
 media_types:
   - name: text/event-stream
-    registered: false
+    iana: false
+    specifications:
+    - name: WHATWG HTML §Server-Sent Events
+      url: https://html.spec.whatwg.org/multipage/server-sent-events.html#parsing-an-event-stream
+    - name: WHATWG HTML §IANA
+      url: https://html.spec.whatwg.org/multipage/iana.html#text/event-stream
 references:
   - section: Sequential Media Types
     anchor: sequential-media-types
+    parent: Media Types
+    parentAnchor: media-types
   - section: Special Considerations for `text/event-stream` Content
     anchor: special-considerations-for-text-event-stream-conten
-  - section: Server-Sent Event Streams (example)
+    parent: Media Type Object
+    parentAnchor: media-type-object
+  - section: Server-Sent Event Stream
     anchor: server-sent-event-streams
+    parent: Media Type Examples
+    parentAnchor: media-type-examples
 layout: default
 ---
 

--- a/registries/_media-type/text.md
+++ b/registries/_media-type/text.md
@@ -1,11 +1,22 @@
 ---
 owner: handrews
-description: Text
+name: Text
+description: Text-based media types
 media_types:
   - name: text/*
-    registered: true
+    iana: https://www.iana.org/assignments/media-types/media-types.xhtml#text
+    specifications:
+    - name: RFC2045
+      url: https://www.rfc-editor.org/rfc/rfc2045
+    - name: RFC2046 §4.1
+      url: https://www.rfc-editor.org/rfc/rfc2046#section-4.1
   - name: text/plain
-    registered: true
+    iana: https://www.iana.org/assignments/media-types/text/plain
+    specifications:
+    - name: RFC2046 §4.1.3
+      url: https://www.rfc-editor.org/rfc/rfc2046#section-4.1.3
+    - name: RFC3676
+      url: https://www.rfc-editor.org/rfc/rfc3676
 default_for: text-based (not just <tt>text/*</tt>)
 references:
   - section: Parameter Object
@@ -27,7 +38,7 @@ A plain text document is modeled as a single string.
 In addition to normal use as HTTP message contents or `multipart` parts, `text/plain` is useful with the `content` field of the Parameter Object or Header Object to work around the automatic percent-encoding triggered by the use of the `schema` field.
 In particular, cookies with multiple values are not well-served by `style: form` and are better modeled as text.
 
-Note that unlike JSON strings, the contents of the string representing the plain text are not quoted when serializing to a document.  While a Schema Object of `{type: string, const: foo}` for JSON validates the JSON value `"foo"`, for plain text it validates `foo`, without quotes.
+Note also that unlike JSON strings, the contents of the string representing the plain text are not quoted when serializing to a document.  While a Schema Object of `{type: string, const: foo}` for JSON validates the JSON value `"foo"`, for plain text it validates `foo`, without quotes.
 {% endcapture %}
 
 {% include media-type-entry.md summary=summary remarks=remarks %}

--- a/registries/_media-type/text.md
+++ b/registries/_media-type/text.md
@@ -1,0 +1,33 @@
+---
+owner: handrews
+description: Text
+media_types:
+  - name: text/*
+    registered: true
+  - name: text/plain
+    registered: true
+default_for: text-based (not just <tt>text/*</tt>)
+references:
+  - section: Parameter Object
+    anchor: parameter-object
+  - section: Header Object
+    anchor: header-object
+  - section: Encoding Object
+    anchor: encoding-object
+  - section: "Appendix D: Serializing Headers and Cookies"
+    anchor: appendix-d-serializing-headers-and-cookies
+layout: default
+---
+
+{% capture summary %}
+A plain text document is modeled as a single string.
+{% endcapture %}
+
+{% capture remarks %}
+In addition to normal use as HTTP message contents or `multipart` parts, `text/plain` is useful with the `content` field of the Parameter Object or Header Object to work around the automatic percent-encoding triggered by the use of the `schema` field.
+In particular, cookies with multiple values are not well-served by `style: form` and are better modeled as text.
+
+Note that unlike JSON strings, the contents of the string representing the plain text are not quoted when serializing to a document.  While a Schema Object of `{type: string, const: foo}` for JSON validates the JSON value `"foo"`, for plain text it validates `foo`, without quotes.
+{% endcapture %}
+
+{% include media-type-entry.md summary=summary remarks=remarks %}

--- a/registries/_media-type/text.md
+++ b/registries/_media-type/text.md
@@ -25,8 +25,6 @@ references:
     anchor: header-object
   - section: Encoding Object
     anchor: encoding-object
-  - section: "Appendix D: Serializing Headers and Cookies"
-    anchor: appendix-d-serializing-headers-and-cookies
 layout: default
 ---
 
@@ -35,10 +33,7 @@ A plain text document is modeled as a single string.
 {% endcapture %}
 
 {% capture remarks %}
-In addition to normal use as HTTP message contents or `multipart` parts, `text/plain` is useful with the `content` field of the Parameter Object or Header Object to work around the automatic percent-encoding triggered by the use of the `schema` field.
-In particular, cookies with multiple values are not well-served by `style: form` and are better modeled as text.
-
-Note also that unlike JSON strings, the contents of the string representing the plain text are not quoted when serializing to a document.  While a Schema Object of `{type: string, const: foo}` for JSON validates the JSON value `"foo"`, for plain text it validates `foo`, without quotes.
+Note that unlike JSON strings, the contents of the string representing the plain text are not quoted when serializing to a document.  While a Schema Object of `{type: string, const: foo}` for JSON validates the JSON value `"foo"`, for plain text it validates `foo`, without quotes.
 {% endcapture %}
 
 {% include media-type-entry.md summary=summary remarks=remarks %}

--- a/registries/_media-type/xml.md
+++ b/registries/_media-type/xml.md
@@ -1,14 +1,28 @@
 ---
 owner: handrews
-description: XML
+name: XML
+description: Extensible markup language
 media_types:
   - name: application/xml
-    registered: true
+    iana: https://www.iana.org/assignments/media-types/application/xml
+    specifications:
+    - name: RFC7303
+      url: https://www.rfc-editor.org/rfc/rfc7303
+    - name: XML 1.0
+      url: https://www.w3.org/TR/xml/
+      note: commonly used
+    - name: XML 1.1
+      url: https://www.w3.org/TR/xml11/
+      note: rarely used
+    - name: WHATWG DOM
+      url: https://dom.spec.whatwg.org/
 references:
   - section: XML Object
     anchor: xml-object
   - section: XML Modeling
     anchor: xml-modeling
+    parent: Schema Object
+    parentAnchor: schema-object
 layout: default
 ---
 
@@ -17,7 +31,7 @@ XML is modeled using the OAS's `xml` extension keyword for JSON Schema, which ha
 {% endcapture %}
 
 {% capture remarks %}
-As of OAS v3.2, the XML Object uses the `nodeType` field to determine the type of [interface node](https://dom.spec.whatwg.org/#interface-node) to which a given Schema Object corresponds: `element`, `attribute`, `text`, `cdata`, or `none`.  If `nodeType` is set to `none`, a Schema Object does not correspond to anything and the nodes corresponding to its immediate subschemas are placed directly under the node of its parent schema.
+As of OAS v3.2, the [XML Object](https://spec.openapis.org/oas/latest.html#xml-object) uses the `nodeType` field to determine the type of [interface node](https://dom.spec.whatwg.org/#interface-node) to which a given Schema Object corresponds: `element`, `attribute`, `text`, `cdata`, or `none`.  If `nodeType` is set to `none`, a Schema Object does not correspond to anything and the nodes corresponding to its immediate subschemas are placed directly under the node of its parent schema.
 
 Certain behaviors are retained for compatibility with OAS v3.1, including implicit text nodes for elements with a primitive type, and somewhat complex rules for the default value of `nodeType`.
 In OAS v3.1 and earlier, only elements, their implicit primitive-type text nodes, and attributes were supported, with the now-deprecated `attribute` and `wrapped` flags as controls.

--- a/registries/_media-type/xml.md
+++ b/registries/_media-type/xml.md
@@ -1,0 +1,26 @@
+---
+owner: handrews
+description: XML
+media_types:
+  - name: application/xml
+    registered: true
+references:
+  - section: XML Object
+    anchor: xml-object
+  - section: XML Modeling
+    anchor: xml-modeling
+layout: default
+---
+
+{% capture summary %}
+XML is modeled using the OAS's `xml` extension keyword for JSON Schema, which has an XML Object as its value.
+{% endcapture %}
+
+{% capture remarks %}
+As of OAS v3.2, the XML Object uses the `nodeType` field to determine the type of [interface node](https://dom.spec.whatwg.org/#interface-node) to which a given Schema Object corresponds: `element`, `attribute`, `text`, `cdata`, or `none`.  If `nodeType` is set to `none`, a Schema Object does not correspond to anything and the nodes corresponding to its immediate subschemas are placed directly under the node of its parent schema.
+
+Certain behaviors are retained for compatibility with OAS v3.1, including implicit text nodes for elements with a primitive type, and somewhat complex rules for the default value of `nodeType`.
+In OAS v3.1 and earlier, only elements, their implicit primitive-type text nodes, and attributes were supported, with the now-deprecated `attribute` and `wrapped` flags as controls.
+{% endcapture %}
+
+{% include media-type-entry.md summary=summary remarks=remarks %}

--- a/registries/_media-type/xml.md
+++ b/registries/_media-type/xml.md
@@ -21,7 +21,7 @@ references:
     anchor: xml-object
   - section: XML Modeling
     anchor: xml-modeling
-    parent: Schema Object
+    parentObject: Schema Object
     parentAnchor: schema-object
 layout: default
 ---

--- a/registry/media-type.md
+++ b/registry/media-type.md
@@ -8,7 +8,7 @@ parent: Registry
 # Media Type Registry
 
 This registry lists the non-JSON media types addressed by the OpenAPI Specification (OAS), and links to the appropriate OAS sections and external specifications.
-See [Working With Data](https://spec.openapis.org/oas/latest.html#working-with-data) and [Parsing and Serializing](https://spec.openapis.org/oas/latest.html#parsing-and-serializing) for a discussion of serialized, schema-ready, and application forms of data, and how to convert among the forms.
+See [Parsing and Serializing](https://spec.openapis.org/oas/latest.html#parsing-and-serializing) for a discussion of serialized, schema-ready, and application forms of data, and how to convert among the forms.
 
 ## Specification Versions
 

--- a/registry/media-type.md
+++ b/registry/media-type.md
@@ -22,8 +22,8 @@ Please open a [discussion](https://github.com/OAI/OpenAPI-Specification/discussi
 
 **Note:** Media types with a structured suffix are handled the same way as the media type corresponding to the suffix (e.g. all `+json` media types are handled as `application/json`).
 
-|Group|Media Types|
-|---|---|
-{% for value in site.media-type %}| <a href="{{ value.slug }}">{{ value.description }}</a> | {% for mt in value.media_types %}<tt>{{ mt.name }}</tt>{% unless forloop.last %}<br />{% endunless%}{% endfor %}{% if value.default_for %}<br />any unknown {{ value.default_for }} media type{% endif %}|
+|Group|Description|Media Types|
+|---|---|---|
+{% for value in site.media-type %}| <a href="{{ value.slug }}">{{ value.name }}</a> | {{ value.description }} | {% for mt in value.media_types %}<tt>{{ mt.name }}</tt>{% unless forloop.last %}<br />{% endunless%}{% endfor %}{% if value.default_for %}<br />any unrecognized {{ value.default_for }} media type{% endif %}|
 {% endfor %}
 

--- a/registry/media-type.md
+++ b/registry/media-type.md
@@ -1,0 +1,29 @@
+---
+title: Media Type Registry
+layout: default
+permalink: /registry/media-type/index.html
+parent: Registry
+---
+
+# Media Type Registry
+
+This registry lists the non-JSON media types addressed by the OpenAPI Specification (OAS), and links to the appropriate OAS sections and external specifications.
+See [Working With Data](https://spec.openapis.org/oas/latest.html#working-with-data) and [Parsing and Serializing](https://spec.openapis.org/oas/latest.html#parsing-and-serializing) for a discussion of serialized, schema-ready, and application forms of data, and how to convert among the forms.
+
+## Specification Versions
+
+This registry is for and [linked from](https://spec.openapis.org/oas/latest.html#media-types)  version 3.2 and later of the OAS.  Earlier versions and other specifications such as Arazzo MAY support approaches added in this registry, as long as the necessary Objects and fields are available in those versions.
+
+## Contributing
+
+Please open a [discussion](https://github.com/OAI/OpenAPI-Specification/discussions) explaining your _**use cases**_ for any media type(s) you would like to see added.
+
+## Media Types
+
+**Note:** Media types with a structured suffix are handled the same way as the media type corresponding to the suffix (e.g. all `+json` media types are handled as `application/json`).
+
+|Group|Media Types|
+|---|---|
+{% for value in site.media-type %}| <a href="{{ value.slug }}">{{ value.description }}</a> | {% for mt in value.media_types %}<tt>{{ mt.name }}</tt>{% unless forloop.last %}<br />{% endunless%}{% endfor %}{% if value.default_for %}<br />any unknown {{ value.default_for }} media type{% endif %}|
+{% endfor %}
+


### PR DESCRIPTION
_[**NOTE:** This is only a "draft" to keep it from being published too early.  It is fully ready for review.]_

This registry groups media types by their data modeling approaches, and provides pages that give a brief overview of that approach as well as links to relevant OAS sections. The section titles and anchors are intended to work with 3.2 (so we should not publish it until 3.2 is published).

The summary and remarks are only intended to give the general idea of how the media types work, and what changes have been made from release to release.

This initial set only includes media types that are mentioned in the OAS, but the layout should work without needing any links to such sections.  We'll have to decide how much detail to put if and when we start making additions outside of the OAS, which we hope to eventually do.  The point of this is to not require a minor OAS version to add future media types, as long as they do not require new fields or Objects.

I omitted YAML since AFAIK it is rarely used in actual API payloads, and the OAS provides no guidance on how to handle YAML features that are not compatible with JSON.  And of course for JSON-compatible YAML, you just treat it like JSON.
