### PR TITLE
main: run validate_markdown action only on pull_request

### DIFF
--- a/.github/workflows/validate-markdown.yaml
+++ b/.github/workflows/validate-markdown.yaml
@@ -3,13 +3,12 @@ name: validate-markdown
 # Author: @MikeRalphson
 # Issue: https://github.com/OAI/OpenAPI-Specification/issues/2130
 
-#
 # This workflow validates markdown files in the project root.
 # It also validates the work-in-progress specification file src/oas.md with slightly different rules.
-#
 
-# run this on push to any branch and creation of pull-requests
-on: [push, pull_request]
+# run this on pull requests (which includes pushes to their head branch)
+on:
+  - pull_request
 
 jobs:
   lint:


### PR DESCRIPTION
Running on pull_request is sufficient, it will be triggered when pushing to the PR's head branch.

When running on pull requests, it only reports broken links in files changed by the PR. (Under the hood it still checks all files and then silently ignores broken links in files not changed by the PR 🤷🏻‍♂️)

When running on push, it reports broken links in all files, which is unfair to the PR author who didn't change the problematic file(s).

----
- [x] no schema changes are needed for this pull request
