### PR TITLE
main: fix check-restricted-files, diff local head with remote base branch

### DIFF
--- a/.github/workflows/check-restricted-files.yaml
+++ b/.github/workflows/check-restricted-files.yaml
@@ -46,6 +46,6 @@ jobs:
 
           echo This PR contains changes to files that should not be changed:
           echo
-          git diff --compact-summary origin/${{ github.event.pull_request.base.ref }} origin/${{ github.event.pull_request.head.ref }} -- versions/
+          git diff --compact-summary origin/${{ github.event.pull_request.base.ref }} -- versions/
 
           exit 1


### PR DESCRIPTION
Fix a recently introduced bug: the head branch doesn't exist on `origin` for PRs from a fork. Comparing the local current branch with the remote base branch does the trick.

- [x] no schema changes are needed for this pull request
