### PR TITLE
Restore markdown link checking

### DIFF
--- a/.github/workflows/validate-markdown.yaml
+++ b/.github/workflows/validate-markdown.yaml
@@ -27,3 +27,19 @@ jobs:
       - name: Lint other files
         run: npx --yes markdownlint-cli2 *.md
 
+      # workaround for https://github.com/UmbrellaDocs/action-linkspector/issues/62
+      - name: Install Chrome
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y google-chrome-stable
+          echo "PUPPETEER_SKIP_DOWNLOAD=true" >> $GITHUB_ENV
+          echo "PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome" >> $GITHUB_ENV
+
+      - name: Check links added to markdown files
+        uses: umbrelladocs/action-linkspector@v1
+        with:
+          config_file: .linkspector.yml
+          reporter: github-check
+          fail_level: any
+          filter_mode: added
+


### PR DESCRIPTION
close #5414

Changes:

* Restored the Linkspector check and Chrome workaround that were temporarily removed in #5413.
* Changed `filter_mode` to `added`.

Rationale:
The previous `file` mode checked the entire modified file, which meant pre-existing broken links or temporary failures on external websites could block otherwise unrelated PRs. Using `added` limits the check to broken links introduced by newly added lines.

Impact:

* Restores Markdown link validation in CI.
* Reduces false positives and prevents unrelated PRs from being blocked by existing link issues.

Validation:

* `actionlint` passed.
* `npm run validate-markdown` passed.
* `npm test` passed: 8/8.
* `git diff --check` passed.

Schema:
No schema changes are required.

AI disclosure:
Codex was used to analyze historical CI logs, update the workflow, and run validation checks. I personally reviewed and confirmed the changes.

- [x] no schema changes are needed for this pull request
