### PR TITLE
OAD schema fix 'parameter object' + in: querystring forbidden fields

### DIFF
--- a/src/schemas/validation/schema.yaml
+++ b/src/schemas/validation/schema.yaml
@@ -392,12 +392,6 @@ $defs:
         then:
           required:
             - content
-          not:
-            required:
-              - schema
-              - style
-              - explode
-              - allowReserved
     dependentSchemas:
       schema:
         properties:

--- a/tests/schema/fail/parameter-object-content-not-with-style.yaml
+++ b/tests/schema/fail/parameter-object-content-not-with-style.yaml
@@ -1,0 +1,14 @@
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  parameters:
+    content-not-with-style:
+      in: querystring
+      name: json
+      content:
+        application/json:
+          schema:
+            type: object
+      style: simple

--- a/tests/schema/fail/parameter-object-querystring-not-with-schema.yaml
+++ b/tests/schema/fail/parameter-object-querystring-not-with-schema.yaml
@@ -1,0 +1,11 @@
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  parameters:
+    querystring-not-with-schema:
+      in: querystring
+      name: json
+      schema:
+        type: object


### PR DESCRIPTION
https://github.com/OAI/OpenAPI-Specification/pull/4590 introduces parameter object with `in: querystring`, which may not have properties `schema`, `style`, `explode`, or `allowReserved`. The accompanying schema change only forbids an object with _all_ of those four properties, though. This fixes to forbid any of them.

- [x] schema changes are included in this pull request
- [ ] schema changes are needed for this pull request but not done yet
- [ ] no schema changes are needed for this pull request
