### PR TITLE
Reusable request bodies need a name

### DIFF
--- a/tests/schema/fail/encoding-enc-item-exclusion.yaml
+++ b/tests/schema/fail/encoding-enc-item-exclusion.yaml
@@ -4,9 +4,10 @@ info:
   version: 1.0.0
 components:
   requestBodies:
-    content:
-      multipart/mixed:
-        prefixEncoding:
-        - contentType: multipart/mixed
-          encoding: {}
-          prefixEncoding: []
+    encoding-with-prefixEncoding-not-allowed:
+      content:
+        multipart/mixed:
+          prefixEncoding:
+          - contentType: multipart/mixed
+            encoding: {}
+            prefixEncoding: []

--- a/tests/schema/fail/encoding-enc-prefix-exclusion.yaml
+++ b/tests/schema/fail/encoding-enc-prefix-exclusion.yaml
@@ -4,9 +4,10 @@ info:
   version: 1.0.0
 components:
   requestBodies:
-    content:
-      multipart/mixed:
-        prefixEncoding:
-        - contentType: multipart/mixed
-          encoding: {}
-          itemEncoding: []
+    encoding-with-itemEncoding-not-allowed:
+      content:
+        multipart/mixed:
+          prefixEncoding:
+          - contentType: multipart/mixed
+            encoding: {}
+            itemEncoding: []


### PR DESCRIPTION
Two of the new "fail" test cases fail for the wrong reason: the name of the reuse component was missing.

With this change they fail for the right reason.

<!--
Thank you for contributing to the OpenAPI Specification!

Please make certain you are submitting your PR on the correct
branch, to the files under the "src/" directory (which is not
present on the main branch, only on the development branches).

* 3.1.x spec and schemas: v3.1-dev branch
* 3.2.x spec and schemas: v3.2-dev branch
* registry templates: gh-pages branch, registry/...
* registry contents: gh-pages branch, registries/...
* process documentation and build infrastructure: main

Note that we do not accept changes to published specifications.
-->

<!-- Tick one of the following options: -->

- [ ] schema changes are included in this pull request
- [ ] schema changes are needed for this pull request but not done yet
- [x] no schema changes are needed for this pull request
