### PR TITLE
AI policy proposal

### DIFF
--- a/AI.md
+++ b/AI.md
@@ -1,0 +1,62 @@
+# OpenAPI Initiative AI Policy
+
+The OpenAPI Initiative is a project that brings together experienced industry experts to collaborate on an open, shared standard that benefits us all.
+It is the result of shared ideas, thoughtful discussion, and careful curation over time.
+As the tools landscape changes, the way we work together on that shared vision should not change.
+
+Well-thought-out and meaningful contributions will always be welcome and considered for their merits, however the advent of AI-generated interactions makes this policy a necessary addition to the project.
+We encourage humans to engage and to gain experience with the project and further the mission, but our volunteer maintainers are not to be put in a position of expending more effort on reviewing contributions than was used to create them because the project is unsustainable in that scenario.
+
+TL;DR we do permit use of AI, with disclosure, but low-effort, inaccurate or overly verbose contributions will be dismissed.
+
+## AI and Standards Development
+
+The nature of this project provides a very particular context and any tool (including AI) should be applied with consideration to the context.
+The tools you use day-to-day can feel helpful, but we expect you to consider how they may best add value to each task within the project.
+
+Standards development means devising and developing standards that do not yet exist, with knowledge of the standards landscape and ongoing work in other standards projects.
+Most AI tools are trained on existing or outdated content, making them less useful for standards development than they might be in other applications, so bear that perspective in mind when working with AI on specification improvements or proposals.
+
+## Permitted Use
+
+AI tools may be used to support contributions to OpenAPI Initiative projects, including use of AI for drafting, editing, checking consistency, or exploring ideas.
+However, you are solely responsible for every part of your submission — the content, its accuracy, and its appropriateness for the project.
+You should expect to be asked followup questions about any detail of your contribution and to have already considered your work as deeply as our maintainers will when they review it.
+Using AI can help you to do a good job but we expect you to use these tools intentionally and considerately for the project and audience.
+
+## Disclosure and Accountability
+
+If AI tools were used in preparing a contribution beyond simple autocomplete or spellcheck, this must be disclosed in the pull request or issue description.
+Add a note with a simple overview of how AI was used to your work and be prepared to answer further questions on that usage.
+
+You must be able to explain and defend every part of your contribution.
+If a reviewer asks why a particular design decision was made, "the AI suggested it" is not an acceptable answer.
+Contributions where the submitter cannot demonstrate understanding of the material will be closed without further discussion or explanation.
+
+## Discussion Conduct
+
+Discussions in OpenAPI Initiative projects are for humans.
+Comments that restate or summarise what has already been said, without advancing the conversation, add burden to volunteers and will be removed.
+A useful comment adds new information, identifies a constraint, asks a precise question, or proposes a concrete resolution.
+We expect you to make good-faith contributions that are concise and to the intended point; overly verbose or general contributions will be hidden or removed.
+Users who frequently have comments removed may be blocked from OpenAPI Initiative repositories.
+
+Do not use AI to generate issue comments, discussion replies, or PR descriptions. These are the primary record of design reasoning for the project; they must reflect genuine human thought.
+
+Do not use AI to summarise discussion content and then reply to the summary. The individual points raised by the other participants all have value and the nuance is one of the main strengths of discussion between experts.
+
+## Enforcement
+
+Maintainers reserve the right to close any pull request, issue, or discussion thread that appears to represent low-effort or AI-generated content, without providing detailed justification.
+Repeated violations may result in a block from OpenAPI Initiative repositories.
+
+Reviewer time and expertise are the scarcest resources this project has, and so this policy is there to protect them and ensure the long-term healthy and viability of the project.
+You are always welcome to reach out to us via GitHub or Slack to discuss any of these points or their application.
+
+## Acknowledgements
+
+This policy builds on and acknowledges the work of:
+
+- [Mastodon AI Contribution Policy](https://github.com/mastodon/mastodon/blob/main/AI_POLICY.md)
+- [W3C: Use of Large Language Models in Standards Work](https://www.w3.org/TR/llms-standards/)
+- [FastAPI / tiangolo contributing guidelines](https://tiangolo.com/open-source/contributing/#automated-code-and-ai), in particular the framing of low-effort AI submissions as a denial-of-service attack on human effort

--- a/AI.md
+++ b/AI.md
@@ -39,7 +39,6 @@ Discussions in OpenAPI Initiative projects are for humans.
 Comments that restate or summarise what has already been said, without advancing the conversation, add burden to volunteers and will be removed.
 A useful comment adds new information, identifies a constraint, asks a precise question, or proposes a concrete resolution.
 We expect you to make good-faith contributions that are concise and to the intended point; overly verbose or general contributions will be hidden or removed.
-Users who frequently have comments removed may be blocked from OpenAPI Initiative repositories.
 
 Do not use AI to generate issue comments, discussion replies, or PR descriptions. These are the primary record of design reasoning for the project; they must reflect genuine human thought.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,8 +2,8 @@
 
 ## Key information
 
-This project is covered by our [Code of Conduct](https://github.com/OAI/OpenAPI-Specification?tab=coc-ov-file#readme).
-All participants are expected to read and follow this code.
+This project is covered by our [Code of Conduct](https://github.com/OAI/OpenAPI-Specification?tab=coc-ov-file#readme) and [AI policy](AI.md).
+All participants are expected to read and follow these policies.
 
 No changes, however trivial, are ever made to the contents of published specifications (the files in the `versions/` folder).
 Exceptions may be made when links to external URLs have been changed by a 3rd party, in order to keep our documents accurate.


### PR DESCRIPTION
Following on from our [discussion](https://github.com/OAI/OpenAPI-Specification/discussions/5209) and some of the recent TDC meetings, I've put together a starting point for an AI policy. We're agreed that AI should be permitted, but that there's an important point about the effort ratio between contributions and maintenance tasks.

- [x] no schema changes are needed for this pull request

Claude proposed the outline of the doc after reviewing my preferred AI example policies, and also copyedited my document when finished.