### PR TITLE
v3.1: parameter style amendments

### DIFF
--- a/src/oas.md
+++ b/src/oas.md
@@ -1261,7 +1261,7 @@ Assume a parameter named `color` has one of the following values:
    object -> { "R": 100, "G": 200, "B": 150 }
 ```
 
-The following table shows serialized examples, as would be shown with the `example` or `examples` keywords, of the different serializations for each value.
+The following table shows serialized examples, as would be shown with the `example` or `examples` keywords, of the different serializations for the value of each supported type.
 
 * The value _empty_ denotes the empty string, and is unrelated to the `allowEmptyValue` field.
 * The behavior of combinations marked _n/a_ is undefined.


### PR DESCRIPTION
direct port of #5080, with merge conflicts resolved.

I have been working through the parameter templating section and filling in some of the styles that I had not previously implemented, and cross-checking against RFC6570, and I found these issues with the "in: path" styles.

Each commit explains the reasoning for the change.

- [x] no schema changes are needed for this pull request
