### PR TITLE
Correct schema $comment for OAD `content` definition (v3.3)

### DIFF
--- a/src/schemas/validation/schema.yaml
+++ b/src/schemas/validation/schema.yaml
@@ -566,7 +566,12 @@ $defs:
       $ref: '#/$defs/request-body'
 
   content:
-    $comment: https://spec.openapis.org/oas/v3.3#fixed-fields-10
+    $comment: |
+      The `content` object is a property of:
+      Parameter Object: https://spec.openapis.org/oas/v3.3#parameter-object
+      Request Body Object: https://spec.openapis.org/oas/v3.3#request-body-object
+      Response Object: https://spec.openapis.org/oas/v3.3#response-object
+      Header Object: https://spec.openapis.org/oas/v3.3#header-object
     type: object
     additionalProperties:
       $ref: '#/$defs/media-type-or-reference'


### PR DESCRIPTION
Same as https://github.com/OAI/OpenAPI-Specification/pull/5289 , for v3.3

The `content` object is a property of Parameter, Request Body, Response, and Header. Currently its schema $comment just links to Request Body.

- [x] schema changes are included in this pull request
