### PR TITLE
main: check links only for changed files

### DIFF
--- a/.github/workflows/validate-markdown.yaml
+++ b/.github/workflows/validate-markdown.yaml
@@ -33,4 +33,4 @@ jobs:
         with:
           reporter: github-check
           fail_level: any
-          filter_mode: nofilter
+          filter_mode: file

--- a/.linkspector.yml
+++ b/.linkspector.yml
@@ -2,7 +2,7 @@ files:
   - src/oas.md
   - CONTRIBUTING.md
   - EDITORS.md
-  # - GOVERNANCE.md
+  - GOVERNANCE.md
   - IMPLEMENTATIONS.md
   - MAINTAINERS.md
   - README.md


### PR DESCRIPTION
Only check files that are changed by a commit or pull request.

This should reduce the likelyhood of links being reported as broken because the host mistakes the link checker for an attacker and responds with 4xx for existing resources (concrete problem: npmjs.org responding with `403` for links to existing packages.

- [x] no schema changes are needed for this pull request
