### PR TITLE
v3.3: Fix formatting of 'Encoding Object' in oas.md

### DIFF
--- a/src/oas.md
+++ b/src/oas.md
@@ -1376,7 +1376,7 @@ Each field has its own set of media types with which it can be used; for all oth
 The behavior of the `encoding` field is designed to support web forms, and is therefore only defined for media types structured as name-value pairs that allow repeat values, most notably `application/x-www-form-urlencoded` and `multipart/form-data`.
 
 To use the `encoding` field, each key under the field MUST exist in the data instance as a property; `encoding` entries with no corresponding property SHALL be ignored.
-When serializing, property values of the array type MUST be handled by applying the given Encoding Object to produce one encoded value per array item, each with the same `name`, as is recommended by [[!RFC7578]] [Section 4.3](https://www.rfc-editor.org/rfc/rfc7578.html#section-4.3) for supplying multiple values per form field; when deserializing, the Encoding object is applied to each item of the array property of the same name.
+When serializing, property values of the array type MUST be handled by applying the given Encoding Object to produce one encoded value per array item, each with the same `name`, as is recommended by [[!RFC7578]] [Section 4.3](https://www.rfc-editor.org/rfc/rfc7578.html#section-4.3) for supplying multiple values per form field; when deserializing, the Encoding Object is applied to each item of the array property of the same name.
 For deserialization to an object, multiple values with the same `name` MUST be collapsed into an array value for that named property, with one item per value, in order.
 For all other value types for both top-level non-array property values and for other values, including items of the array type within a top-level array, the Encoding Object MUST be applied to the entire value.
 
@@ -1938,7 +1938,7 @@ requestBody:
             type: string
             format: uuid
 
-          # An Encoding object allows multiple values to be provided for this
+          # An Encoding Object allows multiple values to be provided for this
           # property, without any attempt to decode the array as application/json
           alias:
             type: [ string, array ]


### PR DESCRIPTION
Can't unsee this 🤷🏻‍♂️

(Port of #5515)

- [x] no schema changes are needed for this pull request
