### PR TITLE
Fix dialect link from 3.1 to 3.2

### DIFF
--- a/versions/3.2.0.md
+++ b/versions/3.2.0.md
@@ -2976,7 +2976,7 @@ Where JSON Schema indicates that behavior is defined by the application (e.g. fo
 
 The OpenAPI Schema Object [dialect](https://www.ietf.org/archive/id/draft-bhutton-json-schema-01.html#section-4.3.3) is defined as requiring the [OAS base vocabulary](#base-vocabulary), in addition to the vocabularies as specified in the JSON Schema Specification Draft 2020-12 [general purpose meta-schema](https://www.ietf.org/archive/id/draft-bhutton-json-schema-01.html#section-8).
 
-The OpenAPI Schema Object dialect for this version of the specification is identified by the URI `https://spec.openapis.org/oas/3.1/dialect/base` (the <a name="dialect-schema-id"></a>"OAS dialect schema id").
+The OpenAPI Schema Object dialect for this version of the specification is identified by the URI `https://spec.openapis.org/oas/3.2/dialect/2025-09-17` (the <a name="dialect-schema-id"></a>"OAS dialect schema id").
 
 The following keywords are taken from the JSON Schema specification but their definitions have been extended by the OAS:
 


### PR DESCRIPTION
- [ ] schema changes are included in this pull request
- [ ] schema changes are needed for this pull request but not done yet
- [x] no schema changes are needed for this pull request

This PR updates link to the new one.
<img width="719" height="63" alt="Screenshot 2025-09-24 at 11 58 34 AM" src="https://github.com/user-attachments/assets/6f09faa7-87c6-4699-978f-e0eb9f8ebe45" />

I noticed that in 3.2 spec there is a lot of references to 3.1, more than 20 cases. Shouldn't be they replaced to be `3.2` ?