### PR TITLE
v3.3: apply the ABNF for path parameter names

### DIFF
--- a/src/schemas/validation/schema.yaml
+++ b/src/schemas/validation/schema.yaml
@@ -417,10 +417,20 @@ $defs:
       - if:
           properties:
             in:
+              const: path
+        then:
+          properties:
+            name:
+              $comment: 'see OAS 3.3.0 §4.8.2'
+              pattern: '^[^{}]+$'
+      - if:
+          properties:
+            in:
               const: header
         then:
           properties:
             name:
+              $comment: 'see RFC9110 §5.1'
               $ref: '#/$defs/token'
     dependentSchemas:
       schema:

--- a/tests/schema/fail/parameter-object-path-name.yaml
+++ b/tests/schema/fail/parameter-object-path-name.yaml
@@ -1,0 +1,10 @@
+openapi: 3.3.0
+info:
+  title: path parameter name has a constrained syntax
+  version: 1.0.0
+components:
+  parameters:
+    BadPath:
+      name: 'Bad{Path}'
+      in: path
+      schema: {}


### PR DESCRIPTION
(port of #5263)

Header parameter names have already been adjusted.

The ABNF for the query component of URIs is at RFC3986 §3.4, but percent-encoding is used, which allows for the use of any character. Additionally, cookies using style=form are also percent-encoded and therefore allow any character.

Moreover, cookie parameter names are percent-encoded when using style=form, and even for style=cookie they are not used in serialization of objects when explode=true, so a restriction on cookie parameter names is not added here; however applications should apply their own restrictions, following the "cookie-name" and "cookie-value" ABNFs at RFC6265 §4.1.1 (and ensure that all disallowed characters are percent-encoded when using style=form).


- [x] schema changes are included in this pull request
