### PR TITLE
Fix missing name for `responses` component in example

### DIFF
--- a/src/oas.md
+++ b/src/oas.md
@@ -4319,15 +4319,16 @@ components:
           xml:
             nodeType: cdata
   responses:
-    content:
-      application/xml:
-        schema:
-          $ref: "#/components/schemas/Documentation"
-        examples:
-          docs:
-            dataValue:
-              content: <html><head><title>Awesome Docs</title></head><body></body><html>
-            externalValue: ./examples/docs.xml
+    AwesomeDocs:
+      content:
+        application/xml:
+          schema:
+            $ref: "#/components/schemas/Documentation"
+          examples:
+            docs:
+              dataValue:
+                content: <html><head><title>Awesome Docs</title></head><body></body><html>
+              externalValue: ./examples/docs.xml
 ```
 
 Where `./examples/docs.xml` would be:


### PR DESCRIPTION
Added missing name. Since each response under `components.responses` should have the name and only then under its name the *Response Object*


Examples from 3.2.0 spec under components object example https://spec.openapis.org/oas/v3.2.0.html#components-object-example:
<img width="543" height="263" alt="Screenshot 2026-02-23 at 11 12 38 PM" src="https://github.com/user-attachments/assets/4a27fe4a-93f0-460f-afb3-fd4ea81c6429" />


<!-- Tick one of the following options and remove the other two: -->

- [ ] schema changes are included in this pull request
- [ ] schema changes are needed for this pull request but not done yet
- [x] no schema changes are needed for this pull request
