### PR TITLE
main: adjust-release-branch: replace release date placeholder with current date

### DIFF
--- a/scripts/adjust-release-branch.sh
+++ b/scripts/adjust-release-branch.sh
@@ -5,6 +5,7 @@
 # Run this script from the root of the repo. It is designed to be run manually in a release branch.
 
 branch=$(git branch --show-current)
+today=$(date +%Y-%m-%d)
 
 if [[ ! $branch =~ ^v[0-9]+\.[0-9]+\.[0-9]+-rel$ ]]; then
   echo "This script is intended to be run from a release branch, e.g. v3.1.2-rel"
@@ -16,7 +17,8 @@ version=${vVersion:1}
 echo Prepare release of $version
 
 cp EDITORS.md versions/$version-editors.md
-mv src/oas.md versions/$version.md
+sed "s/| TBD |/| $today |/g" src/oas.md > versions/$version.md
+diff -w src/oas.md versions/$version.md
 rm -r src
 rm -r tests/schema/pass tests/schema/fail
 rm tests/schema/schema.test.mjs


### PR DESCRIPTION
When we start a release, we add a line to the history table in Appendix A with the new release number and a "TBD" placeholder instead of the release date.

The `adjust-release-branch.sh` script now replaces the placeholder with the current date and shows the differences. One less thing to remember during a release.

- [x] no schema changes are needed for this pull request
