### PR TITLE
v3.2: fix schema test that lacks security scheme definitions

### DIFF
--- a/tests/schema/pass/operation-object-example.yaml
+++ b/tests/schema/pass/operation-object-example.yaml
@@ -2,6 +2,11 @@ openapi: 3.2.0
 info:
   title: API
   version: 1.0.0
+components:
+  securitySchemes:
+    petstore_auth:
+      type: http
+      scheme: basic
 paths:
   /pets/{id}:
     put:
@@ -45,3 +50,5 @@ paths:
         - petstore_auth:
             - write:pets
             - read:pets
+        - 'otherapi#/components/securitySchemes/generic_auth':
+            - read/write:*


### PR DESCRIPTION
..and add an example of a uri reference to a remote security scheme

port of #5533

- [x] no schema changes are needed for this pull request
