### PR TITLE
v3.2: Port of percent-encoding-related fixes from 3.1.2

### DIFF
--- a/src/oas.md
+++ b/src/oas.md
@@ -3112,15 +3112,13 @@ Requiring that a strong `ETag` header (with a value starting with `"` rather tha
 ```yaml
 ETag:
   required: true
-  content:
-    text/plain:
-      schema:
-        type: string
-        # Note that quotation markes are part of the
-        # ETag value, unlike many other headers that
-        # use a quoted string purely for managing
-        # reserved characters.
-        pattern: ^"
+  schema:
+    type: string
+    # Note that quotation markes are part of the
+    # ETag value, unlike many other headers that
+    # use a quoted string purely for managing
+    # reserved characters.
+    pattern: ^"
   example: '"xyzzy"'
 ```
 


### PR DESCRIPTION
This ports the following PRs, each in their own commit (@ralfhandl this was easily done because of the lack of interspersed merge commits 🙂 ), in the following order:

* PR #4819 
    * Fixes #4798 (headers part)
* PR #4820 
    * Fixes #4798 (`multipart` part)
* PR #4821 
    * Groundwork for fixing #4813
* PR #4826
    * only adding periods at the end of the list, which the commit message has been updated to say- it was otherwise a backport from 3.2 to 3.1.2
* PR #4825 
    * Fixes #4813 

Once this is merged, I can finish the `style: cookie` PR, and fix `allowReserved` to only apply to `in` values of `path` and `query`, and do some other related 3.2-specific tweaks that I did not want to mix with the approved PRs.

- [X] no schema changes are needed for this pull request
