### PR TITLE
ci: adds conditions to avoid jobs which depends on tokens to run on forks

### DIFF
--- a/.github/workflows/sync-dev-to-vX.Y-dev.yaml
+++ b/.github/workflows/sync-dev-to-vX.Y-dev.yaml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   sync-branches:
+    if: github.repository == 'OAI/OpenAPI-Specification'
     runs-on: ubuntu-latest
     steps:
       - name: Generate access token

--- a/.github/workflows/sync-main-to-dev.yaml
+++ b/.github/workflows/sync-main-to-dev.yaml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   sync-branch:
+    if: github.repository == 'OAI/OpenAPI-Specification'
     runs-on: ubuntu-latest
     steps:
       - name: Generate access token


### PR DESCRIPTION
this PR adds conditions similar to the Overlay repo for the workflows which rely on a token so they don't run on forks and create noise