### PR TITLE
ci: negates path spec and neutralizes non-zero exit codes

### DIFF
--- a/.github/workflows/sync-dev-to-vX.Y-dev.yaml
+++ b/.github/workflows/sync-dev-to-vX.Y-dev.yaml
@@ -46,6 +46,8 @@ jobs:
             git checkout -b $SYNC origin/$SYNC || git checkout -b $SYNC origin/$BASE
             git merge origin/$HEAD -m "Merge $HEAD into $SYNC"
             git checkout origin/$BASE src/
+            # exclude mjs files because we want to sync from the head
+            # neutralizes non-zero exit code because an empty selection result returns 1
             git checkout origin/$BASE -- tests/schema/ ':!*.mjs' || echo ""
             git commit -m "Restored src/ and tests/schema/" || echo ""
             git push -u origin $SYNC

--- a/.github/workflows/sync-dev-to-vX.Y-dev.yaml
+++ b/.github/workflows/sync-dev-to-vX.Y-dev.yaml
@@ -46,7 +46,7 @@ jobs:
             git checkout -b $SYNC origin/$SYNC || git checkout -b $SYNC origin/$BASE
             git merge origin/$HEAD -m "Merge $HEAD into $SYNC"
             git checkout origin/$BASE src/
-            git checkout origin/$BASE -- tests/schema/ ':*.mjs'
+            git checkout origin/$BASE -- tests/schema/ ':!*.mjs' || echo ""
             git commit -m "Restored src/ and tests/schema/" || echo ""
             git push -u origin $SYNC
 

--- a/.github/workflows/sync-main-to-dev.yaml
+++ b/.github/workflows/sync-main-to-dev.yaml
@@ -42,7 +42,7 @@ jobs:
           git checkout -b $SYNC origin/$SYNC || git checkout -b $SYNC origin/$BASE
           git merge origin/$HEAD -m "Merge $HEAD into $SYNC"
           git checkout origin/$BASE src/
-          git checkout origin/$BASE -- tests/schema/ ':*.mjs'
+          git checkout origin/$BASE -- tests/schema/ ':!*.mjs' || echo ""
           git commit -m "Restored src/ and tests/schema/" || echo ""
           git push -u origin $SYNC
 

--- a/.github/workflows/sync-main-to-dev.yaml
+++ b/.github/workflows/sync-main-to-dev.yaml
@@ -42,6 +42,8 @@ jobs:
           git checkout -b $SYNC origin/$SYNC || git checkout -b $SYNC origin/$BASE
           git merge origin/$HEAD -m "Merge $HEAD into $SYNC"
           git checkout origin/$BASE src/
+          # exclude mjs files because we want to sync from the head
+          # neutralizes non-zero exit code because an empty selection result returns 1
           git checkout origin/$BASE -- tests/schema/ ':!*.mjs' || echo ""
           git commit -m "Restored src/ and tests/schema/" || echo ""
           git push -u origin $SYNC


### PR DESCRIPTION
follow up to #5492 
I forgot two things:
- the negate operator to actually EXCLUDE the file
- the || echo to negate non zero exit code, which happens whens nothing is selected (from main typically)

unblocks #5493 which should also have replicated the mjs file