### PR TITLE
fix Media Type Example Server-Sent Event Streams example (v3.2)

### DIFF
--- a/src/oas.md
+++ b/src/oas.md
@@ -1632,7 +1632,7 @@ data: across two lines
 retry: 5
 
 event: addInt64
-data: 1234.5678
+data: 1234
 unknownField: this is ignored
 
 : This is a comment
@@ -1644,7 +1644,7 @@ To more clearly see how this stream is handled, the following is the equivalent 
 
 ```jsonl
 {"event": "addString", "data": "This data is formatted\nacross two lines", "retry": 5}
-{"event": "addInt64", "data": "1234.5678"}
+{"event": "addInt64", "data": "1234"}
 {"event": "addJSON", "data": "{\"foo\": 42}"}
 ```
 


### PR DESCRIPTION
In this example in Media Type Server-Sent Event Streams, the `data` field's schema is `format: int64`, so the data should be an integer
- [x] no schema changes are needed for this pull request

related https://github.com/OAI/OpenAPI-Specification/pull/5287