### PR TITLE
Use build-infra schema test helpers on dev branches

### DIFF
--- a/tests/schema/schema.test.mjs
+++ b/tests/schema/schema.test.mjs
@@ -1,7 +1,7 @@
 import { readdirSync, readFileSync } from "node:fs";
 import YAML from "yaml";
-import { describe, test, expect } from "vitest";
-import { registerSchema } from "@hyperjump/json-schema-coverage/vitest";
+import { describe, test, expect } from "@oai/build-infra/test";
+import { registerSchema, toMatchJsonSchema } from "@oai/build-infra/schema/vitest";
 import registerOasSchema from "./oas-schema.mjs";
 
 const parseYamlFromFile = (filePath) => {
@@ -10,6 +10,7 @@ const parseYamlFromFile = (filePath) => {
 };
 
 await registerOasSchema();
+expect.extend({ toMatchJsonSchema });
 await registerSchema("./src/schemas/validation/schema.yaml");
 const fixtures = './tests/schema';
 


### PR DESCRIPTION
This was missed in the main shared infrastructure PR because the file does not exist on `main`.  It has changes on the `v3.x-dev` branches so we might see some conflicts.

All this does is parallel the changes to `oas-schema.mjs` (currently only on `main` because of auto-merge issues separate from this issue) to configure through our build package rather than directly.  There are complex JavaScript import issues that make this necessary; it is explained in the build-infra repo.

- [X] no schema changes are needed for this pull request
