### PR TITLE
gh-pages: fix uplinks from registry entry to registry page

### DIFF
--- a/_includes/alternative-schema-entry.md
+++ b/_includes/alternative-schema-entry.md
@@ -1,4 +1,5 @@
-# <a href="..">{{ page.collection }}</a>
+{% assign registry = site.collections | where:"label", page.collection  | first %}
+# <a href=".">{{ registry.name }}</a>
 
 ## {{ page.slug }} - {{ page.description }}
 

--- a/_includes/extension-entry.md
+++ b/_includes/extension-entry.md
@@ -1,4 +1,5 @@
-# <a href="..">{{ page.collection }}</a>
+{% assign registry = site.collections | where:"label", page.collection  | first %}
+# <a href=".">{{ registry.name }}</a>
 
 ## {{ page.slug }} - {{ page.description }}
 

--- a/_includes/format-entry.md
+++ b/_includes/format-entry.md
@@ -1,4 +1,5 @@
-# <a href="..">{{ page.collection }}</a>
+{% assign registry = site.collections | where:"label", page.collection  | first %}
+# <a href=".">{{ registry.name }}</a>
 
 ## {{ page.slug }} - {{ page.description }}
 

--- a/_includes/namespace-entry.md
+++ b/_includes/namespace-entry.md
@@ -1,4 +1,5 @@
-# <a href="..">{{ page.collection }}</a>
+{% assign registry = site.collections | where:"label", page.collection  | first %}
+# <a href=".">{{ registry.name }}</a>
 
 ## {{ page.slug }} - {{ page.description }}
 

--- a/_includes/tag-kind-entry.md
+++ b/_includes/tag-kind-entry.md
@@ -1,4 +1,5 @@
-# <a href="..">{{ page.collection }}</a>
+{% assign registry = site.collections | where:"label", page.collection  | first %}
+# <a href=".">{{ registry.name }}</a>
 
 ## {{ page.slug }} - {{ page.description }}
 

--- a/registries/_draft-feature/alternativeSchema.md
+++ b/registries/_draft-feature/alternativeSchema.md
@@ -6,7 +6,8 @@ description: x-oas-draft-alternativeSchema
 layout: default
 ---
 
-# <a href="..">{{ page.collection }}</a>
+{% assign registry = site.collections | where:"label", page.collection  | first %}
+# <a href=".">{{ registry.name }}</a>
 
 ## {{ page.slug }} - {{ page.description }}
 


### PR DESCRIPTION
Fixes #4811 

Registry entry pages like https://spec.openapis.org/registry/format/base64url.html have an uplink at the top of the page that should lead back to the registry overview page:

<img width="932" height="175" alt="image" src="https://github.com/user-attachments/assets/0d2f20e3-0547-4dcd-b4d3-60313d717b36" />

Currently it leads back to the list of all registries, that is one step up too far.

Noticed this thanks to @handrews in #4808. He also uses the registry name instead of its technical label as uplink text, which looks nicer:

<img width="935" height="178" alt="image" src="https://github.com/user-attachments/assets/b428992f-c224-4b6d-81f1-ead97b5f0485" />


----

<!--
Thank you for contributing to the OpenAPI Specification!

Please make certain you are submitting your PR on the correct
branch, to the files under the "src/" directory (which is not
present on the main branch, only on the development branches).

* 3.1.x spec and schemas: v3.1-dev branch
* 3.2.x spec and schemas: v3.2-dev branch
* registry templates: gh-pages branch, registry/...
* registry contents: gh-pages branch, registries/...
* process documentation and build infrastructure: main

Note that we do not accept changes to published specifications.
-->

<!-- Tick one of the following options: -->

- [ ] schema changes are included in this pull request
- [ ] schema changes are needed for this pull request but not done yet
- [x] no schema changes are needed for this pull request
