### PR TITLE
change "3.1 schema" to "3.1+ schemas" where appropriate

### DIFF
--- a/index.md
+++ b/index.md
@@ -43,7 +43,7 @@ _Note that while schemas can catch many errors, they are not guaranteed to catch
 
 ### OpenAPI Specification Schemas
 
-Note that the OAS 3.1 `schema/YYYY-MM-DD` schema does _not_ validate the Schema Object, as it makes no assumptions about the JSON Schema dialect in use.  The OAS 3.1 `schema-base/YYYY-MM-DD` schema _does_ validate the Schema Object, and requires that if `jsonSchemaDialect` or `$schema` are present, that they use the appropriate `dialect/YYYY-MM-DD`.  The name `schema-base` comes from the JSON Schema dialect including the OAS extensions being referred to as the "base dialect" in the specification.
+Note that the OAS 3.1+ `schema/YYYY-MM-DD` schemas do _not_ validate the Schema Object, as they make no assumptions about the JSON Schema dialect in use.  The OAS 3.1+ `schema-base/YYYY-MM-DD` schemas _do_ validate the Schema Object, and require that if `jsonSchemaDialect` or `$schema` are present, that they use the appropriate `dialect/YYYY-MM-DD`.  The name `schema-base` comes from the JSON Schema dialect including the OAS extensions being referred to as the "base dialect" in the specification.
 
 See [issue #4147](https://github.com/OAI/OpenAPI-Specification/issues/4147) for discussion of other possible JSON Schema dialect options, [issue #4152](https://github.com/OAI/OpenAPI-Specification/issues/4152) for programmatic access to the latest schemas, and [issue #4141](https://github.com/OAI/OpenAPI-Specification/issues/4141) for discussions on possibly providing linting schemas that could catch likely problems that do not directly violate the specification.
 


### PR DESCRIPTION
Now that 3.2 has been released, include the 3.2 schemas in the discussion about the dialect restrictions.