### PR TITLE
Revise URI format for OpenAPI Schema Object dialect

### DIFF
--- a/src/oas.md
+++ b/src/oas.md
@@ -2775,7 +2775,7 @@ Where JSON Schema indicates that behavior is defined by the application (e.g. fo
 
 The OpenAPI Schema Object [dialect](https://tools.ietf.org/html/draft-bhutton-json-schema-00#section-4.3.3) is defined as requiring the [OAS base vocabulary](#base-vocabulary), in addition to the vocabularies as specified in the JSON Schema Specification Draft 2020-12 [general purpose meta-schema](https://tools.ietf.org/html/draft-bhutton-json-schema-00#section-8).
 
-The OpenAPI Schema Object dialect for this version of the specification is identified by the URI `https://spec.openapis.org/oas/3.1/dialect/base` (the <a name="dialect-schema-id"></a>"OAS dialect schema id").
+The OpenAPI Schema Object dialect for this version of the specification is identified by the URI of the form `https://spec.openapis.org/oas/3.1/dialect/YYYY-MM-DD` (the <a name="dialect-schema-id"></a>"OAS dialect schema id" -- see [the list of current schemas](https://spec.openapis.org/oas/) for the specific URI).
 
 The following keywords are taken from the JSON Schema specification but their definitions have been extended by the OAS:
 


### PR DESCRIPTION
Updated the URI format for the OpenAPI Schema Object dialect to include a date placeholder.
https://github.com/OAI/OpenAPI-Specification/pull/4996#issuecomment-3419874110


- [x] no schema changes are needed for this pull request
