### PR TITLE
ci: adds browser installation step to unblock workflow

### DIFF
--- a/.github/workflows/validate-markdown.yaml
+++ b/.github/workflows/validate-markdown.yaml
@@ -27,6 +27,14 @@ jobs:
       - name: Lint other files
         run: npx --yes markdownlint-cli2 *.md
 
+      # workaround for https://github.com/UmbrellaDocs/action-linkspector/issues/62
+      - name: Install Chrome
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y google-chrome-stable
+          echo "PUPPETEER_SKIP_DOWNLOAD=true" >> $GITHUB_ENV
+          echo "PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome" >> $GITHUB_ENV
+
       - name: Check links in markdown files
         uses: umbrelladocs/action-linkspector@v1
         with:


### PR DESCRIPTION
based on https://github.com/OAI/Overlay-Specification/pull/343
I don't think we need it anywhere else, but let me know if I missed anything