### PR TITLE
fix: fix type for Header.schema fixed field

### DIFF
--- a/src/oas.md
+++ b/src/oas.md
@@ -2622,7 +2622,7 @@ The `example` and `examples` fields are mutually exclusive, and if either is pre
 | ---- | :----: | ---- |
 | <a name="header-style"></a>style | `string` | Describes how the header value will be serialized. The default (and only legal value for headers) is `"simple"`. |
 | <a name="header-explode"></a>explode | `boolean` | When this is true, header values of type `array` or `object` generate a single header whose value is a comma-separated list of the array items or key-value pairs of the map, see [Style Examples](#style-examples). For other data types this field has no effect. The default value is `false`. |
-| <a name="header-schema"></a>schema | [Schema Object](#schema-object) \| [Reference Object](#reference-object) | The schema defining the type used for the header. |
+| <a name="header-schema"></a>schema | [Schema Object](#schema-object) | The schema defining the type used for the header. |
 | <a name="header-example"></a>example | Any | Example of the header's potential value; see [Working With Examples](#working-with-examples). |
 | <a name="header-examples"></a>examples | Map[ `string`, [Example Object](#example-object) \| [Reference Object](#reference-object)] | Examples of the header's potential value; see [Working With Examples](#working-with-examples). |
 


### PR DESCRIPTION
Affected section: https://spec.openapis.org/oas/v3.1.1.html#fixed-fields-for-use-with-schema-0

<img width="803" height="68" alt="image" src="https://github.com/user-attachments/assets/8a1dd173-433d-44ee-8b50-f17a3400de00" />

`Schema Object | Reference Object` would create ambiguity as both objects can only have `$ref` field. When `Schema Object` is a type for a field, it shouldn't use union with `Reference Object` as the `Schema Object` is already reference-able by  itself.

<!--
Thank you for contributing to the OpenAPI Specification!

Please make certain you are submitting your PR on the correct
branch, to the files under the "src/" directory (which is not
present on the main branch, only on the development branches).

* 3.1.x spec and schemas: v3.1-dev branch
* 3.2.x spec and schemas: v3.2-dev branch
* registry templates: gh-pages branch, registry/...
* registry contents: gh-pages branch, registries/...
* process documentation and build infrastructure: main

Note that we do not accept changes to published specifications.
-->

<!-- Tick one of the following options: -->

- [ ] schema changes are included in this pull request
- [ ] schema changes are needed for this pull request but not done yet
- [x] no schema changes are needed for this pull request
