### PR TITLE
v3.3 trial balloon: JSON-Compatible Data section

### DIFF
--- a/src/oas.md
+++ b/src/oas.md
@@ -3063,6 +3063,16 @@ properties:
 Some applications might leave the string as a string regardless of programming language, while others might notice the `format` and use it as a `datetime.datetime` instance in Python, or a `java.time.ZonedDateTime` in Java.
 This specification only requires that the data is valid according to the schema, and that [annotations](#extended-validation-with-annotations) such as `format` are available in accordance with the JSON Schema specification.
 
+##### JSON-Compatible Data
+
+Some media types are more-or-less compatible with JSON, in which case their JSON-compatible subsets can be modeled the same way as JSON.  Some examples include:
+
+* `text/toon`, which is an alternate encoding format for the JSON data model, although with some constraints such as object property ordering that are not defined by JSON
+* `application/toml`, which is mostly an alternate encoding for a subset of JSON data structures, but also distinguishes between integers and floats in a way that JSON and JSON Schema do not
+* `application/yaml`, which has much more functionality than JSON, but provides guidance on JSON compatibility in [[RFC9512]] [Section 3.4](https://www.rfc-editor.org/rfc/rfc9512.html#section-3.4)
+
+In many cases, modeling these media types as if they were JSON will suffice, but care must be taken in areas where the specifications diverge.  See the [OpenAPI Media Type Registry](#openapi-media-type-registry) for guidance on specific JSON-like data formats.
+
 ##### Non-JSON Data
 
 Non-JSON serializations can be substantially different from their corresponding data form, and might require several steps to parse.


### PR DESCRIPTION
* Addresses #5140 (beyond putting `text/toon` in the media type registry, which has already been done).

There's a bit of a question if we want to mention TOON in the spec because of the LLM connection and its use in LLM-related HTTP APIs.  I was looking for where to put it and noticed the "[JSON Data](https://spec.openapis.org/oas/v3.2.0.html#json-data)" and "[Non-JSON Data](https://spec.openapis.org/oas/v3.2.0.html#non-json-data)" sections, and thought maybe a "JSON-Compatible Data" section would fit in between them.

Pros of this approach:
* It is a valid class of formats that doesn't quite fit either section
* It lets us treat TOON as one of several things rather than promoting it specifically in a way that might seem dated in another year or two

Cons of this approach:
* Unlike our sections on `text/event-stream`, `multipart`, and `form-urlencoded`, TOON would not appear in the Table of Contents
* The other examples here (TOML and YAML) are popular formats, but not ones that are all that frequently used in HTTP APIs as far as I know (although obviously we use YAML for authoring OADs), so I'm not sure we want to call attention to them here (this is why they're not in the Media Type Registry- I did consider including them and decided not to).

Additional questions:
* Should the format name (TOON, TOML, YAML) and acronym expansions (Token-Oriented Object Notation, Tom's Obvious Minimal Language, YAML Ain't a Markup Language) be included in addition to the media types?

I'm fine with this going in, or reworking it substantially, or dropping the idea and closing #5140 as completed based on the media type registry entry.  But I figured it would be easier to discuss a concrete change than the abstract.

<img width="853" height="430" alt="Screenshot 2026-02-12 at 10 59 20 AM" src="https://github.com/user-attachments/assets/8d7c2df3-7387-4257-9764-012f4cb3c462" />


- [X] no schema changes are needed for this pull request
