### PR TITLE
main: check-restricted-files.yaml uses sync branch names to test for allowed PRs

### DIFF
--- a/.github/workflows/check-restricted-files.yaml
+++ b/.github/workflows/check-restricted-files.yaml
@@ -8,28 +8,32 @@ name: check-restricted-files
 on:
   pull_request:
     paths:
-      - 'schemas/**/*.yaml'
-      - 'versions/*.md'
+      - "versions/*.md"
 
 jobs:
   check-files:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v5 # checkout repo content
+        with:
+          fetch-depth: 0
+
       - name: Check changed files
         shell: bash
         run: |
           if [[ "${{ github.event.pull_request.head.repo.full_name }}" == "OAI/OpenAPI-Specification" ]] && \
              [[ "${{ github.event.pull_request.base.repo.full_name }}" == "OAI/OpenAPI-Specification" ]]; then
- 
-            if [[ "${{ github.event.pull_request.head.ref }}" == "main" ]] && \
+
+            if [[ "${{ github.event.pull_request.head.ref }}" == "dev-sync-with-main" ]] && \
                [[ "${{ github.event.pull_request.base.ref }}" == "dev" ]]; then
-              echo Sync from main to dev
+              echo Sync from main to dev via ${{ github.event.pull_request.head.ref }}
               exit 0
             fi
 
-            if [[ "${{ github.event.pull_request.head.ref }}" == "dev" ]] && \
-               [[ "${{ github.event.pull_request.base.ref }}" =~ ^v[0-9]+\.[0-9]+-dev$ ]]; then
-              echo Sync from dev to ${{ github.event.pull_request.base.ref }}
+            if [[ "${{ github.event.pull_request.head.ref }}" =~ ^v[0-9]+\.[0-9]+-dev-sync-with-dev$ ]] && \
+               [[ "${{ github.event.pull_request.base.ref }}" =~ ^v[0-9]+\.[0-9]+-dev$ ]] && \
+               [[ ${{ github.event.pull_request.head.ref }} == ${{ github.event.pull_request.base.ref }}* ]]; then
+              echo Sync from dev to ${{ github.event.pull_request.base.ref }} via ${{ github.event.pull_request.head.ref }}
               exit 0
             fi
 
@@ -40,5 +44,8 @@ jobs:
             fi
           fi
 
-          echo This PR contains changes to files that should not be changed
+          echo This PR contains changes to files that should not be changed:
+          echo
+          git diff --compact-summary origin/${{ github.event.pull_request.base.ref }} origin/${{ github.event.pull_request.head.ref }} -- versions/
+
           exit 1


### PR DESCRIPTION
This workflow is triggered if a file in the `versions` folder is changed. This is only allowed for
- release PRs into `main`
- sync PRs into `dev` and `vX.Y-dev`

Sync PRs now use intermediate branches, and the workflow now tests for these sync branch names.
It also now lists the files changed in the `versions` folder.

----

- [x] no schema changes are needed for this pull request
