### PR TITLE
Update the editors list before releasing 3.2 and 3.1.2

### DIFF
--- a/EDITORS.md
+++ b/EDITORS.md
@@ -4,7 +4,7 @@
 
 * Henry Andrews [@handrews](https://github.com/handrews)
 * Jeremy Whitlock [@whitlockjc](https://github.com/whitlockjc)
-* Karen Etheridge [karenetheridge](https://github.com/karenetheridge)
+* Karen Etheridge [@karenetheridge](https://github.com/karenetheridge)
 * Lorna Mitchell [@lornajane](https://github.com/lornajane)
 * Marsh Gardiner [@earth2marsh](https://github.com/earth2marsh)
 * Miguel Quintero [@miqui](https://github.com/miqui)

--- a/EDITORS.md
+++ b/EDITORS.md
@@ -2,18 +2,20 @@
 
 ## Active
 
-* Darrel Miller [@darrelmiller](https://github.com/darrelmiller)
 * Henry Andrews [@handrews](https://github.com/handrews)
 * Jeremy Whitlock [@whitlockjc](https://github.com/whitlockjc)
+* Karen Etheridge [karenetheridge](https://github.com/karenetheridge)
 * Lorna Mitchell [@lornajane](https://github.com/lornajane)
 * Marsh Gardiner [@earth2marsh](https://github.com/earth2marsh)
 * Miguel Quintero [@miqui](https://github.com/miqui)
 * Mike Kistler [@mikekistler](https://github.com/mikekistler)
 * Ralf Handl [@ralfhandl](https://github.com/ralfhandl)
 * Ron Ratovsky [@webron](https://github.com/webron)
+* Vincent Biret [@baywet](https://github.com/baywet)
 
 ## Emeritus
 
+* Darrel Miller [@darrelmiller](https://github.com/darrelmiller)
 * Mike Ralphson [@MikeRalphson](https://github.com/MikeRalphson)
 * Uri Sarid [@usarid](https://github.com/usarid)
 * Jason Harmon [@jharmn](https://github.com/jharmn)


### PR DESCRIPTION
For the upcoming releases, I am proposing to credit TSC (updated to put Darrel on the Emeritus list) plus:
 - @handrews
 - @karenetheridge 
 - @baywet 

I'll tag you three as reviewers, could you please approve to indicate that you're happy to be named? And @OAI/tsc you can also approve - then we need to propagate the change to the relevant dev branches before building the releases.