### PR TITLE
3.1 XML With `null` Values: remove confusing sentence

### DIFF
--- a/src/oas.md
+++ b/src/oas.md
@@ -3863,7 +3863,6 @@ animals:
 ###### XML With `null` Values
 
 Recall that the schema validates the in-memory data, not the XML document itself.
-The properties of the `"metadata"` element are omitted for brevity as it is here to show how the `null` value is represented.
 
 ```json
 {


### PR DESCRIPTION
The removed sentence sounds like a left-over from a more complicated example, I can't find a "metadata" element anywhere.

<!--
Thank you for contributing to the OpenAPI Specification!

Please make certain you are submitting your PR on the correct
branch, to the files under the "src/" directory (which is not
present on the main branch, only on the development branches).

* 3.1.x spec and schemas: v3.1-dev branch
* 3.2.x spec and schemas: v3.2-dev branch
* registry templates: gh-pages branch, registry/...
* registry contents: gh-pages branch, registries/...
* process documentation and build infrastructure: main

Note that we do not accept changes to published specifications.
-->

<!-- Tick one of the following options: -->

- [ ] schema changes are included in this pull request
- [ ] schema changes are needed for this pull request but not done yet
- [x] no schema changes are needed for this pull request
