### PR TITLE
main: use Linkspector action in validate-markdown,yam

### DIFF
--- a/.github/workflows/validate-markdown.yaml
+++ b/.github/workflows/validate-markdown.yaml
@@ -29,4 +29,8 @@ jobs:
         run: npx --yes markdownlint-cli2 *.md
 
       - name: Check links in markdown files
-        run: npx --yes @umbrelladocs/linkspector check
+        uses: umbrelladocs/action-linkspector@v1
+        with:
+          reporter: github-check
+          fail_level: any
+          filter_mode: nofilter


### PR DESCRIPTION
The Linkspector hyperlink checker introduced in 
* #5012

fails in Github workflows when naively called via bash and its CLI.

Instead use https://github.com/UmbrellaDocs/action-linkspector.

- [x] no schema changes are needed for this pull request
