### PR TITLE
main: sync-dev-to-vX.Y-dev - wait after creating sync PR for status checks to be triggered

### DIFF
--- a/.github/workflows/sync-dev-to-vX.Y-dev.yaml
+++ b/.github/workflows/sync-dev-to-vX.Y-dev.yaml
@@ -46,7 +46,9 @@ jobs:
               --label "Housekeeping" \
               --title "$BASE: update from $HEAD" \
               --body "Merge \`$HEAD\` into \`$BASE\`.")
+            echo ""
             echo "PR to sync $DEV_BRANCH: $PR"
+            sleep 10 # allow status checks to be triggered
             
             gh pr checks $PR --watch --required || continue
             gh pr merge $PR --merge --admin


### PR DESCRIPTION
Wait for 10 seconds after creating a sync PR to allow triggering of its status checks.

The script already tests for pending status checks and waits for them to finish, but in rare cases that test can happen before the status checks are triggered.

<!--
Thank you for contributing to the OpenAPI Specification!

Please make certain you are submitting your PR on the correct
branch, to the files under the "src/" directory (which is not
present on the main branch, only on the development branches).

* 3.1.x spec and schemas: v3.1-dev branch
* 3.2.x spec and schemas: v3.2-dev branch
* registry templates: gh-pages branch, registry/...
* registry contents: gh-pages branch, registries/...
* process documentation and build infrastructure: main

Note that we do not accept changes to published specifications.
-->

<!-- Tick one of the following options: -->

- [ ] schema changes are included in this pull request
- [ ] schema changes are needed for this pull request but not done yet
- [x] no schema changes are needed for this pull request
