### PR TITLE
Fix xml example

### DIFF
--- a/src/oas.md
+++ b/src/oas.md
@@ -4291,6 +4291,7 @@ application/xml:
         name: Fluffy
       - kind: Dog
         name: Fido
+      externalValue: ./examples/pets.xml
 ```
 
 Where `./examples/pets.xml` would be:


### PR DESCRIPTION
Fixed incorrect xml closing tags.

Also the example assumed to have `externalValue` since it then shows externalValue content with matching shape. So I added `externalValue` field.

<!-- Tick one of the following options and remove the other two: -->

- [ ] schema changes are included in this pull request
- [ ] schema changes are needed for this pull request but not done yet
- [x] no schema changes are needed for this pull request
