### PR TITLE
Explain current policy on schema dates.

### DIFF
--- a/index.md
+++ b/index.md
@@ -37,7 +37,7 @@ Registry shortcuts:
 
 _Note that while schemas can catch many errors, they are not guaranteed to catch all specification violations.  In the event of a disagreement between the schemas and the corresponding specificaton text, the specification text is presumed to be correct._
 
-All schemas for a given minor release (e.g. OAS 3.1) apply to all patch releases within that minor release (e.g. 3.1.0, 3.1.1, 3.1.2, etc.).  The dates are purely a way to uniquely identify the revision, and are not intended to be correlated with patch release publication dates.  The latest date within a minor release is always the most correct schema for all patch releases, and previous versions are obsolete.
+A minor release (e.g. OAS 3.1) has one or more published schemas, identified with the release 3.1 and a revision date like 2021-03-02.  All schemas for a given minor release apply to all patch releases within that minor release (e.g. 3.1.0, 3.1.1, 3.1.2, etc.).  The dates are purely a way to uniquely identify the revision, and are not intended to be correlated with patch release publication dates.  The latest date within a minor release is always the most correct schema for all patch releases, and previous versions are obsolete.
 
 ### Arazzo Schemas
 


### PR DESCRIPTION
There are currently discussions regarding how schema `$id`s are to be formulated and whether/how they relate to patch releases.  In order to have agreement on the starting point, let's document what the current expectation is.  I did not realize it was not already on here.

Approving this PR ***does not*** indicate agreement with the policy, nor does it reduce the chances of changing the policy in the near future.  We will likely need an explanation of the old dates even if we change the `$id` structure and move to a new policy.

This is my interpretation, ~~but we should have at least two TSC approvals on this to ensure that it is correct, even if usually for gh-pages we only require one maintainers approval.~~ (made it a draft as it is more to help our discussions than an urgent need to publish).

- [ ] schema changes are included in this pull request
- [ ] schema changes are needed for this pull request but not done yet
- [X] no schema changes are needed for this pull request
