### PR TITLE
Correct schema $comment for OAD `content` definition

### DIFF
--- a/src/schemas/validation/schema.yaml
+++ b/src/schemas/validation/schema.yaml
@@ -566,7 +566,12 @@ $defs:
       $ref: '#/$defs/request-body'
 
   content:
-    $comment: https://spec.openapis.org/oas/v3.2#fixed-fields-10
+    $comment: |
+      The `content` object is a property of:
+      Parameter Object: https://spec.openapis.org/oas/v3.2#parameter-object
+      Request Body Object: https://spec.openapis.org/oas/v3.2#request-body-object
+      Response Object: https://spec.openapis.org/oas/v3.2#response-object
+      Header Object: https://spec.openapis.org/oas/v3.2#header-object
     type: object
     additionalProperties:
       $ref: '#/$defs/media-type-or-reference'


### PR DESCRIPTION
The `content` object is a property of Parameter, Request Body, Response, and Header. Currently its schema $comment just links to Request Body.

I'm targeting this at 3.2 instead of 3.3 because, in the linked anchors "fixed-fields-{n}", the numbers seem likely to end up different by publication. Not sure what to do about that. All of the other $comment spec links use more unique anchors.

- [x] schema changes are included in this pull request
