### PR TITLE
main: longer wait time when syncing dev to vX.Y-dev

### DIFF
--- a/.github/workflows/sync-dev-to-vX.Y-dev.yaml
+++ b/.github/workflows/sync-dev-to-vX.Y-dev.yaml
@@ -63,7 +63,7 @@ jobs:
               --body "Merge relevant changes from \`$HEAD\` into \`$BASE\`.")
             echo ""
             echo "PR to sync $BASE with $HEAD: $PR"
-            sleep 10 # allow status checks to be triggered
+            sleep 60 # allow status checks to be triggered
             
             gh pr checks $PR --watch --required || continue
             gh pr merge $PR --merge --admin


### PR DESCRIPTION
This workflow creates PRs to sync `dev` branch changes into the `vX.Y-dev` branches. These PRs are auto-approved and auto-merged if all checks succeed.

Github takes some time for the first check to start after PR creation, so the script waits a while for the first check to start. Apparently ten seconds wasn't enough, so let's wait a minute, this is not time-critical.


- [x] no schema changes are needed for this pull request
