### PR TITLE
v3.1: "example" and "examples" cannot appear together

### DIFF
--- a/src/schemas/validation/schema.yaml
+++ b/src/schemas/validation/schema.yaml
@@ -951,6 +951,10 @@ $defs:
         type: object
         additionalProperties:
           $ref: '#/$defs/example-or-reference'
+    not:
+      required:
+        - example
+        - examples
 
   map-of-strings:
     type: object

--- a/tests/schema/fail/example-examples.yaml
+++ b/tests/schema/fail/example-examples.yaml
@@ -1,0 +1,20 @@
+openapi: 3.1.1
+
+# this example should fail, as example cannot be used together with examples.
+
+info:
+  title: API
+  version: 1.0.0
+components:
+  parameters:
+    animal:
+      name: animal
+      in: header
+      schema: {}
+      example: bear
+      examples:
+        a mammalian example:
+          value: bear
+
+
+    


### PR DESCRIPTION
This affects the places where examples are used: parameter, header, and media-type objects

for #4598 and #4776, ported from #4912.

- [x] schema changes are included in this pull request
