### PR TITLE
main: turn auto-merge for sync PRs back on and describe it in CONTRIBUTING

### DIFF
--- a/.github/workflows/sync-dev-to-vX.Y-dev.yaml
+++ b/.github/workflows/sync-dev-to-vX.Y-dev.yaml
@@ -61,11 +61,11 @@ jobs:
               --title "$BASE: sync with $HEAD" \
               --body "Merge relevant changes from \`$HEAD\` into \`$BASE\`.")
             echo ""
-            echo "PR to sync $DEV_BRANCH: $PR"
+            echo "PR to sync $BASE with $HEAD: $PR"
             sleep 10 # allow status checks to be triggered
             
             gh pr checks $PR --watch --required || continue
-            # gh pr merge $PR --merge --admin
+            gh pr merge $PR --merge --admin
           done
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -503,10 +503,9 @@ gitGraph TB:
 
 To keep changes in sync, we have some GitHub actions that open pull requests to take changes from `main` onto the `dev` branch, and from `dev` to each active version branch.
 
-- `sync-main-to-dev` opens a pull request with all the changes from the `main` branch that aren't yet included on `dev`.
-- `sync-dev-to-vX.Y-dev` opens pull requests with all the changes from `dev` that aren't yet included on the corresponding `vX.Y-dev` branch.
+- `sync-main-to-dev` opens a pull request with all the changes from the `main` branch that aren't yet included on `dev`. This pull request needs a single approval from either maintainers or TSC and can be merged.
+- `sync-dev-to-vX.Y-dev` opens pull requests with all the changes from `dev` that aren't yet included on the corresponding `vX.Y-dev` branch. These pull requests are automatically merged if all required status checks pass.
 
-These need a single approval from either maintainers or TSC and can be merged.
 The aim is to bring build script and repository documentation changes to the other branches.
 Published versions of the specifications and schemas will also move across branches with this approach.
 


### PR DESCRIPTION
The automatically created PRs for syncing `dev` into the `vX.Y-dev` branches were auto-merged until recently.

Now that the adjusted workflows have proven to create the expected PRs, auto-merge can be turned on again to save us from needing six approvals for syncing three development branches.

Closes #4999

----

- [x] no schema changes are needed for this pull request
