### PR TITLE
v3.2: apply the ABNF for header names at rfc9110 §5.1

### DIFF
--- a/src/schemas/validation/schema.yaml
+++ b/src/schemas/validation/schema.yaml
@@ -243,7 +243,7 @@ $defs:
           $ref: '#/$defs/operation'
         propertyNames:
           $comment: RFC9110 restricts methods to "1*tchar" in ABNF
-          pattern: "^[a-zA-Z0-9!#$%&'*+.^_`|~-]+$"
+          $ref: '#/$defs/token'
           not:
             enum:
               - GET
@@ -414,6 +414,14 @@ $defs:
         then:
           required:
             - content
+      - if:
+          properties:
+            in:
+              const: header
+        then:
+          properties:
+            name:
+              $ref: '#/$defs/token'
     dependentSchemas:
       schema:
         properties:
@@ -604,6 +612,8 @@ $defs:
         format: media-range
       headers:
         type: object
+        propertyNames:
+          $ref: '#/$defs/token'
         additionalProperties:
           $ref: '#/$defs/header-or-reference'
       style:
@@ -679,6 +689,8 @@ $defs:
         type: string
       headers:
         type: object
+        propertyNames:
+          $ref: '#/$defs/token'
         additionalProperties:
           $ref: '#/$defs/header-or-reference'
       content:
@@ -1149,3 +1161,8 @@ $defs:
       properties:
         explode:
           default: false
+
+  token:
+    $comment: see https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2
+    type: string
+    pattern: ^[0-9A-Za-z!#$%&'*+.^_`|~-]+$

--- a/tests/schema/fail/header-object-name.yaml
+++ b/tests/schema/fail/header-object-name.yaml
@@ -1,0 +1,12 @@
+openapi: 3.2.0
+info:
+  title: the header name, as used in serialization, has a constrained syntax
+  version: 1.0.0
+paths:
+  /foo:
+    get:
+      responses:
+        default:
+          headers:
+            'Bad=Header':
+              schema: {}

--- a/tests/schema/fail/parameter-object-header-name.yaml
+++ b/tests/schema/fail/parameter-object-header-name.yaml
@@ -1,0 +1,10 @@
+openapi: 3.2.0
+info:
+  title: header name has a constrained syntax
+  version: 1.0.0
+components:
+  parameters:
+    BadHeader:
+      name: 'Bad[Header]'
+      in: header
+      schema: {}


### PR DESCRIPTION
..and the same pattern applies to HTTP method names too

- [x] schema changes are included in this pull request
