### PR TITLE
fix: header and parameter objects cannot have examples with "content"

### DIFF
--- a/src/schemas/validation/schema.yaml
+++ b/src/schemas/validation/schema.yaml
@@ -369,8 +369,8 @@ $defs:
         - schema
       - required:
         - content
+    $ref: '#/$defs/specification-extensions'
     allOf:
-      - $ref: '#/$defs/specification-extensions'
       - if:
           properties:
             in:
@@ -539,14 +539,14 @@ $defs:
           $ref: '#/$defs/encoding'
       itemEncoding:
         $ref: '#/$defs/encoding'
+    dependentSchemas:
+      encoding:
+        properties:
+          prefixEncoding: false
+          itemEncoding: false
     allOf:
       - $ref: '#/$defs/examples'
       - $ref: '#/$defs/specification-extensions'
-      - dependentSchemas:
-          encoding:
-            properties:
-              prefixEncoding: false
-              itemEncoding: false
     unevaluatedProperties: false
 
   media-type-or-reference:
@@ -592,14 +592,14 @@ $defs:
           $ref: '#/$defs/encoding'
       itemEncoding:
         $ref: '#/$defs/encoding'
+    dependentSchemas:
+      encoding:
+        properties:
+          prefixEncoding: false
+          itemEncoding: false
     allOf:
       - $ref: '#/$defs/specification-extensions'
       - $ref: '#/$defs/styles-for-form'
-      - dependentSchemas:
-          encoding:
-            properties:
-              prefixEncoding: false
-              itemEncoding: false
     unevaluatedProperties: false
 
   responses:
@@ -784,8 +784,7 @@ $defs:
             default: false
             type: boolean
         $ref: '#/$defs/examples'
-    allOf:
-    - $ref: '#/$defs/specification-extensions'
+    $ref: '#/$defs/specification-extensions'
     unevaluatedProperties: false
 
   header-or-reference:

--- a/src/schemas/validation/schema.yaml
+++ b/src/schemas/validation/schema.yaml
@@ -370,7 +370,6 @@ $defs:
       - required:
         - content
     allOf:
-      - $ref: '#/$defs/examples'
       - $ref: '#/$defs/specification-extensions'
       - if:
           properties:
@@ -403,6 +402,7 @@ $defs:
             default: false
             type: boolean
         allOf:
+          - $ref: '#/$defs/examples'
           - $ref: '#/$defs/parameter/dependentSchemas/schema/$defs/styles-for-path'
           - $ref: '#/$defs/parameter/dependentSchemas/schema/$defs/styles-for-header'
           - $ref: '#/$defs/parameter/dependentSchemas/schema/$defs/styles-for-query'
@@ -785,7 +785,6 @@ $defs:
             type: boolean
         $ref: '#/$defs/examples'
     allOf:
-    - $ref: '#/$defs/examples'
     - $ref: '#/$defs/specification-extensions'
     unevaluatedProperties: false
 


### PR DESCRIPTION
The examples instead belong with the media-type object found below.

Also contains a few small no-op optimizations.


<!-- Tick one of the following options: -->

- [x] schema changes are included in this pull request
