### PR TITLE
v3.2: fix regex for openapi version

### DIFF
--- a/src/schemas/validation/schema.yaml
+++ b/src/schemas/validation/schema.yaml
@@ -7,7 +7,7 @@ type: object
 properties:
   openapi:
     type: string
-    pattern: '^3\.2\.\d+(-.+)?$'
+    pattern: '^3\.2\.[0-9]+(-.+)?$'
   $self:
     type: string
     format: uri-reference

--- a/tests/schema/fail/openapi-version.yaml
+++ b/tests/schema/fail/openapi-version.yaml
@@ -1,0 +1,5 @@
+openapi: 3.2.৪
+info:
+  title: BENGALI DIGIT FOUR is a valid digit, but not an ascii digit
+  version: 1.0.0
+paths: {}


### PR DESCRIPTION
The "pattern" keyword is defined as following unicode semantics, where \d will match digits outside of the ascii range. But this is not likely to be treated as a valid version, so we must restrict to ascii digits.


- [x] schema changes are included in this pull request
