### PR TITLE
v3.3: be clear which property we are referring to

### DIFF
--- a/src/oas.md
+++ b/src/oas.md
@@ -1374,7 +1374,7 @@ Each field has its own set of media types with which it can be used; for all oth
 
 The behavior of the `encoding` field is designed to support web forms, and is therefore only defined for media types structured as name-value pairs that allow repeat values, most notably `application/x-www-form-urlencoded` and `multipart/form-data`.
 
-To use the `encoding` field, each key under the field MUST exist as a property; `encoding` entries with no corresponding property SHALL be ignored.
+To use the `encoding` field, each key under the field MUST exist in the data instance as a property; `encoding` entries with no corresponding property SHALL be ignored.
 Array properties MUST be handled by applying the given Encoding Object to produce one encoded value per array item, each with the same `name`, as is recommended by [[!RFC7578]] [Section 4.3](https://www.rfc-editor.org/rfc/rfc7578.html#section-4.3) for supplying multiple values per form field.
 For all other value types for both top-level non-array properties and for values, including array values, within a top-level array, the Encoding Object MUST be applied to the entire value.
 The order of these name-value pairs in the target media type is implementation-defined.


### PR DESCRIPTION
It's not entirely clear whether this refers to a property in the data instance or a `property` keyword in the schema. (v3.1 says that encoding properties must correspond to schema properties; in v3.2, the "Encoding by Position" section says that prefixEncoding entries must correspond to a schema indicating an array.)

Either way, let's clarify this and be consistent with the rules between object data and array data.

- [x] no schema changes are needed for this pull request
