### PR TITLE
fix schema error in contentType

### DIFF
--- a/src/schemas/validation/schema.yaml
+++ b/src/schemas/validation/schema.yaml
@@ -618,8 +618,8 @@ $defs:
     type: object
     properties:
       contentType:
+        $comment: one or more comma-separated media-ranges
         type: string
-        format: media-range
       headers:
         type: object
         propertyNames:


### PR DESCRIPTION
a contentType may be a comma-separated list of media-ranges, not just a single media-range

relates to #5280

- [x] schema changes are included in this pull request
