### PR TITLE
v3.2: Update RFC1866 to WHATWG-URL for application/x-www-form-urlencoded

### DIFF
--- a/src/oas.md
+++ b/src/oas.md
@@ -5208,7 +5208,7 @@ For use in URIs, each part is encoded based on the media type (e.g. `text/plain`
 #### Interoperability with Historical Specifications
 
 Prior versions of this specification required [[?RFC1866]] and its use of [[?RFC1738]] percent-encoding rules in place of [[WHATWG-URL]].
-The [[WHATWG-URL]] `form-urlencoded` rules represent the current browser consensus on that media type, and avoid the ambiguity introduce by unclear paraphrasing of RFC1738 in RFC1866.
+The [[WHATWG-URL]] `form-urlencoded` rules represent the current browser consensus on that media type, and avoid the ambiguity introduced by unclear paraphrasing of RFC1738 in RFC1866.
 
 Users needing conformance with RFC1866/RFC1738 are advised to check their tooling and library behavior carefully.
 

--- a/src/oas.md
+++ b/src/oas.md
@@ -1191,7 +1191,7 @@ In order to support common ways of serializing simple parameters, a set of `styl
 
 All API URLs MUST successfully parse and percent-decode using [[RFC3986]] rules.
 
-Content in the `application/x-www-form-urlencoded` format, including query strings produced by [Parameter Objects](#parameter-object) with `in: "query"`, MUST also successfully parse and percent-decode using [[RFC1866]] rules, including treating non-percent-encoded `+` as an escaped space character.
+Content in the `application/x-www-form-urlencoded` format, including query strings produced by [Parameter Objects](#parameter-object) with `in: "query"`, MUST also successfully parse and percent-decode using [[WHATWG-URL]] rules, including treating non-percent-encoded `+` as an escaped space character.
 
 These requirements are specified in terms of percent-_decoding_ rules, which are consistently tolerant across different versions of the various standards that apply to URIs.
 
@@ -1201,10 +1201,10 @@ Percent-_encoding_ is performed in several places:
 * By the Parameter or [Encoding](#encoding-object) Objects when incorporating a value serialized with a [Media Type Object](#media-type-object) for a media type that does not already incorporate URI percent-encoding
 * By the user, prior to passing data through RFC6570's reserved expansion process
 
-When percent-encoding, the safest approach is to percent-encode all characters not in RFC3986's "unreserved" set, and for `form-urlencoded` to also percent-encode the tilde character (`~`) to align with the historical requirements of [[RFC1738]], which is cited by RFC1866.
+When percent-encoding, the safest approach is to percent-encode all characters not in RFC3986's "unreserved" set, and for `form-urlencoded` to also percent-encode the tilde character (`~`) to align with historical requirements that are traced back to [[RFC1738]], the URI RFC at the time `form-urlencoded` was created.
 This approach is used in examples in this specification.
 
-For `form-urlencoded`, while the encoding algorithm given by RFC1866 requires escaping the space character as `+`, percent-encoding it as `%20` also meets the above requirements.
+For `form-urlencoded`, while the encoding algorithm given by [[WHATWG-URL]] requires escaping the space character as `+`, percent-encoding it as `%20` also meets the above requirements.
 Examples in this specification will prefer `%20` when using RFC6570's default (non-reserved) form-style expansion, and `+` otherwise.
 
 Reserved characters MUST NOT be percent-encoded when being used for reserved purposes such as `&=+` for `form-urlencoded` or `,` for delimiting non-exploded array and object values in RFC6570 expansions.
@@ -2005,8 +2005,8 @@ Implementations MUST support one level of nesting, and MAY support additional le
 
 ##### Encoding the `x-www-form-urlencoded` Media Type
 
-To work with content using form url encoding via [RFC1866](https://tools.ietf.org/html/rfc1866), use the `application/x-www-form-urlencoded` media type in the [Media Type Object](#media-type-object).
-This configuration means that the content MUST be encoded per [RFC1866](https://tools.ietf.org/html/rfc1866) when passed to the server, after any complex objects have been serialized to a string representation.
+To work with content using form url encoding via [[WHATWG-URL]], use the `application/x-www-form-urlencoded` media type in the [Media Type Object](#media-type-object).
+This configuration means that the content MUST be percent-encoded per [[WHATWG-URL]]'s rules for that media type, after any complex objects have been serialized to a string representation.
 
 See [Appendix E](#appendix-e-percent-encoding-and-form-media-types) for a detailed examination of percent-encoding concerns for form media types.
 


### PR DESCRIPTION
This updates our reference for `application/x-www-form-urlencoded`.  The question of whether it is strictly compatible is very hard to answer, as RFC1866 paraphrases RFC1738 _incorrectly_, and implementations that I can find that use these don't behave quite like either the paraphrase or the actual requirements.  Which are hard to figure out in the first place.

Given that we are defining percent-encoding in terms of whether you can successfully _decode_ the encoded string, this is compatible.  If we think in terms of exactly what gets encoded, it's not, but also it's probably never been implemented "correctly" because I've never seen a library that percent-encoded _every_ non-alphanumeric character (RFC1866's paraphrase), and the most strict reading of RFC1738 is problematic in terms of its successor, RFC3986, although all in weird corners that would take several more paragraphs to explain.

I think this update is an improvement, as it brings us in line with the current IANA-registered specification for `form-urlencoded`, and is less of a nightmare to try to understand by reading the source specifications.

<!--
Thank you for contributing to the OpenAPI Specification!

Please make certain you are submitting your PR on the correct
branch, to the files under the "src/" directory (which is not
present on the main branch, only on the development branches).

* 3.1.x spec and schemas: v3.1-dev branch
* 3.2.x spec and schemas: v3.2-dev branch
* registry templates: gh-pages branch, registry/...
* registry contents: gh-pages branch, registries/...
* process documentation and build infrastructure: main

Note that we do not accept changes to published specifications.
-->

<!-- Tick one of the following options: -->

- [ ] schema changes are included in this pull request
- [ ] schema changes are needed for this pull request but not done yet
- [X] no schema changes are needed for this pull request
