### PR TITLE
3.2 schema tests: correct test suite name

### DIFF
--- a/tests/schema/schema.test.mjs
+++ b/tests/schema/schema.test.mjs
@@ -13,7 +13,7 @@ await registerOasSchema();
 await registerSchema("./src/schemas/validation/schema.yaml");
 const fixtures = './tests/schema';
 
-describe("v3.1", () => {
+describe("v3.2", () => {
   describe("Pass", () => {
     readdirSync(`${fixtures}/pass`, { withFileTypes: true })
       .filter((entry) => entry.isFile() && /\.yaml$/.test(entry.name))


### PR DESCRIPTION
The old suite name "v3.1" was confusing when checking workflow logs.


- [x] no schema changes are needed for this pull request
