### PR TITLE
3.1: initialize src/oas.md for patch release 3.1.3

### DIFF
--- a/src/oas.md
+++ b/src/oas.md
@@ -1,6 +1,6 @@
 # OpenAPI Specification
 
-## Version 3.1.2
+## Version 3.1.3
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [BCP 14](https://tools.ietf.org/html/bcp14) [RFC2119](https://tools.ietf.org/html/rfc2119) [RFC8174](https://tools.ietf.org/html/rfc8174) when, and only when, they appear in all capitals, as shown here.
 
@@ -4259,6 +4259,7 @@ Certain fields allow the use of Markdown which can contain HTML including script
 
 | Version | Date | Notes |
 | ---- | ---- | ---- |
+| 3.1.3 | TBD | Patch release of the OpenAPI Specification 3.1.3 |
 | 3.1.2 | 2025-09-19 | Patch release of the OpenAPI Specification 3.1.2 |
 | 3.1.1 | 2024-10-24 | Patch release of the OpenAPI Specification 3.1.1 |
 | 3.1.0 | 2021-02-15 | Release of the OpenAPI Specification 3.1.0 |


### PR DESCRIPTION
- Initialize `src/oas.md` from `versions/3.1.2.md` on the `main` branch with empty history
- Bump version to 3.1.3

This PR's head branch was created with `scripts/start-release.sh` from
- #5034

----
- [x] no schema changes are needed for this pull request
