### PR TITLE
There is no src dir on main

### DIFF
--- a/.linkspector.yml
+++ b/.linkspector.yml
@@ -1,5 +1,4 @@
 files:
-  - src/oas.md
   - CONTRIBUTING.md
   - EDITORS.md
   - GOVERNANCE.md


### PR DESCRIPTION
This silences a noisy but otherwise harmless linkspector error showing up in the CI log for #5424 (although it is not the real error- that is being fixed in OAI/build-infra#16).

***The auto-merge of this will need to be closed, not merged!!!.***
