### PR TITLE
v3.3: restore "propertyName" as required in the discriminator object

### DIFF
--- a/src/schemas/validation/meta.yaml
+++ b/src/schemas/validation/meta.yaml
@@ -34,6 +34,8 @@ $defs:
         type: string
       propertyName:
         type: string
+    required:
+      - propertyName
     type: object
     unevaluatedProperties: false
 


### PR DESCRIPTION
- the 3.2.0 release notes imply that `propertyName` is now an optional field in the discriminator object: "The discriminator propertyName can now be an optional field."  (https://github.com/OAI/OpenAPI-Specification/releases/tag/3.2.0)
- the `required` keyword was removed in the 3.2.0 validation schema (PR #4966, yes that was me)
- the 3.2.0 specification continues to identify `propertyName` as required (https://spec.openapis.org/oas/latest#fixed-fields-21)

Which results in the question:  How is the mapping supposed to work without knowing what property name is to be used as the discriminating property?

When working through the examples I think the error is in the schema change (mea culpa), and the spec itself is correct.

- [x] schema changes are included in this pull request
