### PR TITLE
dependency: replace deprecated action parameter app-id with client-id

### DIFF
--- a/.github/workflows/respec.yaml
+++ b/.github/workflows/respec.yaml
@@ -22,7 +22,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.OAI_SPEC_PUBLISHER_APPID }}
+          client-id: ${{ secrets.OAI_SPEC_PUBLISHER_APPID }}
           private-key: ${{ secrets.OAI_SPEC_PUBLISHER_PRIVATE_KEY }}
           owner: OAI
           repositories: spec.openapis.org

--- a/.github/workflows/schema-publish.yaml
+++ b/.github/workflows/schema-publish.yaml
@@ -25,7 +25,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.OAI_SPEC_PUBLISHER_APPID }}
+          client-id: ${{ secrets.OAI_SPEC_PUBLISHER_APPID }}
           private-key: ${{ secrets.OAI_SPEC_PUBLISHER_PRIVATE_KEY }}
           owner: OAI
           repositories: spec.openapis.org

--- a/.github/workflows/sync-dev-to-vX.Y-dev.yaml
+++ b/.github/workflows/sync-dev-to-vX.Y-dev.yaml
@@ -22,7 +22,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.OAI_SPEC_PUBLISHER_APPID }}
+          client-id: ${{ secrets.OAI_SPEC_PUBLISHER_APPID }}
           private-key: ${{ secrets.OAI_SPEC_PUBLISHER_PRIVATE_KEY }}
 
       - name: Checkout repository

--- a/.github/workflows/sync-main-to-dev.yaml
+++ b/.github/workflows/sync-main-to-dev.yaml
@@ -22,7 +22,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.OAI_SPEC_PUBLISHER_APPID }}
+          client-id: ${{ secrets.OAI_SPEC_PUBLISHER_APPID }}
           private-key: ${{ secrets.OAI_SPEC_PUBLISHER_PRIVATE_KEY }}
 
       - name: Checkout repository


### PR DESCRIPTION
The v3 version of github action create-github-app-token "renames" parameter `app-id` to `client-id`, a more appropriate and less confusing name.

The old parameter name still works and is deprecated, using the new/better parameter name to be future-proof.

See https://github.com/actions/create-github-app-token#client-id-or-app-id

<!--
Thank you for contributing to the OpenAPI Specification!

Please make certain you are submitting your PR on the correct
branch, to the files under the "src/" directory (which is not
present on the main branch, only on the development branches).

* 3.1.x spec and schemas: v3.1-dev branch
* 3.2.x spec and schemas: v3.2-dev branch
* 3.3.x spec and schemas: v3.3-dev branch
* process documentation and build infrastructure: main

Note that we do not accept changes to published specifications.
-->

- [x] no schema changes are needed for this pull request
