### PR TITLE
ci: pass linkspector config to workflow

### DIFF
--- a/.github/workflows/validate-markdown.yaml
+++ b/.github/workflows/validate-markdown.yaml
@@ -38,6 +38,7 @@ jobs:
       - name: Check links in markdown files
         uses: umbrelladocs/action-linkspector@v1
         with:
+          config_file: .linkspector.yml
           reporter: github-check
           fail_level: any
           filter_mode: file


### PR DESCRIPTION
## Summary
- pass the repository Linkspector config file explicitly to the GitHub Action
- ensure the action uses the existing URL suppression rules from .linkspector.yml

## Validation
- 
pm test
- 
pm run validate-markdown *(fails locally in Linkspector startup with Network.enable timed out)*