### PR TITLE
v3.1 specification: minor clarifications, markup improvements

### DIFF
--- a/src/oas.md
+++ b/src/oas.md
@@ -1192,7 +1192,7 @@ Using `content` with a `text/plain` media type is RECOMMENDED for `in: "cookie"`
 
 ##### Style Values
 
-In order to support common ways of serializing simple parameters, a set of `style` values are defined.
+In order to support common ways of serializing simple parameters, a set of `style` values are defined. Combinations not represented in this table are not permitted.
 
 | `style` | [`type`](#data-types) | `in` | Comments |
 | ---- | ---- | ---- | ---- |


### PR DESCRIPTION
This is a port of the relevant bits in #4959.

- Literal style names are now rendered in sans-serif as code
- "primitive" is not rendered as code, as it refers to one of string, number, boolean or null, not a literal type name.
-  be explicit that the style table shows ALL valid combinations

- [x] no schema changes are needed for this pull request
