### PR TITLE
v3.2 schema edits

### DIFF
--- a/src/schemas/validation/schema.yaml
+++ b/src/schemas/validation/schema.yaml
@@ -587,7 +587,6 @@ $defs:
         additionalProperties:
           $ref: '#/$defs/header-or-reference'
       style:
-        default: form
         enum:
           - form
           - spaceDelimited
@@ -596,7 +595,6 @@ $defs:
       explode:
         type: boolean
       allowReserved:
-        default: false
         type: boolean
       encoding:
         type: object
@@ -613,6 +611,20 @@ $defs:
         properties:
           prefixEncoding: false
           itemEncoding: false
+      style:
+        properties:
+          allowReserved:
+            default: false
+      explode:
+        properties:
+          style:
+            default: form
+          allowReserved:
+            default: false
+      allowReserved:
+        properties:
+          style:
+            default: form
     allOf:
       - $ref: '#/$defs/specification-extensions'
       - $ref: '#/$defs/styles-for-form'

--- a/src/schemas/validation/schema.yaml
+++ b/src/schemas/validation/schema.yaml
@@ -539,14 +539,14 @@ $defs:
           $ref: '#/$defs/encoding'
       itemEncoding:
         $ref: '#/$defs/encoding'
+    dependentSchemas:
+      encoding:
+        properties:
+          prefixEncoding: false
+          itemEncoding: false
     allOf:
       - $ref: '#/$defs/examples'
       - $ref: '#/$defs/specification-extensions'
-      - dependentSchemas:
-          encoding:
-            properties:
-              prefixEncoding: false
-              itemEncoding: false
     unevaluatedProperties: false
 
   media-type-or-reference:
@@ -592,14 +592,14 @@ $defs:
           $ref: '#/$defs/encoding'
       itemEncoding:
         $ref: '#/$defs/encoding'
+    dependentSchemas:
+      encoding:
+        properties:
+          prefixEncoding: false
+          itemEncoding: false
     allOf:
       - $ref: '#/$defs/specification-extensions'
       - $ref: '#/$defs/styles-for-form'
-      - dependentSchemas:
-          encoding:
-            properties:
-              prefixEncoding: false
-              itemEncoding: false
     unevaluatedProperties: false
 
   responses:

--- a/src/schemas/validation/schema.yaml
+++ b/src/schemas/validation/schema.yaml
@@ -485,7 +485,9 @@ $defs:
               properties:
                 style:
                   default: form
-                  const: form
+                  enum:
+                    - form
+                    - cookie
 
     unevaluatedProperties: false
 

--- a/src/schemas/validation/schema.yaml
+++ b/src/schemas/validation/schema.yaml
@@ -376,8 +376,6 @@ $defs:
           properties:
             in:
               const: query
-          required:
-            - in
         then:
           properties:
             allowEmptyValue:
@@ -387,8 +385,6 @@ $defs:
           properties:
             in:
               const: querystring
-          required:
-            - in
         then:
           required:
             - content
@@ -415,8 +411,6 @@ $defs:
               properties:
                 in:
                   const: path
-              required:
-                - in
             then:
               properties:
                 style:
@@ -435,8 +429,6 @@ $defs:
               properties:
                 in:
                   const: header
-              required:
-                - in
             then:
               properties:
                 style:
@@ -448,8 +440,6 @@ $defs:
               properties:
                 in:
                   const: query
-              required:
-                - in
             then:
               properties:
                 style:
@@ -465,8 +455,6 @@ $defs:
               properties:
                 in:
                   const: cookie
-              required:
-                - in
             then:
               properties:
                 style:
@@ -871,8 +859,6 @@ $defs:
           properties:
             type:
               const: apiKey
-          required:
-            - type
         then:
           properties:
             name:
@@ -891,8 +877,6 @@ $defs:
           properties:
             type:
               const: http
-          required:
-            - type
         then:
           properties:
             scheme:
@@ -921,8 +905,6 @@ $defs:
           properties:
             type:
               const: oauth2
-          required:
-            - type
         then:
           properties:
             flows:
@@ -938,8 +920,6 @@ $defs:
           properties:
             type:
               const: openIdConnect
-          required:
-            - type
         then:
           properties:
             openIdConnectUrl:

--- a/src/schemas/validation/schema.yaml
+++ b/src/schemas/validation/schema.yaml
@@ -204,7 +204,7 @@ $defs:
         additionalProperties:
           $ref: '#/$defs/media-type-or-reference'
     patternProperties:
-      '^(schemas|responses|parameters|examples|requestBodies|headers|securitySchemes|links|callbacks|pathItems|mediaTypes)$':
+      '^(?:schemas|responses|parameters|examples|requestBodies|headers|securitySchemes|links|callbacks|pathItems|mediaTypes)$':
         $comment: Enumerating all of the property names in the regex above is necessary for unevaluatedProperties to work as expected
         propertyNames:
           pattern: '^[a-zA-Z0-9._-]+$'

--- a/src/schemas/validation/schema.yaml
+++ b/src/schemas/validation/schema.yaml
@@ -783,7 +783,6 @@ $defs:
           allowReserved:
             default: false
             type: boolean
-        $ref: '#/$defs/examples'
     allOf:
     - $ref: '#/$defs/examples'
     - $ref: '#/$defs/specification-extensions'

--- a/src/schemas/validation/schema.yaml
+++ b/src/schemas/validation/schema.yaml
@@ -236,9 +236,7 @@ $defs:
         items:
           $ref: '#/$defs/server'
       parameters:
-        type: array
-        items:
-          $ref: '#/$defs/parameter-or-reference'
+        $ref: '#/$defs/parameters'
       additionalOperations:
         type: object
         additionalProperties:
@@ -295,9 +293,7 @@ $defs:
       operationId:
         type: string
       parameters:
-        type: array
-        items:
-          $ref: '#/$defs/parameter-or-reference'
+        $ref: '#/$defs/parameters'
       requestBody:
         $ref: '#/$defs/request-body-or-reference'
       responses:
@@ -333,6 +329,36 @@ $defs:
       - url
     $ref: '#/$defs/specification-extensions'
     unevaluatedProperties: false
+
+  parameters:
+    type: array
+    items:
+      $ref: '#/$defs/parameter-or-reference'
+    not:
+      allOf:
+        - contains:
+            type: object
+            properties:
+              in:
+                const: query
+            required:
+              - in
+        - contains:
+            type: object
+            properties:
+              in:
+                const: querystring
+            required:
+              - in
+    contains:
+      type: object
+      properties:
+        in:
+          const: querystring
+      required:
+        - in
+    minContains: 0
+    maxContains: 1
 
   parameter:
     $comment: https://spec.openapis.org/oas/v3.2#parameter-object

--- a/tests/schema/fail/example-examples.yaml
+++ b/tests/schema/fail/example-examples.yaml
@@ -15,6 +15,3 @@ components:
       examples:
         a mammalian example:
           dataValue: bear
-
-
-    

--- a/tests/schema/fail/invalid_schema_types.yaml
+++ b/tests/schema/fail/invalid_schema_types.yaml
@@ -10,4 +10,3 @@ components:
     invalid_null: null
     invalid_number: 0
     invalid_array: []
-

--- a/tests/schema/fail/operation-object-query-with-querystring.yaml
+++ b/tests/schema/fail/operation-object-query-with-querystring.yaml
@@ -1,0 +1,20 @@
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  pathItems:
+    my-path-item:
+      get:
+        description: a query parameter cannot be used together with a querystring parameter
+        parameters:
+          - name: myquerystring
+            in: querystring
+            content:
+              application/json:
+                schema:
+                  type: string
+          - name: myquery
+            in: query
+            schema:
+              type: string

--- a/tests/schema/fail/operation-object-two-querystrings.yaml
+++ b/tests/schema/fail/operation-object-two-querystrings.yaml
@@ -1,0 +1,20 @@
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  pathItems:
+    my-path-item:
+      get:
+        description: querystring cannot be used twice
+        parameters:
+          - name: myquerystring1
+            in: querystring
+            content:
+              application/json:
+                schema: {}
+          - name: myquerystring2
+            in: querystring
+            content:
+              application/json:
+                schema: {}

--- a/tests/schema/fail/path-item-object-query-with-querystring.yaml
+++ b/tests/schema/fail/path-item-object-query-with-querystring.yaml
@@ -1,0 +1,19 @@
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  pathItems:
+    my-path-item:
+      parameters:
+        - name: myquerystring
+          in: querystring
+          content:
+            application/json:
+              schema:
+                type: string
+        - name: myquery
+          in: query
+          schema:
+            type: string
+      get: {}

--- a/tests/schema/fail/path-item-object-two-querystrings.yaml
+++ b/tests/schema/fail/path-item-object-two-querystrings.yaml
@@ -1,0 +1,20 @@
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  pathItems:
+    my-path-item:
+      description: querystring cannot be used twice
+      parameters:
+        - name: myquerystring1
+          in: querystring
+          content:
+            application/json:
+              schema: {}
+        - name: myquerystring2
+          in: querystring
+          content:
+            application/json:
+              schema: {}
+      get: {}

--- a/tests/schema/pass/example-object-examples.yaml
+++ b/tests/schema/pass/example-object-examples.yaml
@@ -29,7 +29,7 @@ components:
               summary: This is a text example
               externalValue: https://foo.bar/examples/address-example.txt
   parameters:
-    with-example:   
+    with-example:
       name: zipCode
       in: query
       schema:

--- a/tests/schema/pass/parameter-object-examples.yaml
+++ b/tests/schema/pass/parameter-object-examples.yaml
@@ -52,6 +52,14 @@ paths:
                   type: number
                 long:
                   type: number
+      - in: cookie
+        name: my_cookie1
+        style: form
+        schema: {}
+      - in: cookie
+        name: my_cookie2
+        style: cookie
+        schema: {}
   /user:
     parameters:
       - in: querystring

--- a/tests/schema/pass/parameter-object-examples.yaml
+++ b/tests/schema/pass/parameter-object-examples.yaml
@@ -62,7 +62,6 @@ paths:
               # Allow an arbitrary JSON object to keep
               # the example simple
               type: object
-            example: {
-              "numbers": [1, 2],
-              "flag": null
-            }
+            example:
+              numbers: [1, 2]
+              flag: null

--- a/tests/schema/pass/schema-object-deprecated-example-keyword.yaml
+++ b/tests/schema/pass/schema-object-deprecated-example-keyword.yaml
@@ -12,7 +12,6 @@ paths:
           # the example simple
           type: object
           # DEPRECATED: don't use example keyword inside Schema Object
-          example: {
-            "numbers": [1, 2],
-            "flag": null
-          }
+          example:
+            numbers: [1, 2]
+            flag: null


### PR DESCRIPTION
Several schema improvements for v3.2.  One of them MUST be in the release, as it allows for the use of `in: cookie, style: cookie` that was prohibited before.

I will backport to v3.1 the things that are relevant there.

- [x] schema changes are included in this pull request
