### PR TITLE
Update workflows to LTS node version

### DIFF
--- a/.github/workflows/respec.yaml
+++ b/.github/workflows/respec.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: actions/setup-node@v6 # setup Node.js
         with:
-          node-version: "22.x"
+          node-version: "24.x"
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/schema-publish.yaml
+++ b/.github/workflows/schema-publish.yaml
@@ -36,7 +36,7 @@ jobs:
 
       - uses: actions/setup-node@v6 # setup Node.js
         with:
-          node-version: "22.x"
+          node-version: "24.x"
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/schema-tests.yaml
+++ b/.github/workflows/schema-tests.yaml
@@ -25,7 +25,7 @@ jobs:
 
     - uses: actions/setup-node@v6 # setup Node.js
       with:
-        node-version: '20.x'
+        node-version: '24.x'
 
     - name: Install dependencies
       run: npm ci


### PR DESCRIPTION
Current long-term support version of Node.js is 24.x - use it instead of outdated versions 20.x and 22.x.

<!-- Tick one of the following options and remove the other two: -->

- [x] no schema changes are needed for this pull request
