### PR TITLE
3.1 schema tests: keyword coverage

### DIFF
--- a/tests/schema/pass/link-object-examples.yaml
+++ b/tests/schema/pass/link-object-examples.yaml
@@ -45,6 +45,10 @@ paths:
               operationRef: https://na2.gigantic-server.com/#/paths/~12.0~1repositories~1%7Busername%7D/get
               parameters:
                 username: $response.body#/username
+            withBody:
+              operationId: queryUserWithBody
+              requestBody:
+                userId: $request.path.id
   # the path item of the linked operation
   /users/{userid}/address:
     parameters:

--- a/tests/schema/pass/schema-object-deprecated-example-keyword.yaml
+++ b/tests/schema/pass/schema-object-deprecated-example-keyword.yaml
@@ -1,0 +1,18 @@
+openapi: 3.1.0
+info:
+  title: API
+  version: 1.0.0
+paths:
+  /user:
+    parameters:
+      - in: query
+        name: example
+        schema:
+          # Allow an arbitrary JSON object to keep
+          # the example simple
+          type: object
+          # DEPRECATED: don't use example keyword inside Schema Object
+          example: {
+            "numbers": [1, 2],
+            "flag": null
+          }

--- a/tests/schema/pass/specification-extensions.yaml
+++ b/tests/schema/pass/specification-extensions.yaml
@@ -1,0 +1,6 @@
+openapi: 3.1.0
+info:
+  title: API
+  version: 1.0.0
+paths: {}
+x-tensions: specification extensions are prefixed with `x-`

--- a/tests/schema/schema.test.mjs
+++ b/tests/schema/schema.test.mjs
@@ -14,6 +14,24 @@ await registerSchema("./src/schemas/validation/schema.yaml");
 const fixtures = './tests/schema';
 
 describe("v3.1", () => {
+  test("schema.yaml schema test", async () => {
+    // Files in the pass/fail folders get run against schema-base.yaml.
+    // This instance is instead run against schema.yaml.
+    const oad = {
+      openapi: "3.1.0",
+      info: {
+        title: "API",
+        version: "1.0.0"
+      },
+      components: {
+        schemas: {
+          foo: {}
+        }
+      }
+    };
+    await expect(oad).to.matchJsonSchema("./src/schemas/validation/schema.yaml"); // <-- "schema.yaml" instead of "schema-base.yaml"
+  });
+
   describe("Pass", () => {
     readdirSync(`${fixtures}/pass`, { withFileTypes: true })
       .filter((entry) => entry.isFile() && /\.yaml$/.test(entry.name))


### PR DESCRIPTION
Raise keyword/line coverage of our OAS schemas to 100% by adding "pass" test cases:
- Link Object with `requestBody`
- Schema Object with (deprecated) `example` keyword
- Specification Extension
- technical test: Schema Object via `schema.yaml` instead of `schema-base.yaml`

<!--
Thank you for contributing to the OpenAPI Specification!

Please make certain you are submitting your PR on the correct
branch, to the files under the "src/" directory (which is not
present on the main branch, only on the development branches).

* 3.1.x spec and schemas: v3.1-dev branch
* 3.2.x spec and schemas: v3.2-dev branch
* registry templates: gh-pages branch, registry/...
* registry contents: gh-pages branch, registries/...
* process documentation and build infrastructure: main

Note that we do not accept changes to published specifications.
-->

<!-- Tick one of the following options: -->

- [ ] schema changes are included in this pull request
- [ ] schema changes are needed for this pull request but not done yet
- [x] no schema changes are needed for this pull request
