### PR TITLE
3.2: initialize src/oas.md for patch release 3.2.1

### DIFF
--- a/src/oas.md
+++ b/src/oas.md
@@ -1857,7 +1857,7 @@ Using `contentEncoding` for a multipart field is equivalent to specifying an [En
 If `contentEncoding` is used for a multipart field that has an Encoding Object with a `headers` field containing `Content-Transfer-Encoding` with a schema that disallows the value from `contentEncoding`, the result is undefined for serialization and parsing.
 
 Note that as stated in [Working with Binary Data](#working-with-binary-data), if the Encoding Object's `contentType`, whether set explicitly or implicitly through its default value rules, disagrees with the `contentMediaType` in a Schema Object, the `contentMediaType` SHALL be ignored.
-Because of this, and because the Encoding Object's `contentType` defaulting rules do not take the Schema Object's`contentMediaType` into account, the use of `contentMediaType` with an Encoding Object is NOT RECOMMENDED.
+Because of this, and because the Encoding Object's `contentType` defaulting rules do not take the Schema Object's `contentMediaType` into account, the use of `contentMediaType` with an Encoding Object is NOT RECOMMENDED.
 
 Note also that `Content-Transfer-Encoding` is deprecated for `multipart/form-data` ([RFC7578](https://www.rfc-editor.org/rfc/rfc7578.html#section-4.7)) where binary data is supported, as it is in HTTP.
 


### PR DESCRIPTION
- Initialize `src/oas.md` from released `versions/3.2.0.md` via new script `start-release.sh`
- Cherry-pick changes to `src/oas.md` since releasing 3.2.0

----
- [x] no schema changes are needed for this pull request
