### PR TITLE
Fix broken $ref in example

### DIFF
--- a/src/oas.md
+++ b/src/oas.md
@@ -2769,7 +2769,7 @@ components:
       content:
         application/linkset+json:
           schema:
-            $ref: '#/components/mediaTypes/CollectionLinks'
+            $ref: '#/components/schemas/CollectionLinks'
 ```
 
 #### Representing the `Set-Cookie` Header


### PR DESCRIPTION
In the example `CollectionLinks` is the `schema` itself and not *Media Type Object* and it is correctly defined in the `components.schemas` so I just fixed broken $ref to correctly point to it.

<!-- Tick one of the following options and remove the other two: -->

- [ ] schema changes are included in this pull request
- [ ] schema changes are needed for this pull request but not done yet
- [x] no schema changes are needed for this pull request
