### PR TITLE
v3.3: Fix RFC reference with stray space

### DIFF
--- a/src/oas.md
+++ b/src/oas.md
@@ -1872,7 +1872,7 @@ Note that there are significant restrictions on what headers can be used with `m
 
 ##### Handling Multiple `contentType` Values
 
-When multiple values are provided for `contentType`, deserializing remains straightforward as, per [[RFC 2046]] [Section 5.1](https://datatracker.ietf.org/doc/html/rfc2046#section-5.1) each part will include a `Content-Type` header, or can reasonably be assumed to be `text/plain; charset=US-ASCII`.  To ensure interoperability, OAD authors SHOULD ensure that all reasonably expected media types are provided in `contentType`.
+When multiple values are provided for `contentType`, deserializing remains straightforward as, per [[RFC2046]] [Section 5.1](https://datatracker.ietf.org/doc/html/rfc2046#section-5.1) each part will include a `Content-Type` header, or can reasonably be assumed to be `text/plain; charset=US-ASCII`.  To ensure interoperability, OAD authors SHOULD ensure that all reasonably expected media types are provided in `contentType`.
 
 For encoding and serialization, implementations MUST provide a mechanism for applications to indicate which media type is intended.
 Implementations MAY choose to offer media type sniffing ([[SNIFF]]) as an alternative, but this MUST NOT be the default behavior due to the security risks inherent in the process.


### PR DESCRIPTION
The RFC resolve does not understand spaces between "RFC" and the RFC number.


- [X] no schema changes are needed for this pull request
