### PR TITLE
main: sync workflows main -> dev -> vX.Y-dev use sync branches

### DIFF
--- a/.github/workflows/sync-dev-to-vX.Y-dev.yaml
+++ b/.github/workflows/sync-dev-to-vX.Y-dev.yaml
@@ -11,6 +11,7 @@ on:
   push:
     branches:
       - dev
+  workflow_dispatch: {}
 
 jobs:
   sync-branches:
@@ -22,36 +23,49 @@ jobs:
         with:
           app-id: ${{ secrets.OAI_SPEC_PUBLISHER_APPID }}
           private-key: ${{ secrets.OAI_SPEC_PUBLISHER_PRIVATE_KEY }}
-    
+
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Create pull requests
         id: pull_requests
         shell: bash
         run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
           DEV_BRANCHES=$(git branch -r --list origin/v?.?-dev)
           for DEV_BRANCH in $DEV_BRANCHES; do
             BASE=${DEV_BRANCH:7}
-            EXISTS=$(gh pr list --base $BASE --head $HEAD \
+            SYNC="$BASE-sync-with-$HEAD"
+            
+            git checkout -b $SYNC origin/$SYNC || git checkout -b $SYNC origin/$BASE
+            git merge origin/$HEAD -m "Merge $HEAD into $SYNC"
+            git checkout origin/$BASE src/*
+            git checkout origin/$BASE tests/*
+            git commit -m "Restored src/* and tests/*" || echo ""
+            git push -u origin $SYNC
+
+            EXISTS=$(gh pr list --base $BASE --head $SYNC \
               --json number --jq '.[] | .number')
             if [ ! -z "$EXISTS" ]; then
-              echo "PR #$EXISTS already wants to merge $HEAD into $BASE"
+              echo "PR #$EXISTS already wants to merge $SYNC into $BASE"
               continue
             fi
 
-            PR=$(gh pr create --base $BASE --head $HEAD \
+            PR=$(gh pr create --base $BASE --head $SYNC \
               --label "Housekeeping" \
-              --title "$BASE: update from $HEAD" \
-              --body "Merge \`$HEAD\` into \`$BASE\`.")
+              --title "$BASE: sync with $HEAD" \
+              --body "Merge relevant changes from \`$HEAD\` into \`$BASE\`.")
             echo ""
             echo "PR to sync $DEV_BRANCH: $PR"
             sleep 10 # allow status checks to be triggered
             
             gh pr checks $PR --watch --required || continue
-            gh pr merge $PR --merge --admin
+            # gh pr merge $PR --merge --admin
           done
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/sync-main-to-dev.yaml
+++ b/.github/workflows/sync-main-to-dev.yaml
@@ -11,6 +11,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch: {}
 
 jobs:
   sync-branch:
@@ -25,22 +26,36 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Create pull request
         id: pull_request
         shell: bash
         run: |
-          EXISTS=$(gh pr list --base $BASE --head $HEAD \
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          SYNC="$BASE-sync-with-$HEAD"
+
+          git checkout -b $SYNC origin/$SYNC || git checkout -b $SYNC origin/$BASE
+          git merge origin/$HEAD -m "Merge $HEAD into $SYNC"
+          git checkout origin/$BASE src/*
+          git checkout origin/$BASE tests/*
+          git commit -m "Restored src/* and tests/*" || echo ""
+          git push -u origin $SYNC
+
+          EXISTS=$(gh pr list --base $BASE --head $SYNC \
             --json number --jq '.[] | .number')
           if [ ! -z "$EXISTS" ]; then
-            echo "PR #$EXISTS already wants to merge $HEAD into $BASE"
+            echo "PR #$EXISTS already wants to merge $SYNC into $BASE"
             exit 0
           fi
 
-          gh pr create --base $BASE --head $HEAD \
+          gh pr create --base $BASE --head $SYNC \
             --label "Housekeeping" \
-            --title "$BASE: update from $HEAD" \
-            --body "Merge \`$HEAD\` into \`$BASE\`."
+            --title "$BASE: sync with $HEAD" \
+            --body "Merge relevant changes from \`$HEAD\` into \`$BASE\`."
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
           HEAD: main


### PR DESCRIPTION
Fixes
* #4999 

The structure of the spec version development branches intentionally differs from the structure of the `main` branch. In addition to the files in `main` the development branches contain
- the spec and schemas source files in the `src` folder
- the schema tests files in the `tests` folder

All files except those in the `src` and `tests` folders should be identical between `main` and the development branches, and are regularly synced from `main` -> `dev` -> `vX.Y-dev`.

Merging a spec release into `main` with its full history makes subsequent the subsequent sync from `main` -> `dev` -> `vX.Y-dev` a bit more challenging than simply creating a PR merging the head branch into the base branch (which is what we did until now).

A sync that preserves the intentionally different structure of the base branch needs to perform these steps:

- create sync branch from base branch
- merge head branch into sync branch
- restore `src/*` and `tests/*` files from base branch - these are the only intended structural differences
- commit & push
- create PR for merging sync branch into base branch

This PR updates the two sync workflows to automatically perform these steps.

The workflows have been tested in fork https://github.com/ralfhandl/OpenAPI-Specification, both with an "initial" sync of a spec release from `main` -> `dev` -> `vX.Y-dev` and with subsequent syncs of changes to files in `main` outside of the two special folders `src` and `test`:

Release syncs:
* https://github.com/ralfhandl/OpenAPI-Specification/pull/65
* https://github.com/ralfhandl/OpenAPI-Specification/pull/70
* https://github.com/ralfhandl/OpenAPI-Specification/pull/76

Non-release syncs:
* https://github.com/ralfhandl/OpenAPI-Specification/pull/74
* https://github.com/ralfhandl/OpenAPI-Specification/pull/75
* https://github.com/ralfhandl/OpenAPI-Specification/pull/73

----

- [x] no schema changes are needed for this pull request
