### PR TITLE
v3.1: fix schema error in contentType

### DIFF
--- a/src/schemas/validation/schema.yaml
+++ b/src/schemas/validation/schema.yaml
@@ -494,8 +494,8 @@ $defs:
     type: object
     properties:
       contentType:
+        $comment: one or more comma-separated media-ranges
         type: string
-        format: media-range
       headers:
         type: object
         additionalProperties:


### PR DESCRIPTION
a contentType may be a comma-separated list of media-ranges, not just a single media-range

backport of #5283. This is a fix, not an improvement, so it should go into 3.1 as well.

- [x] schema changes are included in this pull request
