### PR TITLE
Fix slack link, stop inspecting it

### DIFF
--- a/.linkspector.yml
+++ b/.linkspector.yml
@@ -11,6 +11,7 @@ files:
   - style-guide.md
   - TOB.md
 ignorePatterns:
+  - pattern: 'slack.com'  # Slack invite links 403 with linkspector
   - pattern: 'clientdomain.com'
   - pattern: 'example.org'
   - pattern: 'https://www.w3.org/TR/xml-names11/'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -390,7 +390,7 @@ The triage team keeps an eye on the backlog and closes issues and discussions th
 
 To get in touch with other people on the project, ask questions, or anything else:
 
-- Find us [on the OpenAPI Slack](https://join.slack.com/t/open-api/shared_invite/zt-45j57ones-BcErzGqJKA5Ib4wrM83Cgw).
+- Find us [on the OpenAPI Slack](https://open-api.slack.com/join/shared_invite/zt-45hwx39lu-L5kfOMIyFc4qt0v~FPGaXQ).
 - Start a [GitHub Discussion](https://github.com/OAI/OpenAPI-Specification/discussions/).
 - Join one of our weekly meetings by checking the [issues list for an upcoming meetings](https://github.com/OAI/OpenAPI-Specification/issues?q=is%3Aissue%20state%3Aopen%20label%3AHousekeeping).
 


### PR DESCRIPTION
Slack returns 403 for linkspector, it will never work.

Also, used wrong invite somehow, just re-copied this from the web site.  But the other one worked, it was just linkspector couldn't access it in CI.  This one is no different, it just changes who it says the invitation came from.


- [X] no schema changes are needed for this pull request
