### PR TITLE
Use "Registries" over "Registry", add a page title to "Registries", and get child titles closer to consistent

### DIFF
--- a/registry/index.md
+++ b/registry/index.md
@@ -1,16 +1,20 @@
 ---
-title: Registry
+title: Registries
 layout: default
 permalink: /registry/index.html
 has_children: true
 children:
-- title: Alternative Schema Registry
+- title: Alternative Schema Type Registry
 - title: Draft Features Registry
+- title: Specification Extension Registry
 - title: Format Registry
+- title: Media Type Registry
 - title: Namespace Registry
 - title: Tag Kinds Registry
 has_toc: false
 ---
+
+# Registries
 
 ## Contributing
 


### PR DESCRIPTION
This makes us more consistent about having a Registries (plural) page, with a matching title, with each registry being more consistent about its linking and name.

This does not make everything perfectly consistent due to lack of time to track down all of the magical places where Jekyll or Liquid does whatever it does.  For example, I cannot find where "Tag Kind" singular comes from in one list when it is plural everywhere else, among other minor inconsistencies.

- [ ] schema changes are included in this pull request
- [ ] schema changes are needed for this pull request but not done yet
- [X] no schema changes are needed for this pull request
