### PR TITLE
v3.3: fix schema error in contentType

### DIFF
--- a/src/schemas/validation/schema.yaml
+++ b/src/schemas/validation/schema.yaml
@@ -608,8 +608,8 @@ $defs:
     type: object
     properties:
       contentType:
+        $comment: one or more comma-separated media-ranges
         type: string
-        format: media-range
       headers:
         type: object
         propertyNames:


### PR DESCRIPTION
a contentType may be a comma-separated list of media-ranges, not just a single media-range

port of #5281.

- [x] schema changes are included in this pull request
