### PR TITLE
Fix `const` value in example to match requestBody data

### DIFF
--- a/src/oas.md
+++ b/src/oas.md
@@ -1603,7 +1603,7 @@ content:
             format: int64
       - properties:
           event:
-            const: addJson
+            const: addJSON
           data:
             $comment: |
               These content fields indicate


### PR DESCRIPTION
The document below the example uses `addJSON`:
here: https://github.com/OAI/OpenAPI-Specification/blob/v3.3-dev/src/oas.md?plain=1#L1637
and here: https://github.com/OAI/OpenAPI-Specification/blob/v3.3-dev/src/oas.md?plain=1#L1646

Since the value **is** case sensitive I changed the schema of event to match it

<!-- Tick one of the following options and remove the other two: -->

- [ ] schema changes are included in this pull request
- [ ] schema changes are needed for this pull request but not done yet
- [x] no schema changes are needed for this pull request
